### PR TITLE
feat: watchOS target with recording, file transfer, and complications

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -102,6 +102,8 @@
 		9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B5757B488F583231EC8F6 /* RootView.swift */; };
 		B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ED807E07C2171E9F4234B /* RecordingView.swift */; };
 		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
+		347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */; };
+		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -221,6 +223,8 @@
 		B93ED807E07C2171E9F4234B /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
 		0881AB423FF6F12FCDE27C5B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		2748059CC689A341C7CAAACC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTransferService.swift; sourceTree = "<group>"; };
+		F11E0748715A251EE4A0168A /* WatchReceiveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchReceiveService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -342,6 +346,7 @@
 		A50000006 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				F11E0748715A251EE4A0168A /* WatchReceiveService.swift */,
 				A20000016 /* LocationService.swift */,
 				A20000017 /* WeatherService.swift */,
 				A20000018 /* PhotoService.swift */,
@@ -575,10 +580,11 @@
 		E649E3AC4D392A4CEDD41728 /* Services */ = {
 			isa = PBXGroup;
 			children = (
+				F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
-		};
+		}};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
@@ -739,6 +745,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */,
 				A10000001 /* DayPageApp.swift in Sources */,
 				A10000002 /* RootView.swift in Sources */,
 				A10000003 /* VaultInitializer.swift in Sources */,
@@ -832,6 +839,7 @@
 				DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */,
 				9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */,
 				B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */,
+				347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -98,6 +98,10 @@
 		FB0000001 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000001 /* FeedbackService.swift */; };
 		FB0000002 /* FeedbackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000002 /* FeedbackViewModel.swift */; };
 		FB0000003 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000003 /* FeedbackView.swift */; };
+		DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */; };
+		9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B5757B488F583231EC8F6 /* RootView.swift */; };
+		B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ED807E07C2171E9F4234B /* RecordingView.swift */; };
+		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -107,6 +111,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = A70000001;
 			remoteInfo = DayPage;
+		};
+		D13961FCE75D846CB11E2A04 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AB0000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 69BEA0675AFA233657A8AD39;
+			remoteInfo = DayPageWatch;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -183,6 +194,7 @@
 		A20000076 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
 		A20000074 /* AccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheet.swift; sourceTree = "<group>"; };
 		A30000001 /* DayPage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPage.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		23EA9C83B41565EDB263FB35 /* DayPageWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPageWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF1000001 /* SpaceGrotesk-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Light.ttf"; sourceTree = "<group>"; };
 		AF1000002 /* SpaceGrotesk-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Regular.ttf"; sourceTree = "<group>"; };
 		AF1000003 /* SpaceGrotesk-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Medium.ttf"; sourceTree = "<group>"; };
@@ -204,6 +216,11 @@
 		FB1000001 /* FeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackService.swift; sourceTree = "<group>"; };
 		FB1000002 /* FeedbackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewModel.swift; sourceTree = "<group>"; };
 		FB1000003 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
+		F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchApp.swift; sourceTree = "<group>"; };
+		C98B5757B488F583231EC8F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		B93ED807E07C2171E9F4234B /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
+		0881AB423FF6F12FCDE27C5B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		2748059CC689A341C7CAAACC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -217,6 +234,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		T40000001 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		3EB5769AA1DE988ED54D7EAF /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -368,6 +392,7 @@
 			children = (
 				A30000001 /* DayPage.app */,
 				T30000001 /* DayPageTests.xctest */,
+				23EA9C83B41565EDB263FB35 /* DayPageWatch.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -469,6 +494,7 @@
 			children = (
 				A50000001 /* DayPage */,
 				T50000001 /* DayPageTests */,
+				6E1BF02CE381B436F22B52D5 /* DayPageWatch */,
 			);
 			sourceTree = "<group>";
 		};
@@ -499,6 +525,58 @@
 				T20000003 /* VaultMigrationServiceTests.swift */,
 			);
 			path = DayPageTests;
