### PR TITLE
fix(auth): simplify onOpenURL to avoid double session assignment

### DIFF
--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -63,13 +63,10 @@ struct DayPageApp: App {
             RootView()
                 .environmentObject(authService)
                 .onOpenURL { url in
+                    // Handle both Magic Link callbacks (daypage://...) and OTP deep links.
+                    // Session update is handled by authStateChanges listener — no manual assignment needed.
                     Task {
-                        do {
-                            try await authService.supabase.auth.session(from: url)
-                            authService.session = try? await authService.supabase.auth.session
-                        } catch {
-                            // URL may not be an auth callback — ignore silently
-                        }
+                        try? await authService.supabase.auth.session(from: url)
                     }
                 }
                 .onAppear {


### PR DESCRIPTION
authStateChanges listener already handles session updates; manually assigning authService.session after session(from:) caused a race condition and is now removed.