### PR TITLE
ci: auto-release to TestFlight on merge to main

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -4,10 +4,28 @@
 
 | 触发 | 说明 |
 |------|------|
-| push to `main`（影响 app 代码） | 自动构建并上传 TestFlight |
-| 手动 `workflow_dispatch` | 可选 `beta`（TestFlight）或 `release`（App Store） |
+| push to `main`（通常是 PR 合并） | 自动 patch +1 → 打 tag → 构建并上传 TestFlight |
+| 手动 `workflow_dispatch` | 可选 `beta`（TestFlight）/ `release`（App Store），可传 `version_override` 跳过自动 patch |
 
-纯文档/设计稿改动（`design/`、`**.md`）**不会**触发构建。
+纯文档/设计稿改动（`design/`、`**.md`、`scripts/ralph/**`、`tasks/**`、`.gitignore`）**不会**触发构建。
+
+### 版本号规则
+
+1. **首次发布**：仓库无 `v*.*.*` tag，从 `DayPage.xcodeproj/project.pbxproj` 的 `MARKETING_VERSION` 读取（目前是 `0.0.1`）。
+2. **后续发布**：读取最近的 `v*.*.*` tag，patch 段 +1（如 `v0.0.1` → `v0.0.2`）。
+3. **手动覆盖**：`workflow_dispatch` 传 `version_override=0.1.0`，workflow 会打 `v0.1.0` tag。
+
+tag 只在 TestFlight 上传成功后才会被 push 到 origin，失败不留脏 tag。
+
+### Changelog 来源
+
+按优先级：
+
+1. 从合并的 PR 取 `title + body`（通过 commit message 里的 `(#123)` 定位 PR）。
+2. 没有 PR 引用（例如直接 push 到 main）：用 head commit 的完整 message。
+3. 本地 fastlane 手动跑：回退到最近 10 条 commit message。
+
+内容会被截到 3800 字符（TestFlight "What to Test" 上限 4000）。
 
 ---
 

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -1,12 +1,18 @@
 name: Deploy to TestFlight
 
 on:
-  # Tag 驱动发布：推送 v* tag 时触发（例如 v1.1.0, v1.2.0-beta）
+  # 合并到 main 自动发版：patch +1 → 打 tag → 上 TestFlight
   push:
-    tags:
-      - "v*"
+    branches:
+      - main
+    paths-ignore:
+      - "design/**"
+      - "scripts/ralph/**"
+      - "tasks/**"
+      - "**.md"
+      - ".gitignore"
 
-  # 支持手动触发
+  # 手动触发（可选指定 lane / 强制版本号）
   workflow_dispatch:
     inputs:
       lane:
@@ -17,27 +23,124 @@ on:
         options:
           - beta
           - release
+      version_override:
+        description: "Override version (e.g. 0.1.0). Leave empty to auto-bump patch."
+        required: false
+        type: string
+
+# 需要写仓库（push tag）和读取 PR 信息
+permissions:
+  contents: write
+  pull-requests: read
 
 jobs:
   deploy:
     name: Build & Upload to TestFlight
-    runs-on: macos-15   # 免费用于开源项目，包含 Xcode 16
+    runs-on: macos-15
 
     steps:
       # ── 1. Checkout ──────────────────────────────────────────────────────
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0    # 拉取完整 git 历史，用于计算 build number
+          fetch-depth: 0          # 需要完整 tag/commit 历史用于计算版本
+          persist-credentials: true  # 允许后续 git push tag
 
