### PR TITLE
test(vault): add VaultLocatorTests covering issue #107 acceptance criteria

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -97,6 +97,7 @@
 		A10000077 /* ConflictMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000077 /* ConflictMerger.swift */; };
 		A10000078 /* VaultMigrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000078 /* VaultMigrationService.swift */; };
 		T10000003 /* VaultMigrationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000003 /* VaultMigrationServiceTests.swift */; };
+		T10000004 /* VaultLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000004 /* VaultLocatorTests.swift */; };
 		FB0000001 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000001 /* FeedbackService.swift */; };
 		FB0000002 /* FeedbackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000002 /* FeedbackViewModel.swift */; };
 		FB0000003 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000003 /* FeedbackView.swift */; };
@@ -221,6 +222,7 @@
 		A20000077 /* ConflictMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMerger.swift; sourceTree = "<group>"; };
 		A20000078 /* VaultMigrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationService.swift; sourceTree = "<group>"; };
 		T20000003 /* VaultMigrationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationServiceTests.swift; sourceTree = "<group>"; };
+		T20000004 /* VaultLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultLocatorTests.swift; sourceTree = "<group>"; };
 		FB1000001 /* FeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackService.swift; sourceTree = "<group>"; };
 		FB1000002 /* FeedbackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewModel.swift; sourceTree = "<group>"; };
 		FB1000003 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
@@ -538,6 +540,7 @@
 				T20000001 /* DayDetailViewStateTests.swift */,
 				T20000002 /* ConflictMergerTests.swift */,
 				T20000003 /* VaultMigrationServiceTests.swift */,
+				T20000004 /* VaultLocatorTests.swift */,
 			);
 			path = DayPageTests;
 			sourceTree = "<group>";
@@ -843,6 +846,7 @@
 				T10000001 /* DayDetailViewStateTests.swift in Sources */,
 				T10000002 /* ConflictMergerTests.swift in Sources */,
 				T10000003 /* VaultMigrationServiceTests.swift in Sources */,
