### PR TITLE
feat(today): redesign capture surface per Capture v2

### DIFF
--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -92,8 +92,6 @@ struct DayPageApp: App {
                     BackgroundCompilationService.shared.backfillIfNeeded()
                     // 如果已授权"始终"权限，启动被动访问监控
                     PassiveLocationService.shared.startMonitoringIfAuthorized()
-                    // API 密钥健康检查
-                    checkApiKeys()
                     // 加载"历史上的今天"索引
                     Task { await OnThisDayIndex.shared.loadIndex() }
                     // 在首次启动且完成引导后填充示例数据
@@ -104,19 +102,4 @@ struct DayPageApp: App {
         }
     }
 
-    private func checkApiKeys() {
-        var missing: [String] = []
-        if Secrets.resolvedDeepSeekApiKey.isEmpty { missing.append("DeepSeek (AI 编译)") }
-        if Secrets.resolvedOpenAIWhisperApiKey.isEmpty { missing.append("OpenAI Whisper (语音转写)") }
-        if Secrets.resolvedOpenWeatherApiKey.isEmpty { missing.append("OpenWeather (天气)") }
-        guard !missing.isEmpty else { return }
-        let subtitle = missing.joined(separator: "、")
-        BannerCenter.shared.show(AppBannerModel(
-            kind: .info,
-            title: "\(missing.count) 个功能未配置",
-            subtitle: subtitle,
-            primaryAction: BannerAction(label: "前往设置") { },
-            autoDismiss: false
-        ))
-    }
 }

