### PR TITLE
fix(build): register iCloudConflictMonitor.swift + fix AuthService computed property

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		A10000055 /* PressToTalkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000055 /* PressToTalkButton.swift */; };
 		A10000056 /* VaultLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000056 /* VaultLocator.swift */; };
 		A10000079 /* iCloudSyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000079 /* iCloudSyncMonitor.swift */; };
+		A10000085 /* iCloudConflictMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000085 /* iCloudConflictMonitor.swift */; };
 		A10000080 /* AppNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000080 /* AppNavigationModel.swift */; };
 		A10000081 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000081 /* SidebarView.swift */; };
 		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
@@ -194,6 +195,7 @@
 		A20000063 /* SwipeableMemoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMemoCard.swift; sourceTree = "<group>"; };
 		A20000064 /* AttachmentMenuSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMenuSheet.swift; sourceTree = "<group>"; };
 		A20000079 /* iCloudSyncMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncMonitor.swift; sourceTree = "<group>"; };
+		A20000085 /* iCloudConflictMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudConflictMonitor.swift; sourceTree = "<group>"; };
 		A20000080 /* AppNavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationModel.swift; sourceTree = "<group>"; };
 		A20000081 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		A20000070 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
@@ -373,6 +375,7 @@
 				A20000047 /* OnThisDayScheduler.swift */,
 				A20000049 /* SampleDataSeeder.swift */,
 				A20000079 /* iCloudSyncMonitor.swift */,
+				A20000085 /* iCloudConflictMonitor.swift */,
 				A20000077 /* ConflictMerger.swift */,
 				A20000078 /* VaultMigrationService.swift */,
 				A20000070 /* AuthService.swift */,
@@ -821,6 +824,7 @@
 				A10000063 /* SwipeableMemoCard.swift in Sources */,
 				A10000042 /* RelativeTimeFormatter.swift in Sources */,
 				A10000079 /* iCloudSyncMonitor.swift in Sources */,
+				A10000085 /* iCloudConflictMonitor.swift in Sources */,
 				A10000080 /* AppNavigationModel.swift in Sources */,
 				A10000081 /* SidebarView.swift in Sources */,
 				A10000077 /* ConflictMerger.swift in Sources */,

--- a/DayPage/Services/AuthService.swift
+++ b/DayPage/Services/AuthService.swift
@@ -75,7 +75,7 @@ final class AuthService: NSObject, ObservableObject {
         case unknown
     }
 
-    private(set) var loginProvider: LoginProvider {
+    var loginProvider: LoginProvider {
         guard let email = session?.user.email else { return .unknown }
         if let appleEmail = KeychainHelper.get(forKey: Self.appleEmailKey),
            appleEmail == email {


### PR DESCRIPTION
## Summary
- Register `iCloudConflictMonitor.swift` in `project.pbxproj` (was missing since #165 added the call to `startMonitoring` but never added the file to the build graph)
- Remove invalid `private(set)` from read-only computed property `loginProvider` in `AuthService` — Swift does not allow access-level modifiers on computed properties with no setter

## Root Cause
Both issues were introduced in PR #165 (iCloudConflictMonitor activation). The `.swift` file was created and referenced but not registered, so `xcodebuild -scheme DayPage build` fails with `cannot find 'iCloudConflictMonitor' in scope`.

## Test plan
- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [ ] Verify conflict monitor activates: create a duplicate `.icloud` file in the vault and confirm it gets resolved on app launch

Closes #177