### PR TITLE
Center voice input as primary CTA in collapsed InputBar

### DIFF
--- a/DayPage/Features/Today/InputBarV3.swift
+++ b/DayPage/Features/Today/InputBarV3.swift
@@ -5,12 +5,12 @@ import UIKit
 
 // MARK: - InputBarV3 (Voice-First)
 //
-// Voice-first home composer for Issue #76. Two states:
+// Voice-first home composer. Two states:
 //
-//   • collapsed — empty default. A centered 80pt primary mic (press-and-hold
-//     to record, slide-up to cancel, slide-left to transcribe-into-draft,
-//     release-in-place to send) with a small muted text affordance under
-//     it. Nothing else competes for attention.
+//   • collapsed — 64pt black mic centered as the primary CTA. Long-press to
+//     talk (slide-up to cancel, slide-left to transcribe-into-draft, release
+//     to send) or short-tap for the persistent recording bar. Text pill and
+//     camera sit below as a secondary action row.
 //
 //   • composing — user tapped the text affordance or has draft content or
 //     pending attachments. Reveals a capsule TextEditor with `+` on the
@@ -217,22 +217,17 @@ struct InputBarV3: View {
         }
     }
 
-    // MARK: - Collapsed Row (text + voice side-by-side)
+    // MARK: - Collapsed Row (centered primary mic + secondary action bar)
     //
-    // Previously a 80pt centered mic button with a tiny "写点什么" affordance that
-    // failed WCAG AA contrast (2.4:1). Redesigned to a horizontal bar where text
-    // and voice have equal visual weight — new users can find either entry instantly.
-    //
-    // Layout: [mic 44pt] [tappable text pill — fills remaining width]
-    // The text pill is visually identical to the composingRow capsule so the
-    // transition reads as "the same field expanded" rather than a mode swap.
+    // Voice is the primary action — 64pt black circle, centered, visually dominant.
+    // Text and camera sit below as a compact secondary bar so they remain reachable
+    // without competing for attention with the mic.
 
     @ViewBuilder
     private var collapsedRow: some View {
-        HStack(alignment: .center, spacing: 10) {
-            // Voice button — 44pt so it satisfies HIG minimum hit target.
-            // Hint labels above the button tell new users the gesture affordances.
-            VStack(spacing: 4) {
+        VStack(spacing: 12) {
+            // Primary: centered voice button
+            VStack(spacing: 8) {
                 PressToTalkButton(
                     onTap: { handleTapToRecord() },
                     onPressStart: { handlePressToTalkStart() },
@@ -244,40 +239,38 @@ struct InputBarV3: View {
                             pressToTalkPhase = phase
                         }
                     },
-                    size: 44
+                    size: 64,
+                    idleBackgroundColor: DSColor.primary,
+                    idleIconColor: DSColor.onPrimary
                 )
-                Text("说话")
-                    .font(.custom("Inter-Regular", size: 10))
+                Text("按住说话")
+                    .font(.custom("Inter-Medium", size: 12))
                     .foregroundColor(DSColor.onSurfaceVariant)
             }
+            .frame(maxWidth: .infinity)
 
-            // Text entry pill — always visible, tapping focuses the real TextEditor
-            // in composingRow. Using a Button with a ZStack so the entire area is
-            // tappable and the placeholder reads at full onSurfaceVariant opacity
-            // (contrast ≥ 4.5:1 against surface #f9f9f9).
-            Button {
-                UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                userExpandedText = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
-                    isFocused = true
+            // Secondary: text + camera
+            HStack(alignment: .center, spacing: 10) {
+                Button {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    userExpandedText = true
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
+                        isFocused = true
+                    }
+                } label: {
+                    ZStack(alignment: .leading) {
+                        Text("记点什么…")
+                            .font(.custom("Inter-Regular", size: 15))
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .padding(.horizontal, 14)
+                    }
+                    .frame(maxWidth: .infinity, minHeight: 40)
+                    .background(DSColor.surfaceContainerLow)
+                    .clipShape(Capsule())
                 }
-            } label: {
-                ZStack(alignment: .leading) {
-                    Text("记点什么…")
-                        .font(.custom("Inter-Regular", size: 15))
-                        .foregroundColor(DSColor.onSurfaceVariant)
-                        .padding(.horizontal, 14)
-                }
-                .frame(maxWidth: .infinity, minHeight: 44)
-                .background(DSColor.surfaceContainerLow)
-                .clipShape(Capsule())
-            }
-            .buttonStyle(.plain)
-            .accessibilityLabel("打开文字输入，记点什么")
+                .buttonStyle(.plain)
+                .accessibilityLabel("打开文字输入，记点什么")
 
-            // Camera shortcut — 1-tap access to capture a photo without needing
-            // to enter composing mode first. Nomads' highest-frequency attachment action.
-            VStack(spacing: 4) {
                 Button {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     onCapturePhoto()
@@ -285,19 +278,16 @@ struct InputBarV3: View {
                     Image(systemName: "camera")
                         .font(.system(size: 18, weight: .regular))
                         .foregroundColor(DSColor.onSurfaceVariant)
-                        .frame(width: 44, height: 44)
+                        .frame(width: 40, height: 40)
                         .background(DSColor.surfaceContainerLow)
                         .clipShape(Circle())
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("拍照")
-                Text("拍照")
-                    .font(.custom("Inter-Regular", size: 10))
-                    .foregroundColor(DSColor.onSurfaceVariant)
             }
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 10)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 16)
         .background(DSColor.surface)
     }
 

--- a/DayPage/Features/Today/PressToTalkButton.swift
+++ b/DayPage/Features/Today/PressToTalkButton.swift
@@ -64,6 +64,13 @@ struct PressToTalkButton: View {
     /// Diameter of the circular button and its hit target.
     var size: CGFloat = 40
 
+    /// Override idle-state background. Recording/cancel/transcribe phases
+    /// keep their own colors regardless of this value.
+    var idleBackgroundColor: Color? = nil
+
+    /// Override idle-state icon color.
+    var idleIconColor: Color? = nil
+
     // MARK: Constants
 
     /// Duration (seconds) that separates a "tap" from a "hold". Under this threshold
@@ -210,7 +217,7 @@ struct PressToTalkButton: View {
         case .cancelArmed: return DSColor.error
         case .transcribeArmed: return Color(red: 0.12, green: 0.30, blue: 0.65)
         case .recording: return DSColor.onPrimary
-        default: return DSColor.onSurface
+        default: return idleIconColor ?? DSColor.onSurface
         }
     }
 
@@ -219,7 +226,7 @@ struct PressToTalkButton: View {
         case .cancelArmed: return DSColor.errorContainer
         case .transcribeArmed: return Color(red: 0.85, green: 0.92, blue: 1.0)
         case .recording, .transcribing: return DSColor.primary
-        default: return DSColor.surfaceContainerHigh
+        default: return idleBackgroundColor ?? DSColor.surfaceContainerHigh
         }
     }
 }


