### PR TITLE
fix: voice transcript duplicate + compilation JSON parsing + retry logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,12 @@ jobs:
       - name: Run EntityPage tests
         run: xcrun swift scripts/tests/test_entity_page.swift
 
+      - name: Run CompilationParsing tests
+        run: xcrun swift scripts/tests/test_compilation_parsing.swift
+
+      - name: Run VoiceTranscript tests
+        run: xcrun swift scripts/tests/test_voice_transcript.swift
+
   build:
     name: Xcode Build (no signing)
     runs-on: macos-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
       - "tasks/**"
       - "**.md"
       - ".gitignore"
+  schedule:
+    - cron: "0 2 * * *"   # 每天 UTC 02:00（北京时间 10:00）对 main 跑全量回归
 
 jobs:
   unit-tests:
@@ -27,17 +29,45 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Run RawStorage tests
-        run: xcrun swift scripts/tests/test_raw_storage.swift
+      - name: Show Swift version
+        run: xcrun swift --version
 
-      - name: Run EntityPage tests
-        run: xcrun swift scripts/tests/test_entity_page.swift
+      - name: Run all unit tests (fail-fast=false)
+        run: |
+          set +e
+          OVERALL=0
 
-      - name: Run CompilationParsing tests
-        run: xcrun swift scripts/tests/test_compilation_parsing.swift
+          run_test() {
+            local FILE="$1"
+            echo ""
+            echo "══════════════════════════════════════════"
+            echo "  Running: $FILE"
+            echo "══════════════════════════════════════════"
+            xcrun swift "$FILE"
+            local RC=$?
+            if [ $RC -ne 0 ]; then
+              echo "  ❌ FAILED: $FILE (exit $RC)"
+              OVERALL=1
+            else
+              echo "  ✅ PASSED: $FILE"
+            fi
+            return $RC
+          }
 
-      - name: Run VoiceTranscript tests
-        run: xcrun swift scripts/tests/test_voice_transcript.swift
+          run_test scripts/tests/test_raw_storage.swift
+          run_test scripts/tests/test_entity_page.swift
+          run_test scripts/tests/test_compilation_parsing.swift
+          run_test scripts/tests/test_voice_transcript.swift
+
+          echo ""
+          echo "══════════════════════════════════════════"
+          if [ $OVERALL -eq 0 ]; then
+            echo "  ✅ All tests passed"
+          else
+            echo "  ❌ One or more tests failed"
+          fi
+          echo "══════════════════════════════════════════"
+          exit $OVERALL
 
   build:
     name: Xcode Build (no signing)

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -227,14 +227,10 @@ final class TodayViewModel: ObservableObject {
                 memoType = .text
             }
 
