### PR TITLE
perf: cache vault URL lookups to avoid repeated FileManager allocations (issue #113)

### DIFF
--- a/DayPage/Storage/VaultInitializer.swift
+++ b/DayPage/Storage/VaultInitializer.swift
@@ -41,9 +41,9 @@ enum VaultInitializer {
     // MARK: - iCloud Migration Trigger
 
     private static func triggerMigrationIfNeeded() {
-        // Only relevant when iCloud is available and user has not yet migrated.
-        let locator = iCloudVaultLocator()
-        guard locator.isUsingiCloud else { return }
+        // Reuse the already-resolved shared locator instead of constructing a new
+        // iCloudVaultLocator — avoids a redundant ubiquity-container lookup.
+        guard shared.isUsingiCloud else { return }
         guard AppSettings.currentVaultLocation() == .local else { return }
         Task { @MainActor in
             VaultMigrationService.shared.migrateIfNeeded()

--- a/DayPage/Storage/VaultLocator.swift
+++ b/DayPage/Storage/VaultLocator.swift
@@ -14,10 +14,14 @@ protocol VaultLocator {
 /// Default implementation: stores vault under the app's local Documents directory.
 /// Behavior is identical to the previous hard-coded VaultInitializer.vaultURL.
 struct LocalVaultLocator: VaultLocator {
-    var vaultURL: URL {
+    // FileManager.urls(for:) is safe to call repeatedly but allocates on every
+    // call. Cache the result once at the static level — the Documents path never
+    // changes within a process lifetime.
+    private static let _localDocuments: URL =
         FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
             .appendingPathComponent("vault", isDirectory: true)
-    }
+
+    var vaultURL: URL { Self._localDocuments }
 
     var isUsingiCloud: Bool { false }
 }


### PR DESCRIPTION
## Summary

Fixes #113

Two call sites were performing unnecessary repeated work on every vault path access:

- **`LocalVaultLocator.vaultURL`** was a computed property that called `FileManager.urls(for: .documentDirectory)` on every access. This allocates each time and is called from SwiftUI view bodies, services, and storage layers on every vault path lookup. Changed to a `private static let` — the Documents directory path is stable for the entire process lifetime.

- **`VaultInitializer.triggerMigrationIfNeeded()`** constructed a new `iCloudVaultLocator()` instance on every call solely to check `isUsingiCloud`. This triggered the ubiquity-container static cache lookup unnecessarily when `VaultInitializer.shared` was already resolved at startup. Changed to reuse `shared.isUsingiCloud` directly.

## Files changed

- `DayPage/Storage/VaultLocator.swift` — `LocalVaultLocator.vaultURL` cached via `private static let _localDocuments`
- `DayPage/Storage/VaultInitializer.swift` — `triggerMigrationIfNeeded()` uses `shared.isUsingiCloud` instead of constructing a new locator

## What was not changed

`VaultMigrationService.migrateIfNeeded()` keeps its own `iCloudVaultLocator()` construction intentionally — that code path handles the runtime case where `shared` starts as `LocalVaultLocator` (iCloud unavailable at launch) but iCloud becomes available later via Settings. Changing it would break that swap.

## Test plan

- [ ] Build succeeds on iOS target
- [ ] Cold launch: vault directories created correctly under Documents/vault
- [ ] iCloud enabled: vault correctly resolves to ubiquity container
- [ ] iCloud disabled / Simulator: graceful fallback to local vault