### PR TITLE
fix: read onboarding API keys from UserDefaults at runtime

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		A10000002 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000002 /* RootView.swift */; };
 		A10000003 /* VaultInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000003 /* VaultInitializer.swift */; };
 		A10000004 /* GeneratedSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000004 /* GeneratedSecrets.swift */; };
+		A100000B4 /* SecretsRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000B4 /* SecretsRuntime.swift */; };
 		A10000005 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000005 /* Colors.swift */; };
 		A10000006 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000006 /* Typography.swift */; };
 		A10000007 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000007 /* Components.swift */; };
@@ -117,6 +118,7 @@
 		A20000002 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		A20000003 /* VaultInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultInitializer.swift; sourceTree = "<group>"; };
 		A20000004 /* GeneratedSecrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedSecrets.swift; sourceTree = "<group>"; };
+		A200000B4 /* SecretsRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsRuntime.swift; sourceTree = "<group>"; };
 		A20000005 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		A20000006 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		A20000007 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
@@ -346,6 +348,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000004 /* GeneratedSecrets.swift */,
+				A200000B4 /* SecretsRuntime.swift */,
 				068FB068A000B6E61B1D8032 /* AppSettings.swift */,
 			);
 			path = Config;
@@ -629,6 +632,7 @@
 				A10000002 /* RootView.swift in Sources */,
 				A10000003 /* VaultInitializer.swift in Sources */,
 				A10000004 /* GeneratedSecrets.swift in Sources */,
+				A100000B4 /* SecretsRuntime.swift in Sources */,
 				A10000005 /* Colors.swift in Sources */,
 				A10000006 /* Typography.swift in Sources */,
 				A10000007 /* Components.swift in Sources */,