-            // For voice-only memo body: use transcript when no explicit text
-            let finalBody: String
-            if !hasText, hasVoice, memoAttachments.count == 1,
-               let tr = memoAttachments.first?.transcript {
-                finalBody = tr
-            } else {
-                finalBody = trimmed
-            }
+            // Body is always the user-typed text (trimmed). For voice-only memos this
+            // is empty — the transcript lives exclusively in attachment.transcript and
+            // is rendered by VoiceMemoPlayerRow, preventing duplicate display.
+            let finalBody = trimmed
 
             let memo = Memo(
                 type: memoType,
@@ -305,8 +301,7 @@ final class TodayViewModel: ObservableObject {
         Task {
             defer { isCompiling = false }
             do {
-                try await compilationService.compile(for: date, trigger: "manual")
-                // Refresh daily page status after successful compile
+                try await compileWithRetry()
                 checkDailyPage()
             } catch let error as CompilationError {
                 submitError = error.errorDescription ?? "编译失败，请重试"
@@ -314,6 +309,27 @@ final class TodayViewModel: ObservableObject {
                 submitError = "编译失败：\(error.localizedDescription)"
             }
         }
+    }
+
+    private func compileWithRetry(maxAttempts: Int = 3) async throws {
+        var lastError: Error?
+        for attempt in 0..<maxAttempts {
+            do {
+                try await compilationService.compile(for: date, trigger: "manual")
+                return
+            } catch CompilationError.networkError(let msg) {
+                lastError = CompilationError.networkError(msg)
+            } catch CompilationError.apiError(let code, let body) where code == 429 {
+                lastError = CompilationError.apiError(statusCode: code, body: body)
+            } catch {
+                throw error  // Non-retryable errors surface immediately
+            }
+            if attempt < maxAttempts - 1 {
+                let delayNs = UInt64(pow(2.0, Double(attempt))) * 1_000_000_000
+                try await Task.sleep(nanoseconds: delayNs)
+            }
+        }
+        throw lastError!
     }
 
     // MARK: - Private Helpers

--- a/DayPage/Services/CompilationService.swift
+++ b/DayPage/Services/CompilationService.swift
@@ -57,7 +57,7 @@ final class CompilationService {
         let compiledText = try await callDashScope(prompt: prompt, apiKey: apiKey)
 
         // 5. Parse structured output (Daily Page + Entity update instructions + hot cache)
-        let (dailyPageText, entityInstructions, hotCacheText) = parseStructuredOutputWithHot(compiledText)
+        let (dailyPageText, entityInstructions, hotCacheText) = try parseStructuredOutputWithHot(compiledText)
 
         // 6. Write Daily Page (backup existing if present)
         let dailyURL = dailyPageURL(for: dateString)
@@ -322,14 +322,14 @@ final class CompilationService {
     // MARK: - Hot Cache
 
     /// Parses the LLM structured output and extracts daily page, entity instructions, and hot cache.
-    /// Returns a tuple: (dailyPage, entityInstructions, hotCacheSummary).
-    /// hotCacheSummary is an empty string if the field is missing.
+    /// Throws `parseError` when the response contains no valid JSON or is missing `daily_page`.
     private func parseStructuredOutputWithHot(
         _ rawLLMResponse: String
-    ) -> (dailyPage: String, instructions: [EntityUpdateInstruction], hotCache: String) {
+    ) throws -> (dailyPage: String, instructions: [EntityUpdateInstruction], hotCache: String) {
         let (dailyPage, instructions) = EntityPageService.parseStructuredOutput(rawLLMResponse)
-
-        // Also extract hot_cache from the same JSON block
+        guard !dailyPage.isEmpty else {
+            throw CompilationError.parseError("LLM 响应中未找到有效 JSON 或缺少 daily_page 字段")
+        }
         let hotCache = extractHotCacheFromJSON(rawLLMResponse) ?? ""
         return (dailyPage, instructions, hotCache)
     }

--- a/DayPage/Services/EntityPageService.swift
+++ b/DayPage/Services/EntityPageService.swift
@@ -324,15 +324,15 @@ final class EntityPageService {
     /// }
     /// ```
     static func parseStructuredOutput(_ rawLLMResponse: String) -> (dailyPage: String, instructions: [EntityUpdateInstruction]) {
-        // Try to extract JSON block from the response
+        // Try to extract and parse a JSON block from the response
         guard let jsonBlock = extractJSONBlock(from: rawLLMResponse),
               let data = jsonBlock.data(using: .utf8),
-              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            // Fallback: treat entire response as daily page, no entity updates
-            return (rawLLMResponse, [])
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let dailyPage = json["daily_page"] as? String,
+              !dailyPage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            // Extraction or validation failed — signal failure via empty dailyPage sentinel
+            return ("", [])
         }
-
-        let dailyPage = (json["daily_page"] as? String) ?? rawLLMResponse
         var instructions: [EntityUpdateInstruction] = []
 
         if let updates = json["entity_updates"] as? [[String: Any]] {
@@ -380,12 +380,15 @@ final class EntityPageService {
     // MARK: - Private Helpers
 
     private static func extractJSONBlock(from text: String) -> String? {
-        // Look for ```json ... ``` fenced block first
-        if let fenceStart = text.range(of: "```json\n"),
-           let fenceEnd = text.range(of: "\n```", range: fenceStart.upperBound ..< text.endIndex) {
-            return String(text[fenceStart.upperBound ..< fenceEnd.lowerBound])
+        // Match ```json (with optional space/uppercase) ... ``` fenced blocks
+        let fencePatterns = ["```json\n", "```json \n", "```JSON\n", "```\n"]
+        for pattern in fencePatterns {
+            if let fenceStart = text.range(of: pattern, options: .caseInsensitive),
+               let fenceEnd = text.range(of: "\n```", range: fenceStart.upperBound ..< text.endIndex) {
+                return String(text[fenceStart.upperBound ..< fenceEnd.lowerBound])
+            }
         }
-        // Fallback: look for raw { ... } spanning the whole response
+        // Fallback: raw { ... } spanning the whole response
         if let braceStart = text.firstIndex(of: "{"),
            let braceEnd = text.lastIndex(of: "}") {
             return String(text[braceStart ... braceEnd])

--- a/scripts/tests/test_compilation_parsing.swift
+++ b/scripts/tests/test_compilation_parsing.swift
@@ -1,0 +1,157 @@
+#!/usr/bin/env xcrun swift
+// Tests for CompilationService / EntityPageService JSON parsing logic.
+// Run: xcrun swift scripts/tests/test_compilation_parsing.swift
+
+import Foundation
+
+// MARK: - Inline the parsing logic under test
+
+func extractJSONBlock(from text: String) -> String? {
+    let fencePatterns = ["```json\n", "```json \n", "```JSON\n", "```\n"]
+    for pattern in fencePatterns {
+        if let fenceStart = text.range(of: pattern, options: .caseInsensitive),
+           let fenceEnd = text.range(of: "\n```", range: fenceStart.upperBound ..< text.endIndex) {
+            return String(text[fenceStart.upperBound ..< fenceEnd.lowerBound])
+        }
+    }
+    if let braceStart = text.firstIndex(of: "{"),
+       let braceEnd = text.lastIndex(of: "}") {
+        return String(text[braceStart ... braceEnd])
+    }
+    return nil
+}
+
+/// Returns ("", []) sentinel on failure — empty dailyPage means parse failed.
+func parseStructuredOutput(_ rawLLMResponse: String) -> (dailyPage: String, hasEntityUpdates: Bool) {
+    guard let jsonBlock = extractJSONBlock(from: rawLLMResponse),
+          let data = jsonBlock.data(using: .utf8),
+          let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+          let dailyPage = json["daily_page"] as? String,
+          !dailyPage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        return ("", false)
+    }
+    let hasUpdates = (json["entity_updates"] as? [[String: Any]])?.isEmpty == false
+    return (dailyPage, hasUpdates)
+}
+
+// MARK: - Test runner
+
+var passed = 0
+var failed = 0
+
+func test(_ name: String, _ body: () throws -> Void) {
+    do {
+        try body()
+        print("  PASS  \(name)")
+        passed += 1
+    } catch {
+        print("  FAIL  \(name): \(error)")
+        failed += 1
+    }
+}
+
+func assertEqual<T: Equatable>(_ lhs: T, _ rhs: T, file: StaticString = #file, line: Int = #line) throws {
+    if lhs != rhs {
+        throw NSError(domain: "Test", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Expected \(rhs), got \(lhs) at line \(line)"
+        ])
+    }
+}
+
+func assertTrue(_ condition: Bool, _ message: String = "condition false") throws {
+    if !condition {
+        throw NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}
+
+// MARK: - Tests
+
+print("\n=== Compilation Parsing Tests ===\n")
+
+test("bare JSON parsed correctly") {
+    let raw = #"{"daily_page": "# Day\nContent here", "entity_updates": [], "hot_cache": "summary"}"#
+    let (page, _) = parseStructuredOutput(raw)
+    try assertTrue(!page.isEmpty, "dailyPage should not be empty")
+    try assertTrue(page.contains("Content here"), "dailyPage should contain expected text")
+}
+
+test("markdown-fenced ```json block parsed correctly") {
+    let raw = """
+    Here is your output:
+    ```json
+    {"daily_page": "# Daily\nNarrative.", "entity_updates": [], "hot_cache": "cache"}
+    ```
+    That's all.
+    """
+    let (page, _) = parseStructuredOutput(raw)
+    try assertTrue(!page.isEmpty, "should extract dailyPage from fenced block")
+    try assertTrue(page.contains("Narrative"), "content should match")
+}
+
+test("uppercase ```JSON fence parsed correctly") {
+    let raw = """
+    ```JSON
+    {"daily_page": "# Entry", "entity_updates": []}
+    ```
+    """
+    let (page, _) = parseStructuredOutput(raw)
+    try assertTrue(!page.isEmpty, "uppercase JSON fence should be handled")
+}
+
+test("plain ``` fence parsed correctly") {
+    let raw = """
+    ```
+    {"daily_page": "# Plain fence", "entity_updates": []}
+    ```
+    """
+    let (page, _) = parseStructuredOutput(raw)
+    try assertTrue(!page.isEmpty, "plain fence should be handled")
+}
+
+test("missing daily_page field returns empty sentinel") {
+    let raw = #"{"entity_updates": [], "hot_cache": "some cache"}"#
+    let (page, _) = parseStructuredOutput(raw)
+    try assertEqual(page, "", "missing daily_page should return empty sentinel")
+}
+
+test("empty daily_page string returns empty sentinel") {
+    let raw = #"{"daily_page": "  ", "entity_updates": []}"#
+    let (page, _) = parseStructuredOutput(raw)
+    try assertEqual(page, "", "whitespace-only daily_page should return empty sentinel")
+}
+
+test("invalid JSON returns empty sentinel") {
+    let raw = "This is just plain text, not JSON at all."
+    let (page, _) = parseStructuredOutput(raw)
+    try assertEqual(page, "", "plain text should return empty sentinel")
+}
+
+test("truncated JSON returns empty sentinel") {
+    let raw = #"{"daily_page": "# Start"#  // missing closing brace
+    let (page, _) = parseStructuredOutput(raw)
+    try assertEqual(page, "", "truncated JSON should return empty sentinel")
+}
+
+test("entity_updates correctly detected") {
+    let raw = """
+    {"daily_page": "# Day", "entity_updates": [{"entity_type": "places", "entity_slug": "tokyo", "display_name": "Tokyo", "section": "## Visits", "content": "Visited today"}], "hot_cache": ""}
+    """
+    let (page, hasUpdates) = parseStructuredOutput(raw)
+    try assertTrue(!page.isEmpty, "dailyPage should be present")
+    try assertTrue(hasUpdates, "entity_updates should be detected")
+}
+
+test("extractJSONBlock prefers fenced over bare braces") {
+    let raw = """
+    Some text with a { stray brace } in it.
+    ```json
+    {"daily_page": "# Correct", "entity_updates": []}
+    ```
+    """
+    let block = extractJSONBlock(from: raw)
+    try assertTrue(block != nil, "should find a JSON block")
+    try assertTrue(block!.contains("Correct"), "should prefer fenced block content")
+}
+
+print("\n=== Results: \(passed) passed, \(failed) failed ===")
+if failed > 0 { exit(1) } else { exit(0) }

--- a/scripts/tests/test_compilation_parsing.swift
+++ b/scripts/tests/test_compilation_parsing.swift
@@ -50,11 +50,10 @@ func test(_ name: String, _ body: () throws -> Void) {
     }
 }
 
-func assertEqual<T: Equatable>(_ lhs: T, _ rhs: T, file: StaticString = #file, line: Int = #line) throws {
+func assertEqual<T: Equatable>(_ lhs: T, _ rhs: T, _ message: String = "", file: StaticString = #file, line: Int = #line) throws {
     if lhs != rhs {
-        throw NSError(domain: "Test", code: 1, userInfo: [
-            NSLocalizedDescriptionKey: "Expected \(rhs), got \(lhs) at line \(line)"
-        ])
+        let msg = message.isEmpty ? "Expected \(rhs), got \(lhs) at line \(line)" : "\(message) — Expected \(rhs), got \(lhs) at line \(line)"
+        throw NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])
     }
 }
 
@@ -69,7 +68,7 @@ func assertTrue(_ condition: Bool, _ message: String = "condition false") throws
 print("\n=== Compilation Parsing Tests ===\n")
 
 test("bare JSON parsed correctly") {
-    let raw = #"{"daily_page": "# Day\nContent here", "entity_updates": [], "hot_cache": "summary"}"#
+    let raw = "{\"daily_page\": \"# Day\\nContent here\", \"entity_updates\": [], \"hot_cache\": \"summary\"}"
     let (page, _) = parseStructuredOutput(raw)
     try assertTrue(!page.isEmpty, "dailyPage should not be empty")
     try assertTrue(page.contains("Content here"), "dailyPage should contain expected text")
@@ -127,7 +126,7 @@ test("invalid JSON returns empty sentinel") {
 }
 
 test("truncated JSON returns empty sentinel") {
-    let raw = #"{"daily_page": "# Start"#  // missing closing brace
+    let raw = "{\"daily_page\": \"# Start\""  // missing closing brace
     let (page, _) = parseStructuredOutput(raw)
     try assertEqual(page, "", "truncated JSON should return empty sentinel")
 }

--- a/scripts/tests/test_compilation_parsing.swift
+++ b/scripts/tests/test_compilation_parsing.swift
@@ -79,7 +79,7 @@ test("markdown-fenced ```json block parsed correctly") {
     let raw = """
     Here is your output:
     ```json
-    {"daily_page": "# Daily\nNarrative.", "entity_updates": [], "hot_cache": "cache"}
+    {"daily_page": "# Daily\\nNarrative.", "entity_updates": [], "hot_cache": "cache"}
     ```
     That's all.
     """

--- a/scripts/tests/test_voice_transcript.swift
+++ b/scripts/tests/test_voice_transcript.swift
@@ -1,0 +1,139 @@
+#!/usr/bin/env xcrun swift
+// Tests for voice transcript duplicate-display fix.
+// Run: xcrun swift scripts/tests/test_voice_transcript.swift
+//
+// The bug: voice-only memos had transcript copied to memo.body,
+// causing it to render twice (once in VoiceMemoPlayerRow, once as body text).
+// Fix: body is always the user-typed text; transcript lives only in attachment.
+
+import Foundation
+
+// MARK: - Minimal type stubs
+
+struct Attachment {
+    let kind: String       // "audio" | "photo"
+    let file: String
+    let transcript: String?
+    let duration: Double?
+}
+
+struct Memo {
+    let type: MemoType
+    let body: String
+    let attachments: [Attachment]
+}
+
+enum MemoType { case text, voice, photo, mixed }
+
+// MARK: - Logic under test (mirrors TodayViewModel submit logic)
+
+/// Simulates TodayViewModel.submit() finalBody calculation.
+/// - Parameters:
+///   - userTypedText: Text the user typed in the input bar (trimmed).
+///   - attachments: Pending attachments to be submitted.
+/// - Returns: The `body` value that will be stored in the Memo.
+func computeFinalBody(userTypedText: String, attachments: [Attachment]) -> String {
+    // After the fix: body is always userTypedText.
+    // Transcript lives exclusively in attachment.transcript.
+    return userTypedText
+}
+
+/// Determines whether the card would display duplicate content.
+/// Returns true if body equals attachment transcript (the bug condition).
+func wouldDisplayDuplicate(memo: Memo) -> Bool {
+    guard let audioAtt = memo.attachments.first(where: { $0.kind == "audio" }),
+          let transcript = audioAtt.transcript,
+          !transcript.isEmpty else { return false }
+    let bodyTrimmed = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
+    return !bodyTrimmed.isEmpty && bodyTrimmed == transcript
+}
+
+// MARK: - Test runner
+
+var passed = 0
+var failed = 0
+
+func test(_ name: String, _ body: () throws -> Void) {
+    do {
+        try body()
+        print("  PASS  \(name)")
+        passed += 1
+    } catch {
+        print("  FAIL  \(name): \(error)")
+        failed += 1
+    }
+}
+
+func assertEqual<T: Equatable>(_ lhs: T, _ rhs: T, file: StaticString = #file, line: Int = #line) throws {
+    if lhs != rhs {
+        throw NSError(domain: "Test", code: 1, userInfo: [
+            NSLocalizedDescriptionKey: "Expected \(rhs), got \(lhs) at line \(line)"
+        ])
+    }
+}
+
+func assertTrue(_ condition: Bool, _ message: String = "condition false") throws {
+    if !condition {
+        throw NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+    }
+}
+
+// MARK: - Tests
+
+print("\n=== Voice Transcript Tests ===\n")
+
+test("voice-only memo: body is empty, transcript in attachment") {
+    let transcript = "I don't know. I don't know a hair."
+    let audio = Attachment(kind: "audio", file: "rec.m4a", transcript: transcript, duration: 2.0)
+    let body = computeFinalBody(userTypedText: "", attachments: [audio])
+    try assertEqual(body, "", "voice-only memo body should be empty")
+}
+
+test("voice-only memo: no duplicate display") {
+    let transcript = "I don't know. I don't know a hair."
+    let audio = Attachment(kind: "audio", file: "rec.m4a", transcript: transcript, duration: 2.0)
+    let body = computeFinalBody(userTypedText: "", attachments: [audio])
+    let memo = Memo(type: .voice, body: body, attachments: [audio])
+    try assertTrue(!wouldDisplayDuplicate(memo: memo), "voice-only memo should not show duplicate content")
+}
+
+test("voice + text memo: body equals user text, not transcript") {
+    let transcript = "Spoken content here."
+    let userText = "Note: see above"
+    let audio = Attachment(kind: "audio", file: "rec.m4a", transcript: transcript, duration: 3.0)
+    let body = computeFinalBody(userTypedText: userText, attachments: [audio])
+    try assertEqual(body, userText, "body should be user-typed text, not transcript")
+}
+
+test("voice + text memo: no duplicate when body != transcript") {
+    let transcript = "Spoken content here."
+    let userText = "Note: see above"
+    let audio = Attachment(kind: "audio", file: "rec.m4a", transcript: transcript, duration: 3.0)
+    let memo = Memo(type: .mixed, body: userText, attachments: [audio])
+    try assertTrue(!wouldDisplayDuplicate(memo: memo), "body != transcript, should not duplicate")
+}
+
+test("text-only memo: body preserved, no audio attachment") {
+    let body = computeFinalBody(userTypedText: "Just a note", attachments: [])
+    try assertEqual(body, "Just a note", "text-only memo body should be the typed text")
+}
+
+test("voice memo with no transcript: body stays empty") {
+    let audio = Attachment(kind: "audio", file: "rec.m4a", transcript: nil, duration: 5.0)
+    let body = computeFinalBody(userTypedText: "", attachments: [audio])
+    try assertEqual(body, "", "body should be empty when there is no transcript")
+}
+
+test("regression: old buggy behavior would have set body = transcript") {
+    // This test documents the old (buggy) behavior and confirms it no longer occurs.
+    let transcript = "I don't know. I don't know a hair."
+    let audio = Attachment(kind: "audio", file: "rec.m4a", transcript: transcript, duration: 2.0)
+    let body = computeFinalBody(userTypedText: "", attachments: [audio])
+    // Old code: body = transcript → duplicate display
+    // New code: body = ""        → no duplicate
+    try assertTrue(body != transcript, "body must NOT equal transcript after the fix")
+    try assertEqual(body, "", "body must be empty for voice-only memo")
+}
+
+print("\n=== Results: \(passed) passed, \(failed) failed ===")
+if failed > 0 { exit(1) } else { exit(0) }

--- a/scripts/tests/test_voice_transcript.swift
+++ b/scripts/tests/test_voice_transcript.swift
@@ -64,11 +64,10 @@ func test(_ name: String, _ body: () throws -> Void) {
     }
 }
 
-func assertEqual<T: Equatable>(_ lhs: T, _ rhs: T, file: StaticString = #file, line: Int = #line) throws {
+func assertEqual<T: Equatable>(_ lhs: T, _ rhs: T, _ message: String = "", file: StaticString = #file, line: Int = #line) throws {
     if lhs != rhs {
-        throw NSError(domain: "Test", code: 1, userInfo: [
-            NSLocalizedDescriptionKey: "Expected \(rhs), got \(lhs) at line \(line)"
-        ])
+        let msg = message.isEmpty ? "Expected \(rhs), got \(lhs) at line \(line)" : "\(message) — Expected \(rhs), got \(lhs) at line \(line)"
+        throw NSError(domain: "Test", code: 1, userInfo: [NSLocalizedDescriptionKey: msg])
     }
 }
 


### PR DESCRIPTION
- TodayViewModel: voice-only memo body is now always empty; transcript
  lives exclusively in attachment.transcript, preventing VoiceMemoPlayerRow
  and body Text from rendering the same content twice (#53)

- EntityPageService.extractJSONBlock: handle ```json, ```JSON, plain ```
  fence variants so LLM responses with varied formatting are parsed correctly

- EntityPageService.parseStructuredOutput: empty dailyPage sentinel ("") is
  returned when JSON extraction or daily_page field validation fails, instead
  of silently using the raw LLM response as page content (#54)

- CompilationService.parseStructuredOutputWithHot: now throws parseError
  when the sentinel is detected, surfacing parse failures to the user (#54)

- TodayViewModel.compileWithRetry: wraps compilation in 3-attempt exponential
  back-off (1s/2s) for transient networkError and 429 apiError; all other
  errors surface immediately (#54)

- ci.yml: add test_compilation_parsing.swift and test_voice_transcript.swift
  steps to the unit-tests job (#55 #56)

- scripts/tests/test_compilation_parsing.swift: 10 TDD tests covering bare
  JSON, fenced JSON variants, missing/empty daily_page, invalid JSON, and
  entity_updates detection

- scripts/tests/test_voice_transcript.swift: 7 TDD tests covering voice-only
  body, voice+text body, no-duplicate invariant, and regression guard

https://claude.ai/code/session_011WWH8ZucBVTSWf61o1MVtF