### PR TITLE
fix(icloud): start iCloudConflictMonitor on app launch (#109)

### DIFF
--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -68,9 +68,10 @@ struct DayPageApp: App {
         BackgroundCompilationService.shared.registerTask()
         // 设置通知代理以处理点击
         UNUserNotificationCenter.current().delegate = notificationDelegate
-        // 在 vault 初始化后启动 iCloud 同步监控
+        // 在 vault 初始化后启动 iCloud 同步监控和冲突自动合并
         Task { @MainActor in
             iCloudSyncMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
+            iCloudConflictMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
         }
     }
 


### PR DESCRIPTION
## Problem

The conflict auto-merge system (`iCloudConflictMonitor` + `ConflictMerger`) was fully implemented but **never activated** because `startMonitoring(vaultURL:)` was never called from the app lifecycle.

Without this call:
- iCloud conflict copies accumulate silently with no automatic resolution
- `ConflictMerger.mergeRawMemos` / `mergeLogLines` / `mergeJSONEntries` are dead code in production
- Users with multiple devices see duplicate or conflicting data

## Fix

Add `iCloudConflictMonitor.shared.startMonitoring(vaultURL:)` alongside the existing `iCloudSyncMonitor` call in `DayPageApp.init()`:

```swift
// Before
Task { @MainActor in
    iCloudSyncMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
}

// After
Task { @MainActor in
    iCloudSyncMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
    iCloudConflictMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
}
```

`iCloudConflictMonitor` is already fully implemented with NSMetadataQuery watching for conflict items and `ConflictMerger` handling deduplication. The only missing piece was wiring it into app startup.

Closes #109