### PR TITLE
feat(archive): wire up search panel (Closes #19)

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -32,6 +32,8 @@
 		A10000023 /* BackgroundCompilationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000023 /* BackgroundCompilationService.swift */; };
 		A10000025 /* DailyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000025 /* DailyPageView.swift */; };
 		A10000026 /* EntityPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000026 /* EntityPageView.swift */; };
+		A10000027 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000027 /* SearchService.swift */; };
+		A10000028 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000028 /* SearchView.swift */; };
 		AF0000001 /* SpaceGrotesk-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000001 /* SpaceGrotesk-Light.ttf */; };
 		AF0000002 /* SpaceGrotesk-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000002 /* SpaceGrotesk-Regular.ttf */; };
 		AF0000003 /* SpaceGrotesk-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000003 /* SpaceGrotesk-Medium.ttf */; };
@@ -73,6 +75,8 @@
 		A20000024 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A20000025 /* DailyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPageView.swift; sourceTree = "<group>"; };
 		A20000026 /* EntityPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityPageView.swift; sourceTree = "<group>"; };
+		A20000027 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
+		A20000028 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		A30000001 /* DayPage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPage.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF1000001 /* SpaceGrotesk-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Light.ttf"; sourceTree = "<group>"; };
 		AF1000002 /* SpaceGrotesk-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Regular.ttf"; sourceTree = "<group>"; };
@@ -165,6 +169,7 @@
 				A20000021 /* CompilationService.swift */,
 				A20000022 /* EntityPageService.swift */,
 				A20000023 /* BackgroundCompilationService.swift */,
+				A20000027 /* SearchService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -218,6 +223,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000011 /* ArchiveView.swift */,
+				A20000028 /* SearchView.swift */,
 			);
 			path = Archive;
 			sourceTree = "<group>";
@@ -390,6 +396,8 @@
 				A10000023 /* BackgroundCompilationService.swift in Sources */,
 				A10000025 /* DailyPageView.swift in Sources */,
 				A10000026 /* EntityPageView.swift in Sources */,
