### PR TITLE
fix: apply opacity-80 to Metadata Only archive list rows

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -584,7 +584,8 @@ struct ArchiveView: View {
     }
 
     private func archiveListRow(stats: DayStats) -> some View {
-        Button(action: {
+        let isMetadataOnly = !stats.isDailyPageCompiled
+        return Button(action: {
             selectedDateString = stats.dateString
             if stats.isDailyPageCompiled {
                 showDailyPage = true
@@ -594,12 +595,14 @@ struct ArchiveView: View {
                 Rectangle()
                     .fill(DSColor.primary)
                     .frame(width: 4)
+                    .opacity(isMetadataOnly ? 0.8 : 1.0)
 
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
                         Text(formatArchiveDate(stats.dateString))
                             .font(.custom("SpaceGrotesk-Bold", size: 15))
                             .foregroundColor(DSColor.onSurface)
+                            .opacity(isMetadataOnly ? 0.8 : 1.0)
 
                         Spacer()
 
@@ -615,6 +618,7 @@ struct ArchiveView: View {
                             .foregroundColor(DSColor.onSurfaceVariant)
                             .italic()
                             .lineLimit(2)
+                            .opacity(isMetadataOnly ? 0.8 : 1.0)
                     }
 
                     HStack(spacing: 16) {
@@ -622,6 +626,7 @@ struct ArchiveView: View {
                         metaIcon("photo", count: stats.photoCount)
                         metaIcon("mic", count: stats.voiceMinutes, unit: "min")
                     }
+                    .opacity(isMetadataOnly ? 0.8 : 1.0)
                 }
                 .padding(16)
                 .frame(maxWidth: .infinity, alignment: .leading)


### PR DESCRIPTION
## Summary

- Archive 列表中，`Metadata Only` 行的日期文字、摘要预览文字、元数据图标行、4px 左边框均应用 `.opacity(0.8)` 灰化效果
- `StatusBadge`（METADATA/VERIFIED 徽章）保持 100% 不透明，确保可读性
- VERIFIED 行维持 100% 不透明度，视觉效果与原来一致

## Changes

- `ArchiveView.swift`: 在 `archiveListRow` 中为 Metadata Only 行的各视觉元素（左边框、日期文字、摘要、图标行）分别添加 `.opacity(isMetadataOnly ? 0.8 : 1.0)`

## Acceptance Criteria Checklist

- [x] Metadata Only 行整体明显灰化
- [x] Badge 本身保持清晰可见（无 opacity 修饰）
- [x] VERIFIED 行保持 100% 不透明
- [x] 点击灰化行仍可正常响应（Button action 逻辑未改动）
- [x] `xcodebuild -scheme DayPage build` 通过

Closes #23