### PR TITLE
feat: add swipeable memo card with delete/pin actions

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -65,6 +65,7 @@
 		A10000060 /* DailySharePosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000060 /* DailySharePosterView.swift */; };
 		A10000061 /* PosterRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000061 /* PosterRenderer.swift */; };
 		A10000062 /* InputBarV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000062 /* InputBarV3.swift */; };
+		A10000063 /* SwipeableMemoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000063 /* SwipeableMemoCard.swift */; };
 		AF0000001 /* SpaceGrotesk-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000001 /* SpaceGrotesk-Light.ttf */; };
 		AF0000002 /* SpaceGrotesk-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000002 /* SpaceGrotesk-Regular.ttf */; };
 		AF0000003 /* SpaceGrotesk-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000003 /* SpaceGrotesk-Medium.ttf */; };
@@ -152,6 +153,7 @@
 		A20000060 /* DailySharePosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySharePosterView.swift; sourceTree = "<group>"; };
 		A20000061 /* PosterRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterRenderer.swift; sourceTree = "<group>"; };
 		A20000062 /* InputBarV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV3.swift; sourceTree = "<group>"; };
+		A20000063 /* SwipeableMemoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMemoCard.swift; sourceTree = "<group>"; };
 		A30000001 /* DayPage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPage.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF1000001 /* SpaceGrotesk-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Light.ttf"; sourceTree = "<group>"; };
 		AF1000002 /* SpaceGrotesk-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Regular.ttf"; sourceTree = "<group>"; };
@@ -318,6 +320,7 @@
 				A20000052 /* AttachmentMenuPopover.swift */,
 				A20000054 /* RecordingOverlayView.swift */,
 				A20000055 /* PressToTalkButton.swift */,
+				A20000063 /* SwipeableMemoCard.swift */,
 			);
 			path = Today;
 			sourceTree = "<group>";
@@ -607,6 +610,7 @@
 				A10000053 /* InputTokens.swift in Sources */,
 				A10000054 /* RecordingOverlayView.swift in Sources */,
 				A10000055 /* PressToTalkButton.swift in Sources */,
