### PR TITLE
feat(migration): add local backup cleanup after 30-day iCloud window (#111)

### DIFF
--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -433,6 +433,7 @@ struct SettingsView: View {
             iCloudStatusRow
             attachmentPolicyPicker
             rollbackButton
+            cleanupBackupButton
         } header: {
             Text("iCloud 同步")
         }
@@ -548,6 +549,36 @@ struct SettingsView: View {
             title: "已切换回本地存储",
             autoDismiss: true
         ))
+    }
+
+    // Shows only when: migrated to iCloud + 30-day window elapsed + local backup still exists
+    @ViewBuilder
+    private var cleanupBackupButton: some View {
+        if let migratedAt = appSettings.migrationCompletedAt,
+           Date().timeIntervalSince(migratedAt) >= 30 * 24 * 3600,
+           appSettings.vaultLocation == .iCloud,
+           FileManager.default.fileExists(atPath: LocalVaultLocator().vaultURL.path) {
+            Button(role: .destructive, action: cleanupLocalBackup) {
+                Label("清理本地备份", systemImage: "trash")
+            }
+        }
+    }
+
+    private func cleanupLocalBackup() {
+        do {
+            try VaultMigrationService.shared.deleteLocalBackup()
+            bannerCenter.show(AppBannerModel(
+                kind: .info,
+                title: "本地备份已清理",
+                autoDismiss: true
+            ))
+        } catch {
+            bannerCenter.show(AppBannerModel(
+                kind: .error,
+                title: "清理失败：\(error.localizedDescription)",
+                autoDismiss: true
+            ))
+        }
     }
 
     private func lastSyncLabel(_ date: Date) -> String {

--- a/DayPage/Services/VaultMigrationService.swift
+++ b/DayPage/Services/VaultMigrationService.swift
@@ -212,6 +212,22 @@ final class VaultMigrationService: ObservableObject {
         return digest.compactMap { String(format: "%02x", $0) }.joined()
     }
 
+    // MARK: - Local backup cleanup
+
+    /// Deletes the local vault backup after the user confirms they no longer need it.
+    /// Only safe to call when vaultLocation == .iCloud and 30-day window has passed.
+    /// Clears migrationCompletedAt so the cleanup button disappears after use.
+    func deleteLocalBackup() throws {
+        let localVault = LocalVaultLocator().vaultURL
+        let fm = FileManager.default
+        guard fm.fileExists(atPath: localVault.path) else {
+            AppSettings.shared.migrationCompletedAt = nil
+            return
+        }
+        try fm.removeItem(at: localVault)
+        AppSettings.shared.migrationCompletedAt = nil
+    }
+
     // MARK: - Auto-migration trigger
 
     /// Called from VaultInitializer when iCloud becomes available.


### PR DESCRIPTION
## Problem

Issue #111 acceptance criterion: _"30 天后显示'清理本地备份'选项"_

After migrating to iCloud, the local vault was retained for 30 days as a rollback safety net. Once that window closed, the rollback button correctly disappeared — but there was **no UI to delete the now-redundant local backup**. Users had no way to reclaim that storage space.

## Changes

### `VaultMigrationService.deleteLocalBackup()`
New method that:
1. Removes the entire local vault directory (`LocalVaultLocator().vaultURL`)
2. Clears `AppSettings.migrationCompletedAt` so the cleanup button disappears after use
3. Is a no-op (just clears the date) if the local vault no longer exists

### `SettingsView.cleanupBackupButton`
New `@ViewBuilder` property shown in the iCloud Sync section when **all three conditions** are true:
- `appSettings.vaultLocation == .iCloud` — already on iCloud
- `Date().timeIntervalSince(migratedAt) >= 30 * 24 * 3600` — 30-day window has passed
- `FileManager.default.fileExists(atPath: LocalVaultLocator().vaultURL.path)` — backup still exists

Shows a destructive "清理本地备份" button. On tap, calls `deleteLocalBackup()` and shows a success or failure banner.

## Before / After

| State | Before | After |
|---|---|---|
| < 30 days after migration | Shows rollback button | Shows rollback button (unchanged) |
| ≥ 30 days, backup exists | Nothing shown | Shows "清理本地备份" button |
| After cleanup | N/A | Button disappears, storage reclaimed |

Partially closes #111