### PR TITLE
feat(ci): integrate AgentBoard token usage reporting

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,3 +47,11 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
+      - name: Report token usage to AgentBoard
+        if: always() && secrets.AGENTBOARD_TOKEN != ''
+        env:
+          AGENTBOARD_TOKEN: ${{ secrets.AGENTBOARD_TOKEN }}
+          AGENTBOARD_URL: ${{ secrets.AGENTBOARD_URL || 'https://agentboard.cc' }}
+        run: |
+          curl -fsSL "${AGENTBOARD_URL}/install" | bash -s -- "${AGENTBOARD_TOKEN}" "${AGENTBOARD_URL}"
+

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,3 +52,11 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
 
+      - name: Report token usage to AgentBoard
+        if: always() && secrets.AGENTBOARD_TOKEN != ''
+        env:
+          AGENTBOARD_TOKEN: ${{ secrets.AGENTBOARD_TOKEN }}
+          AGENTBOARD_URL: ${{ secrets.AGENTBOARD_URL || 'https://agentboard.cc' }}
+        run: |
+          curl -fsSL "${AGENTBOARD_URL}/install" | bash -s -- "${AGENTBOARD_TOKEN}" "${AGENTBOARD_URL}"
+

--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -152,8 +152,17 @@ jobs:
             printf '%s' "$COMMIT_MSG" > "$CHANGELOG_FILE"
           fi
 
-          # 清理 Windows 行尾，去掉末尾空行
+          # 清理 Windows 行尾
           sed -i '' -e 's/\r$//' "$CHANGELOG_FILE" || true
+          # 替换 Markdown checkbox 符号为 ASCII（App Store Connect 不接受 Unicode）
+          sed -i '' \
+            -e 's/\[✓\]/[x]/g' \
+            -e 's/\[✗\]/[ ]/g' \
+            -e 's/✓/[x]/g'    \
+            -e 's/✗/[ ]/g'    \
+            -e 's/✅/[x]/g'   \
+            -e 's/❌/[ ]/g'   \
+            "$CHANGELOG_FILE" || true
           # 限长：TestFlight "What to Test" 上限 4000 字符
           head -c 3800 "$CHANGELOG_FILE" > "$CHANGELOG_FILE.trimmed"
           mv "$CHANGELOG_FILE.trimmed" "$CHANGELOG_FILE"


### PR DESCRIPTION
## Summary
- 在 `claude.yml` 和 `claude-code-review.yml` 两个 workflow 中，各新增一个 `Report token usage to AgentBoard` step
- Token 通过 `AGENTBOARD_TOKEN` Secret 传入，URL 通过 `AGENTBOARD_URL` Secret 覆盖（默认 `https://agentboard.cc`），均不硬编码在代码中
- 使用 `if: always()` 确保即使 Claude step 失败也能上报；未配置 Secret 时自动跳过

## 配置步骤
在仓库 **Settings → Secrets and variables → Actions** 中添加：
| Secret 名 | 说明 |
|---|---|
| `AGENTBOARD_TOKEN` | 从 agentboard.cc 控制台生成的新 token（请先吊销旧 token）|
| `AGENTBOARD_URL` | 可选，默认 `https://agentboard.cc` |

## Test plan
- [ ] 配置 `AGENTBOARD_TOKEN` Secret 后，触发一次 `@claude` 评论，确认 AgentBoard step 出现在 Actions 日志中
- [ ] 确认 Actions 日志中 token 值被 GitHub 自动遮蔽（显示为 `***`）
- [ ] 未配置 Secret 时 step 被跳过，不影响正常 CI 流程