### PR TITLE
feat(today): restore STREAM dock as Capture v2 idle composer

### DIFF
--- a/DayPage/Features/Today/AttachmentMenuPopover.swift
+++ b/DayPage/Features/Today/AttachmentMenuPopover.swift
@@ -2,10 +2,16 @@ import SwiftUI
 
 // MARK: - AttachmentMenuPopover
 //
-// Capture v2 minimal design: single-color line icons + text label list,
-// ultraThinMaterial background matching InputBarV4 capsule aesthetic.
-// Uses SF Symbols thin variants (camera, photo, paperclip, mappin) unfilled.
-// Subtle tap animation: depresses + micro-scale.
+// Capture v2 STREAM "more tray" — translated from VariationStream.jsx's
+// AttachItem grid. Four equal-weight tiles in a single row:
+//
+//   拍照 · 相册 · 位置 · 附件
+//
+// Each tile is a 56×56 rounded square in surfaceSunken with a monochrome
+// SF Symbol; below it a 12pt muted label. The whole tray sits on a small
+// rounded card with a subtle warm border — no full-height list, no big
+// dividers, no drag handle clutter. Matches the design's "elegant,
+// uncluttered" brief from chat round 4 ("没有必要占满啊，优雅美观简洁就可以").
 
 struct AttachmentMenuPopover: View {
 
@@ -19,73 +25,81 @@ struct AttachmentMenuPopover: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Drag handle
-            RoundedRectangle(cornerRadius: 2)
+            // Slim drag handle (Apple-style; sheet still draggable)
+            Capsule()
                 .fill(DSColor.borderDefault)
                 .frame(width: 36, height: 4)
-                .padding(.top, 10)
-                .padding(.bottom, 20)
+                .padding(.top, 8)
+                .padding(.bottom, 22)
 
-            VStack(spacing: 0) {
-                attachmentRow(icon: "camera", label: "拍照", action: onCapturePhoto)
-                Divider().padding(.leading, 48).foregroundColor(DSColor.borderSubtle)
-                attachmentRow(icon: "photo", label: "从相册选", action: onPickPhoto)
-                Divider().padding(.leading, 48).foregroundColor(DSColor.borderSubtle)
-                attachmentRow(icon: "paperclip", label: "附件", action: onAddFile)
-                Divider().padding(.leading, 48).foregroundColor(DSColor.borderSubtle)
-                attachmentRow(
-                    icon: "mappin",
-                    label: hasPendingLocation ? "更新位置" : "位置",
-                    isLoading: isLocating,
-                    action: onAddLocation
-                )
+            // 4-up tile row, evenly distributed
+            HStack(spacing: 0) {
+                tile(icon: "camera",     label: "拍照",
+                     action: onCapturePhoto)
+                tile(icon: "photo.on.rectangle", label: "相册",
+                     action: onPickPhoto)
+                tile(icon: hasPendingLocation ? "mappin.circle.fill" : "mappin",
+                     label: hasPendingLocation ? "更新位置" : "位置",
+                     isLoading: isLocating,
+                     action: onAddLocation)
+                tile(icon: "paperclip",  label: "附件",
+                     action: onAddFile)
             }
+            .padding(.horizontal, 8)
+            .padding(.vertical, 16)
+            .frame(maxWidth: .infinity)
             .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
                     .fill(.ultraThinMaterial)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
-                    .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
+                RoundedRectangle(cornerRadius: 22, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.6), lineWidth: 0.5)
             )
+            .shadow(color: DSColor.accentAmber.opacity(0.08), radius: 16, x: 0, y: 8)
             .padding(.horizontal, 16)
-            .padding(.bottom, 28)
+
+            Spacer(minLength: 28)
         }
         .frame(maxWidth: .infinity)
         .background(DSColor.backgroundWarm)
-        .presentationDetents([.height(280)])
+        .presentationDetents([.height(220)])
         .presentationDragIndicator(.hidden)
         .modifier(AttachmentSheetPresentation())
     }
 
-    // MARK: - Attachment Row
+    // MARK: - Tile (icon square + label)
 
     @ViewBuilder
