### PR TITLE
fix(entitlements): use literal iCloud container ID to match provisioning profile

### DIFF
--- a/DayPage/App/DayPage.entitlements
+++ b/DayPage/App/DayPage.entitlements
@@ -12,7 +12,7 @@
 	</array>
 	<key>com.apple.developer.ubiquity-container-identifiers</key>
 	<array>
-		<string>iCloud.$(TeamIdentifierPrefix)com.daypage.app</string>
+		<string>iCloud.com.daypage.app</string>
 	</array>
 	<key>com.apple.developer.icloud-services</key>
 	<array>


### PR DESCRIPTION
## Problem

CI TestFlight build still failing after provisioning profile update:

```
Provisioning profile "DayPage AppStore" doesn't match the entitlements file's value for the
com.apple.developer.ubiquity-container-identifiers entitlement.
```

## Root cause

`DayPage.entitlements` used `iCloud.$(TeamIdentifierPrefix)com.daypage.app` — a build variable that Xcode **does not expand** during Release archive. The provisioning profile stores the literal string `iCloud.com.daypage.app`. String comparison fails → archive rejected.

## Fix

Replace `iCloud.$(TeamIdentifierPrefix)com.daypage.app` with the literal `iCloud.com.daypage.app` to match the profile exactly.

This is the standard pattern for App Store distribution profiles — `$(TeamIdentifierPrefix)` is only valid in development/wildcard profiles.

Closes #120