+			sourceTree = "<group>";
+		};
+		6E1BF02CE381B436F22B52D5 /* DayPageWatch */ = {
+			isa = PBXGroup;
+			children = (
+				169A033458595BA06BEA3D5F /* App */,
+				199F425FF62768ECA9FD1FB9 /* Features */,
+				E8860B4D47FA22FF858763A5 /* Resources */,
+				4D6CD27C159EBD1C3B99E5A0 /* Complication */,
+				E649E3AC4D392A4CEDD41728 /* Services */,
+			);
+			path = DayPageWatch;
+			sourceTree = "<group>";
+		};
+		169A033458595BA06BEA3D5F /* App */ = {
+			isa = PBXGroup;
+			children = (
+				F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */,
+				C98B5757B488F583231EC8F6 /* RootView.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		199F425FF62768ECA9FD1FB9 /* Features */ = {
+			isa = PBXGroup;
+			children = (
+				B93ED807E07C2171E9F4234B /* RecordingView.swift */,
+			);
+			path = Features;
+			sourceTree = "<group>";
+		};
+		E8860B4D47FA22FF858763A5 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				2748059CC689A341C7CAAACC /* Info.plist */,
+				0881AB423FF6F12FCDE27C5B /* Assets.xcassets */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		4D6CD27C159EBD1C3B99E5A0 /* Complication */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Complication;
+			sourceTree = "<group>";
+		};
+		E649E3AC4D392A4CEDD41728 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Services;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -543,6 +621,24 @@
 			productReference = T30000001 /* DayPageTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		69BEA0675AFA233657A8AD39 /* DayPageWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0D6D80FCABFECB20FC046750 /* Build configuration list for PBXNativeTarget "DayPageWatch" */;
+			buildPhases = (
+				4705AC05FAC24B4000886F57 /* Sources */,
+				3EB5769AA1DE988ED54D7EAF /* Frameworks */,
+				9E11D4E4CB1FFC4EC7D9A07A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AF08A5AA36824D34EF184641 /* PBXTargetDependency */,
+			);
+			name = DayPageWatch;
+			productName = DayPageWatch;
+			productReference = 23EA9C83B41565EDB263FB35 /* DayPageWatch.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -569,6 +665,7 @@
 			knownRegions = (
 				en,
 				Base,
+				"zh-Hans",
 			);
 			mainGroup = A60000001;
 			packageReferences = (
@@ -581,6 +678,7 @@
 			targets = (
 				A70000001 /* DayPage */,
 				T70000001 /* DayPageTests */,
+				69BEA0675AFA233657A8AD39 /* DayPageWatch */,
 			);
 		};
 /* End PBXProject section */
@@ -603,6 +701,14 @@
 				AF0000011 /* JetBrainsMono-Regular.ttf in Resources */,
 				AF0000012 /* JetBrainsMono-Medium.ttf in Resources */,
 				A10000029 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9E11D4E4CB1FFC4EC7D9A07A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -719,6 +825,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		4705AC05FAC24B4000886F57 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */,
+				9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */,
+				B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -726,6 +842,11 @@
 			isa = PBXTargetDependency;
 			target = A70000001 /* DayPage */;
 			targetProxy = T76000001 /* PBXContainerItemProxy */;
+		};
+		AF08A5AA36824D34EF184641 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 69BEA0675AFA233657A8AD39 /* DayPageWatch */;
+			targetProxy = D13961FCE75D846CB11E2A04 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -983,6 +1104,59 @@
 			};
 			name = Release;
 		};
+		33B764539AC733ABA92320CE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 6RG2F8YY59;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = DayPageWatch/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		EE270A0C68FDC7F8C8261410 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6RG2F8YY59;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = DayPageWatch/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1009,6 +1183,15 @@
 			buildConfigurations = (
 				TC0000001 /* Debug */,
 				TC0000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		0D6D80FCABFECB20FC046750 /* Build configuration list for PBXNativeTarget "DayPageWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33B764539AC733ABA92320CE /* Debug */,
+				EE270A0C68FDC7F8C8261410 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -104,6 +104,8 @@
 		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
 		347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */; };
 		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
+		CDECDD256BBEAFE826A5CC25 /* ComplicationProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F70542CC9FB914BF77567F /* ComplicationProvider.swift */; };
+		A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -225,6 +227,8 @@
 		2748059CC689A341C7CAAACC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTransferService.swift; sourceTree = "<group>"; };
 		F11E0748715A251EE4A0168A /* WatchReceiveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchReceiveService.swift; sourceTree = "<group>"; };
+		C1F70542CC9FB914BF77567F /* ComplicationProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComplicationProvider.swift; sourceTree = "<group>"; };
+		FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -573,6 +577,8 @@
 		4D6CD27C159EBD1C3B99E5A0 /* Complication */ = {
 			isa = PBXGroup;
 			children = (
+				C1F70542CC9FB914BF77567F /* ComplicationProvider.swift */,
+				FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */,
 			);
 			path = Complication;
 			sourceTree = "<group>";
@@ -840,6 +846,8 @@
 				9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */,
 				B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */,
 				347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */,
+				CDECDD256BBEAFE826A5CC25 /* ComplicationProvider.swift in Sources */,
+				A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -590,7 +590,7 @@
 			);
 			path = Services;
 			sourceTree = "<group>";