+				T10000004 /* VaultLocatorTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPageTests/VaultLocatorTests.swift
+++ b/DayPageTests/VaultLocatorTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import DayPage
+
+/// Unit tests for VaultLocator protocol, LocalVaultLocator, iCloudVaultLocator,
+/// and VaultInitializer.testOverrideURL — covering the acceptance criteria in issue #107.
+final class VaultLocatorTests: XCTestCase {
+
+    private var tempDir: URL!
+    private let fm = FileManager.default
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = fm.temporaryDirectory
+            .appendingPathComponent("VaultLocatorTests-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        VaultInitializer.testOverrideURL = nil
+    }
+
+    override func tearDownWithError() throws {
+        VaultInitializer.testOverrideURL = nil
+        try? fm.removeItem(at: tempDir)
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - LocalVaultLocator
+
+    func testLocalVaultLocator_isNotUsingiCloud() {
+        let locator = LocalVaultLocator()
+        XCTAssertFalse(locator.isUsingiCloud, "LocalVaultLocator must never report iCloud usage")
+    }
+
+    func testLocalVaultLocator_vaultURLEndsWithVault() {
+        let locator = LocalVaultLocator()
+        XCTAssertEqual(locator.vaultURL.lastPathComponent, "vault",
+                       "LocalVaultLocator.vaultURL must end in 'vault'")
+    }
+
+    func testLocalVaultLocator_vaultURLIsInDocumentsDirectory() {
+        let locator = LocalVaultLocator()
+        let documentsDir = fm.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        XCTAssertTrue(
+            locator.vaultURL.path.hasPrefix(documentsDir.path),
+            "LocalVaultLocator.vaultURL must be inside the app Documents directory"
+        )
+    }
+
+    func testLocalVaultLocator_returnsConsistentURL() {
+        // Multiple calls must return the same path (cached static let).
+        let locator = LocalVaultLocator()
+        let first = locator.vaultURL
+        let second = locator.vaultURL
+        XCTAssertEqual(first, second, "LocalVaultLocator.vaultURL must be stable across calls")
+    }
+
+    // MARK: - iCloudVaultLocator
+
+    func testICloudVaultLocator_vaultURLContainsVaultComponent() {
+        let locator = iCloudVaultLocator()
+        // In the Simulator without an iCloud account the ubiquity container URL is nil,
+        // so iCloudVaultLocator falls back to LocalVaultLocator.vaultURL.
+        // Either way, the returned path must end with "vault".
+        XCTAssertEqual(locator.vaultURL.lastPathComponent, "vault",
+                       "iCloudVaultLocator.vaultURL must end in 'vault' (local fallback or iCloud path)")
+    }
+
+    func testICloudVaultLocator_isUsingiCloud_matchesContainerAvailability() {
+        let locator = iCloudVaultLocator()
+        let containerAvailable = fm.url(forUbiquityContainerIdentifier: locator.containerID) != nil
+        XCTAssertEqual(
+            locator.isUsingiCloud, containerAvailable,
+            "isUsingiCloud must reflect whether the ubiquity container URL is non-nil"
+        )
+    }
+
+    // MARK: - VaultInitializer.testOverrideURL
+
+    func testOverrideURL_nil_returnsDelegateVaultURL() {
+        VaultInitializer.testOverrideURL = nil
+        let expected = VaultInitializer.shared.vaultURL
+        XCTAssertEqual(VaultInitializer.vaultURL, expected,
+                       "When testOverrideURL is nil, vaultURL must match shared.vaultURL")
+    }
+
+    func testOverrideURL_set_takesHighestPriority() {
+        let fakeVault = tempDir.appendingPathComponent("fake-vault")
+        VaultInitializer.testOverrideURL = fakeVault
+        XCTAssertEqual(VaultInitializer.vaultURL, fakeVault,
+                       "testOverrideURL must override shared.vaultURL when set")
+    }
+
+    func testOverrideURL_cleared_resumesDelegateURL() {
+        let fakeVault = tempDir.appendingPathComponent("fake-vault")
+        VaultInitializer.testOverrideURL = fakeVault
+        XCTAssertEqual(VaultInitializer.vaultURL, fakeVault)
+
+        VaultInitializer.testOverrideURL = nil
+        let expected = VaultInitializer.shared.vaultURL
+        XCTAssertEqual(VaultInitializer.vaultURL, expected,
+                       "After clearing testOverrideURL, vaultURL must revert to shared.vaultURL")
+    }
+
+    func testOverrideURL_doesNotMutateShared() {
+        let before = VaultInitializer.shared.vaultURL
+        let fakeVault = tempDir.appendingPathComponent("fake-vault")
+        VaultInitializer.testOverrideURL = fakeVault
+        let after = VaultInitializer.shared.vaultURL
+        XCTAssertEqual(before, after,
+                       "testOverrideURL must not mutate VaultInitializer.shared")
+    }
+}


### PR DESCRIPTION
## Problem

Issue #107 acceptance criterion: _"`testOverrideURL` hook 保留，单测可用"_

The `VaultLocator` protocol, `LocalVaultLocator`, `iCloudVaultLocator` and `VaultInitializer.testOverrideURL` were all implemented but had **zero dedicated unit tests**. `DayDetailViewStateTests` uses `testOverrideURL` as a test utility, but never verifies the override mechanism itself.

## New file: `VaultLocatorTests.swift` (9 test cases)

### `LocalVaultLocator`
| Test | Verifies |
|---|---|
| `testLocalVaultLocator_isNotUsingiCloud` | Always returns `false` for `isUsingiCloud` |
| `testLocalVaultLocator_vaultURLEndsWithVault` | Path ends in `"vault"` |
| `testLocalVaultLocator_vaultURLIsInDocumentsDirectory` | Path is inside the app's Documents dir |
| `testLocalVaultLocator_returnsConsistentURL` | Cached static — same URL on repeated calls |

### `iCloudVaultLocator`
| Test | Verifies |
|---|---|
| `testICloudVaultLocator_vaultURLContainsVaultComponent` | Ends in `"vault"` (iCloud or local fallback) |
| `testICloudVaultLocator_isUsingiCloud_matchesContainerAvailability` | Reflects real ubiquity container presence |

### `VaultInitializer.testOverrideURL`
| Test | Verifies |
|---|---|
| `testOverrideURL_nil_returnsDelegateVaultURL` | `nil` → delegates to `shared.vaultURL` |
| `testOverrideURL_set_takesHighestPriority` | Override wins over `shared` |
| `testOverrideURL_cleared_resumesDelegateURL` | Clearing restores `shared.vaultURL` |
| `testOverrideURL_doesNotMutateShared` | Override never mutates `VaultInitializer.shared` |

Closes #107 (partial — test coverage for the testOverrideURL criterion)