### PR TITLE
fix(ci): upgrade runner to macos-26 for iOS 26 SDK requirement

### DIFF
--- a/.github/workflows/testflight.yml
+++ b/.github/workflows/testflight.yml
@@ -36,7 +36,7 @@ permissions:
 jobs:
   deploy:
     name: Build & Upload to TestFlight
-    runs-on: macos-15
+    runs-on: macos-26
     timeout-minutes: 90
 
     steps:


### PR DESCRIPTION
## 问题

GitHub Actions run [#25090655232](https://github.com/getyak/daypage/actions/runs/25090655232/job/73515866479) 上传 TestFlight 失败，错误信息：

```
Validation failed (409) SDK version issue. This app was built with the iOS 18.5 SDK.
All iOS and iPadOS apps must be built with the iOS 26 SDK or later, included in
Xcode 26 or later, in order to be uploaded to App Store Connect or submitted for distribution.
```

## 根本原因

Apple 强制要求从 2025 年 4 月起，所有上传到 App Store Connect 的 app 必须使用 **iOS 26 SDK（Xcode 26 或更高版本）** 构建。

- 之前：`macos-15` runner 默认使用 Xcode 16.4（iOS 18.5 SDK）
- 要求：必须使用 Xcode 26（iOS 26 SDK）

## 修复

将 `testflight.yml` 中的 runner 从 `macos-15` 改为 `macos-26`，`macos-26` runner 预装了 Xcode 26，满足 Apple 的新要求。

## 变更

- `.github/workflows/testflight.yml`: `runs-on: macos-15` → `runs-on: macos-26`

## 测试

重新触发 TestFlight 部署 workflow 验证构建成功上传。