### PR TITLE
feat(settings): wire accent color selection to global SwiftUI tint (issue #143)

### DIFF
--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -41,6 +41,11 @@ struct RootView: View {
             }
         }
         .preferredColorScheme(resolvedColorScheme)
+        // Apply user-selected accent color to all SwiftUI tintable controls
+        // (Button highlight, Toggle, Picker selection, TextField cursor) app-wide.
+        // AppSettings.accentColor setter calls objectWillChange.send(), so RootView
+        // re-renders immediately when the user changes this in Settings.
+        .tint(appSettings.accentColor.color)
     }
 
     // MARK: - Main Content with Sidebar Overlay


### PR DESCRIPTION
## Summary

Partial fix for #143 — sub-task 4: **accent color actually applied app-wide**.

### Problem

`AccentColorOption` (amber / sage / slate / rose / ink) was fully defined in `AppSettings` and exposed in the Settings UI picker, but **never wired to the app's tint**. Changing the setting had zero visible effect — the app always rendered with the system default tint regardless of what the user chose.

### Root cause

`RootView` applied `.preferredColorScheme()` from `AppSettings.themeMode`, but had no corresponding `.tint()` call for `AppSettings.accentColor`.

### Fix

One line added to `RootView.body`:

```swift
.tint(appSettings.accentColor.color)
```

This propagates the selected accent to all SwiftUI tintable controls across every screen:
- `Button` highlight / tap color
- `Toggle` thumb
- `Picker` selection ring
- `TextField` cursor and selection highlight
- `ProgressView` tint

### Why this works without extra wiring

`AppSettings` is already `@ObservedObject` in `RootView`. The `accentColor` setter already calls `objectWillChange.send()`, so `RootView` re-renders immediately when the user picks a new color in Settings — no notification, no binding, no environment value needed.

### What this does NOT change

Explicit `DSColor.accentAmber` / `DSColor.primary` usages throughout the app are intentional design tokens and are not affected by `.tint()`. This PR targets SwiftUI's implicit tint system only.

## Files changed

- `DayPage/App/RootView.swift` — 5 lines added (4 comment + 1 modifier)

## Test plan

- [ ] Open Settings → 外观 → 强调色 → select "鼠尾草" (sage) → Toggles / Pickers across app switch to green immediately
- [ ] Select "玫瑰" (rose) → tint changes to rose across all screens without restart
- [ ] Relaunch app → persisted accent color is restored on next launch
- [ ] Default (amber) still looks correct for users who never changed the setting
- [ ] Dark mode + accent color change both work independently