### PR TITLE
fix(ci): make testflight tag bump idempotent against existing tags

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -48,26 +48,58 @@ jobs:
 
       # ── 2. Compute next version ──────────────────────────────────────────
       # 规则：
-      #   1) 手动触发 + version_override 非空  → 用 override
-      #   2) 最近一个 v*.*.* tag 存在          → patch +1
+      #   1) 手动触发 + version_override 非空  → 用 override（必须是未占用的 tag）
+      #   2) 最近一个 v*.*.* tag 存在          → 从 latest patch 开始，循环 +1 直到找到未占用的 tag
       #   3) 无 tag                            → 从 pbxproj 读 MARKETING_VERSION 作起点
+      #
+      # 为什么用循环：workflow 可能因并发推送、重跑、或与外部 tag（如手动发版）
+      # 竞争而碰到"目标 tag 已存在"的情况。幂等的做法是找第一个空位而不是直接报错。
       - name: Compute next version
         id: version
         run: |
           set -euo pipefail
 
+          # 额外拉一次远端 tag，防止 checkout 到 tag push 之间有并发写入。
+          git fetch --tags --force origin
+
+          # 辅助：某个 tag 是否已被占用（本地或远端任一存在即算占用）。
+          tag_exists() {
+            local t="$1"
+            if git rev-parse -q --verify "refs/tags/$t" >/dev/null 2>&1; then return 0; fi
+            if git ls-remote --tags origin "refs/tags/$t" | grep -q "refs/tags/$t$"; then return 0; fi
+            return 1
+          }
+
           OVERRIDE="${{ github.event.inputs.version_override }}"
           if [ -n "$OVERRIDE" ]; then
             NEXT="$OVERRIDE"
+            TAG="v$NEXT"
+            if tag_exists "$TAG"; then
+              echo "::error::Tag $TAG already exists (local or remote). Pick a different version_override."
+              exit 1
+            fi
             echo "Using manual override: $NEXT"
           else
             LAST_TAG=$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname | head -n 1 || true)
             if [ -n "$LAST_TAG" ]; then
               BASE="${LAST_TAG#v}"
               IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE"
-              PATCH=$((PATCH + 1))
-              NEXT="${MAJOR}.${MINOR}.${PATCH}"
-              echo "Bumping from $LAST_TAG → v$NEXT"
+              # 从 patch+1 开始，循环直到找到未占用的 tag。上限 50 次防呆。
+              for i in $(seq 1 50); do
+                CANDIDATE_PATCH=$((PATCH + i))
+                CANDIDATE="${MAJOR}.${MINOR}.${CANDIDATE_PATCH}"
+                if ! tag_exists "v$CANDIDATE"; then
+                  NEXT="$CANDIDATE"
+                  TAG="v$NEXT"
+                  echo "Bumping from $LAST_TAG → $TAG (tried $i candidate(s))"
+                  break
+                fi
+                echo "Candidate v$CANDIDATE already exists, trying next patch"
+              done
+              if [ -z "${NEXT:-}" ]; then
+                echo "::error::Could not find an unused patch within 50 attempts from $LAST_TAG."
+                exit 1
+              fi
             else
               CURRENT=$(grep -m1 -E 'MARKETING_VERSION = ' DayPage.xcodeproj/project.pbxproj \
                 | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
@@ -78,19 +110,17 @@ jobs:
               else
                 NEXT="0.0.1"
               fi
-              echo "No tag found, using pbxproj MARKETING_VERSION=$CURRENT → v$NEXT"
+              TAG="v$NEXT"
+              if tag_exists "$TAG"; then
+                echo "::error::No newest tag found, but fallback $TAG already exists. Set version_override."
+                exit 1
+              fi
+              echo "No tag found, using pbxproj MARKETING_VERSION=$CURRENT → $TAG"
             fi
           fi
 
-          TAG="v$NEXT"
-          # 防御：tag 已存在时直接报错，避免覆盖历史
-          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
-            echo "::error::Tag $TAG already exists. Set workflow_dispatch.version_override to a new version."
-            exit 1
-          fi
-
           echo "release_version=$NEXT" >> "$GITHUB_OUTPUT"
-          echo "release_tag=$TAG"     >> "$GITHUB_OUTPUT"
+          echo "release_tag=$TAG"      >> "$GITHUB_OUTPUT"
 
       # ── 3. Build changelog from merged PR title+body ─────────────────────
       # 从 head commit message 里抓 (#123)；抓不到就回退到 commit message 本身


### PR DESCRIPTION
## Summary

TestFlight workflow 在 #77 合并时失败：算出 `v0.1.4` 但这个 tag 已经存在（远端早就打过了），于是 `git push origin $TAG` 被 reject，整个发版流程中断。链接：https://github.com/getyak/daypage/actions/runs/24596747652/job/71928059372

根因：版本计算逻辑是"取最新 tag + 1"，这在并发推送、workflow 重跑、或与外部 tag 竞争时**不幂等**。

## Fix

- 版本计算从"盲目 +1"改成**循环找第一个未被占用的 patch**（最多 50 次）
- 占用检查同时查**本地和远端 tag**（之前只查本地，远端并发打的 tag 检测不到）
- 计算前显式 `git fetch --tags --force origin`，减少 checkout → tag-push 之间的窗口
- 手动 override 和无 tag 的 fallback 路径也都用同一个 `tag_exists()` helper 校验
- 错误消息明确指向 `version_override`，方便运维手动推

## Test plan

- [ ] 本地 dry-run：手工在本地 repo 造一个假 `v0.1.5` tag（或不造），`act` / 手跑 step 2 看它分别选到什么
- [ ] Merge 这个 PR 后观察下一次 TestFlight workflow：应该跳过所有已占用 tag、打到 `v0.1.5`（或更高）并成功 push
- [ ] 手动触发 `workflow_dispatch` 并传入一个已占用的 `version_override`，确认会在 step 2 报错而不是跑到后面 fastlane 才失败