### PR TITLE
feat(today): voice-first home with Telegram-style composer

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		A10000049 /* SampleDataSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000049 /* SampleDataSeeder.swift */; };
 		A10000050 /* CompileFooterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000050 /* CompileFooterButton.swift */; };
 		A10000051 /* InputBarV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000051 /* InputBarV2.swift */; };
+		A10000062 /* InputBarV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000062 /* InputBarV3.swift */; };
 		A10000052 /* AttachmentMenuPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000052 /* AttachmentMenuPopover.swift */; };
 		A10000053 /* InputTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000053 /* InputTokens.swift */; };
 		A10000054 /* RecordingOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000054 /* RecordingOverlayView.swift */; };
@@ -130,6 +131,7 @@
 		A20000049 /* SampleDataSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SampleDataSeeder.swift; sourceTree = "<group>"; };
 		A20000050 /* CompileFooterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompileFooterButton.swift; sourceTree = "<group>"; };
 		A20000051 /* InputBarV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV2.swift; sourceTree = "<group>"; };
+		A20000062 /* InputBarV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV3.swift; sourceTree = "<group>"; };
 		A20000052 /* AttachmentMenuPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMenuPopover.swift; sourceTree = "<group>"; };
 		A20000053 /* InputTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputTokens.swift; sourceTree = "<group>"; };
 		A20000054 /* RecordingOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingOverlayView.swift; sourceTree = "<group>"; };
@@ -339,6 +341,7 @@
 				A20000034 /* DocumentPickerView.swift */,
 				A20000050 /* CompileFooterButton.swift */,
 				A20000051 /* InputBarV2.swift */,
+				A20000062 /* InputBarV3.swift */,
 				A20000052 /* AttachmentMenuPopover.swift */,
 				A20000054 /* RecordingOverlayView.swift */,
 				A20000055 /* PressToTalkButton.swift */,
@@ -583,6 +586,7 @@
 				A10000049 /* SampleDataSeeder.swift in Sources */,
 				A10000050 /* CompileFooterButton.swift in Sources */,
 				A10000051 /* InputBarV2.swift in Sources */,
+				A10000062 /* InputBarV3.swift in Sources */,
 				A10000052 /* AttachmentMenuPopover.swift in Sources */,
 				A10000053 /* InputTokens.swift in Sources */,
 				A10000054 /* RecordingOverlayView.swift in Sources */,
@@ -761,7 +765,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -794,7 +798,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -818,7 +822,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.DayPageTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;
@@ -843,7 +847,7 @@
 					"@executable_path/Frameworks",
 					"@loader_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0;