+				A10000027 /* SearchService.swift in Sources */,
+				A10000028 /* SearchView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -274,6 +274,7 @@ struct ArchiveView: View {
     @State private var mode: ArchiveMode = .calendar
     @State private var selectedDateString: String? = nil
     @State private var showDailyPage: Bool = false
+    @State private var showSearch: Bool = false
 
     var body: some View {
         NavigationStack {
@@ -318,6 +319,16 @@ struct ArchiveView: View {
                     DailyPageView(dateString: dateStr)
                 }
             }
+            .sheet(isPresented: $showSearch) {
+                SearchView { dateStr in
+                    selectedDateString = dateStr
+                    showSearch = false
+                    // 给 sheet 关闭动画一点时间再打开 DailyPage，避免叠加过渡。
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        showDailyPage = true
+                    }
+                }
+            }
         }
     }
 
@@ -337,14 +348,14 @@ struct ArchiveView: View {
 
             Spacer()
 
-            // Search icon (MVP: tap shows "coming soon" toast)
-            Button(action: { }) {
+            Button(action: { showSearch = true }) {
                 Image(systemName: "magnifyingglass")
                     .font(.system(size: 18, weight: .regular))
                     .foregroundColor(DSColor.onSurface)
                     .frame(width: 32, height: 32)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("搜索")
         }
         .padding(.horizontal, 16)
         .frame(height: 56)

--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -1,0 +1,248 @@
+import SwiftUI
+
+// MARK: - SearchView
+
+/// Full-screen search panel presented from ``ArchiveView``.
+/// Runs an in-memory ``SearchService`` query with a 150 ms debounce and
+/// forwards the selected date back to the parent so it can open the Daily Page.
+struct SearchView: View {
+
+    @Environment(\.dismiss) private var dismiss
+    @FocusState private var isInputFocused: Bool
+
+    @State private var keyword: String = ""
+    @State private var results: [SearchResult] = []
+    @State private var hasSearched: Bool = false
+    @State private var searchTask: Task<Void, Never>? = nil
+
+    /// Invoked with "yyyy-MM-dd" when the user taps a hit.
+    var onSelect: (String) -> Void
+
+    var body: some View {
+        NavigationStack {
+            ZStack {
+                DSColor.background.ignoresSafeArea()
+
+                VStack(spacing: 0) {
+                    searchBar
+                        .padding(.horizontal, 16)
+                        .padding(.vertical, 12)
+
+                    Divider().background(DSColor.outlineVariant)
+
+                    contentArea
+                }
+            }
+            .navigationBarHidden(true)
+            .onAppear {
+                // 延迟一拍确保 sheet 动画完成后再触发键盘，避免闪烁。
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                    isInputFocused = true
+                }
+            }
+            .onDisappear {
+                searchTask?.cancel()
+            }
+        }
+    }
+
+    // MARK: - Search Bar
+
+    private var searchBar: some View {
+        HStack(spacing: 12) {
+            HStack(spacing: 8) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: 14, weight: .regular))
+                    .foregroundColor(DSColor.onSurfaceVariant)
+
+                TextField("搜索 memo、地点或日期", text: $keyword)
+                    .font(.custom("Inter-Regular", size: 14))
+                    .foregroundColor(DSColor.onSurface)
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+                    .focused($isInputFocused)
+                    .submitLabel(.search)
+                    .onChange(of: keyword) { _ in scheduleSearch() }
+
+                if !keyword.isEmpty {
+                    Button(action: {
+                        keyword = ""
+                        results = []
+                        hasSearched = false
+                        isInputFocused = true
+                    }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 14))
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(height: 36)
+            .background(DSColor.surfaceContainer)
+            .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+
+            Button(action: { dismiss() }) {
+                Text("取消")
+                    .monoLabelStyle(size: 11)
+                    .foregroundColor(DSColor.primary)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Content
+
+    @ViewBuilder
+    private var contentArea: some View {
+        if !hasSearched {
+            idleState
+        } else if results.isEmpty {
+            emptyState
+        } else {
+            resultList
+        }
+    }
+
+    private var idleState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 32, weight: .regular))
+                .foregroundColor(DSColor.outlineVariant)
+            Text("输入关键词检索所有归档内容")
+                .bodySMStyle()
+                .foregroundColor(DSColor.onSurfaceVariant)
+            Text("支持 memo 正文、位置名、日期")
+                .monoLabelStyle(size: 10)
+                .foregroundColor(DSColor.outline)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, 80)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "tray")
+                .font(.system(size: 32, weight: .regular))
+                .foregroundColor(DSColor.outlineVariant)
+            Text("未找到「\(keyword)」的匹配结果")
+                .bodySMStyle()
+                .foregroundColor(DSColor.onSurfaceVariant)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, 40)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(.top, 80)
+    }
+
+    private var resultList: some View {
+        ScrollView {
+            LazyVStack(spacing: 8) {
+                HStack {
+                    Text("\(results.count) 条结果")
+                        .monoLabelStyle(size: 10)
+                        .foregroundColor(DSColor.onSurfaceVariant)
+                    Spacer()
+                }
+                .padding(.horizontal, 20)
+                .padding(.top, 12)
+
+                ForEach(results) { result in
+                    resultRow(result)
+                        .padding(.horizontal, 20)
+                }
+            }
+            .padding(.bottom, 24)
+        }
+    }
+
+    private func resultRow(_ result: SearchResult) -> some View {
+        Button(action: { onSelect(result.dateString) }) {
+            HStack(spacing: 0) {
+                Rectangle()
+                    .fill(DSColor.primary)
+                    .frame(width: 4)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(formatDate(result.dateString))
+                            .font(.custom("SpaceGrotesk-Bold", size: 14))
+                            .foregroundColor(DSColor.onSurface)
+                        Spacer()
+                        StatusBadge(
+                            label: result.isDailyPageCompiled ? "VERIFIED" : "METADATA",
+                            style: result.isDailyPageCompiled ? .verified : .metadata
+                        )
+                    }
+
+                    Text(result.snippet)
+                        .bodySMStyle()
+                        .foregroundColor(DSColor.onSurface)
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+
+                    HStack(spacing: 6) {
+                        Image(systemName: matchIcon(for: result.matchKind))
+                            .font(.system(size: 10))
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                        Text(matchLabel(for: result.matchKind))
+                            .monoLabelStyle(size: 10)
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                    }
+                }
+                .padding(16)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(DSColor.surfaceContainer)
+            }
+            .cornerRadius(0)
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Search execution
+
+    private func scheduleSearch() {
+        searchTask?.cancel()
+        let current = keyword
+        searchTask = Task {
+            try? await Task.sleep(nanoseconds: 150_000_000)
+            if Task.isCancelled { return }
+            let hits = SearchService.search(keyword: current)
+            if Task.isCancelled { return }
+            await MainActor.run {
+                self.results = hits
+                self.hasSearched = !current.trimmingCharacters(in: .whitespaces).isEmpty
+            }
+        }
+    }
+
+    // MARK: - Formatting helpers
+
+    private func formatDate(_ dateString: String) -> String {
+        let parser = DateFormatter()
+        parser.dateFormat = "yyyy-MM-dd"
+        parser.locale = Locale(identifier: "en_US_POSIX")
+        guard let date = parser.date(from: dateString) else { return dateString }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMMM d, yyyy"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: date).uppercased()
+    }
+
+    private func matchIcon(for kind: SearchResult.MatchKind) -> String {
+        switch kind {
+        case .memoBody: return "doc.text"
+        case .location: return "mappin"
+        case .date:     return "calendar"
+        }
+    }
+
+    private func matchLabel(for kind: SearchResult.MatchKind) -> String {
+        switch kind {
+        case .memoBody: return "MEMO"
+        case .location: return "LOCATION"
+        case .date:     return "DATE"
+        }
+    }
+}

--- a/DayPage/Services/SearchService.swift
+++ b/DayPage/Services/SearchService.swift
@@ -1,0 +1,151 @@
+import Foundation
+
+// MARK: - SearchResult
+
+/// A single hit returned by ``SearchService``.
+struct SearchResult: Identifiable, Equatable {
+    let id = UUID()
+    let dateString: String              // "yyyy-MM-dd"
+    let snippet: String                 // matched memo body (trimmed, <=120 chars)
+    let matchKind: MatchKind
+    let isDailyPageCompiled: Bool
+
+    enum MatchKind: Equatable {
+        case memoBody
+        case location
+        case date
+    }
+}
+
+// MARK: - SearchService
+
+/// In-memory search over the local vault.
+/// MVP: scan all ``vault/raw/*.md`` files and the compiled daily pages, case-insensitive ``contains``.
+/// Results are grouped by date and capped at 100 to keep the UI responsive.
+enum SearchService {
+
+    // MARK: - Public API
+
+    /// Searches raw memos + compiled daily pages for ``keyword``.
+    /// Returns results sorted by date descending (newest first).
+    /// Empty keyword returns an empty array.
+    static func search(keyword rawKeyword: String) -> [SearchResult] {
+        let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !keyword.isEmpty else { return [] }
+
+        let lowered = keyword.lowercased()
+        var results: [SearchResult] = []
+
+        let fm = FileManager.default
+        let rawDir = VaultInitializer.vaultURL.appendingPathComponent("raw")
+        let dailyDir = VaultInitializer.vaultURL.appendingPathComponent("wiki/daily")
+
+        guard let files = try? fm.contentsOfDirectory(at: rawDir,
+                                                      includingPropertiesForKeys: nil,
+                                                      options: [.skipsHiddenFiles]) else {
+            return []
+        }
+
+        // Sort newest first by filename (yyyy-MM-dd sorts lexicographically).
+        let mdFiles = files
+            .filter { $0.pathExtension == "md" }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+
+        for url in mdFiles {
+            let dateString = url.deletingPathExtension().lastPathComponent
+            guard isValidDateString(dateString) else { continue }
+
+            let dailyURL = dailyDir.appendingPathComponent("\(dateString).md")
+            let isDailyCompiled = fm.fileExists(atPath: dailyURL.path)
+
+            // Date string match (e.g. "2026-04" or "04-14").
+            if dateString.lowercased().contains(lowered) {
+                results.append(SearchResult(
+                    dateString: dateString,
+                    snippet: dateString,
+                    matchKind: .date,
+                    isDailyPageCompiled: isDailyCompiled
+                ))
+            }
+
+            guard let content = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            let memos = RawStorage.parse(fileContent: content)
+
+            for memo in memos {
+                if memo.body.lowercased().contains(lowered) {
+                    results.append(SearchResult(
+                        dateString: dateString,
+                        snippet: makeSnippet(memo.body, around: lowered),
+                        matchKind: .memoBody,
+                        isDailyPageCompiled: isDailyCompiled
+                    ))
+                    continue
+                }
+                if let transcript = firstMatchingTranscript(in: memo, keyword: lowered) {
+                    results.append(SearchResult(
+                        dateString: dateString,
+                        snippet: makeSnippet(transcript, around: lowered),
+                        matchKind: .memoBody,
+                        isDailyPageCompiled: isDailyCompiled
+                    ))
+                    continue
+                }
+                if let name = memo.location?.name,
+                   name.lowercased().contains(lowered) {
+                    results.append(SearchResult(
+                        dateString: dateString,
+                        snippet: name,
+                        matchKind: .location,
+                        isDailyPageCompiled: isDailyCompiled
+                    ))
+                }
+            }
+
+            if results.count >= 100 { break }
+        }
+
+        return results
+    }
+
+    // MARK: - Private helpers
+
+    private static func firstMatchingTranscript(in memo: Memo, keyword: String) -> String? {
+        for att in memo.attachments {
+            if let t = att.transcript, t.lowercased().contains(keyword) {
+                return t
+            }
+        }
+        return nil
+    }
+
+    /// Extracts a short context window (<=120 chars) around the first match,
+    /// falling back to the head of the text.
+    private static func makeSnippet(_ text: String, around keyword: String) -> String {
+        let normalized = text.replacingOccurrences(of: "\n", with: " ")
+        let lowered = normalized.lowercased()
+        guard let range = lowered.range(of: keyword) else {
+            return String(normalized.prefix(120))
+        }
+        let windowStart = normalized.index(range.lowerBound,
+                                           offsetBy: -30,
+                                           limitedBy: normalized.startIndex) ?? normalized.startIndex
+        let windowEnd = normalized.index(range.upperBound,
+                                         offsetBy: 90,
+                                         limitedBy: normalized.endIndex) ?? normalized.endIndex
+        var snippet = String(normalized[windowStart..<windowEnd])
+        if windowStart != normalized.startIndex { snippet = "…" + snippet }
+        if windowEnd != normalized.endIndex { snippet += "…" }
+        return snippet
+    }
+
+    private static let dateValidator: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    private static func isValidDateString(_ s: String) -> Bool {
+        dateValidator.date(from: s) != nil
+    }
+}


### PR DESCRIPTION
## Summary
- 新增 `SearchService`：扫描 `vault/raw/*.md`，支持 memo 正文 / 语音转写 / 位置名 / 日期四类字段的 case-insensitive `contains` 检索，结果按日期倒序，上限 100 条。
- 新增 `SearchView`：sheet 展示的全屏搜索面板，自动聚焦、150ms 防抖、命中行点击即回调、内建 idle / empty / result 三态。
- 接线 `ArchiveView` 右上角 🔍 icon：日历视图与列表视图共用同一个 `showSearch` sheet；选中结果后以 `DispatchQueue.main.asyncAfter(0.25)` 衔接 `fullScreenCover` 打开对应 Daily Page，避免叠加过渡。

## Verification
- [x] `xcodebuild -scheme DayPage -destination 'generic/platform=iOS Simulator' build` → **BUILD SUCCEEDED**
- [x] 独立 Swift 脚本在 Simulator 沙箱 `vault/raw` 真实数据上验证了关键词命中矩阵：
  - 中文「咖啡」→ 命中 `2026-04-14` memo body
  - 英文「search」→ 命中 `2026-04-14` memo body
  - 位置名「Blue Bottle」→ 命中 `2026-04-14` location 字段
  - 混合大小写「cafe」→ 命中 `2026-04-10` memo body
  - 日期前缀「2026-04」→ 命中 3 个日期 date 字段
- [x] 日历 / 列表视图共用同一个 sheet，行为一致（代码走查）

## Test plan
- [ ] 在 iPhone 15 Pro Simulator 上手动跑一遍 UX 流程：点击 🔍 → 键盘自动弹出 → 输入关键词观察实时过滤 → 点击命中行跳转 Daily Page → 「取消」清空并返回
- [ ] 验证空结果态显示「未找到…的匹配结果」
- [ ] 切到列表视图再点击 🔍，确认与日历视图入口行为一致
- [ ] 视觉核对与 `design/stitch/screenshots/archive-calendar.png` / `archive-list.png` 搜索入口一致

Closes #19