-      # ── 2. Setup Ruby (for Fastlane) ─────────────────────────────────────
+      # ── 2. Compute next version ──────────────────────────────────────────
+      # 规则：
+      #   1) 手动触发 + version_override 非空  → 用 override
+      #   2) 最近一个 v*.*.* tag 存在          → patch +1
+      #   3) 无 tag                            → 从 pbxproj 读 MARKETING_VERSION 作起点
+      - name: Compute next version
+        id: version
+        run: |
+          set -euo pipefail
+
+          OVERRIDE="${{ github.event.inputs.version_override }}"
+          if [ -n "$OVERRIDE" ]; then
+            NEXT="$OVERRIDE"
+            echo "Using manual override: $NEXT"
+          else
+            LAST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1 || true)
+            if [ -n "$LAST_TAG" ]; then
+              BASE="${LAST_TAG#v}"
+              IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
+              PATCH=$((PATCH + 1))
+              NEXT="${MAJOR}.${MINOR}.${PATCH}"
+              echo "Bumping from $LAST_TAG → v$NEXT"
+            else
+              CURRENT=$(grep -m1 -E 'MARKETING_VERSION = ' DayPage.xcodeproj/project.pbxproj \
+                | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+              if [[ "$CURRENT" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                NEXT="$CURRENT"
+              elif [[ "$CURRENT" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                NEXT="${CURRENT}.0"
+              else
+                NEXT="0.0.1"
+              fi
+              echo "No tag found, using pbxproj MARKETING_VERSION=$CURRENT → v$NEXT"
+            fi
+          fi
+
+          TAG="v$NEXT"
+          # 防御：tag 已存在时直接报错，避免覆盖历史
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::Tag $TAG already exists. Set workflow_dispatch.version_override to a new version."
+            exit 1
+          fi
+
+          echo "release_version=$NEXT" >> "$GITHUB_OUTPUT"
+          echo "release_tag=$TAG"     >> "$GITHUB_OUTPUT"
+
+      # ── 3. Build changelog from merged PR title+body ─────────────────────
+      # 从 head commit message 里抓 (#123)；抓不到就回退到 commit message 本身
+      - name: Build release changelog
+        id: changelog
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+        run: |
+          set -euo pipefail
+
+          PR_NUM=$(printf '%s' "$COMMIT_MSG" | grep -oE '#[0-9]+' | head -n1 | tr -d '#' || true)
+
+          CHANGELOG_FILE="$RUNNER_TEMP/changelog.txt"
+
+          if [ -n "${PR_NUM:-}" ]; then
+            echo "Found PR reference: #$PR_NUM"
+            # jq -r 的 null 会输出字符串 "null"，这里用 // "" 兜底
+            gh pr view "$PR_NUM" \
+              --repo "$GITHUB_REPOSITORY" \
+              --json title,body \
+              --jq '.title + "\n\n" + (.body // "")' \
+              > "$CHANGELOG_FILE" || {
+                echo "gh pr view failed, falling back to commit message"
+                printf '%s' "$COMMIT_MSG" > "$CHANGELOG_FILE"
+              }
+          else
+            echo "No PR reference in commit message, using commit message as changelog"
+            printf '%s' "$COMMIT_MSG" > "$CHANGELOG_FILE"
+          fi
+
+          # 清理 Windows 行尾，去掉末尾空行
+          sed -i '' -e 's/\r$//' "$CHANGELOG_FILE" || true
+          # 限长：TestFlight "What to Test" 上限 4000 字符
+          head -c 3800 "$CHANGELOG_FILE" > "$CHANGELOG_FILE.trimmed"
+          mv "$CHANGELOG_FILE.trimmed" "$CHANGELOG_FILE"
+
+          echo "---- changelog ----"
+          cat "$CHANGELOG_FILE"
+          echo "-------------------"
+          echo "changelog_path=$CHANGELOG_FILE" >> "$GITHUB_OUTPUT"
+
+      # ── 4. Setup Ruby (for Fastlane) ─────────────────────────────────────
       - name: Setup Ruby
         uses: ruby/setup-ruby@v1
         with:
           ruby-version: "3.1"
-          bundler-cache: true   # 自动 bundle install + 缓存 gems
+          bundler-cache: true
 
-      # ── 3. Restore Xcode DerivedData cache ───────────────────────────────
+      # ── 5. Restore Xcode DerivedData cache ───────────────────────────────
       - name: Cache DerivedData
         uses: actions/cache@v4
         with:
@@ -46,15 +149,13 @@ jobs:
           restore-keys: |
             deriveddata-
 
-      # ── 3.5 Validate Fastfile syntax (fail fast before long build) ───────
+      # ── 6. Validate Fastfile syntax ──────────────────────────────────────
       - name: Validate Fastfile
         run: |
           ruby -c fastlane/Fastfile
           bundle exec fastlane lanes > /dev/null
 
-      # ── 4. Write .env from GitHub Secret ─────────────────────────────────
-      # .env 不提交到仓库，在 CI 中通过 secret 注入
-      # GitHub Secret: ENV_FILE — 存储完整的 .env 文件内容（多行）
+      # ── 7. Write .env from GitHub Secret ─────────────────────────────────
       - name: Write .env file
         env:
           ENV_FILE_CONTENT: ${{ secrets.ENV_FILE }}
@@ -62,22 +163,18 @@ jobs:
           echo "$ENV_FILE_CONTENT" > .env
           echo ".env written ($(wc -l < .env) lines)"
 
-      # ── 5. Import signing certificate ────────────────────────────────────
-      # GitHub Secret: BUILD_CERTIFICATE_BASE64 — p12 证书的 base64 编码
-      # GitHub Secret: P12_PASSWORD — p12 证书密码
+      # ── 8. Import signing certificate ────────────────────────────────────
       - name: Import code signing certificate
         env:
           BUILD_CERTIFICATE_BASE64: ${{ secrets.BUILD_CERTIFICATE_BASE64 }}
           P12_PASSWORD: ${{ secrets.P12_PASSWORD }}
           KEYCHAIN_PASSWORD: ${{ secrets.KEYCHAIN_PASSWORD }}
         run: |
-          # 创建临时 keychain
           KEYCHAIN_PATH=$RUNNER_TEMP/build.keychain
           security create-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
           security set-keychain-settings -lut 21600 $KEYCHAIN_PATH
           security unlock-keychain -p "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
-          # 导入证书
           CERTIFICATE_PATH=$RUNNER_TEMP/certificate.p12
           echo -n "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o $CERTIFICATE_PATH
           security import $CERTIFICATE_PATH \
@@ -88,11 +185,9 @@ jobs:
             -S apple-tool:,apple: \
             -s -k "$KEYCHAIN_PASSWORD" $KEYCHAIN_PATH
 
-          # 设为默认 keychain
           security list-keychain -d user -s $KEYCHAIN_PATH
 
-      # ── 6. Import provisioning profile ───────────────────────────────────
-      # GitHub Secret: BUILD_PROVISION_PROFILE_BASE64 — .mobileprovision 的 base64
+      # ── 9. Import provisioning profile ───────────────────────────────────
       - name: Install provisioning profile
         env:
           BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
@@ -102,21 +197,19 @@ jobs:
           mkdir -p ~/Library/MobileDevice/Provisioning\ Profiles
           cp $PP_PATH ~/Library/MobileDevice/Provisioning\ Profiles/
 
-          # 读取描述文件 UUID，传给后续步骤
           UUID=$(security cms -D -i $PP_PATH | plutil -extract UUID raw -)
           echo "PROVISIONING_PROFILE_UUID=$UUID" >> $GITHUB_ENV
           echo "Provisioning profile UUID: $UUID"
 
-      # ── 7. Write App Store Connect API Key ───────────────────────────────
-      # 写成文件供 Fastlane 读取（也可以通过环境变量传，Fastfile 里两种方式都支持）
+      # ── 10. Write App Store Connect API Key ──────────────────────────────
       - name: Write App Store Connect API key
         env:
           ASC_API_KEY_CONTENT: ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
         run: |
           echo "$ASC_API_KEY_CONTENT" > /tmp/asc_key.p8
 
-      # ── 8. Run Fastlane ───────────────────────────────────────────────────
-      - name: Run Fastlane beta
+      # ── 11. Run Fastlane ─────────────────────────────────────────────────
+      - name: Run Fastlane
         env:
           DEVELOPMENT_TEAM:                     ${{ secrets.DEVELOPMENT_TEAM }}
           APP_STORE_CONNECT_API_KEY_ID:         ${{ secrets.APP_STORE_CONNECT_API_KEY_ID }}
@@ -124,23 +217,36 @@ jobs:
           APP_STORE_CONNECT_API_KEY_CONTENT:    ${{ secrets.APP_STORE_CONNECT_API_KEY_CONTENT }}
           PROVISIONING_PROFILE_UUID:            ${{ env.PROVISIONING_PROFILE_UUID }}
           GH_TOKEN:                             ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REF_NAME:                      ${{ github.ref_name }}
-          GITHUB_REF_TYPE:                      ${{ github.ref_type }}
+          GITHUB_REF_NAME:                      ${{ steps.version.outputs.release_tag }}
+          GITHUB_REF_TYPE:                      tag
+          RELEASE_VERSION:                      ${{ steps.version.outputs.release_version }}
+          RELEASE_CHANGELOG_FILE:               ${{ steps.changelog.outputs.changelog_path }}
           FASTLANE_XCODE_LIST_TIMEOUT:          "120"
           FASTLANE_SKIP_UPDATE_CHECK:           "1"
         run: |
-          echo "KEY_ID length: ${#APP_STORE_CONNECT_API_KEY_ID}"
-          echo "ISSUER_ID length: ${#APP_STORE_CONNECT_ISSUER_ID}"
-          echo "KEY_CONTENT length: ${#APP_STORE_CONNECT_API_KEY_CONTENT}"
           LANE="${{ github.event.inputs.lane || 'beta' }}"
+          echo "Running lane=$LANE for version=$RELEASE_VERSION"
           bundle exec fastlane $LANE
 
-      # ── 9. Upload build artifacts (保留 IPA 和日志供排查) ─────────────────
+      # ── 12. Tag the release (only after fastlane succeeds) ───────────────
+      - name: Tag release and push
+        if: success()
+        env:
+          TAG: ${{ steps.version.outputs.release_tag }}
+        run: |
+          set -euo pipefail
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "Pushed tag $TAG"
+
+      # ── 13. Upload build artifacts ───────────────────────────────────────
       - name: Upload IPA artifact
         if: success()
         uses: actions/upload-artifact@v4
         with:
-          name: DayPage-${{ github.sha }}
+          name: DayPage-${{ steps.version.outputs.release_tag }}
           path: build/DayPage.ipa
           retention-days: 14
 
@@ -152,7 +258,7 @@ jobs:
           path: fastlane/logs/
           retention-days: 7
 
-      # ── 10. Cleanup keychain ──────────────────────────────────────────────
+      # ── 14. Cleanup keychain ──────────────────────────────────────────────
       - name: Cleanup keychain
         if: always()
         run: |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -110,10 +110,7 @@ platform :ios do
         in_house:     false
       ),
       skip_waiting_for_build_processing: true,
-      changelog:                         changelog_from_git_commits(
-        commits_count: 10,
-        pretty:        "- %s"
-      )
+      changelog:                         resolve_changelog
     )
 
     # Create GitHub Release (only meaningful on tag push; skip if no token or not a tag build)
@@ -122,7 +119,7 @@ platform :ios do
       tag = ENV["GITHUB_REF_NAME"]
       ipa_path = "build/DayPage.ipa"
       if File.exist?(ipa_path)
-        release_notes = changelog_from_git_commits(commits_count: 20, pretty: "- %s")
+        release_notes = resolve_changelog
         begin
           sh("gh release create '#{tag}' '#{ipa_path}' \
               --title 'DayPage #{tag}' \
@@ -198,18 +195,29 @@ platform :ios do
   end
 
   private_lane :increment_build do
-    # Marketing version 从最近的 git tag 读取（例如 v1.2.0 → 1.2.0）
-    # 无 tag 时回退到 pbxproj 里的现有值
-    raw_tag = sh("git describe --tags --abbrev=0 2>/dev/null || echo ''").strip
-    if raw_tag =~ /\Av?(\d+\.\d+(\.\d+)?)\z/
-      marketing_version = $1
+    # Marketing version 优先级：
+    #   1) RELEASE_VERSION 环境变量（CI 在打 tag 前注入，例如 0.0.2）
+    #   2) 最近的 git tag（例如 v1.2.0 → 1.2.0）
+    #   3) 保持 pbxproj 里的现有值
+    injected = ENV["RELEASE_VERSION"].to_s.strip
+    if injected =~ /\A\d+\.\d+\.\d+\z/
       increment_version_number(
-        version_number: marketing_version,
+        version_number: injected,
         xcodeproj:      "DayPage.xcodeproj"
       )
-      UI.message "Marketing version set to #{marketing_version} (from tag #{raw_tag})"
+      UI.message "Marketing version set to #{injected} (from RELEASE_VERSION env)"
     else
-      UI.message "No semver tag found, keeping existing MARKETING_VERSION"
+      raw_tag = sh("git describe --tags --abbrev=0 2>/dev/null || echo ''").strip
+      if raw_tag =~ /\Av?(\d+\.\d+(\.\d+)?)\z/
+        marketing_version = $1
+        increment_version_number(
+          version_number: marketing_version,
+          xcodeproj:      "DayPage.xcodeproj"
+        )
+        UI.message "Marketing version set to #{marketing_version} (from tag #{raw_tag})"
+      else
+        UI.message "No RELEASE_VERSION or semver tag found, keeping existing MARKETING_VERSION"
+      end
     end
 
     # Build number 用 git commit 总数，保证单调递增
@@ -219,6 +227,24 @@ platform :ios do
       xcodeproj:    "DayPage.xcodeproj"
     )
     UI.message "Build number set to #{build_number}"
+  end
+
+  # TestFlight changelog 优先来自 RELEASE_CHANGELOG_FILE（CI 注入 PR title+body），
+  # 否则回退到最近 10 条 git commit message。
+  def resolve_changelog
+    path = ENV["RELEASE_CHANGELOG_FILE"].to_s.strip
+    if !path.empty? && File.exist?(path)
+      content = File.read(path).strip
+      unless content.empty?
+        UI.message "Using changelog from #{path} (#{content.bytesize} bytes)"
+        return content
+      end
+    end
+    UI.message "RELEASE_CHANGELOG_FILE not provided; falling back to recent commits"
+    changelog_from_git_commits(
+      commits_count: 10,
+      pretty:        "- %s"
+    )
   end
 
   private_lane :notify_success do |message|


### PR DESCRIPTION
## Summary
- Switch `testflight.yml` trigger from tag-driven to `push: main` so every merge auto-releases
- Auto-bump patch segment of the latest `v*.*.*` tag (falls back to pbxproj `MARKETING_VERSION` if no tag)
- Push the tag **only after** TestFlight upload succeeds (no dirty tags on failure)
- Derive TestFlight changelog from the merged PR's title + body (falls back to head commit message if no `#N` ref)
- `Fastfile` now prefers `RELEASE_VERSION` / `RELEASE_CHANGELOG_FILE` env vars, keeping existing tag/commit behavior as a local fallback
- `workflow_dispatch` gains an optional `version_override` input to skip auto-bump

## Test plan
- [ ] Merge this PR → confirm workflow triggers on `push: main`
- [ ] Workflow computes next version from latest tag (or `0.0.1` if no tag exists yet) and logs it
- [ ] Changelog step resolves PR `#N` from the squash-merge commit and logs the title + body
- [ ] TestFlight build uploads with `MARKETING_VERSION` = the computed version
- [ ] Tag `vX.Y.Z` appears on `origin` only after upload succeeds
- [ ] Manual `workflow_dispatch` with `version_override=0.1.0` tags `v0.1.0` instead of bumping patch
- [ ] Doc-only change (`**.md`) on main does **not** trigger the workflow