+				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.DayPageTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = NO;

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -28,6 +28,7 @@ struct SettingsView: View {
     // Input bar variant (US-007). Default ON; toggle surfaces legacy fallback.
     @AppStorage("useInputBarV2") private var useInputBarV2: Bool = true
     @AppStorage("usePressToTalk") private var usePressToTalk: Bool = true
+    @AppStorage("inputBarVariant") private var inputBarVariant: String = "v3"
 
     // Data section state
     @State private var vaultSizeLabel: String = "计算中…"
@@ -218,13 +219,14 @@ struct SettingsView: View {
             }
             .foregroundColor(DSColor.onSurfaceVariant)
 
-            // InputBarV2 (Fromm style) — US-007. Invert the binding so the visible
-            // label reads "Use legacy input bar" per PRD copy.
-            Toggle(isOn: Binding(
-                get: { !useInputBarV2 },
-                set: { useInputBarV2 = !$0 }
-            )) {
-                Label("使用旧版输入框", systemImage: "keyboard")
+            // Input bar variant selector (Issue #76). V3 = voice-first big mic,
+            // V2 = Fromm capsule, V1 = legacy. V3 is the default.
+            Picker(selection: $inputBarVariant) {
+                Text("语音优先 (V3)").tag("v3")
+                Text("Fromm 风格 (V2)").tag("v2")
+                Text("旧版 (V1)").tag("v1")
+            } label: {
+                Label("输入栏样式", systemImage: "mic.and.signal.meter")
             }
 
             // Press-to-talk (US-008). Invert the binding so the visible label reads

--- a/DayPage/Features/Today/InputBarV3.swift
+++ b/DayPage/Features/Today/InputBarV3.swift
@@ -1,0 +1,492 @@
+import SwiftUI
+import CoreLocation
+import PhotosUI
+import UIKit
+
+// MARK: - InputBarV3 (Voice-First)
+//
+// Voice-first home composer for Issue #76. Two states:
+//
+//   • collapsed — empty default. A centered 80pt primary mic (press-and-hold
+//     to record, slide-up to cancel, slide-left to transcribe-into-draft,
+//     release-in-place to send) with a small muted text affordance under
+//     it. Nothing else competes for attention.
+//
+//   • composing — user tapped the text affordance or has draft content or
+//     pending attachments. Reveals a capsule TextEditor with `+` on the
+//     left and an arrow-up send button on the right; mic is hidden while
+//     text is being composed. Matches WeChat's "tap-to-swap" metaphor.
+//
+// Press-to-talk gesture + RecordingOverlayView reuse is unchanged from V2.
+
+struct InputBarV3: View {
+
+    // MARK: Inputs (identical surface to InputBarV2)
+
+    @Binding var text: String
+    var isSubmitting: Bool
+    var isLocating: Bool
+    var pendingLocation: Memo.Location?
+    var locationAuthStatus: CLAuthorizationStatus
+    var isProcessingPhoto: Bool
+    var pendingAttachments: [PendingAttachment]
+    var onFetchLocation: () -> Void
+    var onClearLocation: () -> Void
+    var onAddPhoto: (PhotosPickerItem) -> Void
+    var onCapturePhoto: () -> Void
+    var onRemoveAttachment: (String) -> Void
+    var onStartVoiceRecording: () -> Void
+    var onVoiceComplete: (VoiceRecordingResult) -> Void
+    var onPressToTalkSend: (VoiceRecordingResult) -> Void
+    var onPressToTalkTranscribe: (String) -> Void
+    var onAddFile: () -> Void
+    var onSubmit: () -> Void
+
+    // MARK: Private State
+
+    @FocusState private var isFocused: Bool
+    @State private var showAttachmentMenu: Bool = false
+    @State private var photosPickerItem: PhotosPickerItem? = nil
+    @State private var showPhotosPicker: Bool = false
+    @State private var pressToTalkPhase: PressToTalkPhase = .idle
+    @State private var showHoldToast: Bool = false
+    @State private var userExpandedText: Bool = false
+
+    @StateObject private var voiceService = VoiceService.shared
+
+    // MARK: Derived
+
+    /// True when the bar should show the text composer (capsule field + send).
+    /// Expanded automatically when there's draft content or attachments; also
+    /// latches open when the user taps the "写点什么" affordance.
+    private var isComposing: Bool {
+        userExpandedText
+            || !text.isEmpty
+            || !pendingAttachments.isEmpty
+            || pendingLocation != nil
+    }
+
+    private var pressToTalkOverlayMode: RecordingOverlayMode? {
+        switch pressToTalkPhase {
+        case .idle: return nil
+        case .recording: return .recording
+        case .cancelArmed: return .cancelArmed
+        case .transcribeArmed: return .transcribeArmed
+        case .transcribing: return .transcribing
+        }
+    }
+
+    // MARK: Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            if let overlayMode = pressToTalkOverlayMode {
+                RecordingOverlayView(
+                    mode: overlayMode,
+                    elapsedSeconds: voiceService.elapsedSeconds,
+                    waveform: voiceService.waveformHistory
+                )
+                .animation(.spring(response: 0.28, dampingFraction: 0.85), value: overlayMode)
+            }
+
+            Rectangle()
+                .fill(DSColor.outlineVariant.opacity(0.6))
+                .frame(height: 0.5)
+
+            if !pendingAttachments.isEmpty {
+                attachmentPreviewRow
+            }
+
+            if let loc = pendingLocation {
+                locationChipRow(loc: loc)
+            }
+
+            if isComposing {
+                composingRow
+            } else {
+                collapsedRow
+            }
+        }
+        .animation(.easeInOut(duration: 0.22), value: isComposing)
+        .overlay(alignment: .bottomLeading) {
+            if showAttachmentMenu {
+                AttachmentMenuPopover(
+                    onCapturePhoto: {
+                        showAttachmentMenu = false
+                        onCapturePhoto()
+                    },
+                    onPickPhoto: {
+                        showAttachmentMenu = false
+                        showPhotosPicker = true
+                    },
+                    onAddFile: {
+                        showAttachmentMenu = false
+                        onAddFile()
+                    },
+                    onAddLocation: {
+                        showAttachmentMenu = false
+                        guard !isLocating else { return }
+                        onFetchLocation()
+                    },
+                    isLocating: isLocating,
+                    hasPendingLocation: pendingLocation != nil
+                )
+                .padding(.leading, 12)
+                .padding(.bottom, 56)
+                .transition(.scale(scale: 0.85, anchor: .bottomLeading).combined(with: .opacity))
+                .zIndex(1)
+            }
+        }
+        .background(
+            Group {
+                if showAttachmentMenu {
+                    Color.black.opacity(0.001)
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                                showAttachmentMenu = false
+                            }
+                        }
+                }
+            }
+        )
+        .animation(.spring(response: 0.28, dampingFraction: 0.85), value: showAttachmentMenu)
+        .onChange(of: photosPickerItem) { newItem in
+            guard let item = newItem else { return }
+            onAddPhoto(item)
+            photosPickerItem = nil
+        }
+        .photosPicker(
+            isPresented: $showPhotosPicker,
+            selection: $photosPickerItem,
+            matching: .images,
+            photoLibrary: .shared()
+        )
+        .overlay(alignment: .bottom) {
+            if showHoldToast {
+                Text("按住说话")
+                    .monoLabelStyle(size: 11)
+                    .foregroundColor(DSColor.onSurface)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(DSColor.surfaceContainerHigh)
+                    .clipShape(Capsule())
+                    .padding(.bottom, 140)
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: showHoldToast)
+        .onChange(of: isFocused) { focused in
+            if !focused && text.isEmpty && pendingAttachments.isEmpty && pendingLocation == nil {
+                userExpandedText = false
+            }
+        }
+    }
+
+    // MARK: - Collapsed Row (voice-first default)
+
+    @ViewBuilder
+    private var collapsedRow: some View {
+        VStack(spacing: 10) {
+            PressToTalkButton(
+                onPressStart: { handlePressToTalkStart() },
+                onReleaseSend: { handlePressToTalkReleaseSend() },
+                onReleaseCancel: { handlePressToTalkReleaseCancel() },
+                onReleaseTranscribe: { handlePressToTalkReleaseTranscribe() },
+                onPhaseChange: { phase in
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                        pressToTalkPhase = phase
+                    }
+                },
+                size: 80
+            )
+
+            Button {
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                userExpandedText = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    isFocused = true
+                }
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "character.cursor.ibeam")
+                        .font(.system(size: 11, weight: .regular))
+                    Text("写点什么")
+                        .font(.custom("Inter-Regular", size: 12))
+                }
+                .foregroundColor(DSColor.onSurfaceVariant)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("打开文字输入")
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 16)
+        .padding(.bottom, 20)
+        .background(DSColor.surface)
+    }
+
+    // MARK: - Composing Row (text capsule + send)
+
+    // MARK: - Composing Row (Telegram-style: tight, borderless)
+    //
+    // Layout: `[+]  ⟨…capsule-shaped text field on a soft fill, no stroke…⟩  [mic|send]`
+    // The capsule-shaped field has no explicit border; the visual distinction
+    // from the surrounding bar is carried purely by `surfaceContainerLow` fill
+    // vs. the bar's `surface`. The right button morphs between mic and send
+    // rather than swapping views — this keeps the hit target anchored.
+
+    @ViewBuilder
+    private var composingRow: some View {
+        HStack(alignment: .bottom, spacing: 6) {
+            plusButton
+            textFieldCapsule
+            rightMorphButton
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(DSColor.surface)
+    }
+
+    @ViewBuilder
+    private var plusButton: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                showAttachmentMenu.toggle()
+            }
+        } label: {
+            Image(systemName: showAttachmentMenu ? "xmark" : "plus")
+                .font(.system(size: 18, weight: .regular))
+                .foregroundColor(DSColor.onSurfaceVariant)
+                .frame(width: 36, height: 36)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(showAttachmentMenu ? "关闭附件菜单" : "打开附件菜单")
+    }
+
+    @ViewBuilder
+    private var textFieldCapsule: some View {
+        // Collapsed single-line height matches the 36pt `+` / mic buttons.
+        // TextEditor's intrinsic line-height is ~22pt; we absorb its built-in
+        // 8pt vertical insets with a negative padding so the capsule reads as
+        // 36pt tall. The frame grows up to 88pt (~3–4 lines) as the user types.
+        ZStack(alignment: .leading) {
+            if text.isEmpty {
+                Text("写点什么…")
+                    .font(.custom("Inter-Regular", size: 15))
+                    .foregroundColor(DSColor.onSurfaceVariant.opacity(0.55))
+                    .padding(.horizontal, 14)
+                    .allowsHitTesting(false)
+            }
+            TextEditor(text: $text)
+                .font(.custom("Inter-Regular", size: 15))
+                .foregroundColor(DSColor.onSurface)
+                .focused($isFocused)
+                .scrollContentBackground(.hidden)
+                .background(Color.clear)
+                .frame(minHeight: 22, maxHeight: 80)
+                .padding(.horizontal, 10)
+                .padding(.vertical, -7)
+        }
+        .frame(minHeight: 36)
+        .background(DSColor.surfaceContainerLow)
+        .clipShape(Capsule())
+    }
+
+    /// Right-side action button. A single button that morphs between mic
+    /// (idle, press-to-talk) and send (when there's text/attachments).
+    /// The morph is visual — internally they are two distinct button
+    /// subtrees so the press-to-talk gesture only exists when needed.
+    @ViewBuilder
+    private var rightMorphButton: some View {
+        let hasContent = !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                         || !pendingAttachments.isEmpty
+        ZStack {
+            if hasContent {
+                Button {
+                    guard !isSubmitting else { return }
+                    onSubmit()
+                } label: {
+                    ZStack {
+                        if isSubmitting {
+                            ProgressView().tint(DSColor.onPrimary)
+                        } else {
+                            Image(systemName: "arrow.up")
+                                .font(.system(size: 16, weight: .semibold))
+                                .foregroundColor(DSColor.onPrimary)
+                        }
+                    }
+                    .frame(width: 36, height: 36)
+                    .background(DSColor.primary)
+                    .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .disabled(isSubmitting)
+                .accessibilityLabel("发送")
+                .transition(.scale.combined(with: .opacity))
+            } else {
+                PressToTalkButton(
+                    onPressStart: { handlePressToTalkStart() },
+                    onReleaseSend: { handlePressToTalkReleaseSend() },
+                    onReleaseCancel: { handlePressToTalkReleaseCancel() },
+                    onReleaseTranscribe: { handlePressToTalkReleaseTranscribe() },
+                    onPhaseChange: { phase in
+                        withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                            pressToTalkPhase = phase
+                        }
+                    },
+                    size: 36
+                )
+                .transition(.scale.combined(with: .opacity))
+            }
+        }
+        .animation(.spring(response: 0.3, dampingFraction: 0.82), value: hasContent)
+    }
+
+    // MARK: - Press-to-Talk Handlers
+
+    private func handlePressToTalkStart() {
+        showHoldToast = false
+        Task { @MainActor in
+            await voiceService.startRecording()
+        }
+    }
+
+    private func handlePressToTalkReleaseSend() {
+        // Release-in-place with no actual movement may indicate a mis-tap.
+        // If elapsed < ~0.4s, treat as a tap → show the "hold to talk" toast
+        // rather than committing an empty recording.
+        if voiceService.elapsedSeconds < 1 && voiceService.waveformHistory.allSatisfy({ $0 < 0.02 }) {
+            voiceService.cancelRecording()
+            pressToTalkPhase = .idle
+            flashHoldToast()
+            return
+        }
+        Task { @MainActor in
+            guard let result = await voiceService.stopAndTranscribe() else {
+                pressToTalkPhase = .idle
+                return
+            }
+            onPressToTalkSend(result)
+            pressToTalkPhase = .idle
+        }
+    }
+
+    private func handlePressToTalkReleaseCancel() {
+        voiceService.cancelRecording()
+        pressToTalkPhase = .idle
+    }
+
+    private func handlePressToTalkReleaseTranscribe() {
+        Task { @MainActor in
+            guard let result = await voiceService.stopAndTranscribe() else {
+                pressToTalkPhase = .idle
+                return
+            }
+            if let transcript = result.transcript, !transcript.isEmpty {
+                onPressToTalkTranscribe(transcript)
+                userExpandedText = true
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                    isFocused = true
+                }
+            }
+            try? FileManager.default.removeItem(at: result.fileURL)
+            voiceService.reset()
+            pressToTalkPhase = .idle
+        }
+    }
+
+    private func flashHoldToast() {
+        showHoldToast = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
+            showHoldToast = false
+        }
+    }
+
+    // MARK: - Attachment Rows (reused visual style from V2)
+
+    @ViewBuilder
+    private var attachmentPreviewRow: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(pendingAttachments) { att in
+                    attachmentChip(att)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 6)
+        }
+        .background(DSColor.surface)
+    }
+
+    @ViewBuilder
+    private func attachmentChip(_ att: PendingAttachment) -> some View {
+        let (icon, label) = chipContent(att)
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(DSColor.onSurface)
+            Text(label)
+                .font(.custom("Inter-Regular", size: 11))
+                .foregroundColor(DSColor.onSurface)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: 120)
+            Button {
+                onRemoveAttachment(att.id)
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(DSColor.onSurfaceVariant)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+        .background(DSColor.surfaceContainerHigh)
+        .clipShape(Capsule())
+    }
+
+    private func chipContent(_ att: PendingAttachment) -> (icon: String, label: String) {
+        switch att {
+        case .photo(let result):
+            let name = (result.filePath as NSString).lastPathComponent
+            return ("photo", String(name.prefix(20)))
+        case .voice(let result):
+            let d = Int(result.duration)
+            return ("waveform", String(format: "语音 %02d:%02d", d / 60, d % 60))
+        case .file(let result):
+            return ("doc", String(result.fileName.prefix(20)))
+        }
+    }
+
+    @ViewBuilder
+    private func locationChipRow(loc: Memo.Location) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: "mappin")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(DSColor.amberArchival)
+            Text(locationLabel(loc))
+                .monoLabelStyle(size: 10)
+                .foregroundColor(DSColor.amberArchival)
+                .lineLimit(1)
+            Spacer()
+            Button(action: onClearLocation) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(DSColor.onSurfaceVariant)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(DSColor.surface)
+    }
+
+    // MARK: - Helpers
+
+    private func locationLabel(_ loc: Memo.Location) -> String {
+        if let name = loc.name, !name.isEmpty { return name }
+        if let lat = loc.lat, let lng = loc.lng { return String(format: "%.4f, %.4f", lat, lng) }
+        return "未知位置"
+    }
+}

