### PR TITLE
feat: Today Weekly Recap (Phase 1 of time-pyramid recap)

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -67,6 +67,8 @@
 		A10000080 /* AppNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000080 /* AppNavigationModel.swift */; };
 		A10000081 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000081 /* SidebarView.swift */; };
 		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
+		A10000083 /* WeeklyRecapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000083 /* WeeklyRecapService.swift */; };
+		A10000084 /* WeeklyRecapSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000084 /* WeeklyRecapSection.swift */; };
 		A10000060 /* DailySharePosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000060 /* DailySharePosterView.swift */; };
 		A10000061 /* PosterRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000061 /* PosterRenderer.swift */; };
 		A10000063 /* SwipeableMemoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000063 /* SwipeableMemoCard.swift */; };
@@ -171,6 +173,8 @@
 		A20000060 /* DailySharePosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySharePosterView.swift; sourceTree = "<group>"; };
 		A20000061 /* PosterRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterRenderer.swift; sourceTree = "<group>"; };
 		A20000082 /* InputBarV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV4.swift; sourceTree = "<group>"; };
+		A20000083 /* WeeklyRecapService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapService.swift; sourceTree = "<group>"; };
+		A20000084 /* WeeklyRecapSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapSection.swift; sourceTree = "<group>"; };
 		A20000063 /* SwipeableMemoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMemoCard.swift; sourceTree = "<group>"; };
 		A20000064 /* AttachmentMenuSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMenuSheet.swift; sourceTree = "<group>"; };
 		A20000079 /* iCloudSyncMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncMonitor.swift; sourceTree = "<group>"; };
@@ -339,6 +343,7 @@
 				A20000070 /* AuthService.swift */,
 				A20000076 /* KeychainHelper.swift */,
 				FB1000001 /* FeedbackService.swift */,
+				A20000083 /* WeeklyRecapService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -389,6 +394,7 @@
 				A20000054 /* RecordingOverlayView.swift */,
 				A20000055 /* PressToTalkButton.swift */,
 				A20000063 /* SwipeableMemoCard.swift */,
+				A20000084 /* WeeklyRecapSection.swift */,
 			);
 			path = Today;
 			sourceTree = "<group>";
@@ -682,6 +688,8 @@
 				A10000049 /* SampleDataSeeder.swift in Sources */,
 				A10000050 /* CompileFooterButton.swift in Sources */,
 				A10000082 /* InputBarV4.swift in Sources */,
+				A10000083 /* WeeklyRecapService.swift in Sources */,
+				A10000084 /* WeeklyRecapSection.swift in Sources */,
 				A10000052 /* AttachmentMenuPopover.swift in Sources */,
 				A10000064 /* AttachmentMenuSheet.swift in Sources */,
 				A10000053 /* InputTokens.swift in Sources */,

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -235,6 +235,17 @@ struct TodayView: View {
                                         .padding(.horizontal, 20)
                                 }
 
+                                // MARK: Weekly Recap (this week's compiled days, newest first)
+                                // Rendered after today's raw stream so the user scrolls "from now
+                                // into memory" — Phase 1 of the time-pyramid recap. Phase 2/3
+                                // will collapse last week / month / year into coarser cards below.
+                                WeeklyRecapSection(
+                                    entries: viewModel.weeklyRecap,
+                                    onTapEntry: { dateStr in
+                                        onThisDayDateString = dateStr
+                                    }
+                                )
+
                                 Spacer(minLength: 16)
 
                                 // Bottom anchor for CompileFooterButton visibility tracking (US-005).

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -62,6 +62,11 @@ final class TodayViewModel: ObservableObject {
     /// A brief excerpt from the compiled Daily Page (if compiled).
     @Published var dailyPageSummary: String? = nil
 
+    /// Compiled day-pages from this week (Monday → yesterday), newest first.
+    /// Populated in `load()` and refreshed whenever today's data reloads.
+    /// Drives the "Weekly Recap" section beneath today's raw memos.
+    @Published var weeklyRecap: [WeeklyRecapEntry] = []
+
     /// Whether the view is currently loading memos.
     @Published var isLoading: Bool = false
 
@@ -234,6 +239,7 @@ final class TodayViewModel: ObservableObject {
         }
 
         checkDailyPage()
+        weeklyRecap = WeeklyRecapService.shared.entries()
         isLoading = false
         checkOnThisDay()
     }

