### PR TITLE
feat(today): merge input bar with TabBar, drop decorative hamburger

### DIFF
--- a/DayPage/Features/Today/InputBarV2.swift
+++ b/DayPage/Features/Today/InputBarV2.swift
@@ -77,8 +77,13 @@ struct InputBarV2: View {
                 .animation(.spring(response: 0.28, dampingFraction: 0.85), value: overlayMode)
             }
 
-            Divider()
-                .background(DSColor.outline)
+            // Hairline divider above the input row — uses outlineVariant so it
+            // reads as a subtle seam rather than a hard bar. Combined with the
+            // surface-matched background below, the input bar and system TabBar
+            // merge into a single bottom shelf instead of stacking as two bars.
+            Rectangle()
+                .fill(DSColor.outlineVariant.opacity(0.6))
+                .frame(height: 0.5)
 
             // Staged attachment preview row
             if !pendingAttachments.isEmpty {
@@ -97,8 +102,8 @@ struct InputBarV2: View {
                 rightActionButton
             }
             .padding(.horizontal, 16)
-            .padding(.vertical, 6)
-            .background(DSColor.surfaceContainerLow)
+            .padding(.vertical, 8)
+            .background(DSColor.surface)
         }
         // Attachment popover anchored above the `+` button
         .overlay(alignment: .bottomLeading) {

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -65,13 +65,7 @@ struct TodayView: View {
                 VStack(spacing: 0) {
                     // MARK: Header
                     HStack(spacing: 12) {
-                        // Hamburger menu (decorative for MVP)
-                        Image(systemName: "line.3.horizontal")
-                            .font(.system(size: 20, weight: .regular))
-                            .foregroundColor(DSColor.onSurface)
-                            .frame(width: 32, height: 32)
-
-                        // Brand name
+                        // Brand name (anchored to leading edge)
                         Text("DAYPAGE")
                             .font(.custom("SpaceGrotesk-Bold", size: 20))
                             .foregroundColor(DSColor.onSurface)


### PR DESCRIPTION
## Summary
- 删除 Today header 左上角那个不可交互的 `line.3.horizontal` 汉堡图标，`DAYPAGE` 品牌名左锚，右上齿轮作为唯一设置入口，消除"两处设置入口"的视觉歧义
- InputBarV2 的背景从 `surfaceContainerLow` 改为 `surface`（与 `RootView` 中 TabBar 的 `UITabBarAppearance.backgroundColor` 对齐），顶部 `Divider` 换成 0.5pt 的 `outlineVariant` 细线 —— 输入栏与系统 TabBar 融成一整块底部货架，不再是两层叠加的 bar

## Design rationale
原截图里用户反馈"底部 TabBar 浮在白色输入栏上，视觉上两层 bar 叠着"。根因：InputBarV2 坐在 VStack 最底部、系统 TabView 又生出一条标准 TabBar，两者底色/分隔线处理不一致，天然读成两层。
本次采取**保守融合方案**：统一底色 + 细线收边，不改动现有 ScrollView safe area 和 CompileFooterButton 的可见性计算逻辑，风险低。更激进的"输入栏 `.safeAreaInset` 浮在 TabBar 之上"留作 Post-MVP。

## Test plan
- [x] `xcodebuild -scheme DayPage build` 通过
- [x] iPhone 17 Pro 模拟器启动并视觉验收：左上汉堡已移除、`DAYPAGE` 左锚、输入栏与 TabBar 一体化
- [ ] 真机或其它尺寸模拟器（iPhone 16 / iPhone SE）回归，确认细线在不同 scale 下不出现锯齿
- [ ] 输入栏聚焦/有附件/有位置 chip 三种展开态下，背景色过渡仍保持一致