### PR TITLE
feat(ci): add Maestro UI tests and fix CI pipeline

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -47,11 +47,3 @@ jobs:
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
 
-      - name: Report token usage to AgentBoard
-        if: always() && secrets.AGENTBOARD_TOKEN != ''
-        env:
-          AGENTBOARD_TOKEN: ${{ secrets.AGENTBOARD_TOKEN }}
-          AGENTBOARD_URL: ${{ secrets.AGENTBOARD_URL || 'https://agentboard.cc' }}
-        run: |
-          curl -fsSL "${AGENTBOARD_URL}/install" | bash -s -- "${AGENTBOARD_TOKEN}" "${AGENTBOARD_URL}"
-

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,11 +52,3 @@ jobs:
           # or https://code.claude.com/docs/en/cli-reference for available options
           # claude_args: '--allowed-tools Bash(gh pr *)'
 
-      - name: Report token usage to AgentBoard
-        if: always() && secrets.AGENTBOARD_TOKEN != ''
-        env:
-          AGENTBOARD_TOKEN: ${{ secrets.AGENTBOARD_TOKEN }}
-          AGENTBOARD_URL: ${{ secrets.AGENTBOARD_URL || 'https://agentboard.cc' }}
-        run: |
-          curl -fsSL "${AGENTBOARD_URL}/install" | bash -s -- "${AGENTBOARD_TOKEN}" "${AGENTBOARD_URL}"
-


### PR DESCRIPTION
## Summary
- Add Maestro UI test flow that types a memo, sends it, and asserts it appears in the feed
- Fix Maestro flow assertions, swipe syntax, and wait commands to match actual app UI
- Dynamically select available iPhone simulator instead of hardcoding iPhone 17
- Write simulator picker inline in the ui-tests job for portability across runners
- Revert claude.yml and claude-code-review.yml to match main branch (removes insecure `curl | bash` AgentBoard reporting step per security review in #92)

Closes #93

## Test plan
- [ ] CI `ui-tests` job passes on the PR runner
- [ ] Maestro flow: launches app → types memo → taps send → asserts memo visible in feed
- [ ] `xcodebuild` build step succeeds on iOS simulator
- [ ] No regression in `testflight.yml` or `claude.yml` workflows
- [ ] Confirm `claude.yml` and `claude-code-review.yml` match main branch (no AgentBoard step)