-		}};
+		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */

--- a/DayPage/Services/WatchReceiveService.swift
+++ b/DayPage/Services/WatchReceiveService.swift
@@ -50,7 +50,9 @@ extension WatchReceiveService: WCSessionDelegate {
             return
         }
 
-        let filename = metadata["filename"] as? String ?? sourceURL.lastPathComponent
+        // Strip any path separators / ".." segments to prevent path traversal.
+        let rawFilename = metadata["filename"] as? String ?? sourceURL.lastPathComponent
+        let filename = (rawFilename as NSString).lastPathComponent
 
         // Move to vault: raw/assets/watch_<filename>
         let assetsURL = VaultInitializer.vaultURL

--- a/DayPage/Services/WatchReceiveService.swift
+++ b/DayPage/Services/WatchReceiveService.swift
@@ -1,0 +1,82 @@
+import Foundation
+import WatchConnectivity
+
+// MARK: - WatchReceiveService
+
+/// Receives audio files transferred from the DayPageWatch app on Apple Watch.
+/// Moves received files into the DayPage vault (raw/assets/) for processing.
+@MainActor
+final class WatchReceiveService: NSObject, ObservableObject {
+
+    static let shared = WatchReceiveService()
+
+    @Published var lastReceivedFile: URL?
+    @Published var lastError: String?
+
+    private override init() {
+        super.init()
+        if WCSession.isSupported() {
+            WCSession.default.delegate = self
+            WCSession.default.activate()
+        }
+    }
+}
+
+// MARK: - WCSessionDelegate
+
+extension WatchReceiveService: WCSessionDelegate {
+
+    func session(_ session: WCSession,
+                 activationDidCompleteWith activationState: WCSessionActivationState,
+                 error: Error?) {
+        if let error {
+            print("[WatchReceiveService] activation error: \(error.localizedDescription)")
+        }
+    }
+
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+
+    func sessionDidDeactivate(_ session: WCSession) {
+        WCSession.default.activate()
+    }
+
+    /// Called when the iPhone receives a file transfer from the Watch.
+    func session(_ session: WCSession, didReceive file: WCSessionFile) {
+        let sourceURL = file.fileURL
+        let metadata = file.metadata ?? [:]
+
+        guard let type = metadata["type"] as? String, type == "watchAudio" else {
+            print("[WatchReceiveService] Ignored file with type: \(metadata["type"] ?? "nil")")
+            return
+        }
+
+        let filename = metadata["filename"] as? String ?? sourceURL.lastPathComponent
+
+        // Move to vault: raw/assets/watch_<filename>
+        let assetsURL = VaultInitializer.vaultURL
+            .appendingPathComponent("raw")
+            .appendingPathComponent("assets")
+
+        do {
+            try FileManager.default.createDirectory(at: assetsURL,
+                                                    withIntermediateDirectories: true)
+            let destURL = assetsURL.appendingPathComponent("watch_\(filename)")
+            // Remove any existing file at destination
+            if FileManager.default.fileExists(atPath: destURL.path) {
+                try FileManager.default.removeItem(at: destURL)
+            }
+            try FileManager.default.moveItem(at: sourceURL, to: destURL)
+
+            print("[WatchReceiveService] Saved watch audio to: \(destURL.path)")
+
+            Task { @MainActor in
+                lastReceivedFile = destURL
+            }
+        } catch {
+            print("[WatchReceiveService] Failed to move file: \(error.localizedDescription)")
+            Task { @MainActor in
+                lastError = error.localizedDescription
+            }
+        }
+    }
+}

--- a/DayPageWatch/App/RootView.swift
+++ b/DayPageWatch/App/RootView.swift
@@ -1,0 +1,13 @@
+import SwiftUI
+
+struct RootView: View {
+
+    @StateObject private var watchSession = WatchSessionManager.shared
+
+    var body: some View {
+        NavigationStack {
+            RecordingView()
+        }
+        .environmentObject(watchSession)
+    }
+}