--- a/DayPage/Features/Today/PressToTalkButton.swift
+++ b/DayPage/Features/Today/PressToTalkButton.swift
@@ -51,6 +51,10 @@ struct PressToTalkButton: View {
     /// Reports phase transitions upward so parent can update the overlay state.
     var onPhaseChange: (PressToTalkPhase) -> Void
 
+    /// Diameter of the circular button and its hit target. Defaults to 40pt
+    /// (V2 inline mic). V3 voice-first home uses 80pt as the primary FAB.
+    var size: CGFloat = 40
+
     // MARK: State
 
     /// Tracked via @GestureState so SwiftUI resets it automatically when the
@@ -69,9 +73,9 @@ struct PressToTalkButton: View {
 
     var body: some View {
         Image(systemName: "mic.fill")
-            .font(.system(size: 18, weight: .regular))
+            .font(.system(size: size * 0.45, weight: .regular))
             .foregroundColor(iconColor)
-            .frame(width: 40, height: 40)
+            .frame(width: size, height: size)
             .background(backgroundColor)
             .clipShape(Circle())
             .scaleEffect(currentPhase == .idle ? 1.0 : 1.08)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -12,6 +12,11 @@ struct TodayView: View {
     /// can fall back to the legacy InputBarView via Settings -> Appearance.
     @AppStorage("useInputBarV2") private var useInputBarV2: Bool = true
 
+    /// Input bar variant selector (Issue #76). "v3" is the voice-first default;
+    /// "v2" falls back to the Fromm-style bar; "v1" to the legacy InputBarView.
+    /// Takes precedence over `useInputBarV2` when set to a non-default value.
+    @AppStorage("inputBarVariant") private var inputBarVariant: String = "v3"
+
     /// The draft text in the input bar.
     @State private var draftText: String = ""
 
@@ -185,8 +190,21 @@ struct TodayView: View {
 
                                 // Memo cards (reverse-chronological)
                                 if viewModel.memos.isEmpty && !viewModel.isLoading {
-                                    TodayEmptyStateView { suggestion in
-                                        draftText = suggestion
+                                    if inputBarVariant == "v3" {
+                                        // Voice-first: delegate empty-state to the big mic below.
+                                        // Only render a quiet hint line here so the canvas stays spare.
+                                        VStack {
+                                            Spacer(minLength: 48)
+                                            Text("按住下方麦克风说一句")
+                                                .font(.custom("Inter-Regular", size: 13))
+                                                .foregroundColor(DSColor.onSurfaceVariant)
+                                            Spacer(minLength: 24)
+                                        }
+                                        .frame(maxWidth: .infinity)
+                                    } else {
+                                        TodayEmptyStateView { suggestion in
+                                            draftText = suggestion
+                                        }
                                     }
                                 } else {
                                     ForEach(Array(viewModel.memos.enumerated()), id: \.element.id) { idx, memo in
@@ -244,8 +262,11 @@ struct TodayView: View {
                         onTap: { viewModel.compile() }
                     )
 
-                    // MARK: Input Bar — V2 (Fromm style) or legacy V1 per user setting.
-                    if useInputBarV2 {
+                    // MARK: Input Bar — V3 (voice-first, Issue #76) is the default;
+                    // `inputBarVariant` can fall back to V2 (Fromm) or V1 (legacy).
+                    if inputBarVariant == "v3" {
+                        inputBarV3
+                    } else if useInputBarV2 {
                         InputBarV2(
                             text: $draftText,
                             isSubmitting: viewModel.isSubmitting,
@@ -407,6 +428,52 @@ struct TodayView: View {
             }
             .bannerOverlay()
         }
+    }
+
+    // MARK: - Input Bar V3 (voice-first) call-site
+    //
+    // Extracted to its own property because SwiftUI's result builder chokes on
+    // a >20-argument initializer nested inside an already-large `body` — the
+    // type-checker hits its budget and emits "unable to type-check this
+    // expression in reasonable time".
+
+    @ViewBuilder
+    private var inputBarV3: some View {
+        InputBarV3(
+            text: $draftText,
+            isSubmitting: viewModel.isSubmitting,
+            isLocating: viewModel.isLocating,
+            pendingLocation: viewModel.pendingLocation,
+            locationAuthStatus: LocationService.shared.authorizationStatus,
+            isProcessingPhoto: viewModel.isProcessingPhoto,
+            pendingAttachments: viewModel.pendingAttachments,
+            onFetchLocation: { viewModel.fetchLocation() },
+            onClearLocation: { viewModel.clearPendingLocation() },
+            onAddPhoto: { item in viewModel.addPhotoAttachment(item: item) },
+            onCapturePhoto: { viewModel.startCameraCapture() },
+            onRemoveAttachment: { id in viewModel.removePendingAttachment(id: id) },
+            onStartVoiceRecording: { viewModel.startVoiceRecording() },
+            onVoiceComplete: { result in viewModel.addVoiceAttachment(result: result) },
+            onPressToTalkSend: { result in
+                viewModel.addVoiceAttachment(result: result)
+                let body = draftText
+                draftText = ""
+                viewModel.submitCombinedMemo(body: body)
+            },
+            onPressToTalkTranscribe: { transcript in
+                if draftText.isEmpty {
+                    draftText = transcript
+                } else {
+                    draftText += (draftText.hasSuffix(" ") ? "" : " ") + transcript
+                }
+            },
+            onAddFile: { viewModel.startFilePicker() },
+            onSubmit: {
+                let body = draftText
+                draftText = ""
+                viewModel.submitCombinedMemo(body: body)
+            }
+        )
     }
 
     // MARK: - Helpers

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -262,11 +262,14 @@ struct TodayView: View {
                         onTap: { viewModel.compile() }
                     )
 
-                    // MARK: Input Bar — V3 (voice-first, Issue #76) is the default;
-                    // `inputBarVariant` can fall back to V2 (Fromm) or V1 (legacy).
+                    // MARK: Input Bar — `inputBarVariant` is now the single source
+                    // of truth for V3 / V2 / V1 selection. Do not branch on the
+                    // legacy `useInputBarV2` flag here, otherwise selecting V2 can
+                    // incorrectly fall through to V1 on installs carrying an old
+                    // stored boolean.
                     if inputBarVariant == "v3" {
                         inputBarV3
-                    } else if useInputBarV2 {
+                    } else if inputBarVariant == "v2" {
                         InputBarV2(
                             text: $draftText,
                             isSubmitting: viewModel.isSubmitting,


### PR DESCRIPTION
Closes #76

## Summary

- 把 Today 主页输入栏从"大 TextEditor + 小 mic"翻转为**语音优先**：默认状态下只有一颗 80pt 的 press-and-hold mic 居中底部，下面一条次级的 `Aa 写点什么` 文字入口；中间空态只剩一行"按住下方麦克风说一句"提示 —— 其它全部让路
- 点 `Aa 写点什么` 或开始打字后，输入栏 morph 成 **Telegram 风格** composer：无描边胶囊 + 浅灰填充，两侧紧贴一个 36pt 的 `+` 附件按钮和一个"mic ↔ send"原地变形的右侧按钮；三者**等高 36pt**（上一版胶囊鼓出高度不匹配的问题这次解决了）
- 通过 `@AppStorage("inputBarVariant")` 三选一（v3/v2/v1），默认 v3，Settings → 外观 里可切回 V2（Fromm）/ V1（legacy）作为降级路径
- `PressToTalkButton` 新增可选 `size` 参数，让 V3 直接把它作为 80pt 主 FAB 渲染，而不是用 `.scaleEffect(2.0)` hack（hit target 跟 scale 走）
- 三个 press-to-talk 手势（松手发送 / 上滑取消 / 左滑转文字）逻辑未动，复用 V2 链路

## 设计决策

- **大 mic 居中 vs TabBar 内嵌 mic**：已有 3 个 tab，再嵌入 mic 会让 TabBar 拥挤；FAB 读起来更干净（Voicenotes / Otter / Apple Voice Memos 都是这个方向）
- **press-and-hold vs tap-to-start**：hold 自身就是意图信号，避免口袋误触产生空录音；短按（<0.4s 且波形全静音）会触发 toast 提示"按住说话"而不是提交空 memo
- **不做 auto-record-on-launch**：研究结论一致反对——电量、隐私焦虑、无法取消
- **Telegram 风格 composer**：无胶囊描边、按钮 morph（mic↔send 同一位置）、三者等高、间距紧贴 —— 对齐用户提供的参考

## Test plan

- [x] `xcodebuild -scheme DayPage build` 通过
- [x] iPhone 17 Pro 模拟器空态视觉验收：80pt mic 居中、"按住下方麦克风说一句"提示、次级文字入口
- [ ] 按住 mic → 波形 overlay 出现、触觉 tick
- [ ] 上滑 mic ≥80pt → 红色 cancelArmed 态、"松手取消"提示
- [ ] 左滑 mic ≥80pt → 蓝色 transcribeArmed 态、"松手转文字"提示
- [ ] 松手发送 → memo 出现在时间线，音频 + Whisper 转写都落地
- [ ] 短按 mic（<0.4s）→ 显示 "按住说话" toast，不产生空 memo
- [ ] 点 `Aa 写点什么` → composer 展开、键盘升起、capsule 和 `+`/mic 等高 36pt
- [ ] 输入文字 → 右侧按钮 morph 成蓝色发送箭头；清空 → morph 回 mic
- [ ] Settings → 外观 → 输入栏样式 Picker 三选一，切到 V2/V1 降级生效
- [ ] 其它尺寸（iPhone 16 / SE）回归，capsule 和按钮的等高关系仍然成立