--- a/DayPage/Features/Today/WeeklyRecapSection.swift
+++ b/DayPage/Features/Today/WeeklyRecapSection.swift
@@ -1,0 +1,144 @@
+import SwiftUI
+
+// MARK: - WeeklyRecapSection
+
+/// "本周回顾" — appears at the bottom of the Today timeline once today's raw
+/// memos finish rendering. Lists this week's already-compiled day pages
+/// (Monday → yesterday) in newest-first order. Tapping a card opens
+/// `DayDetailView` for that date.
+///
+/// Phase 1 design language:
+/// - A thin labelled separator visually divides "now" (raw memos above) from
+///   "memory" (compiled summaries below). Scrolling down becomes a metaphor:
+///   the further you scroll, the further back in time and the more compressed
+///   the representation. Phase 2/3 will collapse last week / last month / last
+///   year into single coarser-grained cards below this section.
+/// - Cards stay quieter than `DailyPageEntryCard` (the brutalist black
+///   "today is ready" hero). Recap cards use the surface-container palette so
+///   they read as "settled history" rather than active state.
+struct WeeklyRecapSection: View {
+
+    let entries: [WeeklyRecapEntry]
+    let onTapEntry: (String) -> Void
+
+    var body: some View {
+        if entries.isEmpty {
+            EmptyView()
+        } else {
+            VStack(alignment: .leading, spacing: 12) {
+                sectionDivider
+                ForEach(entries) { entry in
+                    WeeklyRecapDayCard(entry: entry) {
+                        onTapEntry(entry.dateString)
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 8)
+        }
+    }
+
+    private var sectionDivider: some View {
+        HStack(spacing: 12) {
+            Rectangle()
+                .fill(DSColor.outlineVariant)
+                .frame(height: 1)
+                .frame(maxWidth: 24)
+            Text("THIS WEEK")
+                .sectionLabelStyle()
+                .foregroundColor(DSColor.onSurfaceVariant)
+            Rectangle()
+                .fill(DSColor.outlineVariant)
+                .frame(height: 1)
+                .frame(maxWidth: .infinity)
+        }
+    }
+}
+
+// MARK: - WeeklyRecapDayCard
+
+/// One compiled-day card inside `WeeklyRecapSection`.
+///
+/// Layout:
+/// - Left rail: weekday label (MON / TUE / ...) + month-day in mono.
+/// - Right column: summary preview, capped at 2 lines.
+/// - Trailing chevron suggests "tap to drill down".
+private struct WeeklyRecapDayCard: View {
+
+    let entry: WeeklyRecapEntry
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .top, spacing: 14) {
+                dateRail
+                summaryColumn
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .padding(.top, 4)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(DSColor.surfaceContainer)
+            .cornerRadius(DSSpacing.radiusCard)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    private var dateRail: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(weekdayLabel)
+                .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
+                .foregroundColor(DSColor.onSurfaceVariant)
+            Text(monthDayLabel)
+                .font(.custom("SpaceGrotesk-Bold", size: 16))
+                .foregroundColor(DSColor.onSurface)
+        }
+        .frame(width: 56, alignment: .leading)
+    }
+
+    private var summaryColumn: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let summary = entry.summary, !summary.isEmpty {
+                Text(summary)
+                    .bodySMStyle()
+                    .foregroundColor(DSColor.onSurface)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+            } else {
+                Text("Daily page compiled.")
+                    .bodySMStyle()
+                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .italic()
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Formatters
+
+    private var weekdayLabel: String {
+        let f = DateFormatter()
+        f.dateFormat = "EEE"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f.string(from: entry.date).uppercased()
+    }
+
+    private var monthDayLabel: String {
+        let f = DateFormatter()
+        f.dateFormat = "MM.dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f.string(from: entry.date)
+    }
+
+    private var accessibilityLabel: String {
+        let summaryText = (entry.summary?.isEmpty == false) ? entry.summary! : "已编译"
+        return "\(entry.dateString)，\(summaryText)"
+    }
+}

--- a/DayPage/Features/Today/WeeklyRecapSection.swift
+++ b/DayPage/Features/Today/WeeklyRecapSection.swift
@@ -138,7 +138,7 @@ private struct WeeklyRecapDayCard: View {
     }
 
     private var accessibilityLabel: String {
-        let summaryText = (entry.summary?.isEmpty == false) ? entry.summary! : "已编译"
+        let summaryText = entry.summary.flatMap { $0.isEmpty ? nil : $0 } ?? "已编译"
         return "\(entry.dateString)，\(summaryText)"
     }
 }

