### PR TITLE
feat(today): add collapse affordance in composing toolbar (issue #143)

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -321,6 +321,20 @@ struct InputBarV4: View {
 
             // Icon toolbar row
             HStack(spacing: 0) {
+                // Collapse — dismiss keyboard and return to idle voice dock.
+                // Draft text / attachments / location are preserved so the user
+                // can re-open the composer without losing their work.
+                toolbarIconButton(
+                    systemImage: "chevron.down",
+                    accessibilityLabel: "收起，回到语音模式"
+                ) {
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                    withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) {
+                        userExpandedText = false
+                    }
+                    isFocused = false
+                }
+
                 // Mic — voice-to-text mode in composing
                 toolbarIconButton(
                     systemImage: isComposingTranscribe ? "waveform" : "mic",


### PR DESCRIPTION
## Summary

Partial fix for #143 — sub-task 2: **text → voice return affordance**.

### Problem

Once the user taps the pen icon or the capsule body to enter composing mode, the mic-hero disappears. The only way back to the idle voice dock was to manually clear all text, attachments, and location — a friction-heavy dead end that effectively traps the user in text mode.

### Fix

Add a `chevron.down` button as the **leftmost icon** in the composing toolbar row (before the mic/camera/photo/location icons). Tapping it:

1. Fires a light haptic (consistent with other dock interactions)
2. Animates `userExpandedText = false` with the same spring used throughout InputBarV4
3. Dismisses the keyboard (`isFocused = false`)

**Draft is preserved** — text, pending attachments, and pending location survive the collapse. Re-expanding the composer restores them exactly as left.

### What was not changed

- `isComposing` logic: if the user has typed text, added attachments, or pinned a location, `isComposing` stays `true` and the idle dock still doesn't appear (correct — there's content to submit). The chevron collapses the *keyboard + expanded layout* but not the composing state itself when content is present.
- No changes to `TodayView`, `AttachmentMenuPopover`, or any other file.

## Test plan

- [ ] Tap pen icon → composer expands → tap `chevron.down` → keyboard dismisses, idle dock animates back in
- [ ] Type text → tap `chevron.down` → idle dock appears but draft text is still present when composer re-opens
- [ ] Add attachment → collapse → re-expand → attachment still pending
- [ ] Pin location → collapse → re-expand → location chip still showing
- [ ] Accessibility: VoiceOver announces "收起，回到语音模式"