### PR TITLE
feat: archive calendar — add bottom-right data indicator dot

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -56,6 +56,18 @@ struct DayStats {
             case .high: return "HIGH"
             }
         }
+
+        /// Color for the bottom-right indicator dot.
+        /// On today cells the dot matches the border (primary / white),
+        /// otherwise it matches the cell's text color so it always contrasts
+        /// with the heat-map background.
+        func dotColor(isToday: Bool) -> Color {
+            if isToday {
+                // today border is DSColor.primary (black); use onPrimary so dot is visible
+                return DSColor.onPrimary
+            }
+            return textColor
+        }
     }
 }
 
@@ -461,6 +473,14 @@ struct ArchiveView: View {
                         .monoLabelStyle(size: 9)
                         .foregroundColor(density.textColor)
                         .padding(4)
+
+                    if let entryCount = stats?.memoCount, entryCount > 0 {
+                        Circle()
+                            .fill(density.dotColor(isToday: isToday))
+                            .frame(width: 4, height: 4)
+                            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+                            .padding(4)
+                    }
                 }
                 .aspectRatio(1, contentMode: .fit)
             }


### PR DESCRIPTION
## Summary

- 在 `ArchiveView.swift` 的 `calendarCell` 中，当 `memoCount > 0` 时，在右下角渲染一个 **4×4 pt 实心圆点**，与设计稿对齐。
- 新增 `DensityLevel.dotColor(isToday:)` 方法：today 格用 `DSColor.onPrimary`（浅色，与黑色边框形成对比）；其他格复用 `textColor`，在所有热力图深浅下均可见。
- 空数据日期（`memoCount == 0`）不渲染圆点，条件判断明确。

## Validation

- [x] 有数据日期格子右下角显示小圆点
- [x] 空数据日期不显示圆点
- [x] today 格圆点颜色用 `onPrimary`，与黑色边框协调
- [x] 暗色模式下 `textColor` / `onPrimary` 均为系统感知色，可见性保证
- [x] 月份切换后 `dayStats` 刷新 → 圆点状态同步刷新（由 ViewModel `@Published` 驱动）
- [x] `xcodebuild -scheme DayPage build` 通过 ✅

Closes #21