### PR TITLE
chore: migrate AI compilation provider from DashScope to OpenAI Chat

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,11 +6,11 @@
 # Apple Developer Team ID (from developer.apple.com → Membership)
 DEVELOPMENT_TEAM=XXXXXXXXXX
 
-# Aliyun DashScope (OpenAI-compatible chat completions)
-# Used by the daily compilation engine.
-DASHSCOPE_API_KEY=sk-replace-me
-DASHSCOPE_BASE_URL=https://coding.dashscope.aliyuncs.com/v1
-DASHSCOPE_MODEL=qwen3.5-plus
+# OpenAI-compatible chat completions (used by the daily compilation engine)
+# Supports any OpenAI-compatible provider (OpenAI, chatanywhere, etc.)
+OPENAI_CHAT_API_KEY=sk-replace-me
+OPENAI_CHAT_BASE_URL=https://api.openai.com/v1
+OPENAI_CHAT_MODEL=gpt-5.4-mini
 
 # OpenAI Whisper (speech-to-text for voice memos)
 OPENAI_WHISPER_API_KEY=sk-replace-me

--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -106,7 +106,7 @@ struct DayPageApp: App {
 
     private func checkApiKeys() {
         var missing: [String] = []
-        if Secrets.dashScopeApiKey.isEmpty { missing.append("DashScope (AI 编译)") }
+        if Secrets.openAIChatApiKey.isEmpty { missing.append("OpenAI Chat (AI 编译)") }
         if Secrets.openAIWhisperApiKey.isEmpty { missing.append("OpenAI Whisper (语音转写)") }
         if Secrets.openWeatherApiKey.isEmpty { missing.append("OpenWeather (天气)") }
         guard !missing.isEmpty else { return }

--- a/DayPage/Features/Onboarding/OnboardingView.swift
+++ b/DayPage/Features/Onboarding/OnboardingView.swift
@@ -256,7 +256,7 @@ private struct PermissionsPage: View {
 private struct ApiKeysPage: View {
     let onComplete: () -> Void
 
-    @State private var dashScopeKey: String = ""
+    @State private var openAIChatKey: String = ""
     @State private var openAIKey: String = ""
     @State private var openWeatherKey: String = ""
 
@@ -276,9 +276,9 @@ private struct ApiKeysPage: View {
 
                 VStack(spacing: 12) {
                     apiKeyField(
-                        label: "DashScope (AI 编译)",
+                        label: "OpenAI Chat (AI 编译)",
                         placeholder: "sk-...",
-                        text: $dashScopeKey
+                        text: $openAIChatKey
                     )
                     apiKeyField(
                         label: "OpenAI Whisper (语音转写)",
@@ -338,8 +338,8 @@ private struct ApiKeysPage: View {
     private func saveAndComplete() {
         // API keys are in a generated file; we write to UserDefaults as a runtime override
         // (GeneratedSecrets.swift reads from environment; store in UserDefaults for runtime use)
-        if !dashScopeKey.isEmpty {
-            UserDefaults.standard.set(dashScopeKey, forKey: "runtimeDashScopeKey")
+        if !openAIChatKey.isEmpty {
+            UserDefaults.standard.set(openAIChatKey, forKey: "runtimeOpenAIChatKey")
         }
         if !openAIKey.isEmpty {
             UserDefaults.standard.set(openAIKey, forKey: "runtimeOpenAIKey")

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -12,12 +12,12 @@ struct SettingsView: View {
     @StateObject private var bannerCenter = BannerCenter.shared
 
     // API test state per key
-    @State private var dashScopeTesting = false
+    @State private var openAIChatTesting = false
     @State private var whisperTesting = false
     @State private var weatherTesting = false
 
     // Inline test result per key (cleared on next test)
-    @State private var dashScopeResult: APITestResult?
+    @State private var openAIChatResult: APITestResult?
     @State private var whisperResult: APITestResult?
     @State private var weatherResult: APITestResult?
 
@@ -71,11 +71,11 @@ struct SettingsView: View {
     private var apiKeysSection: some View {
         Section("API Keys") {
             apiKeyRow(
-                name: "DashScope",
-                key: Secrets.dashScopeApiKey,
-                isTesting: dashScopeTesting,
-                result: dashScopeResult,
-                onTest: { Task { await testDashScope() } }
+                name: "OpenAI Chat",
+                key: Secrets.openAIChatApiKey,
+                isTesting: openAIChatTesting,
+                result: openAIChatResult,
+                onTest: { Task { await testOpenAIChat() } }
             )
             apiKeyRow(
                 name: "OpenAI Whisper",
@@ -505,22 +505,22 @@ struct SettingsView: View {
 
     // MARK: - API Test Implementations
 
-    private func testDashScope() async {
-        dashScopeTesting = true
-        dashScopeResult = nil
-        defer { dashScopeTesting = false }
+    private func testOpenAIChat() async {
+        openAIChatTesting = true
+        openAIChatResult = nil
+        defer { openAIChatTesting = false }
 
-        let key = Secrets.dashScopeApiKey
+        let key = Secrets.openAIChatApiKey
         guard !key.isEmpty else { return }
 
-        // Mirror CompilationService.callDashScope URL resolution so test hits the same endpoint
-        let baseURL = Secrets.dashScopeBaseURL.isEmpty
-            ? "https://dashscope.aliyuncs.com/compatible-mode/v1"
-            : Secrets.dashScopeBaseURL
-        let model = Secrets.dashScopeModel.isEmpty ? "qwen3.5-plus" : Secrets.dashScopeModel
+        // Mirror CompilationService.callChatAPI URL resolution so test hits the same endpoint
+        let baseURL = Secrets.openAIChatBaseURL.isEmpty
+            ? "https://api.openai.com/v1"
+            : Secrets.openAIChatBaseURL
+        let model = Secrets.openAIChatModel.isEmpty ? "gpt-5.4-mini" : Secrets.openAIChatModel
 
         guard let url = URL(string: "\(baseURL)/chat/completions") else {
-            dashScopeResult = .failure("URL 无效：\(baseURL)")
+            openAIChatResult = .failure("URL 无效：\(baseURL)")
             return
         }
 
@@ -539,12 +539,12 @@ struct SettingsView: View {
             let (_, resp) = try await URLSession.shared.data(for: req)
             let code = (resp as? HTTPURLResponse)?.statusCode ?? 0
             if code == 200 {
-                dashScopeResult = .success("连接成功 · 模型 \(model)")
+                openAIChatResult = .success("连接成功 · 模型 \(model)")
             } else {
-                dashScopeResult = .failure("HTTP \(code) · \(hintForDashScope(status: code))")
+                openAIChatResult = .failure("HTTP \(code) · \(hintForChatAPI(status: code))")
             }
         } catch {
-            dashScopeResult = .failure(hintForNetwork(error: error))
+            openAIChatResult = .failure(hintForNetwork(error: error))
         }
     }
 
@@ -600,7 +600,7 @@ struct SettingsView: View {
 
     // MARK: - Error hint helpers
 
-    private func hintForDashScope(status: Int) -> String {
+    private func hintForChatAPI(status: Int) -> String {
         switch status {
         case 401, 403: return "API key 无效或权限不足"
         case 404: return "URL 不存在，检查 baseURL"

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -106,7 +106,7 @@ final class TodayViewModel: ObservableObject {
 
     /// Whether any API key is missing (triggers banner in TodayView).
     var hasApiKeysMissing: Bool {
-        Secrets.dashScopeApiKey.isEmpty
+        Secrets.openAIChatApiKey.isEmpty
             || Secrets.openAIWhisperApiKey.isEmpty
             || Secrets.openWeatherApiKey.isEmpty
     }
@@ -548,7 +548,7 @@ final class TodayViewModel: ObservableObject {
                 UINotificationFeedbackGenerator().notificationOccurred(.error)
                 BannerCenter.shared.show(AppBannerModel(
                     kind: .error,
-                    title: "DashScope API Key 未配置",
+                    title: "OpenAI Chat API Key 未配置",
                     primaryAction: BannerAction(label: "前往设置") { }
                 ))
             } catch CompilationError.apiError(let code, _) where code == 401 {

--- a/DayPage/Services/CompilationService.swift
+++ b/DayPage/Services/CompilationService.swift
@@ -4,11 +4,11 @@ import Sentry
 
 // MARK: - CompilationService
 
-/// Compiles today's raw memos into a structured Daily Page via DashScope LLM API.
+/// Compiles today's raw memos into a structured Daily Page via OpenAI-compatible chat API.
 ///
 /// Responsibilities:
 ///   1. Read vault/raw/YYYY-MM-DD.md (all memos) + vault/wiki/hot.md (context)
-///   2. Call DashScope chat completions (OpenAI-compatible)
+///   2. Call OpenAI-compatible chat completions
 ///   3. Write compiled output to vault/wiki/daily/YYYY-MM-DD.md
 ///      (backs up existing file before overwrite)
 ///   4. Append a row to vault/wiki/log.md
@@ -60,13 +60,13 @@ final class CompilationService {
             memoCount: memos.count
         )
 
-        // 4. Call DashScope API with retry
-        let apiKey = Secrets.dashScopeApiKey
+        // 4. Call chat API with retry
+        let apiKey = Secrets.openAIChatApiKey
         guard !apiKey.isEmpty else {
             throw CompilationError.missingApiKey
         }
 
-        let compiledText = try await callDashScopeWithRetry(
+        let compiledText = try await callAPIWithRetry(
             prompt: prompt,
             apiKey: apiKey,
             onRetry: onRetry
@@ -304,9 +304,9 @@ final class CompilationService {
         """
     }
 
-    // MARK: - DashScope API (with retry)
+    // MARK: - Chat API (with retry)
 
-    private func callDashScopeWithRetry(
+    private func callAPIWithRetry(
         prompt: String,
         apiKey: String,
         onRetry: ((Int, Int) -> Void)?
@@ -322,7 +322,7 @@ final class CompilationService {
                 try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
             }
             do {
-                return try await callDashScope(prompt: prompt, apiKey: apiKey)
+                return try await callChatAPI(prompt: prompt, apiKey: apiKey)
             } catch let error as CompilationError {
                 switch error {
                 case .apiError(let code, _) where code == 401 || code == 403 || code == 400:
@@ -348,11 +348,11 @@ final class CompilationService {
         throw lastError
     }
 
-    private func callDashScope(prompt: String, apiKey: String) async throws -> String {
-        let baseURL = Secrets.dashScopeBaseURL.isEmpty
-            ? "https://dashscope.aliyuncs.com/compatible-mode/v1"
-            : Secrets.dashScopeBaseURL
-        let model = Secrets.dashScopeModel.isEmpty ? "qwen3.5-plus" : Secrets.dashScopeModel
+    private func callChatAPI(prompt: String, apiKey: String) async throws -> String {
+        let baseURL = Secrets.openAIChatBaseURL.isEmpty
+            ? "https://api.openai.com/v1"
+            : Secrets.openAIChatBaseURL
+        let model = Secrets.openAIChatModel.isEmpty ? "gpt-5.4-mini" : Secrets.openAIChatModel
 
         guard let url = URL(string: "\(baseURL)/chat/completions") else {
             throw CompilationError.invalidURL
@@ -377,14 +377,14 @@ final class CompilationService {
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
 
         let span = Secrets.sentryDSN.isEmpty ? nil
-            : SentrySDK.startTransaction(name: "compilation.dashscope", operation: "http.client")
+            : SentrySDK.startTransaction(name: "compilation.chat", operation: "http.client")
         defer { span?.finish() }
 
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let http = response as? HTTPURLResponse else {
             #if DEBUG
-            print("[DashScope] URL=\(url.absoluteString) status=- body=No HTTP response")
+            print("[ChatAPI] URL=\(url.absoluteString) status=- body=No HTTP response")
             #endif
             throw CompilationError.networkError("No HTTP response")
         }
@@ -393,7 +393,7 @@ final class CompilationService {
             let bodyStr = String(data: data, encoding: .utf8) ?? "(empty)"
             #if DEBUG
             let snippet = String(bodyStr.prefix(500))
-            print("[DashScope] URL=\(url.absoluteString) status=\(http.statusCode) body=\(snippet)")
+            print("[ChatAPI] URL=\(url.absoluteString) status=\(http.statusCode) body=\(snippet)")
             #endif
             throw CompilationError.apiError(statusCode: http.statusCode, body: bodyStr)
         }
@@ -569,9 +569,9 @@ enum CompilationError: LocalizedError {
     var errorDescription: String? {
         switch self {
         case .missingApiKey:
-            return "DashScope API Key 未配置，请检查 .env 文件"
+            return "OpenAI Chat API Key 未配置，请检查 .env 文件"
         case .invalidURL:
-            return "DashScope API URL 无效"
+            return "Chat API URL 无效"
         case .networkError(let msg):
             return "网络错误：\(msg)"
         case .apiError(let code, let body):

--- a/scripts/generate_secrets.sh
+++ b/scripts/generate_secrets.sh
@@ -39,9 +39,9 @@ read_env_value() {
 }
 
 # ── Read values ──────────────────────────────────────────────────────────────
-DASHSCOPE_API_KEY=$(read_env_value "DASHSCOPE_API_KEY")
-DASHSCOPE_BASE_URL=$(read_env_value "DASHSCOPE_BASE_URL")
-DASHSCOPE_MODEL=$(read_env_value "DASHSCOPE_MODEL")
+OPENAI_CHAT_API_KEY=$(read_env_value "OPENAI_CHAT_API_KEY")
+OPENAI_CHAT_BASE_URL=$(read_env_value "OPENAI_CHAT_BASE_URL")
+OPENAI_CHAT_MODEL=$(read_env_value "OPENAI_CHAT_MODEL")
 OPENAI_WHISPER_API_KEY=$(read_env_value "OPENAI_WHISPER_API_KEY")
 OPENWEATHER_API_KEY=$(read_env_value "OPENWEATHER_API_KEY")
 SUPABASE_URL=$(read_env_value "SUPABASE_URL")
@@ -57,9 +57,9 @@ cat > "${OUTPUT_FILE}" << SWIFT
 // Regenerated on every build from the project-root .env file.
 
 enum Secrets {
-    static let dashScopeApiKey: String = "${DASHSCOPE_API_KEY}"
-    static let dashScopeBaseURL: String = "${DASHSCOPE_BASE_URL}"
-    static let dashScopeModel: String = "${DASHSCOPE_MODEL}"
+    static let openAIChatApiKey: String = "${OPENAI_CHAT_API_KEY}"
+    static let openAIChatBaseURL: String = "${OPENAI_CHAT_BASE_URL}"
+    static let openAIChatModel: String = "${OPENAI_CHAT_MODEL}"
     static let openAIWhisperApiKey: String = "${OPENAI_WHISPER_API_KEY}"
     static let openWeatherApiKey: String = "${OPENWEATHER_API_KEY}"
     static let supabaseURL: String = "${SUPABASE_URL}"


### PR DESCRIPTION
## Summary
- 将编译引擎的 AI 提供商从阿里云 DashScope（qwen3.5-plus）切换为 OpenAI Chat 兼容接口（gpt-5.4-mini via chatanywhere）
- 重命名所有 `DASHSCOPE_*` 环境变量为 `OPENAI_CHAT_*`，对应 `Secrets.dashScope*` → `Secrets.openAIChat*`
- 更新 `.env.example` 模板、`generate_secrets.sh` 脚本、及所有引用旧常量的 Swift 文件（CompilationService、SettingsView、TodayViewModel、OnboardingView、DayPageApp）

## Test plan
- [ ] 本地 `xcodebuild -scheme DayPage build` 通过（BUILD SUCCEEDED，无编译错误）
- [ ] `.env` 中 `OPENAI_CHAT_*` 正确注入 `GeneratedSecrets.swift`，运行 `scripts/generate_secrets.sh` 验证
- [ ] Settings 页面 API 连接测试：点击"OpenAI Chat"测试按钮，确认返回"连接成功"
- [ ] 手动触发一次编译，确认 Daily Page 正常生成