### PR TITLE
fix(ci): validate provisioning profile includes iCloud entitlements before build

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -240,6 +240,31 @@ jobs:
           echo "PROVISIONING_PROFILE_UUID=$UUID" >> $GITHUB_ENV
           echo "Provisioning profile UUID: $UUID"
 
+          # Validate that the profile includes required iCloud entitlements.
+          # If missing, the build will fail at archive time with a cryptic error.
+          # See: https://github.com/getyak/daypage/issues/120
+          DECODED=$(security cms -D -i $PP_PATH)
+          MISSING_ENTITLEMENTS=()
+          for KEY in \
+            "com.apple.developer.icloud-container-identifiers" \
+            "com.apple.developer.icloud-services" \
+            "com.apple.developer.ubiquity-container-identifiers"; do
+            if ! echo "$DECODED" | grep -q "$KEY"; then
+              MISSING_ENTITLEMENTS+=("$KEY")
+            fi
+          done
+          if [ ${#MISSING_ENTITLEMENTS[@]} -gt 0 ]; then
+            echo "::error::Provisioning profile is missing required iCloud entitlements:"
+            for E in "${MISSING_ENTITLEMENTS[@]}"; do
+              echo "::error::  - $E"
+            done
+            echo "::error::Fix: regenerate 'DayPage AppStore' profile in Apple Developer Portal"
+            echo "::error::after enabling iCloud capability for com.daypage.app, then update"
+            echo "::error::the BUILD_PROVISION_PROFILE_BASE64 GitHub Secret. See issue #120."
+            exit 1
+          fi
+          echo "Provisioning profile includes all required iCloud entitlements ✓"
+
       # ── 10. Write App Store Connect API Key ──────────────────────────────
       - name: Write App Store Connect API key
         env:


### PR DESCRIPTION
## Summary

- Adds an early-exit check in `testflight.yml` after the provisioning profile is installed
- Validates that all three iCloud entitlements are present before attempting `xcodebuild archive`
- Fails fast with a clear diagnostic pointing to the fix, instead of the cryptic fastlane error

## Root cause

The `ralph/icloud-sync` merge added iCloud capabilities to `DayPage.entitlements`, but the `BUILD_PROVISION_PROFILE_BASE64` GitHub Secret still holds the old profile without iCloud entitlements. The archive step fails with:

```
error: Provisioning profile "DayPage AppStore" doesn't include the
com.apple.developer.icloud-container-identifiers,
com.apple.developer.icloud-services
```

Tracked in #120.

## Required action (unblocks CI)

The provisioning profile itself must be regenerated — this PR only improves the error message. To fix the actual build:

1. Apple Developer Portal → App IDs → `com.daypage.app` → Enable **iCloud** → Add container `iCloud.com.daypage.app`
2. Regenerate **DayPage AppStore** provisioning profile
3. `base64 -i DayPage_AppStore.mobileprovision | pbcopy`
4. Update GitHub Secret `BUILD_PROVISION_PROFILE_BASE64`

## Test plan

- [ ] Merge this PR
- [ ] Update `BUILD_PROVISION_PROFILE_BASE64` in repo secrets with a new profile that includes iCloud
- [ ] Re-run `Deploy to TestFlight` workflow — should pass the new validation check and proceed to build