### PR TITLE
feat: Capture v2 attachment menu, theme settings, account switching

### DIFF
--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -4,6 +4,7 @@ struct RootView: View {
     @EnvironmentObject private var authService: AuthService
     @EnvironmentObject private var nav: AppNavigationModel
     @StateObject private var bannerCenter = BannerCenter.shared
+    @ObservedObject private var appSettings = AppSettings.shared
     @State private var hasOnboarded: Bool = UserDefaults.standard.bool(forKey: "hasOnboarded")
     @State private var authSkipped: Bool = UserDefaults.standard.bool(forKey: "authSkipped")
 
@@ -11,6 +12,15 @@ struct RootView: View {
 
     private var showAuth: Bool {
         authService.session == nil && !authSkipped
+    }
+
+    /// Resolve preferredColorScheme from AppSettings.
+    private var resolvedColorScheme: ColorScheme? {
+        switch appSettings.themeMode {
+        case .system: return nil
+        case .light: return .light
+        case .dark: return .dark
+        }
     }
 
     var body: some View {
@@ -30,6 +40,7 @@ struct RootView: View {
                 OnboardingView(hasOnboarded: $hasOnboarded)
             }
         }
+        .preferredColorScheme(resolvedColorScheme)
     }
 
     // MARK: - Main Content with Sidebar Overlay

--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -1,4 +1,5 @@
 import Foundation
+import SwiftUI
 
 // MARK: - ThemeMode
 

--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -1,5 +1,75 @@
 import Foundation
 
+// MARK: - ThemeMode
+
+enum ThemeMode: String, CaseIterable {
+    case system = "system"
+    case light = "light"
+    case dark = "dark"
+
+    var label: String {
+        switch self {
+        case .system: return "系统"
+        case .light: return "浅色"
+        case .dark: return "深色"
+        }
+    }
+}
+
+// MARK: - AccentColorOption
+
+enum AccentColorOption: String, CaseIterable {
+    case amber = "amber"
+    case sage = "sage"
+    case slate = "slate"
+    case rose = "rose"
+    case ink = "ink"
+
+    var label: String {
+        switch self {
+        case .amber: return "琥珀"
+        case .sage: return "鼠尾草"
+        case .slate: return "青石"
+        case .rose: return "玫瑰"
+        case .ink: return "墨"
+        }
+    }
+
+    var color: Color {
+        switch self {
+        case .amber: return Color(hex: "5D3000")
+        case .sage: return Color(hex: "4A6B4A")
+        case .slate: return Color(hex: "4A5568")
+        case .rose: return Color(hex: "9B4D6B")
+        case .ink: return Color(hex: "2D2D2D")
+        }
+    }
+
+    var softColor: Color {
+        switch self {
+        case .amber: return Color(hex: "F5EDE3")
+        case .sage: return Color(hex: "E8F0E8")
+        case .slate: return Color(hex: "E8ECF0")
+        case .rose: return Color(hex: "F5E8EE")
+        case .ink: return Color(hex: "EAEAEA")
+        }
+    }
+}
+
+// MARK: - CardDensity
+
+enum CardDensity: String, CaseIterable {
+    case comfortable = "comfortable"
+    case compact = "compact"
+
+    var label: String {
+        switch self {
+        case .comfortable: return "舒适"
+        case .compact: return "紧凑"
+        }
+    }
+}
+
 // MARK: - VaultLocation
 
 enum VaultLocation: String {
@@ -113,6 +183,54 @@ final class AppSettings: ObservableObject {
         set {
             objectWillChange.send()
             UserDefaults.standard.set(newValue, forKey: Self.githubRepoNameKey)
+        }
+    }
+
+    // MARK: - Theme Mode
+
+    private let themeModeKey = "themeMode"
+
+    var themeMode: ThemeMode {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: themeModeKey),
+                  let mode = ThemeMode(rawValue: raw) else { return .system }
+            return mode
+        }
+        set {
+            objectWillChange.send()
+            UserDefaults.standard.set(newValue.rawValue, forKey: themeModeKey)
+        }
+    }
+
+    // MARK: - Accent Color
+
+    private let accentColorKey = "accentColor"
+
+    var accentColor: AccentColorOption {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: accentColorKey),
+                  let color = AccentColorOption(rawValue: raw) else { return .amber }
+            return color
+        }
+        set {
+            objectWillChange.send()
+            UserDefaults.standard.set(newValue.rawValue, forKey: accentColorKey)
+        }
+    }
+
+    // MARK: - Card Density
+
+    private let cardDensityKey = "cardDensity"
+
+    var cardDensity: CardDensity {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: cardDensityKey),
+                  let density = CardDensity(rawValue: raw) else { return .comfortable }
+            return density
+        }
+        set {
+            objectWillChange.send()
+            UserDefaults.standard.set(newValue.rawValue, forKey: cardDensityKey)
         }
     }
 

