### PR TITLE
fix(today): reset pressToTalkPhase on too-short transcribe release

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -342,6 +342,12 @@ struct InputBarV4: View {
             UINotificationFeedbackGenerator().notificationOccurred(.warning)
             voiceService.cancelRecording()
             flashTooShortToast()
+            // Critical: the transcribe branch in PressToTalkButton.onEnded
+            // early-returns past the unconditional `.idle` reset that the
+            // send/cancel paths fall through to. Without this line the
+            // RecordingOverlayView stays mounted in `.transcribing` until
+            // the user kicks off a new gesture.
+            pressToTalkPhase = .idle
             return
         }
         UIImpactFeedbackGenerator(style: .medium).impactOccurred()


### PR DESCRIPTION
## Summary

Caught by [Claude Code review on PR #140](https://github.com/getyak/daypage/pull/140#issuecomment). When a user performs a **transcribe-armed release** (drags left ≥ 80pt and releases) on a sub-second silent recording, \`RecordingOverlayView\` gets stuck visible in the \`.transcribing\` state until the user kicks off a new gesture.

## Root cause

\`PressToTalkButton.onEnded\` has an asymmetric reset path. The send and cancel branches fall through to an unconditional \`currentPhase = .idle\` at the bottom, but the transcribe branch early-returns:

\`\`\`swift
switch endPhase {
case .cancelArmed:
    onReleaseCancel()                  // falls through ↓
case .transcribeArmed:
    currentPhase = .transcribing
    onPhaseChange(.transcribing)
    onReleaseTranscribe()
    lastTranslation = .zero
    return                             // ← skips the reset below
default:
    onReleaseSend()                    // falls through ↓
}
currentPhase = .idle                   // unconditional reset for send/cancel
onPhaseChange(.idle)
\`\`\`

So the transcribe path requires \`handlePressToTalkReleaseTranscribe\` to reset the phase itself. PR #140's new \`isRecordingTooShort\` guard called \`flashTooShortToast()\` and \`return\`ed without resetting — leaving \`pressToTalkPhase = .transcribing\` indefinitely.

## What changed

One line: \`pressToTalkPhase = .idle\` before the early-return inside the \`isRecordingTooShort\` guard in \`handlePressToTalkReleaseTranscribe\`.

The original \`InputBarV3\` had this reset in the matching branch — it was lost when the logic was ported to V4 during the cleanup. Send path is unaffected since its \`default\` branch falls through to the unconditional reset.

## Test plan

- [x] xcodebuild clean compile (\`-scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'\`) — BUILD SUCCEEDED
- [ ] Manual on-device — slide-left transcribe on silent < 1s recording → toast appears, RecordingOverlayView dismisses cleanly, next gesture works without rebound
- [ ] Manual on-device — slide-left transcribe on audible < 1s ("嗯") → goes through normally (negative test for the guard)