### PR TITLE
test(sync): expand ConflictMerger edge-case coverage (issue #109)

### DIFF
--- a/DayPageTests/ConflictMergerTests.swift
+++ b/DayPageTests/ConflictMergerTests.swift
@@ -97,4 +97,97 @@ final class ConflictMergerTests: XCTestCase {
         let entry1 = array.first { ($0["id"] as? String) == "1" }
         XCTAssertEqual(entry1?["value"] as? String, "original")
     }
+
+    func testMergeJSONEntries_invalidOriginalReturnsFallback() throws {
+        let notJSON = Data("not json".utf8)
+        let conflict = try JSONSerialization.data(withJSONObject: [["id": "1"]])
+        let result = ConflictMerger.mergeJSONEntries(original: notJSON, conflict: conflict, idKey: "id")
+        XCTAssertEqual(result, notJSON)
+    }
+
+    func testMergeJSONEntries_invalidConflictReturnsOriginal() throws {
+        let original = try JSONSerialization.data(withJSONObject: [["id": "1", "value": "A"]])
+        let notJSON = Data("corrupted".utf8)
+        let result = ConflictMerger.mergeJSONEntries(original: original, conflict: notJSON, idKey: "id")
+        let array = try XCTUnwrap(JSONSerialization.jsonObject(with: result) as? [[String: Any]])
+        XCTAssertEqual(array.count, 1)
+    }
+
+    func testMergeJSONEntries_entriesWithoutIdKeyAreIncluded() throws {
+        let original = try JSONSerialization.data(withJSONObject: [["value": "no-id"]])
+        let conflict = try JSONSerialization.data(withJSONObject: [["id": "2", "value": "has-id"]])
+        let result = ConflictMerger.mergeJSONEntries(original: original, conflict: conflict, idKey: "id")
+        let array = try XCTUnwrap(JSONSerialization.jsonObject(with: result) as? [[String: Any]])
+        XCTAssertEqual(array.count, 2)
+    }
+
+    // MARK: - Memo Merge Edge Cases
+
+    func testMerge_manyDuplicatesReducesToUnique() {
+        let sharedID = UUID()
+        let originals = (0..<25).map { _ in makeMemo(id: sharedID, created: Date(timeIntervalSince1970: 1000)) }
+        let conflicts = (0..<25).map { _ in makeMemo(id: sharedID, created: Date(timeIntervalSince1970: 1000)) }
+        let merged = ConflictMerger.mergeRawMemos(original: originals, conflict: conflicts)
+        XCTAssertEqual(merged.count, 1)
+    }
+
+    func testMerge_threeWayConflict() {
+        let a = makeMemo(created: Date(timeIntervalSince1970: 100), body: "A")
+        let b = makeMemo(created: Date(timeIntervalSince1970: 200), body: "B")
+        let c = makeMemo(created: Date(timeIntervalSince1970: 300), body: "C")
+        let sharedID = UUID()
+        let dup = makeMemo(id: sharedID, created: Date(timeIntervalSince1970: 150), body: "dup")
+        let dupConflict = makeMemo(id: sharedID, created: Date(timeIntervalSince1970: 150), body: "dup-copy")
+        // First merge: original + conflict1
+        let firstPass = ConflictMerger.mergeRawMemos(original: [a, dup], conflict: [b, dupConflict])
+        // Second merge: result + conflict2
+        let secondPass = ConflictMerger.mergeRawMemos(original: firstPass, conflict: [c])
+        XCTAssertEqual(secondPass.count, 4)
+        XCTAssertEqual(secondPass.map(\.body), ["A", "dup", "B", "C"])
+    }
+
+    func testMerge_preservesAllUniqueIDsInOrder() {
+        let count = 100
+        let originals = (0..<count).map { i in
+            makeMemo(created: Date(timeIntervalSince1970: Double(i * 2)), body: "orig\(i)")
+        }
+        let conflicts = (0..<count).map { i in
+            makeMemo(created: Date(timeIntervalSince1970: Double(i * 2 + 1)), body: "conf\(i)")
+        }
+        let merged = ConflictMerger.mergeRawMemos(original: originals, conflict: conflicts)
+        XCTAssertEqual(merged.count, count * 2)
+        let dates = merged.map(\.created.timeIntervalSince1970)
+        XCTAssertEqual(dates, dates.sorted())
+    }
+
+    // MARK: - Log Line Merge Edge Cases
+
+    func testMergeLogLines_bothEmpty() {
+        let merged = ConflictMerger.mergeLogLines(original: "", conflict: "")
+        XCTAssertTrue(merged.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    func testMergeLogLines_emptyOriginalReturnsConflictLines() {
+        let conflict = "2025-01-01T00:00:00Z entry A\n2025-01-02T00:00:00Z entry B"
+        let merged = ConflictMerger.mergeLogLines(original: "", conflict: conflict)
+        let lines = merged.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 2)
+    }
+
+    func testMergeLogLines_identicalInputsProduceSingleCopy() {
+        let content = "2025-01-01T00:00:00Z some log line"
+        let merged = ConflictMerger.mergeLogLines(original: content, conflict: content)
+        let lines = merged.components(separatedBy: "\n").filter { !$0.isEmpty }
+        XCTAssertEqual(lines.count, 1)
+    }
+
+    func testMergeLogLines_whitespaceLinesAreSkipped() {
+        let original = "2025-01-01T00:00:00Z A\n   \n\n2025-01-02T00:00:00Z B"
+        let conflict = "2025-01-03T00:00:00Z C"
+        let merged = ConflictMerger.mergeLogLines(original: original, conflict: conflict)
+        let lines = merged.components(separatedBy: "\n").filter {
+            !$0.trimmingCharacters(in: .whitespaces).isEmpty
+        }
+        XCTAssertEqual(lines.count, 3)
+    }
 }


### PR DESCRIPTION
## Summary

Expands `ConflictMergerTests` with 9 new test cases that cover edge conditions not previously tested, fulfilling the Swift Testing requirement from issue #109.

## New test cases

**JSON merge (`mergeJSONEntries`)**
- `testMergeJSONEntries_invalidOriginalReturnsFallback` — corrupt original bytes → returns original unchanged, no crash
- `testMergeJSONEntries_invalidConflictReturnsOriginal` — corrupt conflict bytes → original preserved
- `testMergeJSONEntries_entriesWithoutIdKeyAreIncluded` — entries missing the id field are kept (not silently dropped)

**Memo merge (`mergeRawMemos`)**
- `testMerge_manyDuplicatesReducesToUnique` — 50 duplicate UUIDs (25 each side) → exactly 1 output entry
- `testMerge_threeWayConflict` — sequential double-merge simulating two conflict copies; verifies order and dedup across both passes
- `testMerge_preservesAllUniqueIDsInOrder` — 200 unique memos (100 each side) all preserved, strictly chronological

**Log line merge (`mergeLogLines`)**
- `testMergeLogLines_bothEmpty` — both inputs empty → empty output, no crash
- `testMergeLogLines_emptyOriginalReturnsConflictLines` — empty original → conflict lines returned as-is
- `testMergeLogLines_identicalInputsProduceSingleCopy` — fully duplicate input → single copy output
- `testMergeLogLines_whitespaceLinesAreSkipped` — whitespace-only lines in input are filtered out

## Test plan

- [ ] All 15 tests in `ConflictMergerTests` pass on iOS simulator
- [ ] No regressions in `VaultMigrationServiceTests`

Closes #109 (test coverage sub-task)