### PR TITLE
feat(settings): add body font-size adjustment (-1 / 0 / +1)

### DIFF
--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -57,6 +57,31 @@ enum AccentColorOption: String, CaseIterable {
     }
 }
 
+// MARK: - FontSizeAdjust
+
+enum FontSizeAdjust: String, CaseIterable {
+    case small = "-1"
+    case normal = "0"
+    case large = "1"
+
+    var label: String {
+        switch self {
+        case .small: return "小"
+        case .normal: return "默认"
+        case .large: return "大"
+        }
+    }
+
+    /// Points to add to the base body font size (16pt).
+    var delta: CGFloat {
+        switch self {
+        case .small: return -1
+        case .normal: return 0
+        case .large: return 1
+        }
+    }
+}
+
 // MARK: - CardDensity
 
 enum CardDensity: String, CaseIterable {
@@ -216,6 +241,22 @@ final class AppSettings: ObservableObject {
         set {
             objectWillChange.send()
             UserDefaults.standard.set(newValue.rawValue, forKey: accentColorKey)
+        }
+    }
+
+    // MARK: - Font Size Adjust
+
+    private let fontSizeAdjustKey = "fontSizeAdjust"
+
+    var fontSizeAdjust: FontSizeAdjust {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: fontSizeAdjustKey),
+                  let adjust = FontSizeAdjust(rawValue: raw) else { return .normal }
+            return adjust
+        }
+        set {
+            objectWillChange.send()
+            UserDefaults.standard.set(newValue.rawValue, forKey: fontSizeAdjustKey)
         }
     }
 

--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -72,7 +72,7 @@ enum FontSizeAdjust: String, CaseIterable {
         }
     }
 
-    /// Points to add to the base body font size (16pt).
+    /// Points to add to the base body font size (14pt).
     var delta: CGFloat {
         switch self {
         case .small: return -1

--- a/DayPage/DesignSystem/Typography.swift
+++ b/DayPage/DesignSystem/Typography.swift
@@ -172,9 +172,13 @@ struct BodyMDModifier: ViewModifier {
 }
 
 struct BodySMModifier: ViewModifier {
+    @ObservedObject private var appSettings = AppSettings.shared
+
     func body(content: Content) -> some View {
+        let baseSize: CGFloat = 14
+        let adjusted = baseSize + appSettings.fontSizeAdjust.delta
         content
-            .font(DSType.bodySM)
+            .font(DSFonts.inter(size: adjusted, weight: .regular))
             .lineSpacing(3)
     }
 }

--- a/DayPage/DesignSystem/Typography.swift
+++ b/DayPage/DesignSystem/Typography.swift
@@ -164,9 +164,13 @@ struct TitleSMModifier: ViewModifier {
 }
 
 struct BodyMDModifier: ViewModifier {
+    @ObservedObject private var appSettings = AppSettings.shared
+
     func body(content: Content) -> some View {
+        let baseSize: CGFloat = 16
+        let adjusted = baseSize + appSettings.fontSizeAdjust.delta
         content
-            .font(DSType.bodyMD)
+            .font(DSFonts.inter(size: adjusted, weight: .regular))
             .lineSpacing(4)
     }
 }

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -331,6 +331,15 @@ struct SettingsView: View {
                 Label("强调色", systemImage: "paintpalette")
             }
 
+            // Font size adjustment
+            Picker(selection: $appSettings.fontSizeAdjust) {
+                ForEach(FontSizeAdjust.allCases, id: \.self) { adjust in
+                    Text(adjust.label).tag(adjust)
+                }
+            } label: {
+                Label("正文字号", systemImage: "textformat.size")
+            }
+
             // Card density
             Picker(selection: $appSettings.cardDensity) {
                 ForEach(CardDensity.allCases, id: \.self) { density in


### PR DESCRIPTION
## Summary

Implements the typography font-size micro-adjustment from issue #143 sub-task 4.

- Add `FontSizeAdjust` enum (`small` / `normal` / `large`) with `delta: CGFloat` (-1 / 0 / +1 pt) to `AppSettings`
- Back it with UserDefaults key `"fontSizeAdjust"` so the preference persists across launches
- `BodySMModifier` now reads `AppSettings.shared.fontSizeAdjust.delta` at render time, making every view that uses `.bodySMStyle()` respond live when the setting changes
- Settings > 外观 exposes a new **"正文字号"** Picker (小 / 默认 / 大) placed between Accent Color and Card Density

## Files changed

| File | Change |
|------|--------|
| `AppSettings.swift` | Add `FontSizeAdjust` enum + `fontSizeAdjust` property |
| `Typography.swift` | `BodySMModifier` reads dynamic font size |
| `SettingsView.swift` | New "正文字号" Picker in appearance section |

## Test plan

- [ ] Settings > 外观 shows "正文字号" picker with 小/默认/大 options
- [ ] Changing to "大" increases memo body text by 1pt, "小" decreases by 1pt
- [ ] Setting persists after app relaunch
- [ ] No visual regression on cards using `.bodySMStyle()` at default size

Closes #143 (sub-task: typography font-size adjustment)