-    private func attachmentRow(icon: String, label: String, isLoading: Bool = false, action: @escaping () -> Void) -> some View {
+    private func tile(
+        icon: String,
+        label: String,
+        isLoading: Bool = false,
+        action: @escaping () -> Void
+    ) -> some View {
         Button(action: action) {
-            HStack(spacing: 14) {
+            VStack(spacing: 8) {
                 ZStack {
-                    // Monochrome unfilled line icon
+                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        .fill(DSColor.surfaceSunken)
+                        .frame(width: 56, height: 56)
                     if isLoading {
                         ProgressView()
                             .tint(DSColor.onBackgroundMuted)
-                            .scaleEffect(0.85)
+                            .scaleEffect(0.9)
                     } else {
                         Image(systemName: icon)
-                            .font(.system(size: 18, weight: .regular))
+                            .font(.system(size: 22, weight: .regular))
                             .foregroundStyle(DSColor.onBackgroundMuted)
                     }
                 }
-                .frame(width: 28, height: 28)
 
                 Text(label)
-                    .font(.custom("Inter-Regular", size: 15))
-                    .foregroundStyle(DSColor.onBackgroundPrimary)
-
-                Spacer()
+                    .font(.custom("Inter-Regular", size: 12))
+                    .foregroundStyle(DSColor.onBackgroundMuted)
+                    .lineLimit(1)
             }
-            .padding(.horizontal, 14)
-            .padding(.vertical, 12)
+            .frame(maxWidth: .infinity)
             .contentShape(Rectangle())
         }
         .buttonStyle(AttachmentRowButtonStyle())

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -215,8 +215,15 @@ struct InputBarV4: View {
     // shadow stack approximating the iOS 26 Liquid Glass treatment from the
     // design canvas (inner highlight + soft drop shadow).
 
+    // STREAM dock — three free-floating glass discs.
+    //
+    // No outer container: the page (and any list content behind it) shows
+    // through between the three buttons. Each disc carries its own
+    // ultraThinMaterial fill, fine inner highlight, and a soft warm-amber
+    // drop shadow so the surface reads as elevated glass over the page,
+    // not a solid pill.
     private var streamDock: some View {
-        HStack(spacing: 8) {
+        HStack(spacing: 18) {
             // LEFT — More
             dockSideButton(
                 systemImage: "plus",
@@ -238,7 +245,9 @@ struct InputBarV4: View {
                 idleBackgroundColor: DSColor.accentAmber,
                 idleIconColor: .white
             )
-            .frame(width: 56, height: 44)
+            .frame(width: 56, height: 56)
+            .shadow(color: DSColor.accentAmber.opacity(0.32), radius: 14, x: 0, y: 8)
+            .shadow(color: DSColor.accentAmber.opacity(0.18), radius: 4, x: 0, y: 2)
             .accessibilityLabel("按住说话")
 
             // RIGHT — Pen (expand text composer)
@@ -252,21 +261,10 @@ struct InputBarV4: View {
                 isFocused = true
             }
         }
-        .padding(6)
-        .background(
-            Capsule(style: .continuous)
-                .fill(.ultraThinMaterial)
-        )
-        .overlay(
-            Capsule(style: .continuous)
-                .strokeBorder(Color.white.opacity(0.7), lineWidth: 0.5)
-        )
-        .shadow(color: DSColor.accentAmber.opacity(0.10), radius: 18, x: 0, y: 12)
-        .shadow(color: DSColor.accentAmber.opacity(0.06), radius: 4, x: 0, y: 2)
-        .frame(maxWidth: .infinity)
     }
 
-    // 40pt translucent side button. Plain SF Symbol, no fill, no label.
+    // Translucent glass disc — 44pt. ultraThinMaterial + warm hairline +
+    // soft drop shadow so it reads as a floating glass coin over the page.
     @ViewBuilder
     private func dockSideButton(
         systemImage: String,
@@ -278,17 +276,19 @@ struct InputBarV4: View {
             action()
         } label: {
             Image(systemName: systemImage)
-                .font(.system(size: 17, weight: .regular))
+                .font(.system(size: 18, weight: .regular))
                 .foregroundStyle(DSColor.onBackgroundPrimary)
-                .frame(width: 40, height: 40)
+                .frame(width: 44, height: 44)
                 .background(
                     Circle()
-                        .fill(Color.white.opacity(0.55))
+                        .fill(.ultraThinMaterial)
                 )
                 .overlay(
                     Circle()
-                        .strokeBorder(Color.white.opacity(0.7), lineWidth: 0.5)
+                        .strokeBorder(Color.white.opacity(0.55), lineWidth: 0.5)
                 )
+                .shadow(color: Color.black.opacity(0.10), radius: 10, x: 0, y: 6)
+                .shadow(color: Color.black.opacity(0.04), radius: 2, x: 0, y: 1)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -3,22 +3,30 @@ import CoreLocation
 import PhotosUI
 import UIKit
 
-// MARK: - InputBarV4  "Silent Press-to-Talk"
+// MARK: - InputBarV4  "Capture v2 · STREAM dock"
 //
-// Capture v2 surface. Frosted-glass capsule (ultraThinMaterial) carrying
-// a visible mic-hero on the right; tap the capsule body to expand into a
-// text composer; long-press the mic-hero to record.
+// Capture v2 surface, faithful to the design-handoff STREAM variation:
+// a centered, compact liquid-glass capsule with three slots —
 //
-// States:
-//   collapsed  — capsule: "Hold to talk" hint + visible mic-hero on right
-//   composing  — capsule expands to TextField; + button on left, send
-//                arrow on right
-//   recording  — PressToTalk overlay; capsule stays visible
+//   [+ more]  [ mic-hero (amber, 56×44) ]  [ ✏ pen ]
 //
-// No bottom shelf. Capture v2 design note 03: "Notes / Attach / Camera
-// labels — gone. Iconography under explicit text labels is a tell that
-// the icons are not legible." Attachments live behind the `+` button
-// inside the composing capsule.
+// + opens the attachment menu (camera / album / file / location).
+// mic-hero: tap → Flomo-style recording (separate bar);
+//           long-press (>= 0.35s) → WeChat-style press-to-talk
+//           (drag up to cancel, drag left to transcribe-into-draft,
+//            release to send).
+// pen: expands the dock into a full-width text composer above; send
+//      arrow on the right replaces the dock while composing.
+//
+// Hint line beneath the dock ("点击录音 · 长按发送") sets expectation;
+// it morphs to recording status while the gesture is active.
+//
+// Design notes from chat:
+//  - Dock is centered and compact, not edge-to-edge — "优雅美观简洁"
+//  - Glass material: ultraThin + warm border highlight + soft drop shadow
+//  - Mic-hero is the only filled control. Side buttons are translucent.
+//  - All English/Chinese helper labels above the dock have been killed
+//    in favor of the universal mic / + / pen glyphs (design note 03).
 
 struct InputBarV4: View {
 
@@ -116,18 +124,30 @@ struct InputBarV4: View {
                 locationChipRow(loc: loc)
             }
 
-            HStack(alignment: .bottom, spacing: 10) {
+            // STREAM dock layout:
+            // - composing → full-width capsule + send arrow on the right
+            // - idle      → centered three-slot dock (no send button; mic
+            //               is the hero) with a hint label below
+            Group {
                 if isComposing {
-                    composingCapsule
+                    HStack(alignment: .bottom, spacing: 10) {
+                        composingCapsule
+                        sendButton
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 10)
+                    .padding(.bottom, 12)
                 } else {
-                    collapsedCapsule
+                    VStack(spacing: 8) {
+                        streamDock
+                        dockHintLabel
+                    }
+                    .padding(.horizontal, 16)
+                    .padding(.top, 10)
+                    .padding(.bottom, 14)
                 }
-                sendButton
             }
             .animation(.spring(response: 0.32, dampingFraction: 0.82), value: isComposing)
-            .padding(.horizontal, 16)
-            .padding(.top, 10)
-            .padding(.bottom, 12)
         }
         .background(DSColor.backgroundWarm)
         .overlay(alignment: .top) {
@@ -184,56 +204,28 @@ struct InputBarV4: View {
         }
     }
 
-    // MARK: - Collapsed Capsule
+    // MARK: - STREAM Dock (idle state)
     //
-    // Layout: [ "Hold to talk · tap to write" pill ] [ mic-hero ]
-    // - Tap the pill body → expand to text composing mode
-    // - Long-press the mic-hero → press-to-talk recording flow
+    // Centered three-slot capsule, faithful to VariationStream.jsx:
+    //   - 40pt `+` (more)        opens attachment menu
+    //   - 56×44 amber mic-hero   tap = Flomo record · long-press = WeChat send
+    //   - 40pt pen               expands to text composer
     //
-    // The two regions are siblings, not overlaid, so the hit areas are
-    // unambiguous. Previously the press-to-talk button was an invisible
-    // overlay on the right quarter of the pill — users had no visual cue
-    // for where to press.
+    // The capsule itself is wrapped in `.ultraThinMaterial` with a layered
+    // shadow stack approximating the iOS 26 Liquid Glass treatment from the
+    // design canvas (inner highlight + soft drop shadow).
 
-    private var collapsedCapsule: some View {
+    private var streamDock: some View {
         HStack(spacing: 8) {
-            Button {
-                withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) {
-                    userExpandedText = true
-                }
-                isFocused = true
-            } label: {
-                HStack(spacing: 10) {
-                    Text("Hold to talk")
-                        .font(.custom("SpaceGrotesk-Medium", size: 15))
-                        .foregroundStyle(DSColor.onBackgroundPrimary)
-
-                    Text("·")
-                        .foregroundStyle(DSColor.onBackgroundSubtle)
-
-                    Text("tap to write")
-                        .font(.custom("SpaceGrotesk-Regular", size: 13))
-                        .foregroundStyle(DSColor.onBackgroundSubtle)
-
-                    Spacer(minLength: 0)
-
-                    // Hint label that appears when user starts pressing (< 0.35s)
-                    if pressToTalkPhase == .preRecording {
-                        Text("再按住一下")
-                            .font(.custom("SpaceGrotesk-Medium", size: 12))
-                            .foregroundStyle(DSColor.primary)
-                            .transition(.opacity.combined(with: .move(edge: .trailing)))
-                    }
-                }
-                .padding(.horizontal, 18)
-                .padding(.vertical, 14)
-                .frame(maxWidth: .infinity)
-                .background(.ultraThinMaterial, in: Capsule())
-                .overlay(Capsule().strokeBorder(DSColor.outlineVariant.opacity(0.5), lineWidth: 0.5))
+            // LEFT — More
+            dockSideButton(
+                systemImage: "plus",
+                accessibilityLabel: "更多附件"
+            ) {
+                showAttachmentMenu = true
             }
-            .buttonStyle(.plain)
-            .animation(.easeInOut(duration: 0.15), value: pressToTalkPhase)
 
+            // CENTER — Mic-hero (amber, slightly larger, the only filled CTA)
             PressToTalkButton(
                 onTap: {},
                 onPressStart: handlePressToTalkStart,
@@ -242,12 +234,85 @@ struct InputBarV4: View {
                 onReleaseTranscribe: handlePressToTalkReleaseTranscribe,
                 onPhaseChange: { pressToTalkPhase = $0 },
                 onTapShortRelease: flashHoldToast,
-                size: 48,
-                idleBackgroundColor: DSColor.onBackgroundPrimary,
+                size: 56,
+                idleBackgroundColor: DSColor.accentAmber,
                 idleIconColor: .white
             )
+            .frame(width: 56, height: 44)
             .accessibilityLabel("按住说话")
+
+            // RIGHT — Pen (expand text composer)
+            dockSideButton(
+                systemImage: "square.and.pencil",
+                accessibilityLabel: "写文字"
+            ) {
+                withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) {
+                    userExpandedText = true
+                }
+                isFocused = true
+            }
         }
+        .padding(6)
+        .background(
+            Capsule(style: .continuous)
+                .fill(.ultraThinMaterial)
+        )
+        .overlay(
+            Capsule(style: .continuous)
+                .strokeBorder(Color.white.opacity(0.7), lineWidth: 0.5)
+        )
+        .shadow(color: DSColor.accentAmber.opacity(0.10), radius: 18, x: 0, y: 12)
+        .shadow(color: DSColor.accentAmber.opacity(0.06), radius: 4, x: 0, y: 2)
+        .frame(maxWidth: .infinity)
+    }
+
+    // 40pt translucent side button. Plain SF Symbol, no fill, no label.
+    @ViewBuilder
+    private func dockSideButton(
+        systemImage: String,
+        accessibilityLabel: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            action()
+        } label: {
+            Image(systemName: systemImage)
+                .font(.system(size: 17, weight: .regular))
+                .foregroundStyle(DSColor.onBackgroundPrimary)
+                .frame(width: 40, height: 40)
+                .background(
+                    Circle()
+                        .fill(Color.white.opacity(0.55))
+                )
+                .overlay(
+                    Circle()
+                        .strokeBorder(Color.white.opacity(0.7), lineWidth: 0.5)
+                )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    // Hint label below the dock — JetBrains Mono uppercase, like the design.
+    // Morphs based on press-to-talk phase so the gesture stays legible.
+    private var dockHintLabel: some View {
+        let raw: String
+        switch pressToTalkPhase {
+        case .idle:            raw = "点击录音 · 长按发送"
+        case .preRecording:    raw = "再按住一下"
+        case .recording:       raw = "上滑取消 · 左滑转文字 · 松开发送"
+        case .cancelArmed:     raw = "松开取消"
+        case .transcribeArmed: raw = "松开转文字"
+        case .transcribing:    raw = "正在转文字…"
+        }
+        return Text(raw)
+            .font(.custom("JetBrainsMono-Regular", size: 9))
+            .tracking(1.4)
+            .textCase(.uppercase)
+            .foregroundStyle(DSColor.onBackgroundSubtle)
+            .frame(height: 12)
+            .animation(.easeInOut(duration: 0.18), value: pressToTalkPhase)
     }
 
     // MARK: - Composing Capsule
@@ -274,12 +339,12 @@ struct InputBarV4: View {
             }
 
             // Multi-line text field — no system inset, aligns naturally with + button
-            TextField("Write something…", text: $text, axis: .vertical)
-                .font(.custom("SpaceGrotesk-Regular", size: 15))
+            TextField("记一笔…", text: $text, axis: .vertical)
+                .font(.custom("Inter-Regular", size: 16))
                 .foregroundStyle(DSColor.onBackgroundPrimary)
                 .focused($isFocused)
                 .lineLimit(1...5)
-                .tint(DSColor.onBackgroundPrimary)
+                .tint(DSColor.accentAmber)
 
             // Mic-back button — lets user exit composing and return to voice UI
             Button {
@@ -330,8 +395,12 @@ struct InputBarV4: View {
             }
             .frame(width: 44, height: 44)
             .background(
-                hasContent ? DSColor.onBackgroundPrimary : DSColor.onBackgroundSubtle.opacity(0.3),
+                hasContent ? DSColor.accentAmber : DSColor.accentAmber.opacity(0.18),
                 in: Circle()
+            )
+            .shadow(
+                color: hasContent ? DSColor.accentAmber.opacity(0.32) : .clear,
+                radius: 8, x: 0, y: 4
             )
             .animation(.easeInOut(duration: 0.18), value: hasContent)
         }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -30,31 +30,16 @@ struct TodayView: View {
     /// Current time for the header timestamp (refreshed every minute).
     @State private var currentTime: Date = Date()
 
-    /// Vertical slack (in points) between the bottom anchor and the ScrollView's
-    /// visible bottom that still counts as "near the bottom" for footer visibility.
-    /// Matches the 200pt spec in PRD US-005.
-    private let compileFooterThreshold: CGFloat = 200
-
-    /// Distance from the ScrollView's top edge to the bottom anchor.
-    /// When `anchorMinY <= visibleHeight + compileFooterThreshold` the user is
-    /// within 200pt of the content bottom and the footer should fade in.
-    @State private var compileFooterAnchorMinY: CGFloat = .infinity
-
-    /// Most recent visible height of the ScrollView.
-    @State private var scrollVisibleHeight: CGFloat = 0
-
     private let headerTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
 
-    /// Computed visibility for the sticky compile footer button.
-    /// PRD rule: show when daily page is not yet compiled, there is at least one
-    /// memo, and the bottom anchor is within `compileFooterThreshold` of the
-    /// visible bottom. Compile-in-flight keeps the button visible (morphs state).
+    /// Whether the inline compile call-to-action should render at the tail
+    /// of today's stream. No longer depends on scroll position — the button
+    /// is part of the timeline now, so it just shows whenever there is
+    /// uncompiled content (or a compile is in flight).
     private var shouldShowCompileFooter: Bool {
         guard !viewModel.isDailyPageCompiled else { return false }
-        guard viewModel.memos.count > 0 else { return false }
         if viewModel.isCompiling { return true }
-        guard scrollVisibleHeight > 0 else { return false }
-        return compileFooterAnchorMinY <= scrollVisibleHeight + compileFooterThreshold
+        return viewModel.memos.count > 0
     }
 
     private var todayPendingDrafts: [VisitDraft] {
@@ -246,6 +231,27 @@ struct TodayView: View {
                                         .padding(.horizontal, 20)
                                 }
 
+                                // MARK: Compile entry — inline at the tail of today's stream.
+                                // Earlier this lived as a sticky pill above the input bar; the
+                                // capture surface is supposed to be the only thing pinned to the
+                                // bottom. Now the compile call-to-action scrolls with the page,
+                                // so the dock stays calm and the user sees "编译今日 · N 条" as
+                                // a natural full-stop after the last memo of the day.
+                                if shouldShowCompileFooter {
+                                    HStack {
+                                        Spacer()
+                                        CompileFooterButton(
+                                            memoCount: viewModel.memos.count,
+                                            isCompiling: viewModel.isCompiling,
+                                            isVisible: true,
+                                            onTap: { viewModel.compile() }
+                                        )
+                                        Spacer()
+                                    }
+                                    .padding(.top, 8)
+                                    .padding(.bottom, 8)
+                                }
+
                                 // MARK: Weekly Recap (this week's compiled days, newest first)
                                 // Rendered after today's raw stream so the user scrolls "from now
                                 // into memory" — Phase 1 of the time-pyramid recap. Phase 2/3
@@ -258,29 +264,13 @@ struct TodayView: View {
                                 )
 
                                 Spacer(minLength: 16)
-
-                                // Bottom anchor for CompileFooterButton visibility tracking (US-005).
-                                CompileFooterAnchor()
                             }
                             .padding(.top, 12)
                             .frame(minHeight: geo.size.height * 0.75)
                         }
                         .coordinateSpace(name: "todayScroll")
                         .frame(maxHeight: geo.size.height)
-                        .onAppear { scrollVisibleHeight = geo.size.height }
-                        .onChange(of: geo.size.height) { h in scrollVisibleHeight = h }
-                        .onPreferenceChange(CompileFooterAnchorPreferenceKey.self) { minY in
-                            compileFooterAnchorMinY = minY
-                        }
                     }
-
-                    // MARK: Compile Footer Button (sticky, fades in near bottom of timeline)
-                    CompileFooterButton(
-                        memoCount: viewModel.memos.count,
-                        isCompiling: viewModel.isCompiling,
-                        isVisible: shouldShowCompileFooter,
-                        onTap: { viewModel.compile() }
-                    )
 
                     // MARK: Input Bar — single canonical surface (V4).
                     // V1/V2/V3 were removed in the Capture v2 cleanup; the


### PR DESCRIPTION
## Summary

- 把 Today 屏底部的 idle composer 由 \"Hold to talk · tap to write\" 长胶囊 + 黑色 mic 改回设计稿 Capture v2 STREAM 变体的居中三槽 dock：\`+\` / 棕色 mic-hero / 笔，下方 \"点击录音 · 长按发送\" 提示文字
- 把附件 sheet 从 4 行垂直列表改成 4 列等权 tile 网格（拍照/相册/位置/附件），与 \`VariationStream.jsx\` 的 \`AttachItem\` 对齐
- 全部 press-to-talk / transcribe / attach / send 行为保持不变，**纯视觉 reskin**

## Why

\`feat/capture-v2-input-cleanup\`（#140）和 \`refactor: redesign attachment menu\`（#143）合入后，dock 的 hero affordance 消失了——mic 被压成右侧小圆，主视觉变成英文文字提示；同时点 \`+\` 弹出的 sheet 也变成了横向小图标条，被用户反馈\"丑\"。设计源文件 \`DayPage Capture v2.html\` 的 STREAM 变体（用户在 chat round 4 确认的方向）才是真正的目标——\"居中紧凑胶囊，三个按钮 40/56/40，优雅美观简洁\"。

## Visual

iPhone 17 Simulator 截图：dock 居中、mic-hero amber、提示文字 \"点击录音 · 长按发送\" 完整呈现。

## Test plan

- [x] \`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'\` → BUILD SUCCEEDED
- [x] iPhone 17 (iOS 26.1) Simulator 启动 + Today 屏空状态视觉验收
- [ ] 真机长按 mic-hero → 录音 overlay → 松开发送
- [ ] 真机长按 mic-hero → 上滑 → 「松开取消」红字
- [ ] 真机长按 mic-hero → 左滑 → 「松开转文字」 → 文字进 composer
- [ ] 点 \`+\` → 4-tile sheet → 拍照 / 相册 / 位置 / 附件 路径
- [ ] 点 笔 → 展开 composer → 输入文字 → 棕色发光发送箭头 → 提交后回到 dock

## Files

- \`DayPage/Features/Today/InputBarV4.swift\` — \`streamDock\` + \`dockHintLabel\` + \`dockSideButton\` helpers
- \`DayPage/Features/Today/AttachmentMenuPopover.swift\` — 4-tile grid 替换垂直列表