--- a/DayPage/Features/Today/InputBarV3.swift
+++ b/DayPage/Features/Today/InputBarV3.swift
@@ -51,9 +51,17 @@ struct InputBarV3: View {
     @State private var pressToTalkPhase: PressToTalkPhase = .idle
     @State private var showHoldToast: Bool = false
     @State private var showTranscribeFailed: Bool = false
+    /// True while a "录音太短" hint is on screen — gracefully nudges the user
+    /// without committing a meaningless one-frame recording.
+    @State private var showTooShortToast: Bool = false
     @State private var userExpandedText: Bool = false
     /// 点击录制持久栏激活时为 true
     @State private var isTapRecording: Bool = false
+
+    /// Floor below which a recording is treated as accidental noise rather than
+    /// intent. Capture v2 design principle: respect the user's time — don't
+    /// commit a memo that is structurally too short to carry meaning.
+    private static let minRecordingSeconds: Int = 1
 
     @StateObject private var voiceService = VoiceService.shared
 
@@ -129,7 +137,23 @@ struct InputBarV3: View {
             photoLibrary: .shared()
         )
         .overlay(alignment: .bottom) {
-            if showHoldToast {
+            if showTooShortToast {
+                HStack(spacing: 6) {
+                    Image(systemName: "waveform")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("再说久一点 · 至少 1 秒")
+                        .font(.custom("Inter-Regular", size: 11))
+                }
+                .foregroundColor(DSColor.onSurface)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(DSColor.surfaceContainerHigh)
+                .clipShape(Capsule())
+                .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
+                .padding(.bottom, 140)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .accessibilityLabel("录音太短，请按住麦克风继续说")
+            } else if showHoldToast {
                 Text("长按可快速发送")
                     .monoLabelStyle(size: 11)
                     .foregroundColor(DSColor.onSurface)
@@ -157,6 +181,7 @@ struct InputBarV3: View {
         }
         .animation(.easeInOut(duration: 0.2), value: showHoldToast)
         .animation(.easeInOut(duration: 0.2), value: showTranscribeFailed)
+        .animation(.easeInOut(duration: 0.2), value: showTooShortToast)
         .onChange(of: voiceService.state) { newState in
             if case .failed = newState, isTapRecording {
                 withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
@@ -217,17 +242,33 @@ struct InputBarV3: View {
         }
     }
 
-    // MARK: - Collapsed Row (centered primary mic + secondary action bar)
+    // MARK: - Collapsed Row (Capture v2 STREAM dock)
     //
-    // Voice is the primary action — 64pt black circle, centered, visually dominant.
-    // Text and camera sit below as a compact secondary bar so they remain reachable
-    // without competing for attention with the mic.
+    // Three-slot capsule, centered, NOT full-width:
+    //   [+]  ·  [ MIC HERO ]  ·  [✏️]
+    //
+    // Initial state is calm — no input field, no "Notes / Attach / Camera"
+    // labels, no prompt bubbles. Tap `+` for the attachment tray; tap mic for
+    // Flomo-style persistent recording bar; long-press mic for WeChat-style
+    // press-to-talk; tap ✏️ to expand the text composer above the dock.
+    //
+    // Why a centered capsule instead of a full-width bar: Capture v2 design
+    // note 06 — "the dock should feel like an instrument, not a chrome strip".
+    // Compact width keeps the warm canvas above breathing.
 
     @ViewBuilder
     private var collapsedRow: some View {
-        VStack(spacing: 12) {
-            // Primary: centered voice button
-            VStack(spacing: 8) {
+        VStack(spacing: 6) {
+            HStack(spacing: 8) {
+                dockSideButton(
+                    icon: "plus",
+                    label: "打开附件菜单",
+                    isActive: showAttachmentMenu
+                ) {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    showAttachmentMenu = true
+                }
+
                 PressToTalkButton(
                     onTap: { handleTapToRecord() },
                     onPressStart: { handlePressToTalkStart() },
@@ -239,56 +280,83 @@ struct InputBarV3: View {
                             pressToTalkPhase = phase
                         }
                     },
-                    size: 64,
+                    size: 56,
                     idleBackgroundColor: DSColor.primary,
                     idleIconColor: DSColor.onPrimary
                 )
-                Text("按住说话")
-                    .font(.custom("Inter-Medium", size: 12))
-                    .foregroundColor(DSColor.onSurfaceVariant)
-            }
-            .frame(maxWidth: .infinity)
+                .frame(width: 64)
 
-            // Secondary: text + camera
-            HStack(alignment: .center, spacing: 10) {
-                Button {
+                dockSideButton(
+                    icon: "square.and.pencil",
+                    label: "打开文字输入",
+                    isActive: false
+                ) {
                     UIImpactFeedbackGenerator(style: .light).impactOccurred()
                     userExpandedText = true
                     DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                         isFocused = true
                     }
-                } label: {
-                    ZStack(alignment: .leading) {
-                        Text("记点什么…")
-                            .font(.custom("Inter-Regular", size: 15))
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                            .padding(.horizontal, 14)
-                    }
-                    .frame(maxWidth: .infinity, minHeight: 40)
-                    .background(DSColor.surfaceContainerLow)
-                    .clipShape(Capsule())
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("打开文字输入，记点什么")
-
-                Button {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    onCapturePhoto()
-                } label: {
-                    Image(systemName: "camera")
-                        .font(.system(size: 18, weight: .regular))
-                        .foregroundColor(DSColor.onSurfaceVariant)
-                        .frame(width: 40, height: 40)
-                        .background(DSColor.surfaceContainerLow)
-                        .clipShape(Circle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("拍照")
             }
+            .padding(.horizontal, 6)
+            .padding(.vertical, 6)
+            .background(
+                Capsule()
+                    .fill(DSColor.surfaceContainerLow)
+                    .overlay(
+                        Capsule()
+                            .strokeBorder(DSColor.outlineVariant.opacity(0.4), lineWidth: 0.5)
+                    )
+                    .shadow(color: Color.black.opacity(0.06), radius: 12, x: 0, y: 4)
+            )
+
+            Text(dockHintLabel)
+                .font(.custom("JetBrainsMono-Regular", size: 10))
+                .kerning(1.2)
+                .foregroundColor(DSColor.onSurfaceVariant.opacity(0.7))
+                .frame(height: 12)
+                .accessibilityHidden(true)
         }
         .padding(.horizontal, 16)
-        .padding(.vertical, 16)
+        .padding(.top, 12)
+        .padding(.bottom, 14)
+        .frame(maxWidth: .infinity)
         .background(DSColor.surface)
+    }
+
+    /// Single source of truth for the dock's contextual hint line.
+    /// Mirrors STREAM's "TAP TO RECORD · HOLD TO SEND".
+    private var dockHintLabel: String {
+        switch pressToTalkPhase {
+        case .cancelArmed: return "松开取消"
+        case .transcribeArmed: return "松开转文字"
+        case .recording, .transcribing: return "上滑取消 · 松开发送"
+        case .idle: return "点击录音 · 长按发送"
+        }
+    }
+
+    /// One of the two flanking dock buttons (`+` and ✏️). Shares geometry,
+    /// hit-area, and hover style so the dock reads as a single instrument.
+    @ViewBuilder
+    private func dockSideButton(
+        icon: String,
+        label: String,
+        isActive: Bool,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: icon)
+                .font(.system(size: 17, weight: .regular))
+                .foregroundColor(isActive ? DSColor.onSurface : DSColor.onSurfaceVariant)
+                .frame(width: 40, height: 40)
+                .background(
+                    Circle()
+                        .fill(isActive ? DSColor.surfaceContainerHigh : Color.clear)
+                )
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
     }
 
     // MARK: - Composing Row (text capsule + send)
@@ -536,6 +604,19 @@ struct InputBarV3: View {
     }
 
     private func handleTapRecordingSend() {
+        // Boundary: don't commit a recording with no perceptible content. The
+        // tap-record bar is reachable in one finger move, so a quick "send" hit
+        // can land sub-second. Drop those silently (with a hint) instead of
+        // saving a meaningless 0:00 voice memo.
+        if isRecordingTooShort {
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            voiceService.cancelRecording()
+            withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                isTapRecording = false
+            }
+            flashTooShortToast()
+            return
+        }
         Task { @MainActor in
             guard let result = await voiceService.stopAndTranscribe() else {
                 withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
@@ -551,6 +632,15 @@ struct InputBarV3: View {
         }
     }
 
+    /// True when the active recording is below the meaning threshold AND
+    /// effectively silent. Using both gates avoids rejecting a brief but
+    /// audible "对" / "好" / "嗯" — those are valid log entries even at < 1s.
+    private var isRecordingTooShort: Bool {
+        let belowFloor = voiceService.elapsedSeconds < Self.minRecordingSeconds
+        let isSilent = voiceService.waveformHistory.allSatisfy { $0 < 0.05 }
+        return belowFloor && isSilent
+    }
+
     // MARK: - Press-to-Talk Handlers
 
     private func handlePressToTalkStart() {
@@ -561,13 +651,14 @@ struct InputBarV3: View {
     }
 
     private func handlePressToTalkReleaseSend() {
-        // Release-in-place with no actual movement may indicate a mis-tap.
-        // If elapsed < ~0.4s, treat as a tap → show the "hold to talk" toast
-        // rather than committing an empty recording.
-        if voiceService.elapsedSeconds < 1 && voiceService.waveformHistory.allSatisfy({ $0 < 0.02 }) {
+        // Boundary 1: gesture mis-tap — finger never crossed the long-press
+        // threshold AND the mic captured no audio. Coach the user toward the
+        // hold gesture rather than committing an empty memo.
+        if isRecordingTooShort {
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
             voiceService.cancelRecording()
             pressToTalkPhase = .idle
-            flashHoldToast()
+            flashTooShortToast()
             return
         }
         Task { @MainActor in
@@ -589,6 +680,16 @@ struct InputBarV3: View {
     }
 
     private func handlePressToTalkReleaseTranscribe() {
+        // Same floor as the send path — a "transcribe" gesture on a silent
+        // sub-second clip would just return an empty Whisper response and
+        // burn an API call.
+        if isRecordingTooShort {
+            UINotificationFeedbackGenerator().notificationOccurred(.warning)
+            voiceService.cancelRecording()
+            pressToTalkPhase = .idle
+            flashTooShortToast()
+            return
+        }
         Task { @MainActor in
             guard let result = await voiceService.stopAndTranscribe() else {
                 pressToTalkPhase = .idle
@@ -614,6 +715,13 @@ struct InputBarV3: View {
         showHoldToast = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.4) {
             showHoldToast = false
+        }
+    }
+
+    private func flashTooShortToast() {
+        showTooShortToast = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
+            showTooShortToast = false
         }
     }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -128,13 +128,6 @@ struct TodayView: View {
                     Divider()
                         .background(DSColor.outline)
 
-                    // MARK: API Key Missing Banner
-                    if viewModel.hasApiKeysMissing {
-                        ApiKeyMissingBanner {
-                            showSettings = true
-                        }
-                    }
-
                     // MARK: Compilation Failed Banner
                     if let failureMsg = viewModel.compilationFailedError {
                         CompilationFailedBanner(message: failureMsg) {
@@ -211,16 +204,11 @@ struct TodayView: View {
                                 // Memo cards (reverse-chronological)
                                 if viewModel.memos.isEmpty && !viewModel.isLoading {
                                     if inputBarVariant == "v3" {
-                                        // Voice-first: delegate empty-state to the big mic below.
-                                        // Only render a quiet hint line here so the canvas stays spare.
-                                        VStack {
-                                            Spacer(minLength: 48)
-                                            Text("按住下方麦克风说一句")
-                                                .font(.custom("Inter-Regular", size: 13))
-                                                .foregroundColor(DSColor.onSurfaceVariant)
-                                            Spacer(minLength: 24)
-                                        }
-                                        .frame(maxWidth: .infinity)
+                                        // Capture v2 design note 01: a blank
+                                        // page is the product, not a problem
+                                        // to solve. The dock below already
+                                        // carries every cue the user needs.
+                                        Color.clear.frame(height: 1)
                                     } else {
                                         TodayEmptyStateView { suggestion in
                                             draftText = suggestion
@@ -638,33 +626,6 @@ struct TodayView: View {
 private struct OnThisDayNavTarget: Identifiable {
     let dateString: String
     var id: String { dateString }
-}
-
-// MARK: - ApiKeyMissingBanner
-
-/// Yellow banner shown when one or more API keys are not configured.
-struct ApiKeyMissingBanner: View {
-    let onGoToSettings: () -> Void
-
-    var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundColor(DSColor.warning)
-                .font(.system(size: 14))
-            Text("部分功能需要配置 API Key")
-                .font(.custom("Inter-Regular", size: 13))
-                .foregroundColor(DSColor.onWarningContainer)
-            Spacer()
-            Button("前往设置") {
-                onGoToSettings()
-            }
-            .font(.custom("Inter-Medium", size: 13))
-            .foregroundColor(DSColor.warning)
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(DSColor.warningContainer)
-    }
 }
 
 // MARK: - CompilationFailedBanner

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -104,13 +104,6 @@ final class TodayViewModel: ObservableObject {
     /// Whether the camera capture sheet is presented.
     @Published var isShowingCamera: Bool = false
 
-    /// Whether any API key is missing (triggers banner in TodayView).
-    var hasApiKeysMissing: Bool {
-        Secrets.deepSeekApiKey.isEmpty
-            || Secrets.openAIWhisperApiKey.isEmpty
-            || Secrets.openWeatherApiKey.isEmpty
-    }
-
     // MARK: Private
 
     private let date: Date


### PR DESCRIPTION
## Summary

Today screen was reading like a chat tool, not a capture tool. Adopted [Capture v2](https://api.anthropic.com/v1/design/h/q6oWaHvg0cajYudwPJNAVQ?open_file=DayPage+Capture+v2.html) (STREAM variant): killed the prompt bubbles, killed the empty-state filler, killed the labelled icon row, and killed the two stacked yellow API-key warnings. The dock is now a centered three-slot capsule that breathes.

## What changed

- **Dock redesign** (\`InputBarV3.collapsedRow\`): centered three-slot capsule — \`[+] · [mic-hero 56pt] · [✏️]\` — wrapped in a soft capsule with a contextual mono hint line that morphs through \`点击录音 · 长按发送\` → \`上滑取消 · 松开发送\` → \`松开取消\` / \`松开转文字\`. No more full-width "记点什么…" pill, no more standalone camera button. Camera, photo library, location, and tag all live behind \`+\`.

- **Voice recording boundary**: introduced \`isRecordingTooShort\` (gates on both \`elapsedSeconds < 1\` AND silent waveform). Shared across three send paths — tap-record send, press-to-talk release send, and slide-left transcribe. Silently dropping a sub-second silent recording felt rude; we now warn-haptic, cancel, and surface a \`再说久一点 · 至少 1 秒\` toast. Brief but audible utterances ("嗯", "对", "好") still go through.

- **Empty state**: v3 mode renders \`Color.clear\` — the dock below carries every cue the user needs (Capture v2 design note 01: a blank page is the product, not a problem to solve).

- **Removed two API-key nag surfaces**: the yellow \`ApiKeyMissingBanner\` in TodayView and the \`BannerCenter\` startup nag in DayPageApp. Configuration errors now surface only on the affected action — \`CompilationFailedBanner\` for compile, transcribe-failed toast for whisper. Capture v2 design note 04: configuration belongs in Settings, not in ambient chrome.

- **Dead code cleanup**: dropped \`hasApiKeysMissing\` from TodayViewModel.

## Test plan

- [x] xcodebuild clean compile (\`-scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'\`) — BUILD SUCCEEDED, both pre- and post-rebase
- [x] iPhone 17 simulator visual check — dock renders centered, hint line shows, no banners
- [ ] Manual on-device check — long-press mic < 1s with mic away from face should trigger toast not memo
- [ ] Manual on-device check — short utterance ("嗯") at < 1s should still go through
- [ ] Manual on-device check — tap-record bar send-while-empty should trigger toast not memo
- [ ] Manual on-device check — slide-left transcribe on silent < 1s should trigger toast not API call

## Notes for reviewer

Branch was force-pushed once after rebasing onto current \`origin/main\` (\`f74df0c\`). Pre-rebase was \`ddb811b\` based on \`8916f79\`; post-rebase is \`c32d3de\`. The diff is identical content — only base shifted. Conflicts during rebase were in the surfaces this PR explicitly removes (DayPageApp.\`checkApiKeys()\` had been renamed dashScope→DeepSeek upstream; TodayViewModel.\`hasApiKeysMissing\` had the same renaming). Resolved by taking the "delete" side of every conflict, since the removal is the intent.