+				A10000063 /* SwipeableMemoCard.swift in Sources */,
 				A10000042 /* RelativeTimeFormatter.swift in Sources */,
 				F617270BFC704FF5BBB99FD3 /* AppSettings.swift in Sources */,
 				8C3DEB068D610AAB589EA680 /* TimeZonePickerView.swift in Sources */,

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -22,7 +22,7 @@ struct RootView: View {
                 .tabItem {
                     Label("Today", systemImage: "square.and.pencil")
                 }
-                .swipeTabGesture(selectedTab: $selectedTab, tabIndex: 0, tabCount: tabCount)
+                // No swipeTabGesture here — Today uses swipe gestures on memo cards
 
             ArchiveView()
                 .tag(1)

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -1,0 +1,155 @@
+import SwiftUI
+
+// MARK: - SwipeableMemoCard
+
+/// WeChat-style swipe-to-reveal wrapper around MemoCardView.
+/// Left swipe → trailing Delete button. Right swipe → leading Pin button.
+struct SwipeableMemoCard: View {
+
+    let memo: Memo
+    var onDelete: (() -> Void)? = nil
+    var onPin: (() -> Void)? = nil
+
+    // Settled offset after a gesture ends (negative = trailing open, positive = leading open)
+    @State private var settledOffset: CGFloat = 0
+    // Which panel is currently revealed
+    @State private var revealedSide: Side? = nil
+
+    // Live delta from DragGesture (resets to zero when finger lifts)
+    @GestureState private var dragDelta: CGFloat = 0
+
+    private enum Side { case leading, trailing }
+
+    // Panel widths and thresholds
+    private let panelW: CGFloat     = 80
+    private let openThreshold: CGFloat = 44
+    private let closeThreshold: CGFloat = 20
+
+    // Combined offset while dragging
+    private var currentOffset: CGFloat {
+        let raw = settledOffset + dragDelta
+        return max(-panelW, min(panelW, raw))
+    }
+
+    var body: some View {
+        ZStack(alignment: .center) {
+            // Background action panels
+            HStack(spacing: 0) {
+                pinPanel
+                Spacer()
+                deletePanel
+            }
+
+            // Card — highPriorityGesture wins over PressableCardModifier's
+            // simultaneousGesture(DragGesture(minimumDistance:0)) inside MemoCardView.
+            MemoCardView(memo: memo, onDelete: onDelete)
+                .offset(x: currentOffset)
+                .highPriorityGesture(swipeGesture)
+                .onTapGesture { if revealedSide != nil { snapClose() } }
+        }
+        .clipped()
+    }
+
+    // MARK: - Panels
+
+    private var pinPanel: some View {
+        Button(action: {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+            snapClose()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { onPin?() }
+        }) {
+            VStack(spacing: 4) {
+                Image(systemName: "pin.fill").font(.system(size: 16, weight: .semibold))
+                Text("置顶").font(.custom("Inter-Medium", size: 11))
+            }
+            .foregroundColor(.white)
+            .frame(width: panelW)
+            .frame(maxHeight: .infinity)
+            .background(DSColor.amberArchival)
+        }
+        .opacity(revealedSide == .leading ? 1 : 0)
+        .animation(.easeOut(duration: 0.15), value: revealedSide)
+    }
+
+    private var deletePanel: some View {
+        Button(action: {
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            snapClose()
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { onDelete?() }
+        }) {
+            VStack(spacing: 4) {
+                Image(systemName: "trash.fill").font(.system(size: 16, weight: .semibold))
+                Text("删除").font(.custom("Inter-Medium", size: 11))
+            }
+            .foregroundColor(.white)
+            .frame(width: panelW)
+            .frame(maxHeight: .infinity)
+            .background(DSColor.error)
+        }
+        .opacity(revealedSide == .trailing ? 1 : 0)
+        .animation(.easeOut(duration: 0.15), value: revealedSide)
+    }
+
+    // MARK: - Gesture
+
+    private var swipeGesture: some Gesture {
+        DragGesture(minimumDistance: 10, coordinateSpace: .local)
+            .updating($dragDelta) { value, state, _ in
+                let dx = value.translation.width
+                let dy = value.translation.height
+                guard abs(dx) > abs(dy) * 0.6 else { return }
+                state = dx
+            }
+            .onEnded { value in
+                let dx = value.translation.width
+                let dy = value.translation.height
+                guard abs(dx) > abs(dy) * 0.6 else {
+                    snapToSettled()
+                    return
+                }
+                let vel = value.predictedEndTranslation.width - value.translation.width
+                decideSnap(dx: dx, velocity: vel)
+            }
+    }
+
+    // MARK: - Snap Logic
+
+    private func decideSnap(dx: CGFloat, velocity: CGFloat) {
+        if settledOffset == 0 {
+            if dx < -openThreshold || velocity < -300 {
+                snapOpen(.trailing)
+            } else if dx > openThreshold || velocity > 300 {
+                snapOpen(.leading)
+            } else {
+                snapClose()
+            }
+        } else if settledOffset < 0 {
+            // Trailing was open
+            (dx > closeThreshold || velocity > 200) ? snapClose() : snapOpen(.trailing)
+        } else {
+            // Leading was open
+            (dx < -closeThreshold || velocity < -200) ? snapClose() : snapOpen(.leading)
+        }
+    }
+
+    private func snapOpen(_ side: Side) {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.72)) {
+            revealedSide = side
+            settledOffset = side == .trailing ? -panelW : panelW
+        }
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+    }
+
+    func snapClose() {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.72)) {
+            revealedSide = nil
+            settledOffset = 0
+        }
+    }
+
+    private func snapToSettled() {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.72)) {
+            // dragDelta auto-resets; just keep settledOffset
+        }
+    }
+}

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -210,7 +210,9 @@ struct TodayView: View {
                                     ForEach(Array(viewModel.memos.enumerated()), id: \.element.id) { idx, memo in
                                         TimelineRow(
                                             memo: memo,
-                                            isLast: idx == viewModel.memos.count - 1
+                                            isLast: idx == viewModel.memos.count - 1,
+                                            onDelete: { viewModel.deleteMemo(memo) },
+                                            onPin: { viewModel.pinMemo(memo) }
                                         )
                                         .padding(.leading, 20)
                                         .padding(.trailing, 20)
@@ -717,10 +719,12 @@ private struct LocationDraftRow: View {
 
 // MARK: - TimelineRow
 
-/// Wraps a MemoCardView with a left timeline column (time + connecting line).
+/// Wraps a SwipeableMemoCard with a left timeline column (time + connecting line).
 struct TimelineRow: View {
     let memo: Memo
     let isLast: Bool
+    var onDelete: (() -> Void)? = nil
+    var onPin: (() -> Void)? = nil
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
@@ -746,9 +750,9 @@ struct TimelineRow: View {
             }
             .frame(width: 40)
 
-            // Memo card
-            MemoCardView(memo: memo)
-                .frame(maxWidth: .infinity)
+            // Swipeable memo card (WeChat-style actions)
+            SwipeableMemoCard(memo: memo, onDelete: onDelete, onPin: onPin)
+                .frame(maxWidth: CGFloat.infinity)
         }
     }
 }

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -170,6 +170,60 @@ final class TodayViewModel: ObservableObject {
         }
     }
 