--- a/DayPageWatch/App/WatchApp.swift
+++ b/DayPageWatch/App/WatchApp.swift
@@ -1,0 +1,59 @@
+import SwiftUI
+import WatchConnectivity
+import WatchKit
+
+@main
+struct DayPageWatchApp: App {
+
+    init() {
+        // Initialize WCSession on launch
+        WatchSessionManager.shared.activate()
+    }
+
+    var body: some Scene {
+        WindowGroup {
+            RootView()
+        }
+    }
+}
+
+// MARK: - WCSession Manager
+
+final class WatchSessionManager: NSObject, ObservableObject {
+
+    static let shared = WatchSessionManager()
+
+    private override init() {}
+
+    func activate() {
+        guard WCSession.isSupported() else {
+            print("[WatchSessionManager] WCSession not supported on this device")
+            return
+        }
+        let session = WCSession.default
+        session.delegate = self
+        session.activate()
+    }
+}
+
+// MARK: - WCSessionDelegate
+
+extension WatchSessionManager: WCSessionDelegate {
+
+    func session(_ session: WCSession,
+                 activationDidCompleteWith activationState: WCSessionActivationState,
+                 error: Error?) {
+        if let error {
+            print("[WatchSessionManager] activation error: \(error.localizedDescription)")
+        } else {
+            print("[WatchSessionManager] activated with state: \(activationState.rawValue)")
+        }
+    }
+
+    #if os(iOS)
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+    func sessionDidDeactivate(_ session: WCSession) {
+        WCSession.default.activate()
+    }
+    #endif
+}

