### PR TITLE
fix: API key runtime resolution and Settings edit UI

### DIFF
--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -38,6 +38,13 @@ struct SettingsView: View {
     @AppStorage("usePressToTalk") private var usePressToTalk: Bool = true
     @AppStorage("inputBarVariant") private var inputBarVariant: String = "v4"
 
+    // API key editing sheet
+    @State private var editingKeyName: String = ""
+    @State private var editingKeyUD: String = ""        // UserDefaults key name
+    @State private var editingKeyValue: String = ""
+    @State private var showApiKeyEditor = false
+    @State private var keyRefreshToken: UUID = UUID()   // bump to force apiKeysSection redraw
+
     // Data section state
     @State private var vaultSizeLabel: String = "计算中…"
     @State private var showExportAlert = false
@@ -63,15 +70,79 @@ struct SettingsView: View {
             }
             .onAppear { computeVaultSize() }
             .bannerOverlay()
+            .sheet(isPresented: $showApiKeyEditor) {
+                apiKeyEditorSheet
+            }
         }
+    }
+
+    // MARK: - API Key Editor Sheet
+
+    private var apiKeyEditorSheet: some View {
+        NavigationStack {
+            VStack(spacing: 20) {
+                Text("填入 \(editingKeyName) 的 API Key")
+                    .font(.headline)
+                    .padding(.top, 8)
+
+                SecureField("sk-... 或直接粘贴", text: $editingKeyValue)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled()
+                    .padding(12)
+                    .background(Color(.systemGray6))
+                    .cornerRadius(8)
+                    .padding(.horizontal)
+
+                HStack {
+                    Button("粘贴") {
+                        if let s = UIPasteboard.general.string { editingKeyValue = s }
+                    }
+                    .buttonStyle(.bordered)
+
+                    Spacer()
+
+                    Button("清除") {
+                        editingKeyValue = ""
+                    }
+                    .buttonStyle(.bordered)
+                    .tint(.red)
+                }
+                .padding(.horizontal)
+
+                Spacer()
+            }
+            .navigationTitle("配置 API Key")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("取消") { showApiKeyEditor = false }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("保存") {
+                        let trimmed = editingKeyValue.trimmingCharacters(in: .whitespaces)
+                        if trimmed.isEmpty {
+                            UserDefaults.standard.removeObject(forKey: editingKeyUD)
+                        } else {
+                            UserDefaults.standard.set(trimmed, forKey: editingKeyUD)
+                        }
+                        keyRefreshToken = UUID()
+                        showApiKeyEditor = false
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+        .presentationDetents([.medium])
     }
 
     // MARK: - API Keys Section
 
     private var apiKeysSection: some View {
         Section("API Keys") {
+            let _ = keyRefreshToken  // read token so SwiftUI re-evaluates when key is saved
             apiKeyRow(
                 name: "DashScope",
+                udKey: "runtimeDashScopeKey",
                 key: Secrets.resolvedDashScopeApiKey,
                 isTesting: dashScopeTesting,
                 result: dashScopeResult,
@@ -79,6 +150,7 @@ struct SettingsView: View {
             )
             apiKeyRow(
                 name: "OpenAI Whisper",
+                udKey: "runtimeOpenAIKey",
                 key: Secrets.resolvedOpenAIWhisperApiKey,
                 isTesting: whisperTesting,
                 result: whisperResult,
@@ -86,6 +158,7 @@ struct SettingsView: View {
             )
             apiKeyRow(
                 name: "OpenWeatherMap",
+                udKey: "runtimeOpenWeatherKey",
                 key: Secrets.resolvedOpenWeatherApiKey,
                 isTesting: weatherTesting,
                 result: weatherResult,
@@ -97,6 +170,7 @@ struct SettingsView: View {
     @ViewBuilder
     private func apiKeyRow(
         name: String,
+        udKey: String,
         key: String,
         isTesting: Bool,
         result: APITestResult?,
@@ -118,6 +192,19 @@ struct SettingsView: View {
                     }
                 }
                 Spacer()
+                // Edit button — always visible
+                Button {
+                    editingKeyName = name
+                    editingKeyUD = udKey
+                    editingKeyValue = UserDefaults.standard.string(forKey: udKey) ?? ""
+                    showApiKeyEditor = true
+                } label: {
+                    Image(systemName: "pencil")
+                        .font(.caption)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
                 if key.isEmpty {
                     Text("未配置")
                         .font(.caption)


### PR DESCRIPTION
## Summary
- `SecretsRuntime.swift` 新文件（已提交）存放 `Secrets.resolved*` extension，解决 CI 编译失败（`GeneratedSecrets.swift` 是 gitignored，extension 放在那里 CI 找不到）
- `SettingsView` 每个 API key 行新增 ✏️ 编辑按钮，弹出输入 sheet，用户可随时填写或更新 key，保存后立即生效无需重启

## Root cause fixed
`GeneratedSecrets.swift` 在 `.gitignore` 里，CI 每次从 `.env` 重新生成，手动追加的 `extension Secrets` 不会出现在 CI 构建中，导致 `resolvedDashScopeApiKey` 等成员找不到。

## Test plan
- [ ] CI Xcode Build 通过（不再报 `type 'Secrets' has no member 'resolvedDashScopeApiKey'`）
- [ ] Settings → API Keys，每行显示 ✏️ 按钮，点击弹出输入 sheet
- [ ] 填入 DashScope key 保存后，行状态从「未配置」变为 `…xxxx`，测试连接按钮出现
- [ ] 清空 key 保存后恢复「未配置」