+    // MARK: - Delete / Pin Memo
+
+    /// Removes a memo from today's file and refreshes the in-memory list.
+    func deleteMemo(_ memo: Memo) {
+        let remaining = memos.filter { $0.id != memo.id }
+        do {
+            try rewrite(memos: remaining)
+            // Optimistic UI update
+            withAnimation(.easeInOut(duration: 0.25)) {
+                memos = remaining
+            }
+        } catch {
+            submitError = "删除失败：\(error.localizedDescription)"
+        }
+    }
+
+    /// Moves a memo to the top of today's list (newest created-time wins display order).
+    /// Adjusts the memo's `created` timestamp to just before the current newest so it
+    /// appears first without changing the day boundary.
+    func pinMemo(_ memo: Memo) {
+        guard let idx = memos.firstIndex(where: { $0.id == memo.id }) else { return }
+        var pinned = memos[idx]
+        // Set to one second after the current newest memo's time so it sorts first
+        let newestTime = memos.first?.created ?? Date()
+        pinned.created = max(newestTime, pinned.created) + 1
+        var updated = memos
+        updated.remove(at: idx)
+        updated.insert(pinned, at: 0)
+        do {
+            try rewrite(memos: updated)
+            withAnimation(.easeInOut(duration: 0.25)) {
+                memos = updated
+            }
+        } catch {
+            submitError = "置顶失败：\(error.localizedDescription)"
+        }
+    }
+
+    /// Overwrites today's raw storage file with the given ordered memo list.
+    private func rewrite(memos: [Memo]) throws {
+        let url = RawStorage.fileURL(for: date)
+        if memos.isEmpty {
+            // Remove the file entirely if no memos remain
+            if FileManager.default.fileExists(atPath: url.path) {
+                try FileManager.default.removeItem(at: url)
+            }
+            return
+        }
+        // Write newest-last so the file is chronological (parser sorts later)
+        let ordered = memos.sorted { $0.created < $1.created }
+        let content = ordered.map { $0.toMarkdown() }.joined(separator: RawStorage.memoSeparator)
+        try RawStorage.atomicWrite(string: content, to: url)
+    }
+
     // MARK: - Load Memos
 
     /// Loads today's memos from the raw storage file and checks compiled status.

