### PR TITLE
feat(today): Capture v2 STREAM dock + tap-to-record mic

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -62,8 +62,6 @@ struct InputBarV4: View {
     /// meaningless one-frame recording while gracefully nudging the user
     /// toward the hold gesture.
     @State private var showTooShortToast: Bool = false
-    /// True while a "按住说话" hint is visible after a tap on the mic.
-    @State private var showHoldToast: Bool = false
 
     @StateObject private var voiceService = VoiceService.shared
 
@@ -167,26 +165,9 @@ struct InputBarV4: View {
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                 .accessibilityLabel("录音太短，请按住麦克风继续说")
-            } else if showHoldToast {
-                HStack(spacing: 6) {
-                    Image(systemName: "hand.point.up.fill")
-                        .font(.system(size: 11, weight: .semibold))
-                    Text("按住说话")
-                        .font(.custom("Inter-Regular", size: 11))
-                }
-                .foregroundColor(DSColor.onSurface)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 7)
-                .background(DSColor.surfaceContainerHigh)
-                .clipShape(Capsule())
-                .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
-                .padding(.top, -34)
-                .transition(.opacity.combined(with: .move(edge: .bottom)))
-                .accessibilityLabel("点按即可录音，按住松手发送")
             }
         }
         .animation(.easeInOut(duration: 0.2), value: showTooShortToast)