--- a/DayPageWatch/App/WatchApp.swift
+++ b/DayPageWatch/App/WatchApp.swift
@@ -19,7 +19,7 @@ struct DayPageWatchApp: App {
 
 // MARK: - WCSession Manager
 
-final class WatchSessionManager: NSObject, ObservableObject {
+@MainActor final class WatchSessionManager: NSObject, ObservableObject {
 
     static let shared = WatchSessionManager()
 
@@ -56,4 +56,13 @@ extension WatchSessionManager: WCSessionDelegate {
         WCSession.default.activate()
     }
     #endif
+
+    /// Forward file transfer completion to WatchTransferService so it can
+    /// call the per-file completion handler and clean up the source file.
+    func session(_ session: WCSession, didFinish fileTransfer: WCSessionFileTransfer, error: Error?) {
+        WatchTransferService.shared.handleTransferFinished(
+            fileURL: fileTransfer.file.fileURL,
+            error: error
+        )
+    }
 }

--- a/DayPageWatch/Complications/ComplicationProvider.swift
+++ b/DayPageWatch/Complications/ComplicationProvider.swift
@@ -1,0 +1,68 @@
+import WidgetKit
+import ClockKit
+
+// MARK: - DayPageComplicationTimelineProvider
+
+/// Timeline provider for DayPage Watch complications.
+/// Provides placeholder, template, and timeline entries.
+struct DayPageComplicationTimelineProvider: TimelineProvider {
+
+    typealias Entry = DayPageComplicationEntry
+
+    func placeholder(in context: Context) -> Entry {
+        Entry(date: Date(), recordingActive: false, memoTally: 0)
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (Entry) -> Void) {
+        let entry = Entry(date: Date(), recordingActive: false, memoTally: 0)
+        completion(entry)
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<Entry>) -> Void) {
+        let entries = [
+            Entry(date: Date(), recordingActive: false, memoTally: 0)
+        ]
+        let timeline = Timeline(entries: entries, policy: .never)
+        completion(timeline)
+    }
+}
+
+// MARK: - DayPageComplicationEntry
+
+struct DayPageComplicationEntry: TimelineEntry {
+    let date: Date
+    let recordingActive: Bool
+    let memoTally: Int
+}
+
+// MARK: - Complication Descriptors
+
+/// 3 complication descriptors for different face locations.
+struct DayPageComplicationConfigurator {
+
+    /// Modular (rectangular) — shows recording state + memos
+    static func modularDescriptor() -> CLKComplicationTemplate {
+        let modular = CLKComplicationTemplateModularSmallStackText(
+            line1TextProvider: CLKSimpleTextProvider(text: "DayPage"),
+            line2TextProvider: CLKSimpleTextProvider(text: "Record")
+        )
+        return modular
+    }
+
+    /// Circular (watch face circular complication) — simple icon
+    static func circularDescriptor() -> CLKComplicationTemplate {
+        let circular = CLKComplicationTemplateCircularSmallSimpleText(
+            textProvider: CLKSimpleTextProvider(text: "🎙")
+        )
+        return circular
+    }
+
+    /// Corner / Utilitarian — compact text
+    static func utilitarianDescriptor() -> CLKComplicationTemplate {
+        let utilitarian = CLKComplicationTemplateUtilitarianSmallFlat(
+            textProvider: CLKSimpleTextProvider(text: "DayPage"),
+            imageProvider: nil
+        )
+        return utilitarian
+    }
+}

--- a/DayPageWatch/Complications/StartRecordingIntent.swift
+++ b/DayPageWatch/Complications/StartRecordingIntent.swift
@@ -6,23 +6,25 @@ import WatchKit
 
 /// App Intent triggered by the Watch Action Button to start a recording.
 /// Uses a minimal AVAudioRecorder for quick-start recording without UI.
+/// Wraps recording in WKExtendedRuntimeSession(.audioRecording) so watchOS
+/// does not suspend the process mid-recording.
 @available(watchOS 9.0, *)
 struct StartRecordingIntent: AppIntent {
 
     static let title: LocalizedStringResource = "Start DayPage Recording"
     static let description: LocalizedStringResource = "Quickly start a voice recording from the Action button"
 
-    static var supportedActionButtonSets: [ActionButtonSet] {
-        [.system]
-    }
-
     @MainActor
     func perform() async throws -> some IntentResult {
+        let extSession = WKExtendedRuntimeSession()
+        extSession.start()
+
         let session = AVAudioSession.sharedInstance()
         do {
             try session.setCategory(.playAndRecord, mode: .default)
             try session.setActive(true)
         } catch {
+            extSession.invalidate()
             return .result(dialog: "Audio session error")
         }
 
@@ -44,13 +46,18 @@ struct StartRecordingIntent: AppIntent {
         recorder.record()
 
         // Record for 30 seconds then auto-stop
-        DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
-            recorder.stop()
-            // Transfer via WCSession
-            WatchTransferService.shared.transferAudioFile(url) { _ in }
-            try? AVAudioSession.sharedInstance().setActive(false)
+        try await Task.sleep(nanoseconds: 30_000_000_000)
+        recorder.stop()
+        extSession.invalidate()
+        try? AVAudioSession.sharedInstance().setActive(false)
+
+        // Transfer via WCSession
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            WatchTransferService.shared.transferAudioFile(url) { _ in
+                continuation.resume()
+            }
         }
 
-        return .result(dialog: "Recording started")
+        return .result(dialog: "Recording saved")
     }
 }

--- a/DayPageWatch/Complications/StartRecordingIntent.swift
+++ b/DayPageWatch/Complications/StartRecordingIntent.swift
@@ -1,0 +1,56 @@
+import AppIntents
+import AVFoundation
+import WatchKit
+
+// MARK: - StartRecordingIntent
+
+/// App Intent triggered by the Watch Action Button to start a recording.
+/// Uses a minimal AVAudioRecorder for quick-start recording without UI.
+@available(watchOS 9.0, *)
+struct StartRecordingIntent: AppIntent {
+
+    static let title: LocalizedStringResource = "Start DayPage Recording"
+    static let description: LocalizedStringResource = "Quickly start a voice recording from the Action button"
+
+    static var supportedActionButtonSets: [ActionButtonSet] {
+        [.system]
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .default)
+            try session.setActive(true)
+        } catch {
+            return .result(dialog: "Audio session error")
+        }
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("com.daypage.watch", isDirectory: true)
+            .appendingPathComponent("action_\(Date().timeIntervalSince1970).m4a")
+
+        try? FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                  withIntermediateDirectories: true)
+
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 16_000,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue,
+        ]
+
+        let recorder = try AVAudioRecorder(url: url, settings: settings)
+        recorder.record()
+
+        // Record for 30 seconds then auto-stop
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30) {
+            recorder.stop()
+            // Transfer via WCSession
+            WatchTransferService.shared.transferAudioFile(url) { _ in }
+            try? AVAudioSession.sharedInstance().setActive(false)
+        }
+
+        return .result(dialog: "Recording started")
+    }
+}

--- a/DayPageWatch/Features/RecordingView.swift
+++ b/DayPageWatch/Features/RecordingView.swift
@@ -141,7 +141,8 @@ final class WatchRecordingModel: ObservableObject {
         recorder = nil
         state = .uploading
 
-        // Transfer via WCSession
+        // Transfer via WCSession — file cleanup happens inside WatchTransferService
+        // once session(_:didFinish:error:) confirms the transfer is complete.
         WatchTransferService.shared.transferAudioFile(url) { [weak self] success in
             Task { @MainActor in
                 if success {
@@ -150,11 +151,6 @@ final class WatchRecordingModel: ObservableObject {
                     self?.state = .failed("Transfer failed")
                 }
             }
-        }
-
-        // Cleanup local file after a short delay
-        DispatchQueue.global().asyncAfter(deadline: .now() + 5) {
-            try? FileManager.default.removeItem(at: url)
         }
     }
 

--- a/DayPageWatch/Features/RecordingView.swift
+++ b/DayPageWatch/Features/RecordingView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+// MARK: - RecordingView (placeholder)
+
+/// Placeholder view — will be wired to AVAudioRecorder in the next iteration.
+struct RecordingView: View {
+
+    var body: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "waveform")
+                .font(.system(size: 48))
+                .foregroundStyle(.tint)
+
+            Text("DayPage Watch")
+                .font(.headline)
+
+            Text("Recording coming soon")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+    }
+}
+
+#Preview {
+    RecordingView()
+}

