### PR TITLE
fix: 修复点击拍照按钮导致闪退的问题

### DIFF
--- a/DayPage/App/Info.plist
+++ b/DayPage/App/Info.plist
@@ -61,6 +61,8 @@
 	<array>
 		<string>com.daypage.daily-compilation</string>
 	</array>
+	<key>NSCameraUsageDescription</key>
+	<string>DayPage 需要访问相机，以便拍摄照片并附加到 memo 中。</string>
 	<key>NSMicrophoneUsageDescription</key>
 	<string>DayPage 需要访问麦克风，以便录制语音 memo 并自动转写为文字。</string>
 	<key>NSPhotoLibraryUsageDescription</key>

--- a/DayPage/Features/Today/CameraPickerView.swift
+++ b/DayPage/Features/Today/CameraPickerView.swift
@@ -16,8 +16,13 @@ struct CameraPickerView: UIViewControllerRepresentable {
 
     func makeUIViewController(context: Context) -> UIImagePickerController {
         let picker = UIImagePickerController()
-        picker.sourceType = .camera
-        picker.cameraCaptureMode = .photo
+        // Guard against devices/simulators without a physical camera
+        if UIImagePickerController.isSourceTypeAvailable(.camera) {
+            picker.sourceType = .camera
+            picker.cameraCaptureMode = .photo
+        } else {
+            picker.sourceType = .photoLibrary
+        }
         picker.allowsEditing = false
         picker.delegate = context.coordinator
         return picker


### PR DESCRIPTION
## 问题

点击拍照按钮时 App 立即闪退。

## 根本原因

`Info.plist` 中缺少 `NSCameraUsageDescription` 权限声明。iOS 在 `UIImagePickerController` 尝试访问相机硬件时会检查该 key，若不存在则直接 terminate 进程，错误信息为：

> This app has crashed because it attempted to access privacy-sensitive data without a usage description.

## 修改内容

### 1. `DayPage/App/Info.plist`
- 新增 `NSCameraUsageDescription` key，与已有的麦克风、相册权限声明并列

### 2. `DayPage/Features/Today/CameraPickerView.swift`
- 在创建 `UIImagePickerController` 时先调用 `isSourceTypeAvailable(.camera)` 检查相机是否可用
- 若不可用（模拟器或无摄像头设备）则回退到 `.photoLibrary`，避免二次崩溃

## 测试方式

1. 真机安装后首次点击拍照按钮 → 系统弹出相机权限请求弹窗（而非闪退）
2. 授权后可正常进入相机界面

https://claude.ai/code/session_01JQucqVwg8vP9WaP6M1YkpG

---
_Generated by [Claude Code](https://claude.ai/code/session_01JQucqVwg8vP9WaP6M1YkpG)_