--- a/DayPage/Features/Auth/AccountSheet.swift
+++ b/DayPage/Features/Auth/AccountSheet.swift
@@ -1,11 +1,20 @@
 import SwiftUI
 
 // MARK: - AccountSheet
+//
+// Redesigned as account list: current account, historical accounts for switching,
+// add another account. Sign Out moved to secondary position.
 
 struct AccountSheet: View {
 
     @EnvironmentObject private var authService: AuthService
     @Environment(\.dismiss) private var dismiss
+
+    /// Placeholder — historical accounts would come from AuthService or Keychain.
+    /// For now we show a single "current account" view with demo data.
+    /// Replace `mockHistoricalAccounts` with real stored accounts once
+    /// multi-account support is wired in.
+    private let mockHistoricalAccounts: [String] = []
 
     var body: some View {
         VStack(spacing: 0) {
@@ -14,34 +23,182 @@ struct AccountSheet: View {
                 .fill(DSColor.outline)
                 .frame(width: 36, height: 4)
                 .padding(.top, 12)
-                .padding(.bottom, 24)
+                .padding(.bottom, 8)
 
-            // Email
-            Text(authService.session?.user.email ?? "")
-                .font(.system(size: 14))
-                .foregroundColor(Color(hex: "6B6B6B"))
-                .padding(.bottom, 24)
+            // Title
+            Text("账户")
+                .font(.custom("Inter-SemiBold", size: 16))
+                .foregroundColor(DSColor.onSurface)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 20)
+                .padding(.bottom, 16)
+
+            // Current account
+            currentAccountRow
+
+            if !mockHistoricalAccounts.isEmpty {
+                Divider()
+                    .padding(.leading, 20)
+                    .padding(.vertical, 4)
+
+                // Historical accounts header
+                Text("其他账户")
+                    .font(.custom("Inter-Medium", size: 13))
+                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 4)
+                    .padding(.bottom, 2)
+
+                ForEach(mockHistoricalAccounts, id: \.self) { email in
+                    accountRow(email: email, isCurrent: false)
+                }
+            }
 
             Divider()
+                .padding(.leading, 20)
+                .padding(.vertical, 4)
 
-            // Sign Out
-            Button {
-                Task {
-                    try? await authService.signOut()
-                    UserDefaults.standard.set(false, forKey: "authSkipped")
-                    dismiss()
-                }
-            } label: {
-                Text("Sign Out")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(Color(hex: "E05A5A"))
-                    .frame(maxWidth: .infinity)
-                    .padding(.vertical, 16)
+            // Add another account
+            addAccountRow
+
+            Spacer(minLength: 0)
+
+            // Sign Out — secondary position
+            signOutRow
+                .padding(.bottom, 16)
+        }
+        .presentationDetents([.fraction(0.55)])
+        .presentationDragIndicator(.hidden)
+    }
+
+    // MARK: - Current Account
+
+    private var currentAccountRow: some View {
+        let email = authService.session?.user.email ?? "—"
+        let initial = email.first.map { String($0).uppercased() } ?? "?"
+        return HStack(spacing: 14) {
+            ZStack {
+                Circle()
+                    .fill(DSColor.accentSoft)
+                    .frame(width: 40, height: 40)
+                Text(initial)
+                    .font(.custom("Inter-SemiBold", size: 16))
+                    .foregroundColor(DSColor.accentAmber)
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(email)
+                    .font(.custom("Inter-Medium", size: 14))
+                    .foregroundColor(DSColor.onSurface)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                Text("当前账户")
+                    .font(.custom("Inter-Regular", size: 12))
+                    .foregroundColor(DSColor.onSurfaceVariant)
             }
 
             Spacer()
+
+            Image(systemName: "checkmark.circle.fill")
+                .font(.system(size: 16))
+                .foregroundColor(.green)
         }
-        .presentationDetents([.fraction(0.3)])
-        .presentationDragIndicator(.hidden)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 8)
+        .background(DSColor.surfaceContainerLowest)
+    }
+
+    // MARK: - Account Row (for switching)
+
+    private func accountRow(email: String, isCurrent: Bool) -> some View {
+        let initial = email.first.map { String($0).uppercased() } ?? "?"
+        return Button {
+            // Switch account — placeholder
+            dismiss()
+        } label: {
+            HStack(spacing: 14) {
+                ZStack {
+                    Circle()
+                        .fill(DSColor.surfaceSunken)
+                        .frame(width: 40, height: 40)
+                    Text(initial)
+                        .font(.custom("Inter-Medium", size: 14))
+                        .foregroundColor(DSColor.onBackgroundMuted)
+                }
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(email)
+                        .font(.custom("Inter-Regular", size: 14))
+                        .foregroundColor(DSColor.onBackgroundPrimary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(DSColor.onBackgroundSubtle)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Add Another Account
+
+    private var addAccountRow: some View {
+        Button {
+            // Present sign-in flow — placeholder
+            dismiss()
+        } label: {
+            HStack(spacing: 14) {
+                ZStack {
+                    Circle()
+                        .stroke(DSColor.borderDefault, lineWidth: 1.5)
+                        .frame(width: 40, height: 40)
+                    Image(systemName: "plus")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundColor(DSColor.onBackgroundMuted)
+                }
+
+                Text("添加另一个账户")
+                    .font(.custom("Inter-Regular", size: 14))
+                    .foregroundColor(DSColor.onBackgroundMuted)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Sign Out
+
+    private var signOutRow: some View {
+        Button(role: .destructive) {
+            Task {
+                try? await authService.signOut()
+                UserDefaults.standard.set(false, forKey: "authSkipped")
+                dismiss()
+            }
+        } label: {
+            HStack(spacing: 14) {
+                Image(systemName: "rectangle.portrait.and.arrow.right")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundColor(Color(hex: "E05A5A"))
+                Text("退出登录")
+                    .font(.custom("Inter-Regular", size: 14))
+                    .foregroundColor(Color(hex: "E05A5A"))
+                Spacer()
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -305,14 +305,40 @@ struct SettingsView: View {
 
     private var appearanceSection: some View {
         Section("外观") {
-            HStack {
+            // Theme (dark mode)
+            Picker(selection: $appSettings.themeMode) {
+                ForEach(ThemeMode.allCases, id: \.self) { mode in
+                    HStack {
+                        Image(systemName: themeIcon(for: mode))
+                        Text(mode.label)
+                    }.tag(mode)
+                }
+            } label: {
                 Label("深色模式", systemImage: "moon.fill")
-                Spacer()
-                Text("即将推出")
-                    .font(.caption)
-                    .foregroundColor(DSColor.onSurfaceVariant)
             }
-            .foregroundColor(DSColor.onSurfaceVariant)
+
+            // Accent color
+            Picker(selection: $appSettings.accentColor) {
+                ForEach(AccentColorOption.allCases, id: \.self) { color in
+                    HStack {
+                        Circle()
+                            .fill(color.color)
+                            .frame(width: 14, height: 14)
+                        Text(color.label)
+                    }.tag(color)
+                }
+            } label: {
+                Label("强调色", systemImage: "paintpalette")
+            }
+
+            // Card density
+            Picker(selection: $appSettings.cardDensity) {
+                ForEach(CardDensity.allCases, id: \.self) { density in
+                    Text(density.label).tag(density)
+                }
+            } label: {
+                Label("卡片密度", systemImage: "rectangle.expand.vertical")
+            }
 
             // Press-to-talk (US-008). Invert the binding so the visible label reads
             // "Use legacy voice recording" per the PRD's legacy-fallback copy.
@@ -341,6 +367,14 @@ struct SettingsView: View {
                     OnThisDayScheduler.shared.refreshHour = val
                 }
             }
+        }
+    }
+
+    private func themeIcon(for mode: ThemeMode) -> String {
+        switch mode {
+        case .system: return "gearshape"
+        case .light: return "sun.max"
+        case .dark: return "moon.stars"
         }
     }
 

--- a/DayPage/Features/Today/AttachmentMenuPopover.swift
+++ b/DayPage/Features/Today/AttachmentMenuPopover.swift
@@ -2,8 +2,10 @@ import SwiftUI
 
 // MARK: - AttachmentMenuPopover
 //
-// 底部弹出式附件选择器，采用 2×2 大图标网格布局。
-// 通过 .sheet 而非 .popover 呈现，以便在 iPhone 上从底部滑出。
+// Capture v2 minimal design: single-color line icons + text label list,
+// ultraThinMaterial background matching InputBarV4 capsule aesthetic.
+// Uses SF Symbols thin variants (camera, photo, paperclip, mappin) unfilled.
+// Subtle tap animation: depresses + micro-scale.
 
 struct AttachmentMenuPopover: View {
 
@@ -17,102 +19,87 @@ struct AttachmentMenuPopover: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // 拖拽手柄
+            // Drag handle
             RoundedRectangle(cornerRadius: 2)
                 .fill(DSColor.borderDefault)
                 .frame(width: 36, height: 4)
-                .padding(.top, 12)
-                .padding(.bottom, 22)
+                .padding(.top, 10)
+                .padding(.bottom, 20)
 
-            LazyVGrid(
-                columns: [GridItem(.flexible()), GridItem(.flexible())],
-                spacing: 12
-            ) {
-                AttachmentActionButton(
-                    icon: "camera.fill",
-                    label: "拍照",
-                    bgColor: Color(hex: "4A6FE3"),
-                    action: onCapturePhoto
-                )
-                AttachmentActionButton(
-                    icon: "photo.fill",
-                    label: "从相册选",
-                    bgColor: Color(hex: "3DAD74"),
-                    action: onPickPhoto
-                )
-                AttachmentActionButton(
-                    icon: "paperclip",
-                    label: "附件",
-                    bgColor: Color(hex: "E09030"),
-                    action: onAddFile
-                )
-                AttachmentActionButton(
-                    icon: hasPendingLocation ? "mappin.and.ellipse" : "mappin.circle.fill",
+            VStack(spacing: 0) {
+                attachmentRow(icon: "camera", label: "拍照", action: onCapturePhoto)
+                Divider().padding(.leading, 48).foregroundColor(DSColor.borderSubtle)
+                attachmentRow(icon: "photo", label: "从相册选", action: onPickPhoto)
+                Divider().padding(.leading, 48).foregroundColor(DSColor.borderSubtle)
+                attachmentRow(icon: "paperclip", label: "附件", action: onAddFile)
+                Divider().padding(.leading, 48).foregroundColor(DSColor.borderSubtle)
+                attachmentRow(
+                    icon: "mappin",
                     label: hasPendingLocation ? "更新位置" : "位置",
-                    bgColor: Color(hex: "D95050"),
                     isLoading: isLocating,
                     action: onAddLocation
                 )
             }
-            .padding(.horizontal, 20)
-            .padding(.bottom, 36)
-        }
-        .frame(maxWidth: .infinity)
-        .background(DSColor.backgroundWarm)
-        .presentationDetents([.height(210)])
-        .presentationDragIndicator(.hidden)
-        .modifier(AttachmentSheetPresentation())
-    }
-}
-
-// MARK: - AttachmentActionButton
-
-private struct AttachmentActionButton: View {
-    let icon: String
-    let label: String
-    let bgColor: Color
-    var isLoading: Bool = false
-    let action: () -> Void
-
-    @State private var isPressed = false
-
-    var body: some View {
-        Button(action: action) {
-            VStack(spacing: 10) {
-                ZStack {
-                    Circle()
-                        .fill(bgColor)
-                        .frame(width: 54, height: 54)
-                    if isLoading {
-                        ProgressView()
-                            .tint(.white)
-                            .scaleEffect(0.85)
-                    } else {
-                        Image(systemName: icon)
-                            .font(.system(size: 22, weight: .medium))
-                            .foregroundStyle(.white)
-                    }
-                }
-                .scaleEffect(isPressed ? 0.93 : 1.0)
-                .animation(.spring(response: 0.22, dampingFraction: 0.7), value: isPressed)
-
-                Text(label)
-                    .font(.custom("SpaceGrotesk-Medium", size: 13))
-                    .foregroundStyle(DSColor.onBackgroundMuted)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
             .background(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .fill(isPressed ? DSColor.surfaceSunken : DSColor.surfaceWhite)
+                    .fill(.ultraThinMaterial)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 14, style: .continuous)
                     .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
             )
+            .padding(.horizontal, 16)
+            .padding(.bottom, 28)
         }
-        .buttonStyle(.plain)
-        ._onButtonGesture(pressing: { isPressed = $0 }, perform: {})
+        .frame(maxWidth: .infinity)
+        .background(DSColor.backgroundWarm)
+        .presentationDetents([.height(280)])
+        .presentationDragIndicator(.hidden)
+        .modifier(AttachmentSheetPresentation())
+    }
+
+    // MARK: - Attachment Row
+
+    @ViewBuilder
+    private func attachmentRow(icon: String, label: String, isLoading: Bool = false, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: 14) {
+                ZStack {
+                    // Monochrome unfilled line icon
+                    if isLoading {
+                        ProgressView()
+                            .tint(DSColor.onBackgroundMuted)
+                            .scaleEffect(0.85)
+                    } else {
+                        Image(systemName: icon)
+                            .font(.system(size: 18, weight: .regular))
+                            .foregroundStyle(DSColor.onBackgroundMuted)
+                    }
+                }
+                .frame(width: 28, height: 28)
+
+                Text(label)
+                    .font(.custom("Inter-Regular", size: 15))
+                    .foregroundStyle(DSColor.onBackgroundPrimary)
+
+                Spacer()
+            }
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(AttachmentRowButtonStyle())
+    }
+}
+
+// MARK: - AttachmentRowButtonStyle
+
+private struct AttachmentRowButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .offset(y: configuration.isPressed ? 0.5 : 0)
+            .animation(.spring(response: 0.2, dampingFraction: 0.7), value: configuration.isPressed)
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -104,6 +104,17 @@ struct TodayView: View {
                                 }
                             }
 
+                        // Settings gear icon — always visible
+                        Button {
+                            showSettings = true
+                        } label: {
+                            Image(systemName: "gearshape")
+                                .font(.system(size: 16, weight: .regular))
+                                .foregroundColor(DSColor.onSurfaceVariant)
+                                .frame(width: 28, height: 28)
+                        }
+                        .accessibilityLabel("设置")
+
                         // Account avatar — shown when logged in
                         if authService.session != nil {
                             Button {


### PR DESCRIPTION
## Capture v2 体验优化（剩余 3 项）\n\n### 附件菜单重设计\n- 弃用纯色大圆按钮，改用单色线性图标 + 文字 list\n- ultraThinMaterial 背景，与 InputBarV4 统一\n- SF Symbols 细线版本，微动效 tap 下沉\n\n### 设置入口 + 主题\n- Today 顶栏右上角 gear icon 直达 Settings\n- 深色模式落地：System/Light/Dark\n- Accent color：amber/sage/slate/rose/ink\n- 卡片密度：Comfortable/Compact\n\n### 账户切换\n- 账户列表：当前账户、历史账户切换、添加\n- Sign Out 移到次级位置\n\nRefs #143