### PR DESCRIPTION
## Summary

- **Redesign collapsed InputBarV3 layout**: from a horizontal 3-column bar (mic | text pill | camera) to a vertical stack with the 64pt black mic button centered at the top as the dominant CTA, and text pill + camera below as a compact secondary row
- **Extend PressToTalkButton**: add optional `idleBackgroundColor` / `idleIconColor` params so call sites can override the idle-state appearance without affecting recording/cancel/transcribe phase colors
- **Visual change**: idle mic goes from 44pt gray (`surfaceContainerHigh`) to 64pt black (`primary`), centering it with `frame(maxWidth: .infinity)`

## Design rationale

Voice is the product's primary input modality — the previous layout gave equal visual weight to mic, text, and camera. The new layout makes the hierarchy unambiguous: large black circle = "speak here", smaller secondary row = "or type / photo".

The label changes from "说话" (10pt Regular) to "按住说话" (12pt Medium) to better communicate the long-press gesture on first encounter.

## Test plan

- [ ] Build and run on iPhone 17 Simulator
- [ ] Collapsed state: confirm 64pt black mic button is horizontally centered, text pill + camera appear below
- [ ] Short tap mic → persistent recording bar appears as expected
- [ ] Long press mic → recording overlay appears, swipe-up cancels, swipe-left transcribes, release sends
- [ ] Tap text pill → bar morphs to composing state (capsule TextEditor + send button)
- [ ] Tap camera → photo capture launches
- [ ] Composing → collapse (dismiss keyboard with empty text) → returns to centered mic layout
- [ ] Recording/cancel/transcribe phase button colors are unchanged (not affected by idle override)

https://claude.ai/code/session_01GDCRoVBiFVaqvyu4dSM4fN

---
_Generated by [Claude Code](https://claude.ai/code/session_01GDCRoVBiFVaqvyu4dSM4fN)_