### PR TITLE
feat(auth): show login provider icon in AccountSheet

### DIFF
--- a/DayPage/Features/Auth/AccountSheet.swift
+++ b/DayPage/Features/Auth/AccountSheet.swift
@@ -93,9 +93,15 @@ struct AccountSheet: View {
                     .foregroundColor(DSColor.onSurface)
                     .lineLimit(1)
                     .truncationMode(.middle)
-                Text("当前账户")
-                    .font(.custom("Inter-Regular", size: 12))
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                HStack(spacing: 4) {
+                    let provider = authService.loginProvider
+                    Image(systemName: provider == .apple ? "applelogo" : "envelope")
+                        .font(.system(size: 11))
+                        .foregroundColor(DSColor.onSurfaceVariant)
+                    Text(provider == .apple ? "Apple 登录" : provider == .emailOTP ? "邮箱登录" : "当前账户")
+                        .font(.custom("Inter-Regular", size: 12))
+                        .foregroundColor(DSColor.onSurfaceVariant)
+                }
             }
 
             Spacer()

--- a/DayPage/Features/Auth/AccountSheet.swift
+++ b/DayPage/Features/Auth/AccountSheet.swift
@@ -77,6 +77,14 @@ struct AccountSheet: View {
     private var currentAccountRow: some View {
         let email = authService.session?.user.email ?? "—"
         let initial = email.first.map { String($0).uppercased() } ?? "?"
+        let provider = authService.loginProvider
+        let providerLabel: String = {
+            switch provider {
+            case .apple: return "Apple 登录"
+            case .emailOTP: return "邮箱登录"
+            case .unknown: return "当前账户"
+            }
+        }()
         return HStack(spacing: 14) {
             ZStack {
                 Circle()
@@ -94,11 +102,10 @@ struct AccountSheet: View {
                     .lineLimit(1)
                     .truncationMode(.middle)
                 HStack(spacing: 4) {
-                    let provider = authService.loginProvider
                     Image(systemName: provider == .apple ? "applelogo" : "envelope")
                         .font(.system(size: 11))
                         .foregroundColor(DSColor.onSurfaceVariant)
-                    Text(provider == .apple ? "Apple 登录" : provider == .emailOTP ? "邮箱登录" : "当前账户")
+                    Text(providerLabel)
                         .font(.custom("Inter-Regular", size: 12))
                         .foregroundColor(DSColor.onSurfaceVariant)
                 }

--- a/DayPage/Services/AuthService.swift
+++ b/DayPage/Services/AuthService.swift
@@ -67,6 +67,23 @@ final class AuthService: NSObject, ObservableObject {
     @Published var isLoading: Bool = false
     @Published var error: DPAuthError?
 
+    // MARK: Derived — Login Provider
+
+    enum LoginProvider {
+        case apple
+        case emailOTP
+        case unknown
+    }
+
+    var loginProvider: LoginProvider {
+        guard let email = session?.user.email else { return .unknown }
+        if let appleEmail = KeychainHelper.get(forKey: Self.appleEmailKey),
+           appleEmail == email {
+            return .apple
+        }
+        return .emailOTP
+    }
+
     // MARK: Dependencies
 
     let supabase: SupabaseClient

--- a/DayPage/Services/AuthService.swift
+++ b/DayPage/Services/AuthService.swift
@@ -75,7 +75,7 @@ final class AuthService: NSObject, ObservableObject {
         case unknown
     }
 
-    var loginProvider: LoginProvider {
+    private(set) var loginProvider: LoginProvider {
         guard let email = session?.user.email else { return .unknown }
         if let appleEmail = KeychainHelper.get(forKey: Self.appleEmailKey),
            appleEmail == email {


### PR DESCRIPTION
## Summary

- Add `LoginProvider` enum (`apple` / `emailOTP` / `unknown`) and `loginProvider` computed property to `AuthService`
- Detect provider by comparing session email against the Keychain-stored Apple sign-in email (`appleSignInEmail`)
- `AccountSheet.currentAccountRow` now shows an `applelogo` or `envelope` SF Symbol with a localized label ("Apple 登录" / "邮箱登录") so users instantly see how they authenticated

## Changes

**`AuthService.swift`**
- Added `enum LoginProvider` nested inside `AuthService`
- Added `var loginProvider: LoginProvider` computed property (read-only, reads Keychain — no writes)

**`AccountSheet.swift`**
- Replaced static "当前账户" subtitle with a dynamic `HStack` showing provider icon + label

## Test plan

- [ ] Sign in with Apple → account sheet subtitle shows Apple logo + "Apple 登录"
- [ ] Sign in with email OTP → account sheet subtitle shows envelope + "邮箱登录"
- [ ] Not signed in / unknown state → subtitle shows "当前账户" fallback
- [ ] No regression in sign-out flow

Closes #143 (sub-task: provider icon in account sheet)