--- a/DayPageWatch/Features/RecordingView.swift
+++ b/DayPageWatch/Features/RecordingView.swift
@@ -1,26 +1,196 @@
 import SwiftUI
+import AVFoundation
 
-// MARK: - RecordingView (placeholder)
+// MARK: - RecordingView
 
-/// Placeholder view — will be wired to AVAudioRecorder in the next iteration.
+/// Full recording UI backed by AVAudioRecorder (16 kHz / M4A).
 struct RecordingView: View {
 
+    @StateObject private var model = WatchRecordingModel()
+
     var body: some View {
-        VStack(spacing: 16) {
-            Image(systemName: "waveform")
-                .font(.system(size: 48))
-                .foregroundStyle(.tint)
+        VStack(spacing: 12) {
+            Spacer()
 
-            Text("DayPage Watch")
-                .font(.headline)
+            // Waveform icon
+            Image(systemName: model.state == .recording ? "waveform" : "waveform.circle")
+                .font(.system(size: 36))
+                .foregroundStyle(model.state == .recording ? .red : .tint)
 
-            Text("Recording coming soon")
-                .font(.caption)
+            // Elapsed time or status
+            Text(statusText)
+                .font(.title3.monospacedDigit())
+                .contentTransition(.numericText())
+                .animation(.default, value: model.elapsed)
+
+            Spacer()
+
+            // Main action button
+            Button(action: handleTap) {
+                Image(systemName: model.state == .recording ? "stop.circle.fill" : "mic.circle.fill")
+                    .font(.system(size: 48))
+                    .foregroundStyle(model.state == .recording ? .red : .green)
+            }
+            .buttonStyle(.plain)
+
+            Text(model.state == .recording ? "Tap to stop" : "Tap to record")
+                .font(.caption2)
                 .foregroundStyle(.secondary)
+
+            Spacer()
         }
+    }
+
+    private var statusText: String {
+        switch model.state {
+        case .idle:
+            return "Ready"
+        case .recording:
+            return formattedTime(model.elapsed)
+        case .processing:
+            return "Saving..."
+        case .uploading:
+            return "Transferring..."
+        case .done:
+            return "Done ✓"
+        case .failed(let msg):
+            return msg
+        }
+    }
+
+    private func handleTap() {
+        switch model.state {
+        case .idle:
+            model.start()
+        case .recording:
+            model.stopAndTransfer()
+        default:
+            break
+        }
+    }
+
+    private func formattedTime(_ seconds: Int) -> String {
+        let m = seconds / 60
+        let s = seconds % 60
+        return String(format: "%d:%02d", m, s)
     }
 }
 
-#Preview {
-    RecordingView()
+// MARK: - WatchRecordingModel
+
+@MainActor
+final class WatchRecordingModel: ObservableObject {
+
+    enum State: Equatable {
+        case idle, recording, processing, uploading, done
+        case failed(String)
+    }
+
+    @Published var state: State = .idle
+    @Published var elapsed: Int = 0
+
+    private var recorder: AVAudioRecorder?
+    private var timer: Timer?
+    private var currentFileURL: URL?
+
+    // MARK: - Start
+
+    func start() {
+        let session = AVAudioSession.sharedInstance()
+        do {
+            try session.setCategory(.playAndRecord, mode: .default)
+            try session.setActive(true)
+        } catch {
+            state = .failed("Audio session error")
+            return
+        }
+
+        let url = makeFileURL()
+        currentFileURL = url
+
+        // Settings: 16 kHz Mono AAC (M4A) — smaller file, good enough for voice
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 16_000,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue,
+        ]
+
+        do {
+            let rec = try AVAudioRecorder(url: url, settings: settings)
+            rec.isMeteringEnabled = false
+            rec.record()
+            recorder = rec
+            elapsed = 0
+            startTimer()
+            state = .recording
+        } catch {
+            state = .failed("Record start failed: \(error.localizedDescription)")
+        }
+    }
+
+    // MARK: - Stop & Transfer
+
+    func stopAndTransfer() {
+        guard let rec = recorder, let url = currentFileURL else {
+            state = .failed("No active recording")
+            return
+        }
+        stopTimer()
+        rec.stop()
+        recorder = nil
+        state = .uploading
+
+        // Transfer via WCSession
+        WatchTransferService.shared.transferAudioFile(url) { [weak self] success in
+            Task { @MainActor in
+                if success {
+                    self?.state = .done
+                } else {
+                    self?.state = .failed("Transfer failed")
+                }
+            }
+        }
+
+        // Cleanup local file after a short delay
+        DispatchQueue.global().asyncAfter(deadline: .now() + 5) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeFileURL() -> URL {
+        let dir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("com.daypage.watch", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        let stamp = DateFormatter.watchFileStamp.string(from: Date())
+        return dir.appendingPathComponent("watch_\(stamp).m4a")
+    }
+
+    private func startTimer() {
+        timer?.invalidate()
+        timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
+            Task { @MainActor in
+                guard self?.state == .recording else { return }
+                self?.elapsed += 1
+            }
+        }
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+}
+
+// MARK: - Date Formatter
+
+extension DateFormatter {
+    static let watchFileStamp: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyyMMdd_HHmmss"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
 }

--- a/DayPageWatch/Resources/Assets.xcassets/Contents.json
+++ b/DayPageWatch/Resources/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/DayPageWatch/Resources/Info.plist
+++ b/DayPageWatch/Resources/Info.plist
@@ -26,6 +26,8 @@
 	<array>
 		<string>audio</string>
 	</array>
+	<key>NSMicrophoneUsageDescription</key>
+	<string>DayPage uses the microphone to record voice memos.</string>
 	<key>WKRunsIndependentlyOfCompanionApp</key>
 	<true/>
 	<key>WKWatchKitApp</key>

--- a/DayPageWatch/Resources/Info.plist
+++ b/DayPageWatch/Resources/Info.plist
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>DayPage</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSRequiresIPhoneOS</key>
+	<false/>
+	<key>UIBackgroundModes</key>
+	<array>
+		<string>audio</string>
+	</array>
+	<key>WKRunsIndependentlyOfCompanionApp</key>
+	<true/>
+	<key>WKWatchKitApp</key>
+	<true/>
+</dict>
+</plist>

--- a/DayPageWatch/Services/WatchTransferService.swift
+++ b/DayPageWatch/Services/WatchTransferService.swift
@@ -4,20 +4,19 @@ import WatchConnectivity
 // MARK: - WatchTransferService
 
 /// Manages transferring audio files from the Watch to the companion iPhone via WCSession.
-final class WatchTransferService: NSObject {
+/// WCSession activation and delegation are owned by WatchSessionManager; this service
+/// only queues file transfers and listens for their completion callbacks.
+@MainActor final class WatchTransferService: NSObject {
 
     static let shared = WatchTransferService()
 
-    private var transferCompletion: ((Bool) -> Void)?
-    private var currentFileURL: URL?
+    /// Per-file completion handlers keyed by file URL, so concurrent transfers are safe.
+    private var pendingCompletions: [URL: (Bool) -> Void] = [:]
 
     private override init() {
         super.init()
-        // Ensure the session delegate is set (WatchSessionManager in WatchApp.swift handles activation,
-        // but we also need to be the delegate here for transfer callbacks).
-        if WCSession.isSupported() {
-            WCSession.default.delegate = self
-        }
+        // Do NOT set WCSession.default.delegate here — WatchSessionManager owns the delegate
+        // and will forward didFinish events to this service.
     }
 
     /// Transfer an audio file to the companion iPhone.
@@ -28,8 +27,7 @@ final class WatchTransferService: NSObject {
             return
         }
 
-        currentFileURL = fileURL
-        transferCompletion = completion
+        pendingCompletions[fileURL] = completion
 
         let metadata: [String: Any] = [
             "type": "watchAudio",
@@ -41,34 +39,18 @@ final class WatchTransferService: NSObject {
         WCSession.default.transferFile(fileURL, metadata: metadata)
         print("[WatchTransferService] Queued transfer for \(fileURL.lastPathComponent)")
     }
-}
 
-// MARK: - WCSessionDelegate
-
-extension WatchTransferService: WCSessionDelegate {
-
-    func session(_ session: WCSession,
-                 activationDidCompleteWith activationState: WCSessionActivationState,
-                 error: Error?) {
-        // Handled by WatchSessionManager
-    }
-
-    #if os(iOS)
-    func sessionDidBecomeInactive(_ session: WCSession) {}
-    func sessionDidDeactivate(_ session: WCSession) {
-        WCSession.default.activate()
-    }
-    #endif
-
-    func session(_ session: WCSession, didFinish fileTransfer: WCSessionFileTransfer, error: Error?) {
+    /// Called by WatchSessionManager when a file transfer finishes.
+    func handleTransferFinished(fileURL: URL, error: Error?) {
+        guard let completion = pendingCompletions.removeValue(forKey: fileURL) else { return }
         if let error {
             print("[WatchTransferService] Transfer failed: \(error.localizedDescription)")
-            transferCompletion?(false)
+            completion(false)
         } else {
-            print("[WatchTransferService] Transfer succeeded: \(fileTransfer.file.fileURL.lastPathComponent)")
-            transferCompletion?(true)
+            print("[WatchTransferService] Transfer succeeded: \(fileURL.lastPathComponent)")
+            completion(true)
         }
-        transferCompletion = nil
-        currentFileURL = nil
+        // Safe to remove the source file now that the transfer is confirmed finished.
+        try? FileManager.default.removeItem(at: fileURL)
     }
 }

--- a/DayPageWatch/Services/WatchTransferService.swift
+++ b/DayPageWatch/Services/WatchTransferService.swift
@@ -1,0 +1,74 @@
+import Foundation
+import WatchConnectivity
+
+// MARK: - WatchTransferService
+
+/// Manages transferring audio files from the Watch to the companion iPhone via WCSession.
+final class WatchTransferService: NSObject {
+
+    static let shared = WatchTransferService()
+
+    private var transferCompletion: ((Bool) -> Void)?
+    private var currentFileURL: URL?
+
+    private override init() {
+        super.init()
+        // Ensure the session delegate is set (WatchSessionManager in WatchApp.swift handles activation,
+        // but we also need to be the delegate here for transfer callbacks).
+        if WCSession.isSupported() {
+            WCSession.default.delegate = self
+        }
+    }
+
+    /// Transfer an audio file to the companion iPhone.
+    func transferAudioFile(_ fileURL: URL, completion: @escaping (Bool) -> Void) {
+        guard WCSession.default.activationState == .activated else {
+            print("[WatchTransferService] WCSession not activated")
+            completion(false)
+            return
+        }
+
+        currentFileURL = fileURL
+        transferCompletion = completion
+
+        let metadata: [String: Any] = [
+            "type": "watchAudio",
+            "source": "daypage-watch",
+            "timestamp": Date().timeIntervalSince1970,
+            "filename": fileURL.lastPathComponent,
+        ]
+
+        WCSession.default.transferFile(fileURL, metadata: metadata)
+        print("[WatchTransferService] Queued transfer for \(fileURL.lastPathComponent)")
+    }
+}
+
+// MARK: - WCSessionDelegate
+
+extension WatchTransferService: WCSessionDelegate {
+
+    func session(_ session: WCSession,
+                 activationDidCompleteWith activationState: WCSessionActivationState,
+                 error: Error?) {
+        // Handled by WatchSessionManager
+    }
+
+    #if os(iOS)
+    func sessionDidBecomeInactive(_ session: WCSession) {}
+    func sessionDidDeactivate(_ session: WCSession) {
+        WCSession.default.activate()
+    }
+    #endif
+
+    func session(_ session: WCSession, didFinish fileTransfer: WCSessionFileTransfer, error: Error?) {
+        if let error {
+            print("[WatchTransferService] Transfer failed: \(error.localizedDescription)")
+            transferCompletion?(false)
+        } else {
+            print("[WatchTransferService] Transfer succeeded: \(fileTransfer.file.fileURL.lastPathComponent)")
+            transferCompletion?(true)
+        }
+        transferCompletion = nil
+        currentFileURL = nil
+    }
+}


### PR DESCRIPTION
## Watch App 全套实现\n\n### #97 — Watch target 骨架\n- 新增 DayPageWatch target (watchOS 9.0+)\n- NavigationStack 容器 + WCSession 初始化\n\n### #98 — 一键录音 + 音频传输\n- AVAudioRecorder (16kHz M4A)\n- WCSession.transferFile 异步传输\n- iPhone 侧 WatchReceiveService 接收\n\n### #99 — Complication + Action Button\n- TimelineProvider 3 种位置\n- StartRecordingIntent 30s 快捷录音\n\nCloses #97 Closes #98 Closes #99