### PR TITLE
fix(sync): surface iCloud per-file errors in SyncStatus (issue #110)

### DIFF
--- a/DayPage/Services/iCloudSyncMonitor.swift
+++ b/DayPage/Services/iCloudSyncMonitor.swift
@@ -82,15 +82,31 @@ final class iCloudSyncMonitor: ObservableObject {
 
         var uploadCount = 0
         var downloadCount = 0
+        var firstErrorMessage: String?
 
         for i in 0..<q.resultCount {
             guard let item = q.result(at: i) as? NSMetadataItem else { continue }
+
+            // Surface per-file iCloud errors (e.g. quota exceeded, network issue).
+            if let downloadError = item.value(forAttribute: NSMetadataUbiquitousItemDownloadingErrorKey) as? NSError,
+               firstErrorMessage == nil {
+                firstErrorMessage = downloadError.localizedDescription
+            }
+            if let uploadError = item.value(forAttribute: NSMetadataUbiquitousItemUploadingErrorKey) as? NSError,
+               firstErrorMessage == nil {
+                firstErrorMessage = uploadError.localizedDescription
+            }
 
             let isUploading = item.value(forAttribute: NSMetadataUbiquitousItemIsUploadingKey) as? Bool ?? false
             let isDownloading = item.value(forAttribute: NSMetadataUbiquitousItemIsDownloadingKey) as? Bool ?? false
 
             if isUploading { uploadCount += 1 }
             if isDownloading { downloadCount += 1 }
+        }
+
+        if let errorMessage = firstErrorMessage {
+            status = .error(message: errorMessage)
+            return
         }
 
         let total = uploadCount + downloadCount


### PR DESCRIPTION
## Problem

`iCloudSyncMonitor.processQueryResults()` never set `SyncStatus.error`, making the error UI branch in `SettingsView.iCloudStatusRow` permanently unreachable. Real iCloud errors (quota exceeded, network failures, permission issues) were silently ignored and the UI always showed "已连接" or "同步中" even when files were actually failing.

## Fix

In `processQueryResults()`, before counting in-progress transfers, scan each `NSMetadataItem` for:
- `NSMetadataUbiquitousItemDownloadingErrorKey` — download failures
- `NSMetadataUbiquitousItemUploadingErrorKey` — upload failures

The **first** non-nil error takes priority: `status` is set to `.error(message: error.localizedDescription)` and the function returns early. This directly feeds the existing `case .error(let message)` branch in `SettingsView` that shows a red triangle + error text.

## Files changed

| File | Change |
|------|--------|
| `iCloudSyncMonitor.swift` | `processQueryResults()` — add error key scan before transfer counts |

## Test plan

- [ ] Simulate iCloud quota exceeded → Settings iCloud section shows red "同步错误" with error detail
- [ ] Normal sync in progress → still shows "同步中 N 个文件待传" (error path not triggered)
- [ ] All files synced, no errors → shows "已连接" with last-sync timestamp
- [ ] No regression when iCloud not configured → stays `.notConfigured`

Closes #110 (error state sub-task)