--- a/DayPage/Services/WeeklyRecapService.swift
+++ b/DayPage/Services/WeeklyRecapService.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+// MARK: - WeeklyRecapEntry
+
+/// One compiled day appearing in Today's "Weekly Recap" section.
+///
+/// Phase 1 only carries day-level compiled entries; Phase 2/3 will extend this
+/// into an enum (`case day | week | month | year`). Keeping it flat for now
+/// avoids speculative abstraction.
+struct WeeklyRecapEntry: Identifiable, Equatable {
+
+    /// `yyyy-MM-dd`, also stable id (at most one compiled entry per date).
+    let dateString: String
+
+    /// Local-timezone midnight of the compiled day.
+    let date: Date
+
+    /// Frontmatter `summary:` value; nil/empty if unset or unreadable.
+    let summary: String?
+
+    var id: String { dateString }
+}
+
+// MARK: - WeeklyRecapService
+
+/// Loads the Today screen's "Weekly Recap" section data.
+///
+/// Range (Phase 1):
+/// - Start (inclusive): the earlier of (a) Monday 00:00 of the week containing
+///   `referenceDate`, or (b) yesterday 00:00. The `min(...)` rule guarantees
+///   yesterday is always in range — without it, opening the app on a Monday
+///   collapses the range to empty and the Recap section disappears, which
+///   reads as a bug. Phase 2 will introduce a separate weekly-compilation
+///   feed for last week, removing the need for this overlap.
+/// - End (exclusive): Today 00:00 — today's raw memos render in TodayView's
+///   own timeline, so we never duplicate today here even if its daily page
+///   exists.
+///
+/// Returns newest-first. Days without a `vault/wiki/daily/{date}.md` file are
+/// silently skipped (a missing file means "not compiled yet", not an error).
+@MainActor
+final class WeeklyRecapService {
+
+    static let shared = WeeklyRecapService()
+
+    private let calendar: Calendar
+    private let dateFormatter: DateFormatter
+
+    private init() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone.current
+        cal.firstWeekday = 2  // Monday — matches Archive calendar convention
+        self.calendar = cal
+
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        self.dateFormatter = f
+    }
+
+    /// Compiled day entries from this week's Monday up to (but not including)
+    /// `referenceDate`'s local-midnight, newest first.
+    /// Returns empty when `referenceDate` falls on Monday.
+    func entries(referenceDate: Date = Date()) -> [WeeklyRecapEntry] {
+        let dailyDir = VaultInitializer.vaultURL.appendingPathComponent("wiki/daily")
+        let fm = FileManager.default
+
+        let today = calendar.startOfDay(for: referenceDate)
+        guard let monday = startOfWeek(for: today),
+              let yesterday = calendar.date(byAdding: .day, value: -1, to: today)
+        else { return [] }
+        // Whichever is earlier — usually Monday, but on Monday itself the
+        // Monday-only range would be empty, so yesterday (Sunday) takes over.
+        let lowerBound = min(monday, yesterday)
+
+        var cursor = lowerBound
+        var dates: [Date] = []
+        while cursor < today {
+            dates.append(cursor)
+            guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
+            cursor = next
+        }
+
+        var entries: [WeeklyRecapEntry] = []
+        for date in dates {
+            let dateStr = dateFormatter.string(from: date)
+            let url = dailyDir.appendingPathComponent("\(dateStr).md")
+            guard fm.fileExists(atPath: url.path) else { continue }
+
+            let summary: String?
+            if let content = try? String(contentsOf: url, encoding: .utf8) {
+                summary = Self.extractSummary(from: content)
+            } else {
+                summary = nil
+            }
+
+            entries.append(WeeklyRecapEntry(
+                dateString: dateStr,
+                date: date,
+                summary: summary
+            ))
+        }
+
+        return entries.reversed()
+    }
+
+    // MARK: - Private
+
+    /// Monday 00:00 of the week containing `date`.
+    /// `dateInterval(of: .weekOfYear, for:)` honors `calendar.firstWeekday`,
+    /// which we forced to Monday in init.
+    private func startOfWeek(for date: Date) -> Date? {
+        return calendar.dateInterval(of: .weekOfYear, for: date)?.start
+    }
+
+    /// Extract `summary:` from a daily page's frontmatter. Behaviour matches
+    /// `ArchiveView.extractSummary` and `TodayViewModel.extractSummary`; kept
+    /// local so Phase 2 (weekly/monthly compilations with different schemas)
+    /// can extend parsing here without touching unrelated callers.
+    static func extractSummary(from content: String) -> String? {
+        for line in content.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("summary:") {
+                let value = String(trimmed.dropFirst("summary:".count))
+                    .trimmingCharacters(in: .whitespaces)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                return value.isEmpty ? nil : value
+            }
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
## Summary

- Today now renders this week's already-compiled day pages beneath the raw memo stream — newest first, summary previews capped at 2 lines, tap to drill into `DayDetailView`.
- Range is `[min(this Monday, yesterday), today)` — opening on a Monday still shows yesterday instead of an empty section. Today is intentionally excluded (it lives in TodayView's own raw memo timeline).
- Phase 1 of the time-pyramid recap design: **today is raw → recent days are daily compilations**. Phase 2/3 will collapse last week / month / year into coarser cards below this section, so distance-from-now becomes a natural compression gradient.

## What's new

| Path | Kind | Role |
|---|---|---|
| `DayPage/Services/WeeklyRecapService.swift` | new | Read-only loader scanning `vault/wiki/daily/` for in-range compiled day pages |
| `DayPage/Features/Today/WeeklyRecapSection.swift` | new | Section view: \`THIS WEEK\` divider + day cards (date rail + summary + chevron) |
| `TodayViewModel.swift` | edit | Adds \`@Published weeklyRecap\`, refreshed inside \`load()\` |
| `TodayView.swift` | edit | Section mounted between memo list and bottom Spacer; reuses the existing \`DayDetailView\` fullScreenCover for navigation |
| `DayPage.xcodeproj/project.pbxproj` | edit | Registers the two new files (PBXBuildFile / PBXFileReference / Services + Today groups / Sources phase) |

## Why this design

- **Doesn't touch the compilation pipeline.** Phase 1 only renders existing daily compilations; no changes to \`CompilationService\` / \`BackgroundCompilationService\`. Weekly / monthly / yearly compilations are deferred to Phase 2/3 where the recursive prompt structure deserves its own design pass.
- **Recap cards are visually quieter than \`DailyPageEntryCard\`.** The black brutalist hero stays for "today is compiled"; recap cards use the surface-container palette so they read as "settled history" rather than active state.
- **One-line escape hatch on a Monday.** Naturally-aligned weeks `[Monday, today)` collapse to empty on Mondays, which reads as a bug. Falling back to yesterday is a deliberate Phase 1 overlap with the future Phase 2 weekly card; once Phase 2 ships, last Sunday will live in the weekly compilation card and this fallback becomes redundant.

## Test plan

- [x] \`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build\` → BUILD SUCCEEDED (only pre-existing Swift 6 actor warnings unrelated to this change)
- [x] Visual smoke on iPhone 17 simulator (today = 2026-04-27 Monday, vault contains compiled \`2026-04-26.md\`): \`THIS WEEK\` section renders the Sunday card with summary preview; today's empty state above remains intact
- [ ] Verify drill-down: tap a recap card → opens \`DayDetailView\` for that date
- [ ] Verify range edge cases manually: open on a non-Monday day with multiple compiled days this week — newest-first ordering, today never appears in section
- [ ] Verify graceful empty: when no compiled days exist in range, section is fully hidden (no orphan divider)