--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -106,9 +106,9 @@ struct DayPageApp: App {
 
     private func checkApiKeys() {
         var missing: [String] = []
-        if Secrets.dashScopeApiKey.isEmpty { missing.append("DashScope (AI 编译)") }
-        if Secrets.openAIWhisperApiKey.isEmpty { missing.append("OpenAI Whisper (语音转写)") }
-        if Secrets.openWeatherApiKey.isEmpty { missing.append("OpenWeather (天气)") }
+        if Secrets.resolvedDashScopeApiKey.isEmpty { missing.append("DashScope (AI 编译)") }
+        if Secrets.resolvedOpenAIWhisperApiKey.isEmpty { missing.append("OpenAI Whisper (语音转写)") }
+        if Secrets.resolvedOpenWeatherApiKey.isEmpty { missing.append("OpenWeather (天气)") }
         guard !missing.isEmpty else { return }
         let subtitle = missing.joined(separator: "、")
         BannerCenter.shared.show(AppBannerModel(

--- a/DayPage/Config/SecretsRuntime.swift
+++ b/DayPage/Config/SecretsRuntime.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+// MARK: - Runtime Key Resolution
+// GeneratedSecrets.swift is gitignored (auto-generated from .env).
+// This file is committed and provides computed vars that prefer
+// UserDefaults keys saved during Onboarding over the compiled-in values.
+extension Secrets {
+    static var resolvedDashScopeApiKey: String {
+        UserDefaults.standard.string(forKey: "runtimeDashScopeKey").flatMap { $0.isEmpty ? nil : $0 } ?? dashScopeApiKey
+    }
+    static var resolvedOpenAIWhisperApiKey: String {
+        UserDefaults.standard.string(forKey: "runtimeOpenAIKey").flatMap { $0.isEmpty ? nil : $0 } ?? openAIWhisperApiKey
+    }
+    static var resolvedOpenWeatherApiKey: String {
+        UserDefaults.standard.string(forKey: "runtimeOpenWeatherKey").flatMap { $0.isEmpty ? nil : $0 } ?? openWeatherApiKey
+    }
+}

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -72,21 +72,21 @@ struct SettingsView: View {
         Section("API Keys") {
             apiKeyRow(
                 name: "DashScope",
-                key: Secrets.dashScopeApiKey,
+                key: Secrets.resolvedDashScopeApiKey,
                 isTesting: dashScopeTesting,
                 result: dashScopeResult,
                 onTest: { Task { await testDashScope() } }
             )
             apiKeyRow(
                 name: "OpenAI Whisper",
-                key: Secrets.openAIWhisperApiKey,
+                key: Secrets.resolvedOpenAIWhisperApiKey,
                 isTesting: whisperTesting,
                 result: whisperResult,
                 onTest: { Task { await testWhisper() } }
             )
             apiKeyRow(
                 name: "OpenWeatherMap",
-                key: Secrets.openWeatherApiKey,
+                key: Secrets.resolvedOpenWeatherApiKey,
                 isTesting: weatherTesting,
                 result: weatherResult,
                 onTest: { Task { await testWeather() } }
@@ -511,7 +511,7 @@ struct SettingsView: View {
         dashScopeResult = nil
         defer { dashScopeTesting = false }
 
-        let key = Secrets.dashScopeApiKey
+        let key = Secrets.resolvedDashScopeApiKey
         guard !key.isEmpty else { return }
 
         // Mirror CompilationService.callDashScope URL resolution so test hits the same endpoint
@@ -554,7 +554,7 @@ struct SettingsView: View {
         whisperResult = nil
         defer { whisperTesting = false }
 
-        let key = Secrets.openAIWhisperApiKey
+        let key = Secrets.resolvedOpenAIWhisperApiKey
         guard !key.isEmpty else { return }
 
         var req = URLRequest(url: URL(string: "https://api.openai.com/v1/models")!)
@@ -579,7 +579,7 @@ struct SettingsView: View {
         weatherResult = nil
         defer { weatherTesting = false }
 
-        let key = Secrets.openWeatherApiKey
+        let key = Secrets.resolvedOpenWeatherApiKey
         guard !key.isEmpty else { return }
         let urlStr = "https://api.openweathermap.org/data/2.5/weather?lat=0&lon=0&appid=\(key)"
         guard let url = URL(string: urlStr) else { return }

--- a/DayPage/Services/CompilationService.swift
+++ b/DayPage/Services/CompilationService.swift
@@ -61,7 +61,7 @@ final class CompilationService {
         )
 
         // 4. Call DashScope API with retry
-        let apiKey = Secrets.dashScopeApiKey
+        let apiKey = Secrets.resolvedDashScopeApiKey
         guard !apiKey.isEmpty else {
             throw CompilationError.missingApiKey
         }

--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -236,7 +236,7 @@ final class VoiceService: NSObject, ObservableObject {
     // MARK: - Whisper Transcription
 
     func transcribeAudio(at url: URL) async -> String? {
-        let apiKey = Secrets.openAIWhisperApiKey
+        let apiKey = Secrets.resolvedOpenAIWhisperApiKey
         guard !apiKey.isEmpty else { return nil }
 
         let audioData: Data

--- a/DayPage/Services/WeatherService.swift
+++ b/DayPage/Services/WeatherService.swift
@@ -65,7 +65,7 @@ final class WeatherService {
         }
 
         // Fetch from OpenWeatherMap
-        let apiKey = Secrets.openWeatherApiKey
+        let apiKey = Secrets.resolvedOpenWeatherApiKey
         guard !apiKey.isEmpty else { return nil }
 
         let urlString = "https://api.openweathermap.org/data/2.5/weather?lat=\(lat)&lon=\(lng)&units=metric&lang=zh_cn&appid=\(apiKey)"


### PR DESCRIPTION
## Summary
- `Secrets.*ApiKey` 是编译期常量；Onboarding 将用户填入的 key 存入 `UserDefaults`，但三个 service 从未读取，导致每次启动都报「DashScope 未配置」banner
- 在 `GeneratedSecrets.swift` 新增 `Secrets.resolved*` extension，优先读 `UserDefaults`，fallback 到编译期常量
- `CompilationService`、`VoiceService`、`WeatherService` 及启动时的 `checkApiKeys()` 统一改用 `resolved*` 版本

## Test plan
- [ ] 全新安装（或清除 UserDefaults），完成 Onboarding 填入 DashScope key，确认不再出现「未配置」banner
- [ ] 填入 key 后触发 AI 编译，确认 CompilationService 能正常调用 DashScope API
- [ ] `.env` 中有 `DASH_SCOPE_API_KEY` 的构建环境：编译期常量非空，`resolved*` 应返回编译期值（UserDefaults 为空时）