-        .animation(.easeInOut(duration: 0.2), value: showHoldToast)
         .sheet(isPresented: $showAttachmentMenu) {
             AttachmentMenuPopover(
                 onCapturePhoto: { showAttachmentMenu = false; onCapturePhoto() },
@@ -233,14 +214,22 @@ struct InputBarV4: View {
             }
 
             // CENTER — Mic-hero (amber, slightly larger, the only filled CTA)
+            //
+            // Tap (< 0.35s)  → enter Flomo-style continuous recording sheet
+            //                  (VoiceRecordingView, half-screen, pause/resume/save).
+            // Long-press     → WeChat-style press-to-talk, release to send.
+            //
+            // The two paths are intentionally distinct: a tap is for "I want
+            // to talk for a while, control pause/save myself"; a hold is for
+            // "I want to dictate one quick thought and let go to send".
             PressToTalkButton(
-                onTap: {},
+                onTap: handleMicTap,
                 onPressStart: handlePressToTalkStart,
                 onReleaseSend: handlePressToTalkReleaseSend,
                 onReleaseCancel: handlePressToTalkReleaseCancel,
                 onReleaseTranscribe: handlePressToTalkReleaseTranscribe,
                 onPhaseChange: { pressToTalkPhase = $0 },
-                onTapShortRelease: flashHoldToast,
+                onTapShortRelease: handleMicTap,
                 size: 56,
                 idleBackgroundColor: DSColor.accentAmber,
                 idleIconColor: .white
@@ -421,6 +410,15 @@ struct InputBarV4: View {
         withAnimation(.spring(response: 0.28, dampingFraction: 0.85)) { userExpandedText = false }
     }
 
+    /// Single tap on the mic — open the persistent (Flomo-style) recording
+    /// sheet. The user controls pause / resume / save / discard from inside
+    /// VoiceRecordingView; we don't start VoiceService here, the sheet does
+    /// it itself in `.onAppear`.
+    private func handleMicTap() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        onStartVoiceRecording()
+    }
+
     private func handlePressToTalkStart() {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
         Task { await voiceService.startRecording() }
@@ -477,13 +475,6 @@ struct InputBarV4: View {
         showTooShortToast = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             showTooShortToast = false
-        }
-    }
-
-    private func flashHoldToast() {
-        showHoldToast = true
-        DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
-            showHoldToast = false
         }
     }
 

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -45,7 +45,6 @@ struct InputBarV4: View {
     var onCapturePhoto: () -> Void
     var onRemoveAttachment: (String) -> Void
     var onStartVoiceRecording: () -> Void
-    var onVoiceComplete: (VoiceRecordingResult) -> Void
     var onPressToTalkSend: (VoiceRecordingResult) -> Void
     var onPressToTalkTranscribe: (String) -> Void
     var onAddFile: () -> Void
@@ -223,7 +222,6 @@ struct InputBarV4: View {
             // to talk for a while, control pause/save myself"; a hold is for
             // "I want to dictate one quick thought and let go to send".
             PressToTalkButton(
-                onTap: handleMicTap,
                 onPressStart: handlePressToTalkStart,
                 onReleaseSend: handlePressToTalkReleaseSend,
                 onReleaseCancel: handlePressToTalkReleaseCancel,
@@ -237,7 +235,8 @@ struct InputBarV4: View {
             .frame(width: 56, height: 56)
             .shadow(color: DSColor.accentAmber.opacity(0.32), radius: 14, x: 0, y: 8)
             .shadow(color: DSColor.accentAmber.opacity(0.18), radius: 4, x: 0, y: 2)
-            .accessibilityLabel("按住说话")
+            .accessibilityLabel("麦克风")
+            .accessibilityHint("单击进入录音页；长按说话松手发送")
 
             // RIGHT — Pen (expand text composer)
             dockSideButton(
@@ -288,7 +287,7 @@ struct InputBarV4: View {
     private var dockHintLabel: some View {
         let raw: String
         switch pressToTalkPhase {
-        case .idle:            raw = "点击录音 · 长按发送"
+        case .idle:            raw = "点击进入录音 · 长按发送"
         case .preRecording:    raw = "再按住一下"
         case .recording:       raw = "上滑取消 · 左滑转文字 · 松开发送"
         case .cancelArmed:     raw = "松开取消"

--- a/DayPage/Features/Today/PressToTalkButton.swift
+++ b/DayPage/Features/Today/PressToTalkButton.swift
@@ -6,12 +6,10 @@ import UIKit
 // Dual-mode microphone button:
 //
 //   Short tap (< 0.35s hold):
-//     • Tap → emit onTap, parent switches to "recording bar" mode
-//             (PressToTalkButton is no longer visible while recording bar is shown)
-//
-//   Short press (< 0.35s, then release):
-//     • User pressed briefly then lifted — treat as accidental tap, show
-//       a ring + "再按住一下" hint while pressed, "按住说话" toast on release.
+//     • Press-and-release inside the threshold fires `onTapShortRelease`.
+//       The parent decides what that means (e.g. open a continuous-recording
+//       sheet); this view emits no haptic for the short-tap path so callers
+//       own the feedback story.
 //
 //   Long press (>= 0.35s hold):
 //     WeChat-style press-to-talk flow (original behaviour, unchanged):
@@ -45,10 +43,6 @@ enum PressToTalkPhase: Equatable {
 struct PressToTalkButton: View {
 
     // MARK: Inputs
-
-    /// Called on short tap (< longPressThreshold). Parent should switch to
-    /// the persistent recording bar mode.
-    var onTap: () -> Void = {}
 
     /// Called on long-press-down (>= longPressThreshold). Parent should start
     /// VoiceService.startRecording() for the press-to-talk flow.
@@ -121,8 +115,6 @@ struct PressToTalkButton: View {
                 .scaleEffect(currentPhase == .idle ? 1.0 : 1.08)
                 .animation(.easeOut(duration: 0.12), value: currentPhase)
                 .contentShape(Circle())
-                .accessibilityLabel("点击说话")
-                .accessibilityHint("单击开始录音；长按说话松手发送")
                 .highPriorityGesture(dragGesture)
         }
     }
@@ -177,12 +169,14 @@ struct PressToTalkButton: View {
                     pressStartTime = nil
                 }
 
-                // Short tap — never crossed threshold, still in preRecording phase
+                // Short tap — never crossed threshold, still in preRecording phase.
+                // Haptic is intentionally not emitted here: the short-tap callback
+                // owns its own feedback (e.g. opening a sheet) and a duplicate
+                // light impact at this layer would double-buzz on every tap.
                 if let start = pressStartTime,
                    Date().timeIntervalSince(start) < longPressThreshold,
                    currentPhase == .preRecording {
                     stopRingPulse()
-                    emitHaptic(InputTokens.pressDownHaptic)
                     currentPhase = .idle
                     onPhaseChange(.idle)
                     lastTranslation = .zero

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -462,7 +462,6 @@ struct TodayView: View {
             onCapturePhoto: { viewModel.startCameraCapture() },
             onRemoveAttachment: { id in viewModel.removePendingAttachment(id: id) },
             onStartVoiceRecording: { viewModel.startVoiceRecording() },
-            onVoiceComplete: { result in viewModel.addVoiceAttachment(result: result) },
             onPressToTalkSend: { result in
                 viewModel.addVoiceAttachment(result: result)
                 let body = draftText

--- a/DayPage/Features/Today/VoiceRecordingView.swift
+++ b/DayPage/Features/Today/VoiceRecordingView.swift
@@ -67,6 +67,12 @@ struct VoiceRecordingView: View {
         .frame(maxWidth: .infinity)
         .background(DSColor.surface)
         .onAppear {
+            // Guard against re-entry: a fast double-tap on the mic-hero, or a
+            // previously-stuck session from a press-to-talk gesture, can land
+            // us here while VoiceService is still active. Starting again would
+            // tear down the live AVAudioRecorder mid-frame and orphan its file.
+            // Only kick off a new recording when the service is genuinely idle.
+            guard voiceService.state == .idle else { return }
             Task {
                 await voiceService.startRecording()
             }


### PR DESCRIPTION
## Summary
- Restore the STREAM dock as the Capture v2 idle composer; float the three dock buttons free-standing with an inline compile CTA.
- Wire mic-hero tap → Flomo-style continuous recording sheet (`VoiceRecordingView`), keeping long-press press-to-talk unchanged. Drop the now-dead "按住说话" hold toast.
- Refresh `AttachmentMenuPopover` styling alongside the dock changes.

## Why
The STREAM dock's mic-hero only honored long-press; a single tap just flashed a hint and went nowhere. Design intent was always two paths: tap to open a persistent recording sheet (pause / resume / save / discard) and long-press for a one-shot WeChat-style send. This PR closes that gap while finishing the dock's visual treatment.

## Test plan
- [ ] Build `DayPage` scheme on iPhone 17 simulator (`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build`)
- [ ] Tap mic-hero → `VoiceRecordingView` half-sheet appears, recording starts, pause/resume/save/discard all work
- [ ] Long-press mic-hero → press-to-talk flow unchanged; release sends, swipe-up cancels, swipe-left transcribes
- [ ] No "按住说话" toast appears under any path (replaced by the sheet)
- [ ] Sub-1s silent press still triggers the existing "再说久一点" toast and does not commit a 0:00 memo
- [ ] Dock buttons render free-standing with the new glass treatment in idle state; composing state still routes through the capsule + send arrow