### PR TITLE
fix(today): flash affordance toast on mic single-tap (issue #143)

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -61,6 +61,8 @@ struct InputBarV4: View {
     /// meaningless one-frame recording while gracefully nudging the user
     /// toward the hold gesture.
     @State private var showTooShortToast: Bool = false
+    /// True while the mic-tap mode hint ("按住发送 · 单击录音") is visible.
+    @State private var showMicHintToast: Bool = false
     /// True while composing-mode mic is actively recording for transcription.
     @State private var isComposingTranscribe: Bool = false
 
@@ -159,9 +161,26 @@ struct InputBarV4: View {
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                 .accessibilityLabel("录音太短，请按住麦克风继续说")
+            } else if showMicHintToast {
+                HStack(spacing: 6) {
+                    Image(systemName: "hand.tap")
+                        .font(.system(size: 11, weight: .semibold))
+                    Text("按住发送 · 单击录音")
+                        .font(.custom("Inter-Regular", size: 11))
+                }
+                .foregroundColor(DSColor.onSurface)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 7)
+                .background(DSColor.surfaceContainerHigh)
+                .clipShape(Capsule())
+                .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
+                .padding(.top, -34)
+                .transition(.opacity.combined(with: .move(edge: .bottom)))
+                .accessibilityLabel("单击打开录音页，长按发送语音")
             }
         }
         .animation(.easeInOut(duration: 0.2), value: showTooShortToast)
+        .animation(.easeInOut(duration: 0.2), value: showMicHintToast)
         .sheet(isPresented: $showAttachmentMenu) {
             AttachmentMenuPopover(
                 onCapturePhoto: { showAttachmentMenu = false; onCapturePhoto() },
@@ -463,6 +482,7 @@ struct InputBarV4: View {
     /// it itself in `.onAppear`.
     private func handleMicTap() {
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        flashMicHintToast()
         onStartVoiceRecording()
     }
 
@@ -522,6 +542,13 @@ struct InputBarV4: View {
         showTooShortToast = true
         DispatchQueue.main.asyncAfter(deadline: .now() + 1.6) {
             showTooShortToast = false
+        }
+    }
+
+    private func flashMicHintToast() {
+        showMicHintToast = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.8) {
+            showMicHintToast = false
         }
     }
 


### PR DESCRIPTION
## Summary

Partial fix for #143 — sub-task 1: **mic-hero tap affordance**.

### Problem

Single-tapping the mic-hero opens the recording sheet but gave no visible feedback explaining the two interaction modes. The existing `dockHintLabel` ("点击进入录音 · 长按发送") is small monospace text beneath the dock — low visual weight, easily missed by new users.

### Fix

Flash a **"按住发送 · 单击录音"** capsule toast for 1.8 s on every short tap, appearing above the input bar immediately before the recording sheet opens.

- Visually matches the existing `"录音太短"` toast (same `surfaceContainerHigh` background, `Capsule` shape, shadow, Inter-Regular 11 pt)
- Uses `hand.tap` SF Symbol to reinforce the gesture affordance
- Two toasts are **mutually exclusive** via `else if` — they never overlap
- Accessibility label: `"单击打开录音页，长按发送语音"` for VoiceOver

### Changes (`InputBarV4.swift` only)

| What | Where |
|------|-------|
| `@State private var showMicHintToast: Bool` | new state property |
| `else if showMicHintToast { … }` | overlay branch after tooShort toast |
| `.animation(…, value: showMicHintToast)` | animation modifier |
| `flashMicHintToast()` call in `handleMicTap()` | fires before `onStartVoiceRecording()` |
| `flashMicHintToast()` method | 1.8 s auto-dismiss, parallel to `flashTooShortToast()` |

## Test plan

- [ ] Single-tap mic → `"按住发送 · 单击录音"` toast appears above bar for ~1.8 s, then fades
- [ ] Toast is briefly visible even as the recording sheet animates up
- [ ] Long-press mic past 0.35 s threshold → no hint toast (only recording flow proceeds)
- [ ] Short-press that triggers `"录音太短"` toast → hint toast does **not** appear simultaneously (else-if guard)
- [ ] VoiceOver: single-tap mic → hint announced as `"单击打开录音页，长按发送语音"`