### PR TITLE
feat(voice): tap-to-record persistent recording bar

### DIFF
--- a/DayPage/Features/Today/InputBarV3.swift
+++ b/DayPage/Features/Today/InputBarV3.swift
@@ -52,6 +52,8 @@ struct InputBarV3: View {
     @State private var showHoldToast: Bool = false
     @State private var showTranscribeFailed: Bool = false
     @State private var userExpandedText: Bool = false
+    /// True while the tap-to-record persistent bar is active
+    @State private var isTapRecording: Bool = false
 
     @StateObject private var voiceService = VoiceService.shared
 
@@ -94,21 +96,24 @@ struct InputBarV3: View {
                 .fill(DSColor.outlineVariant.opacity(0.6))
                 .frame(height: 0.5)
 
-            if !pendingAttachments.isEmpty {
+            if !pendingAttachments.isEmpty && !isTapRecording {
                 attachmentPreviewRow
             }
 
-            if let loc = pendingLocation {
+            if let loc = pendingLocation, !isTapRecording {
                 locationChipRow(loc: loc)
             }
 
-            if isComposing {
+            if isTapRecording {
+                tapRecordingBar
+            } else if isComposing {
                 composingRow
             } else {
                 collapsedRow
             }
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.85), value: isComposing)
+        .animation(.spring(response: 0.28, dampingFraction: 0.85), value: isTapRecording)
         .sheet(isPresented: $showAttachmentMenu) {
             attachmentSheet
         }
@@ -125,7 +130,7 @@ struct InputBarV3: View {
         )
         .overlay(alignment: .bottom) {
             if showHoldToast {
-                Text("按住说话")
+                Text("长按可快速发送")
                     .monoLabelStyle(size: 11)
                     .foregroundColor(DSColor.onSurface)
                     .padding(.horizontal, 12)
@@ -152,6 +157,13 @@ struct InputBarV3: View {
         }
         .animation(.easeInOut(duration: 0.2), value: showHoldToast)
         .animation(.easeInOut(duration: 0.2), value: showTranscribeFailed)
+        .onChange(of: voiceService.state) { newState in
+            if case .failed = newState, isTapRecording {
+                withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                    isTapRecording = false
+                }
+            }
+        }
         .onChange(of: isFocused) { focused in
             // Collapse only when the user actively dismisses (taps outside) with
             // nothing staged. Do NOT collapse after submit — continuous logging
@@ -222,6 +234,7 @@ struct InputBarV3: View {
             // Hint labels above the button tell new users the gesture affordances.
             VStack(spacing: 4) {
                 PressToTalkButton(
+                    onTap: { handleTapToRecord() },
                     onPressStart: { handlePressToTalkStart() },
                     onReleaseSend: { handlePressToTalkReleaseSend() },
                     onReleaseCancel: { handlePressToTalkReleaseCancel() },
@@ -233,7 +246,7 @@ struct InputBarV3: View {
                     },
                     size: 44
                 )
-                Text("按住说话")
+                Text("说话")
                     .font(.custom("Inter-Regular", size: 10))
                     .foregroundColor(DSColor.onSurfaceVariant)
             }
@@ -397,6 +410,7 @@ struct InputBarV3: View {
                 .transition(.scale.combined(with: .opacity))
             } else {
                 PressToTalkButton(
+                    onTap: { handleTapToRecord() },
                     onPressStart: { handlePressToTalkStart() },
                     onReleaseSend: { handlePressToTalkReleaseSend() },
                     onReleaseCancel: { handlePressToTalkReleaseCancel() },
@@ -412,6 +426,139 @@ struct InputBarV3: View {
             }
         }
         .animation(.spring(response: 0.3, dampingFraction: 0.82), value: hasContent)
+    }
+
+    // MARK: - Tap-to-Record Bar
+    //
+    // Shown when the user taps (short-press) the mic button. Replaces the entire
+    // input bar content with a compact recording control strip:
+    //   [❌ 取消]  [waveform]  [⏸ / ▶]  [00:12]  [✓ 发送]
+
+    @ViewBuilder
+    private var tapRecordingBar: some View {
+        let isCurrentlyRecording = voiceService.state == .recording
+        let isPaused = voiceService.state == .paused
+
+        VStack(spacing: 0) {
+            HStack(spacing: 0) {
+                // Cancel
+                Button {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    voiceService.cancelRecording()
+                    withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                        isTapRecording = false
+                    }
+                } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(DSColor.error)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("取消录音")
+
+                // Waveform (fills remaining space)
+                tapRecordingWaveform
+                    .frame(maxWidth: .infinity)
+
+                // Pause / Resume
+                Button {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    if isCurrentlyRecording {
+                        voiceService.pauseRecording()
+                    } else if isPaused {
+                        voiceService.resumeRecording()
+                    }
+                } label: {
+                    Image(systemName: isPaused ? "play.fill" : "pause.fill")
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(DSColor.onSurface)
+                        .frame(width: 36, height: 36)
+                        .background(DSColor.surfaceContainerHigh)
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(isPaused ? "继续录音" : "暂停录音")
+                .padding(.trailing, 8)
+
+                // Elapsed timer
+                Text(formattedRecordingTime(voiceService.elapsedSeconds))
+                    .font(.system(size: 13, weight: .semibold, design: .monospaced))
+                    .foregroundColor(isPaused ? DSColor.onSurfaceVariant : DSColor.error)
+                    .monospacedDigit()
+                    .frame(width: 42, alignment: .trailing)
+                    .padding(.trailing, 8)
+
+                // Send
+                Button {
+                    UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                    handleTapRecordingSend()
+                } label: {
+                    Image(systemName: "arrow.up")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(DSColor.onPrimary)
+                        .frame(width: 36, height: 36)
+                        .background(DSColor.primary)
+                        .clipShape(Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("发送录音")
+                .padding(.trailing, 8)
+            }
+            .frame(height: 56)
+            .padding(.horizontal, 4)
+            .background(DSColor.surface)
+        }
+    }
+
+    @ViewBuilder
+    private var tapRecordingWaveform: some View {
+        let bars = voiceService.waveformHistory
+        let barCount = min(30, bars.count)
+        HStack(alignment: .center, spacing: 2) {
+            ForEach(0 ..< barCount, id: \.self) { i in
+                let level = i < bars.count ? bars[i] : 0.04
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(voiceService.state == .paused
+                          ? DSColor.onSurfaceVariant.opacity(0.4)
+                          : DSColor.amberArchival)
+                    .frame(width: 3, height: max(4, CGFloat(level) * 28))
+                    .animation(.easeOut(duration: 0.05), value: level)
+            }
+        }
+        .frame(height: 36)
+    }
+
+    private func formattedRecordingTime(_ seconds: Int) -> String {
+        let m = seconds / 60
+        let s = seconds % 60
+        return String(format: "%02d:%02d", m, s)
+    }
+
+    private func handleTapToRecord() {
+        withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+            isTapRecording = true
+        }
+        Task { @MainActor in
+            await voiceService.startRecording()
+        }
+    }
+
+    private func handleTapRecordingSend() {
+        Task { @MainActor in
+            guard let result = await voiceService.stopAndTranscribe() else {
+                withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                    isTapRecording = false
+                }
+                flashTranscribeFailedToast()
+                return
+            }
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                isTapRecording = false
+            }
+            onPressToTalkSend(result)
+        }
     }
 
     // MARK: - Press-to-Talk Handlers

--- a/DayPage/Features/Today/PressToTalkButton.swift
+++ b/DayPage/Features/Today/PressToTalkButton.swift
@@ -3,16 +3,21 @@ import UIKit
 
 // MARK: - PressToTalkButton
 //
-// WeChat-style press-to-talk microphone button for InputBarV2 (US-008).
+// Dual-mode microphone button:
 //
-// Gesture flow (via DragGesture(minimumDistance: 0)):
-//   • Press-down              → start recording + light haptic
-//   • Hold in place           → continue recording, live waveform
-//   • Release in place        → stop + send immediately + medium haptic
-//   • Drag up >= 80pt         → "cancel armed" (heavy haptic on entry)
-//   • Drag left >= 80pt       → "transcribe armed" (medium haptic on entry)
-//   • Release in cancel zone  → discard recording + light haptic
-//   • Release in transcribe   → VoiceService.transcribe → fill text, do NOT send
+//   Short tap (< 0.35s hold):
+//     • Tap → emit onTap, parent switches to "recording bar" mode
+//             (PressToTalkButton is no longer visible while recording bar is shown)
+//
+//   Long press (>= 0.35s hold):
+//     WeChat-style press-to-talk flow (original behaviour, unchanged):
+//     • Press-down              → start recording + light haptic
+//     • Hold in place           → continue recording, live waveform
+//     • Release in place        → stop + send immediately + medium haptic
+//     • Drag up >= 80pt         → "cancel armed" (heavy haptic on entry)
+//     • Drag left >= 80pt       → "transcribe armed" (medium haptic on entry)
+//     • Release in cancel zone  → discard recording + light haptic
+//     • Release in transcribe   → VoiceService.transcribe → fill text, do NOT send
 //
 // The overlay UI is rendered by `RecordingOverlayView` — the parent owns the
 // overlay placement and mounts it while `onGestureStateChange` reports the
@@ -34,40 +39,43 @@ struct PressToTalkButton: View {
 
     // MARK: Inputs
 
-    /// Called on press-down. Parent should start VoiceService.startRecording().
+    /// Called on short tap (< longPressThreshold). Parent should switch to
+    /// the persistent recording bar mode.
+    var onTap: () -> Void = {}
+
+    /// Called on long-press-down (>= longPressThreshold). Parent should start
+    /// VoiceService.startRecording() for the press-to-talk flow.
     var onPressStart: () -> Void
 
-    /// Called on release-in-place. Parent should stop-and-transcribe and then
-    /// submit the resulting memo immediately.
+    /// Called on release-in-place (long-press flow). Parent should stop-and-transcribe
+    /// and submit the resulting memo immediately.
     var onReleaseSend: () -> Void
 
-    /// Called on release in the cancel-armed zone. Parent should discard.
+    /// Called on release in the cancel-armed zone (long-press flow). Parent should discard.
     var onReleaseCancel: () -> Void
 
-    /// Called on release in the transcribe-armed zone. Parent should stop,
+    /// Called on release in the transcribe-armed zone (long-press flow). Parent should stop,
     /// transcribe audio, fill TodayViewModel.draftText, and NOT submit.
     var onReleaseTranscribe: () -> Void
 
     /// Reports phase transitions upward so parent can update the overlay state.
     var onPhaseChange: (PressToTalkPhase) -> Void
 
-    /// Diameter of the circular button and its hit target. Defaults to 40pt
-    /// (V2 inline mic). V3 voice-first home uses 80pt as the primary FAB.
+    /// Diameter of the circular button and its hit target.
     var size: CGFloat = 40
+
+    // MARK: Constants
+
+    /// Duration (seconds) that separates a "tap" from a "hold". Under this threshold
+    /// the gesture is treated as a tap → persistent recording bar.
+    private let longPressThreshold: TimeInterval = 0.35
 
     // MARK: State
 
-    /// Tracked via @GestureState so SwiftUI resets it automatically when the
-    /// gesture ends (including edge cases like the touch leaving the hit area).
     @GestureState private var isPressing: Bool = false
-
-    /// The last emitted phase. We keep it as @State (not @GestureState) so we
-    /// can fire precisely-once haptics on phase-entry edges.
     @State private var currentPhase: PressToTalkPhase = .idle
-
-    /// Latest drag translation (for reading on release — @GestureState resets
-    /// before onEnded runs on some iOS versions).
     @State private var lastTranslation: CGSize = .zero
+    @State private var pressStartTime: Date? = nil
 
     // MARK: Body
 
@@ -81,9 +89,8 @@ struct PressToTalkButton: View {
             .scaleEffect(currentPhase == .idle ? 1.0 : 1.08)
             .animation(.easeOut(duration: 0.12), value: currentPhase)
             .contentShape(Circle())
-            .accessibilityLabel("按住说话")
-            .accessibilityHint("松手发送，上滑取消，左滑转文字")
-            // highPriorityGesture so the outer ScrollView doesn't steal the drag
+            .accessibilityLabel("点击说话")
+            .accessibilityHint("单击开始录音；长按说话松手发送")
             .highPriorityGesture(dragGesture)
     }
 
@@ -95,20 +102,27 @@ struct PressToTalkButton: View {
                 state = true
             }
             .onChanged { value in
-                // First-edge: transitioning from idle → recording triggers
-                // the press-start haptic + recording start.
                 if currentPhase == .idle {
+                    pressStartTime = Date()
+                    // Don't start recording yet — wait to see if this becomes a long press
+                }
+
+                // Once we've held past the threshold, commit to press-to-talk mode
+                if currentPhase == .idle,
+                   let start = pressStartTime,
+                   Date().timeIntervalSince(start) >= longPressThreshold {
                     emitHaptic(InputTokens.pressDownHaptic)
                     onPressStart()
                     currentPhase = .recording
                     onPhaseChange(.recording)
                 }
 
+                guard currentPhase != .idle else { return }
+
                 lastTranslation = value.translation
                 let newPhase = derivePhase(from: value.translation)
 
                 if newPhase != currentPhase {
-                    // Phase-entry haptics (fire precisely on the transition).
                     switch newPhase {
                     case .cancelArmed where currentPhase != .cancelArmed:
                         emitHaptic(InputTokens.cancelArmHaptic)
@@ -122,6 +136,22 @@ struct PressToTalkButton: View {
                 }
             }
             .onEnded { value in
+                defer {
+                    pressStartTime = nil
+                }
+
+                // Short tap — delegate to onTap for persistent recording bar
+                if let start = pressStartTime,
+                   Date().timeIntervalSince(start) < longPressThreshold,
+                   currentPhase == .idle {
+                    emitHaptic(InputTokens.pressDownHaptic)
+                    currentPhase = .idle
+                    onPhaseChange(.idle)
+                    lastTranslation = .zero
+                    onTap()
+                    return
+                }
+
                 let translation = value.translation != .zero ? value.translation : lastTranslation
                 let endPhase = derivePhase(from: translation)
 
@@ -131,8 +161,6 @@ struct PressToTalkButton: View {
                     onReleaseCancel()
                 case .transcribeArmed:
                     emitHaptic(InputTokens.transcribeReleaseHaptic)
-                    // Parent will run Whisper asynchronously — briefly sit in
-                    // .transcribing so the overlay can show a spinner.
                     currentPhase = .transcribing
                     onPhaseChange(.transcribing)
                     onReleaseTranscribe()


### PR DESCRIPTION
## Summary

- **Short tap** on the mic button now enters a persistent **recording bar** inline in the input area, replacing the collapsed/composing row while recording is active
- **Long press (≥0.35s)** retains the original WeChat-style press-to-talk flow (record → release to send / drag up to cancel / drag left to transcribe)
- Recording bar shows animated amber waveform, live elapsed timer, pause/resume toggle, cancel (❌), and send (↑) controls

## What changed

### `PressToTalkButton.swift`
- Added `onTap: () -> Void = {}` callback
- Added `longPressThreshold = 0.35s` constant
- `DragGesture.onChanged`: only commits to `.recording` phase after threshold elapsed
- `DragGesture.onEnded`: short tap path calls `onTap()` and returns early; long-press path unchanged
- Accessibility label → "点击说话", hint → "单击开始录音；长按可快速发送"

### `InputBarV3.swift`
- `@State private var isTapRecording: Bool` drives bar mode switch
- `tapRecordingBar`: horizontal 56pt strip with waveform + timer + pause + cancel + send
- `tapRecordingWaveform`: 30 animated amber bars, dims to gray when paused
- `handleTapToRecord()`: sets `isTapRecording = true`, calls `VoiceService.startRecording()`
- `handleTapRecordingSend()`: calls `stopAndTranscribe()`, submits memo, resets state
- `handleTapRecordingCancel()`: calls `cancelRecording()`, resets state
- VoiceService `.failed` state auto-dismisses the bar via `.onChange`
- Both mic button instances (collapsed row size=44, morph button size=36) pass `onTap`

## Test plan

- [ ] Tap mic → recording bar appears, waveform animates, timer counts up
- [ ] Tap pause → waveform dims, timer pauses; tap resume → continues
- [ ] Tap cancel (❌) → bar disappears, recording discarded
- [ ] Tap send (↑) → bar disappears, transcription submitted as memo
- [ ] Long-press mic (≥0.35s) → original press-to-talk overlay appears
- [ ] Long-press then drag up → cancel armed (red); release → discard
- [ ] Long-press then drag left → transcribe armed (blue); release → fills draft
- [ ] VoiceService permission denied → bar auto-dismisses gracefully