--- a/ralph/prd.json
+++ b/ralph/prd.json
@@ -1,0 +1,178 @@
+{
+  "project": "DayPage",
+  "branchName": "ralph/auth-login",
+  "description": "Authentication system — Apple Sign-In + Email Magic Link via Supabase, dark Bôr aesthetic UI, email as canonical sync identity",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "Add Supabase Swift SDK via SPM",
+      "description": "As a developer, I need the Supabase Swift package added to the Xcode project so auth APIs are available at compile time.",
+      "acceptanceCriteria": [
+        "Add package dependency `https://github.com/supabase/supabase-swift` (latest stable) to DayPage.xcodeproj via Swift Package Manager",
+        "Link `Supabase` library to the DayPage target",
+        "Project builds successfully with the new dependency",
+        "Typecheck passes"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": "Manual prerequisite: Supabase project must already exist with SUPABASE_URL and SUPABASE_ANON_KEY available. Admin account admin@telepace.cc should be created in Supabase Dashboard manually."
+    },
+    {
+      "id": "US-002",
+      "title": "Add Supabase credentials to GeneratedSecrets",
+      "description": "As a developer, I need SUPABASE_URL and SUPABASE_ANON_KEY available in Config/GeneratedSecrets.swift so AuthService can initialize the Supabase client.",
+      "acceptanceCriteria": [
+        "Add `static let supabaseURL: String` and `static let supabaseAnonKey: String` to `GeneratedSecrets.swift` with placeholder values (empty string or TODO comment)",
+        "Add `SUPABASE_URL` and `SUPABASE_ANON_KEY` entries to the secrets generation script or Makefile (same pattern as existing keys)",
+        "GeneratedSecrets.swift remains in .gitignore",
+        "Typecheck passes"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": "Actual URL/key values must be filled in by the developer from Supabase Dashboard before runtime."
+    },
+    {
+      "id": "US-003",
+      "title": "Implement AuthService",
+      "description": "As a developer, I need a centralized AuthService so all views can observe login state and call sign-in/sign-out methods.",
+      "acceptanceCriteria": [
+        "Create `DayPage/Services/AuthService.swift` as `@MainActor final class AuthService: ObservableObject`",
+        "`@Published var session: Session?` — nil means logged out",
+        "`@Published var isLoading: Bool = false`",
+        "`@Published var error: String? = nil`",
+        "Init creates `SupabaseClient` using `GeneratedSecrets.supabaseURL` and `GeneratedSecrets.supabaseAnonKey`",
+        "On init, restores existing session from Supabase keychain storage",
+        "`func signInWithApple() async throws` — placeholder body with TODO comment (Apple credential wiring done in US-005)",
+        "`func signInWithMagicLink(email: String) async throws` — calls `supabase.auth.signInWithOTP(email:)`",
+        "`func signOut() async throws` — calls `supabase.auth.signOut()`",
+        "`AuthService` added as `@StateObject` in `DayPageApp` and injected as `.environmentObject`",
+        "Typecheck passes"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-004",
+      "title": "Add Apple Sign-In entitlement and capability",
+      "description": "As a developer, I need the Sign in with Apple capability added to the Xcode target so ASAuthorizationAppleIDRequest compiles and works.",
+      "acceptanceCriteria": [
+        "Add `com.apple.developer.applesignin` entitlement to `DayPage.entitlements` with value `[Default]`",
+        "Add `AuthenticationServices` framework import where needed",
+        "Project builds without entitlement-related errors",
+        "Typecheck passes"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": "The actual Apple Sign-In button and credential flow is wired in US-005. This story just ensures the entitlement and framework are in place."
+    },
+    {
+      "id": "US-005",
+      "title": "Build AuthView — dark aesthetic entry screen",
+      "description": "As a new user, I want to see a beautiful dark login screen with Apple and Email options so the first impression feels premium.",
+      "acceptanceCriteria": [
+        "Create `DayPage/Features/Auth/AuthView.swift`",
+        "Full-screen background color `Color(hex: \"#0A0A0A\")`",
+        "Grain texture overlay: use a `Rectangle` with `.fill(.white.opacity(0.04))` and a fine dot pattern via `Canvas` or a bundled `noise.png` asset at 6% opacity with `.blendMode(.overlay)` — tiled to fill screen",
+        "Wordmark 'DayPage' centered in upper third: `Font.custom(\"SpaceGrotesk-Bold\", size: 32)`, color `#F5F0E8`",
+        "Tagline 'Every day, captured.' below wordmark: `Font.custom(\"SpaceGrotesk-Regular\", size: 15)`, color `#6B6B6B`",
+        "'Continue with Apple' button: height 54pt, background `#1A1A1A`, border 1pt `#2A2A2A`, corner radius 14pt, SF Symbol `apple.logo` + white label `Font.custom(\"SpaceGrotesk-Medium\", size: 16)`, calls `authService.signInWithApple()`",
+        "'Continue with Email' button: same geometry, label color `#A0A0A0`, border `#222222`, navigates to `EmailAuthView`",
+        "12pt gap between buttons",
+        "Buttons bottom-anchored with `.safeAreaInset(edge: .bottom)` padding 32pt",
+        "'Skip for now' text button below main buttons: 13pt Inter, color `#4A4A4A`, sets `UserDefaults.standard.set(true, forKey: \"authSkipped\")`",
+        "`AuthService.isLoading == true` shows `.overlay(ProgressView())` on the button area",
+        "`AuthService.error != nil` shows inline error text 14pt `#E05A5A` above buttons",
+        "Auth screen presented as `.fullScreenCover` from `RootView` when `session == nil` AND `!authSkipped`",
+        "Entrance animation: `.transition(.opacity)` with 0.4s ease-out",
+        "Button press: `.scaleEffect(isPressed ? 0.97 : 1.0)` via `@GestureState`",
+        "Typecheck passes"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": "noise.png asset: create a simple 200x200 grayscale noise PNG in Assets.xcassets. If unavailable, use a Canvas with random dots as fallback."
+    },
+    {
+      "id": "US-006",
+      "title": "Wire Apple Sign-In credential to AuthService",
+      "description": "As a user, I want tapping 'Continue with Apple' to trigger the native Apple auth sheet and sign me in.",
+      "acceptanceCriteria": [
+        "Implement `signInWithApple()` in `AuthService` using `ASAuthorizationAppleIDProvider` and `ASAuthorizationController`",
+        "On credential success, call `supabase.auth.signInWithIdToken(credentials: .init(provider: .apple, idToken: identityToken))`",
+        "Extract `email` from `ASAuthorizationAppleIDCredential` and store in `UserDefaults` key `appleSignInEmail` (Apple hides email on repeat sign-ins; fall back to stored value)",
+        "On auth success, `session` publishes new value → `fullScreenCover` dismisses automatically",
+        "On user cancellation (`ASAuthorizationError.canceled`), set `isLoading = false` silently",
+        "On other errors, set `self.error` to localized error description",
+        "Typecheck passes"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-007",
+      "title": "Build EmailAuthView — magic link request screen",
+      "description": "As a user, I want to enter my email on a dedicated screen and receive a magic link to sign in without a password.",
+      "acceptanceCriteria": [
+        "Create `DayPage/Features/Auth/EmailAuthView.swift`",
+        "Same dark background `#0A0A0A` and grain overlay as `AuthView`",
+        "Back chevron top-left: SF Symbol `chevron.left`, color `#6B6B6B`",
+        "Heading 'Enter your email' — Space Grotesk Bold 24pt, `#F5F0E8`",
+        "Email `TextField`: Inter Regular 17pt, text color `#F5F0E8`, background `#1E1E1E`, border 1pt `#2A2A2A`, corner radius 12pt, height 52pt, `.keyboardType(.emailAddress)`, `.autocapitalization(.never)`",
+        "'Send Magic Link' button: full-width, height 54pt, corner radius 14pt — active state background `#F5F0E8` label `#0A0A0A`; disabled state background `#1A1A1A` label `#4A4A4A`; disabled when email field empty or not matching basic email regex `^[^@]+@[^@]+\\.[^@]+$`",
+        "On submit, calls `authService.signInWithMagicLink(email: email)`",
+        "Success state: `TextField` and button replaced with text 'Check your inbox — a magic link is on its way.' Space Grotesk Regular 16pt centered `#A0A0A0`",
+        "`authService.error` shown inline below button as 14pt `#E05A5A`",
+        "Typecheck passes"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-008",
+      "title": "Register deep link scheme and handle auth callback",
+      "description": "As a user, I want tapping the magic link in my email to open DayPage and complete sign-in automatically.",
+      "acceptanceCriteria": [
+        "Add URL scheme `daypage` to `Info.plist` under `CFBundleURLTypes` with role `Editor`",
+        "In `DayPageApp.swift`, add `.onOpenURL { url in Task { try? await supabase.auth.session(from: url) } }` on the root view",
+        "After session exchange succeeds, `AuthService.session` updates and auth screen dismisses",
+        "Typecheck passes"
+      ],
+      "priority": 8,
+      "passes": false,
+      "notes": "Supabase redirect URL `daypage://auth/callback` must also be added in Supabase Dashboard under Authentication > URL Configuration."
+    },
+    {
+      "id": "US-009",
+      "title": "Add account avatar and AccountSheet to Today tab",
+      "description": "As a logged-in user, I want to see my account indicator and be able to sign out from the Today tab.",
+      "acceptanceCriteria": [
+        "When `authService.session != nil`, show circular avatar in `TodayView` navigation bar trailing: 28pt diameter, background `#1E1E1E`, border 1pt `#2A2A2A`, shows first letter of email in Inter Medium 13pt `#A0A0A0`",
+        "Tapping avatar presents `AccountSheet` as `.sheet`",
+        "Create `DayPage/Features/Auth/AccountSheet.swift`: bottom sheet with drag handle, email address 14pt `#6B6B6B`, 'Sign Out' button destructive style `#E05A5A` that calls `authService.signOut()`",
+        "After sign out, `session` nil → `fullScreenCover` re-presents, `UserDefaults` `authSkipped` reset to false",
+        "Typecheck passes"
+      ],
+      "priority": 9,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-010",
+      "title": "Add contextual sync prompt banner",
+      "description": "As a local user after saving 3+ memos, I want a subtle banner prompting me to sync so I discover the cloud feature naturally.",
+      "acceptanceCriteria": [
+        "Track memo save count in `UserDefaults` key `memoSaveCount`; increment each time a memo is saved in `TodayViewModel`",
+        "When `memoSaveCount >= 3` AND `session == nil` AND `authSkipped == true` AND last banner shown > 7 days ago (key `lastSyncBannerDate`), show banner at top of `TodayView`",
+        "Banner: background `#1E1E1E`, text 'Sync your journal across devices →' 13pt Inter `#A0A0A0`, 12pt vertical padding, full-width",
+        "Banner dismissible with swipe-up gesture; sets `lastSyncBannerDate = now`",
+        "Tapping banner presents `AuthView` as a sheet",
+        "Typecheck passes"
+      ],
+      "priority": 10,
+      "passes": false,
+      "notes": ""
+    }
+  ]
+}

--- a/tasks/prd-auth-login.md
+++ b/tasks/prd-auth-login.md
@@ -1,0 +1,199 @@
+# PRD: Authentication — Login & Registration
+
+## Introduction
+
+Add a full authentication system to DayPage iOS app using Supabase Auth. Users can sign in via Apple Sign-In or Email Magic Link. Email serves as the single canonical identity for cross-device sync. The UI follows a dark, textured, high-quality aesthetic — think Notion's clean typography principles applied to a deep dark surface, with subtle grain, generous whitespace, and editorial-grade type hierarchy.
+
+Anonymous local usage remains fully supported; auth is the gateway to sync, not a hard paywall.
+
+---
+
+## Goals
+
+- Let users create an account and sign in with Apple ID or Email Magic Link
+- Make `email` the single unique identifier across all future platforms (iOS, Web)
+- Keep local-first usage intact — login is optional, prompts appear contextually
+- Ship a visually distinctive auth UI that feels premium and intentional
+- Lay the foundation for Supabase-backed cloud sync (actual sync is out of scope here)
+
+---
+
+## User Stories
+
+### US-001: Supabase Project Setup
+**Description:** As a developer, I need a configured Supabase project so auth services are available.
+
+**Acceptance Criteria:**
+- [ ] Supabase project created (or existing project used)
+- [ ] `supabase_url` and `supabase_anon_key` stored in `Config/GeneratedSecrets.swift` (gitignored)
+- [ ] Apple OAuth provider enabled in Supabase Dashboard
+- [ ] Email Magic Link provider enabled in Supabase Dashboard
+- [ ] `profiles` table created: `id (uuid, FK → auth.users)`, `email (text, unique)`, `display_name (text)`, `created_at`
+- [ ] Row-Level Security enabled on `profiles` (users can only read/write their own row)
+- [ ] Admin account `admin@telepace.cc` created manually in Supabase Dashboard (password set there, never in code)
+
+### US-002: Auth Session Manager
+**Description:** As a developer, I need a centralized `AuthService` so all views can react to login state.
+
+**Acceptance Criteria:**
+- [ ] `AuthService.swift` — `@MainActor final class: ObservableObject`
+- [ ] `@Published var session: Session?` — nil means logged out
+- [ ] `@Published var isLoading: Bool`
+- [ ] `signInWithApple()` async throws
+- [ ] `signInWithMagicLink(email: String)` async throws
+- [ ] `signOut()` async throws
+- [ ] Session persisted across app restarts via Supabase's built-in keychain storage
+- [ ] `AuthService` injected as `@EnvironmentObject` from `DayPageApp`
+- [ ] Typecheck passes
+
+### US-003: Auth Entry Screen — Dark Aesthetic
+**Description:** As a new user, I want to see a beautiful, on-brand login screen so the first impression matches DayPage's premium feel.
+
+**Acceptance Criteria:**
+- [ ] Full-screen dark surface: background `#0A0A0A` (near-black)
+- [ ] Subtle noise/grain texture overlay (5–8% opacity SVG or PNG asset, tiled)
+- [ ] App logotype or wordmark "DayPage" centered in upper third — Space Grotesk Bold, 32pt, `#F5F0E8` (warm off-white)
+- [ ] One-line tagline below: Space Grotesk Regular, 15pt, `#6B6B6B`
+- [ ] "Continue with Apple" button: SF Symbol `apple.logo`, white label on `#1A1A1A` surface, 1pt border `#2A2A2A`, rounded 14pt, height 54pt
+- [ ] "Continue with Email" button: same geometry, label `#A0A0A0`, border `#222222`
+- [ ] Buttons separated by 12pt gap; bottom-anchored with safe area padding
+- [ ] "Skip for now" text button — 13pt, `#4A4A4A`, below the two main buttons
+- [ ] No back button / navigation chrome — this is a modal sheet or root replacement
+- [ ] Typecheck passes
+- [ ] Verify visually in Simulator (iPhone 17)
+
+### US-004: Apple Sign-In Flow
+**Description:** As a user, I want to sign in with my Apple ID so I don't need to remember a password.
+
+**Acceptance Criteria:**
+- [ ] Tapping "Continue with Apple" triggers native `ASAuthorizationAppleIDRequest`
+- [ ] On success, Supabase `signInWithIdToken` called with Apple identity token
+- [ ] Email extracted from Apple credential and stored in `profiles.email` (first sign-in only — Apple may hide it on repeat sign-ins, use stored value)
+- [ ] On success, `AuthService.session` updates → app navigates away from auth screen
+- [ ] On cancellation, no error shown — silently dismissed
+- [ ] On failure, shows inline error message (14pt, `#E05A5A`)
+- [ ] `AuthService.isLoading` drives a `ProgressView` overlay during the async call
+- [ ] Typecheck passes
+
+### US-005: Email Magic Link Flow
+**Description:** As a user, I want to enter my email and receive a magic link so I can log in without a password.
+
+**Acceptance Criteria:**
+- [ ] Tapping "Continue with Email" navigates to `EmailAuthView` (push or sheet)
+- [ ] `EmailAuthView` has: dark background matching auth screen, large email text field (Inter Regular 17pt, `#F5F0E8` text, `#1E1E1E` fill, 1pt border `#2A2A2A`, rounded 12pt), "Send Magic Link" CTA button (active state: `#F5F0E8` background, `#0A0A0A` label; disabled when field empty)
+- [ ] Email validated client-side (basic regex) before enabling button
+- [ ] On submit, `AuthService.signInWithMagicLink(email:)` called
+- [ ] Success state: field replaced with confirmation message "Check your inbox — a magic link is on its way." (Space Grotesk, 16pt, centered, `#A0A0A0`)
+- [ ] Supabase deep link (`daypage://auth/callback`) configured in `Info.plist` URL schemes
+- [ ] App handles the deep link in `DayPageApp` → calls Supabase `session` exchange
+- [ ] On link tap from Mail app, user is logged in and lands on Today tab
+- [ ] Typecheck passes
+- [ ] Verify visually in Simulator (iPhone 17)
+
+### US-006: Logged-In State & Profile Header
+**Description:** As a logged-in user, I want subtle confirmation of my identity so I feel grounded in my account.
+
+**Acceptance Criteria:**
+- [ ] When `AuthService.session != nil`, Today tab shows a small account indicator: circular avatar placeholder (initials from email, 28pt, `#1E1E1E` fill, `#2A2A2A` border) in the navigation bar trailing position
+- [ ] Tapping avatar opens `AccountSheet` (bottom sheet): shows email address (14pt, `#6B6B6B`), "Sign Out" button (destructive, `#E05A5A`), dismiss handle
+- [ ] Sign out calls `AuthService.signOut()` → session nil → auth screen re-presented
+- [ ] Typecheck passes
+- [ ] Verify visually in Simulator (iPhone 17)
+
+### US-007: Contextual Sync Prompt (Local → Cloud)
+**Description:** As a local user who has been using DayPage without an account, I want a gentle prompt to sync so I understand the value without being forced.
+
+**Acceptance Criteria:**
+- [ ] After 3 memo saves (tracked in `UserDefaults`), if user is not logged in, show a subtle banner at top of Today view: "Sync your journal across devices →" (`#1E1E1E` background, `#A0A0A0` text, 13pt, dismissible with swipe)
+- [ ] Banner appears at most once per 7 days (cooldown in `UserDefaults`)
+- [ ] Tapping banner presents auth screen as a sheet
+- [ ] Typecheck passes
+
+---
+
+## Functional Requirements
+
+- **FR-1**: Supabase iOS SDK integrated (via Swift Package Manager: `https://github.com/supabase/supabase-swift`)
+- **FR-2**: `email` is the canonical user identifier; Apple Sign-In normalizes to email on first login
+- **FR-3**: Sessions persisted in Keychain; app auto-resumes session on launch without re-auth
+- **FR-4**: Auth screen presented as full-screen cover over `RootView` when `session == nil` AND user has not tapped "Skip"
+- **FR-5**: "Skip" state stored in `UserDefaults` key `authSkipped`; reset on sign-out
+- **FR-6**: Deep link scheme `daypage://auth/callback` registered in `Info.plist` and handled in `DayPageApp.onOpenURL`
+- **FR-7**: All auth errors surfaced as localized inline messages (no system alerts)
+- **FR-8**: No Google Sign-In in this version
+- **FR-9**: Admin account (`admin@telepace.cc`) provisioned manually in Supabase Dashboard — credentials never appear in source code or PRD
+
+---
+
+## Non-Goals
+
+- Cloud sync of memos/vault data (separate feature, depends on this)
+- Google Sign-In
+- Password-based email auth
+- User profile editing (display name, avatar upload)
+- Account deletion flow
+- Web app auth (separate project, same Supabase backend)
+- Push notifications tied to auth state
+
+---
+
+## Design Considerations
+
+### Color Palette
+| Token | Hex | Usage |
+|---|---|---|
+| `surface-base` | `#0A0A0A` | Full-screen backgrounds |
+| `surface-raised` | `#1A1A1A` | Button fills, card backgrounds |
+| `surface-overlay` | `#1E1E1E` | Input fields, avatar fill |
+| `border-subtle` | `#2A2A2A` | Button borders, input borders |
+| `border-mid` | `#222222` | Secondary button borders |
+| `text-primary` | `#F5F0E8` | Headings, primary labels (warm off-white) |
+| `text-secondary` | `#A0A0A0` | Body, subheadings |
+| `text-muted` | `#6B6B6B` | Tagline, metadata |
+| `text-ghost` | `#4A4A4A` | "Skip for now" |
+| `error` | `#E05A5A` | Error messages, destructive actions |
+
+### Typography
+- **Space Grotesk Bold** — wordmark, section headings
+- **Space Grotesk Regular** — tagline, confirmation copy
+- **Inter Regular** — input fields, body text
+- Both fonts already bundled in the project (`DSFonts.registerAll()`)
+
+### Texture
+- Grain overlay: a 200×200px PNG with white noise at 6% opacity, `BlendMode.overlay`, tiled across the full background
+- Adds tactility without distracting from content
+
+### Motion
+- Auth screen entrance: fade-in 0.4s ease-out
+- Button press: scale 0.97, 0.1s spring
+- Error message: slide-in from below, 0.2s
+
+---
+
+## Technical Considerations
+
+- **Supabase Swift SDK** added via SPM — only dependency addition in this PR
+- `AuthService` lives in `DayPage/Services/AuthService.swift`
+- `AuthView`, `EmailAuthView`, `AccountSheet` live in `DayPage/Features/Auth/`
+- Deep link handling added to `DayPageApp.swift` `onOpenURL` modifier
+- Apple Sign-In entitlement (`com.apple.developer.applesignin`) must be added to the Xcode target
+- Supabase URL/key added to `GeneratedSecrets.swift` alongside existing keys — keep the existing `make secrets` or `generate_secrets.sh` pattern
+- No new Xcode targets; no Core Data changes; no vault file format changes
+
+---
+
+## Success Metrics
+
+- User can complete Apple Sign-In in under 3 taps from cold launch
+- Magic Link email sent within 5 seconds of submission
+- Auth screen feels visually cohesive with DayPage's existing dark UI
+- Zero regressions in local memo capture (unauthenticated path)
+- Session survives app restart without re-auth prompt
+
+---
+
+## Open Questions
+
+- Should the grain texture asset be generated programmatically (SwiftUI `Canvas`) or shipped as a PNG bundle asset? PNG is simpler but adds ~10KB.
+- Supabase project — new dedicated project or reuse an existing one? (affects URL/key rotation)
+- Should "Skip" users who later install the Web version see a "You were using DayPage locally — sign in to merge your data" flow? (out of scope now, but worth noting)


### PR DESCRIPTION
## Summary

- Add `SwipeableMemoCard` with left swipe (delete) and right swipe (pin) gesture actions
- Remove global swipe-tab gesture from `RootView` to prevent conflict with card swipes
- Add `deleteMemo` / `pinMemo` methods to `TodayViewModel`
- Include `tasks/prd-auth-login.md` and `ralph/prd.json` for upcoming auth feature

## Test plan

- [ ] Swipe left on a memo card → delete confirmation / deletion
- [ ] Swipe right on a memo card → pin action
- [ ] Tab switching still works via tab bar (swipe-tab gesture removed)
- [ ] Build passes: `xcodebuild -scheme DayPage build`