### PR TITLE
feat: Capture v2 mic-hero tap-and-hold + voice return affordance

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -54,6 +54,8 @@ struct InputBarV4: View {
     /// meaningless one-frame recording while gracefully nudging the user
     /// toward the hold gesture.
     @State private var showTooShortToast: Bool = false
+    /// True while a "按住说话" hint is visible after a tap on the mic.
+    @State private var showHoldToast: Bool = false
 
     @StateObject private var voiceService = VoiceService.shared
 
@@ -81,11 +83,11 @@ struct InputBarV4: View {
 
     private var overlayMode: RecordingOverlayMode? {
         switch pressToTalkPhase {
-        case .idle:           return nil
-        case .recording:      return .recording
-        case .cancelArmed:    return .cancelArmed
-        case .transcribeArmed: return .transcribeArmed
-        case .transcribing:   return .transcribing
+        case .idle, .preRecording: return nil
+        case .recording:           return .recording
+        case .cancelArmed:         return .cancelArmed
+        case .transcribeArmed:     return .transcribeArmed
+        case .transcribing:        return .transcribing
         }
     }
 
@@ -145,9 +147,26 @@ struct InputBarV4: View {
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                 .accessibilityLabel("录音太短，请按住麦克风继续说")
+            } else if showHoldToast {
+                HStack(spacing: 6) {
+                    Image(systemName: "hand.point.up.fill")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("按住说话")
+                        .font(.custom("Inter-Regular", size: 11))
+                }
+                .foregroundColor(DSColor.onSurface)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(DSColor.surfaceContainerHigh)
+                .clipShape(Capsule())
+                .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
+                .padding(.top, -34)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .accessibilityLabel("点按即可录音，按住松手发送")
             }
         }
         .animation(.easeInOut(duration: 0.2), value: showTooShortToast)
+        .animation(.easeInOut(duration: 0.2), value: showHoldToast)
         .sheet(isPresented: $showAttachmentMenu) {
             AttachmentMenuPopover(
                 onCapturePhoto: { showAttachmentMenu = false; onCapturePhoto() },
@@ -197,6 +216,14 @@ struct InputBarV4: View {
                         .foregroundStyle(DSColor.onBackgroundSubtle)
 
                     Spacer(minLength: 0)
+
+                    // Hint label that appears when user starts pressing (< 0.35s)
+                    if pressToTalkPhase == .preRecording {
+                        Text("再按住一下")
+                            .font(.custom("SpaceGrotesk-Medium", size: 12))
+                            .foregroundStyle(DSColor.primary)
+                            .transition(.opacity.combined(with: .move(edge: .trailing)))
+                    }
                 }
                 .padding(.horizontal, 18)
                 .padding(.vertical, 14)
@@ -205,6 +232,7 @@ struct InputBarV4: View {
                 .overlay(Capsule().strokeBorder(DSColor.outlineVariant.opacity(0.5), lineWidth: 0.5))
             }
             .buttonStyle(.plain)
+            .animation(.easeInOut(duration: 0.15), value: pressToTalkPhase)
 
             PressToTalkButton(
                 onTap: {},
@@ -213,6 +241,7 @@ struct InputBarV4: View {
                 onReleaseCancel: handlePressToTalkReleaseCancel,
                 onReleaseTranscribe: handlePressToTalkReleaseTranscribe,
                 onPhaseChange: { pressToTalkPhase = $0 },
+                onTapShortRelease: flashHoldToast,
                 size: 48,
                 idleBackgroundColor: DSColor.onBackgroundPrimary,
                 idleIconColor: .white
@@ -363,6 +392,13 @@ struct InputBarV4: View {
         showTooShortToast = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             showTooShortToast = false
+        }
+    }
+
+    private func flashHoldToast() {
+        showHoldToast = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
+            showHoldToast = false
         }
     }
 

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -280,6 +280,22 @@ struct InputBarV4: View {
                 .focused($isFocused)
                 .lineLimit(1...5)
                 .tint(DSColor.onBackgroundPrimary)
+
+            // Mic-back button — lets user exit composing and return to voice UI
+            Button {
+                withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) {
+                    userExpandedText = false
+                }
+                isFocused = false
+            } label: {
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(DSColor.onBackgroundMuted)
+                    .frame(width: 28, height: 28)
+                    .background(DSColor.surfaceSunken, in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("切换到语音输入")
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 10)

--- a/DayPage/Features/Today/PressToTalkButton.swift
+++ b/DayPage/Features/Today/PressToTalkButton.swift
@@ -9,6 +9,10 @@ import UIKit
 //     • Tap → emit onTap, parent switches to "recording bar" mode
 //             (PressToTalkButton is no longer visible while recording bar is shown)
 //
+//   Short press (< 0.35s, then release):
+//     • User pressed briefly then lifted — treat as accidental tap, show
+//       a ring + "再按住一下" hint while pressed, "按住说话" toast on release.
+//
 //   Long press (>= 0.35s hold):
 //     WeChat-style press-to-talk flow (original behaviour, unchanged):
 //     • Press-down              → start recording + light haptic
@@ -27,6 +31,9 @@ import UIKit
 /// RecordingOverlayView with an appropriate transition.
 enum PressToTalkPhase: Equatable {
     case idle
+    /// User is pressing but hasn't crossed the long press threshold yet (0-0.35s).
+    /// Parent should show a brief ring + "再按住一下" hint.
+    case preRecording
     case recording
     case cancelArmed
     case transcribeArmed
@@ -61,6 +68,10 @@ struct PressToTalkButton: View {
     /// Reports phase transitions upward so parent can update the overlay state.
     var onPhaseChange: (PressToTalkPhase) -> Void
 
+    /// Called when a simple tap (press < 0.35s then release without long-pressing) is detected.
+    /// Parent can show a "按住说话" toast.
+    var onTapShortRelease: () -> Void = {}
+
     /// Diameter of the circular button and its hit target.
     var size: CGFloat = 40
 
@@ -77,28 +88,43 @@ struct PressToTalkButton: View {
     /// the gesture is treated as a tap → persistent recording bar.
     private let longPressThreshold: TimeInterval = 0.35
 
+    /// Duration of the pulsing ring animation cycle (one full scale-up + fade-out).
+    private let ringAnimationDuration: TimeInterval = 0.8
+
     // MARK: State
 
     @GestureState private var isPressing: Bool = false
     @State private var currentPhase: PressToTalkPhase = .idle
     @State private var lastTranslation: CGSize = .zero
     @State private var pressStartTime: Date? = nil
+    @State private var ringScale: CGFloat = 1.0
+    @State private var ringOpacity: Double = 0.0
 
     // MARK: Body
 
     var body: some View {
-        Image(systemName: "mic.fill")
-            .font(.system(size: size * 0.45, weight: .regular))
-            .foregroundColor(iconColor)
-            .frame(width: size, height: size)
-            .background(backgroundColor)
-            .clipShape(Circle())
-            .scaleEffect(currentPhase == .idle ? 1.0 : 1.08)
-            .animation(.easeOut(duration: 0.12), value: currentPhase)
-            .contentShape(Circle())
-            .accessibilityLabel("点击说话")
-            .accessibilityHint("单击开始录音；长按说话松手发送")
-            .highPriorityGesture(dragGesture)
+        ZStack {
+            // Pulsing ring — visible only during preRecording phase
+            if currentPhase == .preRecording {
+                Circle()
+                    .stroke(DSColor.primary.opacity(ringOpacity), lineWidth: 2)
+                    .frame(width: size * ringScale, height: size * ringScale)
+                    .allowsHitTesting(false)
+            }
+
+            Image(systemName: "mic.fill")
+                .font(.system(size: size * 0.45, weight: .regular))
+                .foregroundColor(iconColor)
+                .frame(width: size, height: size)
+                .background(backgroundColor)
+                .clipShape(Circle())
+                .scaleEffect(currentPhase == .idle ? 1.0 : 1.08)
+                .animation(.easeOut(duration: 0.12), value: currentPhase)
+                .contentShape(Circle())
+                .accessibilityLabel("点击说话")
+                .accessibilityHint("单击开始录音；长按说话松手发送")
+                .highPriorityGesture(dragGesture)
+        }
     }
 
     // MARK: - Gesture
@@ -111,20 +137,24 @@ struct PressToTalkButton: View {
             .onChanged { value in
                 if currentPhase == .idle {
                     pressStartTime = Date()
-                    // Don't start recording yet — wait to see if this becomes a long press
+                    // Enter preRecording phase immediately — show ring + hint
+                    currentPhase = .preRecording
+                    onPhaseChange(.preRecording)
+                    startRingPulse()
                 }
 
                 // Once we've held past the threshold, commit to press-to-talk mode
-                if currentPhase == .idle,
+                if currentPhase == .preRecording,
                    let start = pressStartTime,
                    Date().timeIntervalSince(start) >= longPressThreshold {
                     emitHaptic(InputTokens.pressDownHaptic)
+                    stopRingPulse()
                     onPressStart()
                     currentPhase = .recording
                     onPhaseChange(.recording)
                 }
 
-                guard currentPhase != .idle else { return }
+                guard currentPhase != .idle && currentPhase != .preRecording else { return }
 
                 lastTranslation = value.translation
                 let newPhase = derivePhase(from: value.translation)
@@ -147,15 +177,16 @@ struct PressToTalkButton: View {
                     pressStartTime = nil
                 }
 
-                // Short tap — delegate to onTap for persistent recording bar
+                // Short tap — never crossed threshold, still in preRecording phase
                 if let start = pressStartTime,
                    Date().timeIntervalSince(start) < longPressThreshold,
-                   currentPhase == .idle {
+                   currentPhase == .preRecording {
+                    stopRingPulse()
                     emitHaptic(InputTokens.pressDownHaptic)
                     currentPhase = .idle
                     onPhaseChange(.idle)
                     lastTranslation = .zero
-                    onTap()
+                    onTapShortRelease()
                     return
                 }
 
@@ -182,6 +213,24 @@ struct PressToTalkButton: View {
                 onPhaseChange(.idle)
                 lastTranslation = .zero
             }
+    }
+
+    // MARK: - Ring Animation
+
+    private func startRingPulse() {
+        ringScale = 1.0
+        ringOpacity = 0.5
+        withAnimation(
+            .easeInOut(duration: ringAnimationDuration).repeatForever(autoreverses: false)
+        ) {
+            ringScale = 1.35
+            ringOpacity = 0.0
+        }
+    }
+
+    private func stopRingPulse() {
+        ringScale = 1.0
+        ringOpacity = 0.0
     }
 
     // MARK: - Helpers
@@ -214,6 +263,7 @@ struct PressToTalkButton: View {
 
     private var iconColor: Color {
         switch currentPhase {
+        case .preRecording: return DSColor.primary
         case .cancelArmed: return DSColor.error
         case .transcribeArmed: return Color(red: 0.12, green: 0.30, blue: 0.65)
         case .recording: return DSColor.onPrimary
@@ -223,6 +273,7 @@ struct PressToTalkButton: View {
 
     private var backgroundColor: Color {
         switch currentPhase {
+        case .preRecording: return DSColor.primaryContainer
         case .cancelArmed: return DSColor.errorContainer
         case .transcribeArmed: return Color(red: 0.85, green: 0.92, blue: 1.0)
         case .recording, .transcribing: return DSColor.primary


### PR DESCRIPTION
## Capture v2 体验优化（音频部分）\n\n### Sub 1: 长按麦克风提示\n- PressToTalkButton: 新增 preRecording phase + 脉冲 ring 动画\n- InputBarV4: 短按显示「按住说话」toast + 提示文字\n- 触觉反馈 light haptic\n\n### Sub 2: 文本→语音返回入口\n- composing 态新增 mic 图标按钮，点击回到语音 collapsed 态\n- 保留草稿不丢失\n\nRefs #143