### PR TITLE
feat(watch): activate WatchReceiveService on launch + fix nonisolated delegate (#97)

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -64,6 +64,7 @@
 		A10000055 /* PressToTalkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000055 /* PressToTalkButton.swift */; };
 		A10000056 /* VaultLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000056 /* VaultLocator.swift */; };
 		A10000079 /* iCloudSyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000079 /* iCloudSyncMonitor.swift */; };
+		A10000085 /* iCloudConflictMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000085 /* iCloudConflictMonitor.swift */; };
 		A10000080 /* AppNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000080 /* AppNavigationModel.swift */; };
 		A10000081 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000081 /* SidebarView.swift */; };
 		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
@@ -194,6 +195,7 @@
 		A20000063 /* SwipeableMemoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMemoCard.swift; sourceTree = "<group>"; };
 		A20000064 /* AttachmentMenuSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMenuSheet.swift; sourceTree = "<group>"; };
 		A20000079 /* iCloudSyncMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncMonitor.swift; sourceTree = "<group>"; };
+		A20000085 /* iCloudConflictMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudConflictMonitor.swift; sourceTree = "<group>"; };
 		A20000080 /* AppNavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationModel.swift; sourceTree = "<group>"; };
 		A20000081 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		A20000070 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
@@ -373,6 +375,7 @@
 				A20000047 /* OnThisDayScheduler.swift */,
 				A20000049 /* SampleDataSeeder.swift */,
 				A20000079 /* iCloudSyncMonitor.swift */,
+				A20000085 /* iCloudConflictMonitor.swift */,
 				A20000077 /* ConflictMerger.swift */,
 				A20000078 /* VaultMigrationService.swift */,
 				A20000070 /* AuthService.swift */,
@@ -821,6 +824,7 @@
 				A10000063 /* SwipeableMemoCard.swift in Sources */,
 				A10000042 /* RelativeTimeFormatter.swift in Sources */,
 				A10000079 /* iCloudSyncMonitor.swift in Sources */,
+				A10000085 /* iCloudConflictMonitor.swift in Sources */,
 				A10000080 /* AppNavigationModel.swift in Sources */,
 				A10000081 /* SidebarView.swift in Sources */,
 				A10000077 /* ConflictMerger.swift in Sources */,

--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -73,6 +73,9 @@ struct DayPageApp: App {
             iCloudSyncMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
             iCloudConflictMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
         }
+        // Eagerly initialize WatchReceiveService so WCSession activates on launch.
+        // Without this the lazy singleton never starts and Watch audio transfers are lost.
+        _ = WatchReceiveService.shared
     }
 
     var body: some Scene {

--- a/DayPage/Services/AuthService.swift
+++ b/DayPage/Services/AuthService.swift
@@ -75,7 +75,7 @@ final class AuthService: NSObject, ObservableObject {
         case unknown
     }
 
-    private(set) var loginProvider: LoginProvider {
+    var loginProvider: LoginProvider {
         guard let email = session?.user.email else { return .unknown }
         if let appleEmail = KeychainHelper.get(forKey: Self.appleEmailKey),
            appleEmail == email {

--- a/DayPage/Services/WatchReceiveService.swift
+++ b/DayPage/Services/WatchReceiveService.swift
@@ -26,22 +26,25 @@ final class WatchReceiveService: NSObject, ObservableObject {
 
 extension WatchReceiveService: WCSessionDelegate {
 
-    func session(_ session: WCSession,
-                 activationDidCompleteWith activationState: WCSessionActivationState,
-                 error: Error?) {
+    // WCSessionDelegate callbacks arrive on an arbitrary background thread.
+    // Mark each method nonisolated and hop back to MainActor only for @Published mutations.
+
+    nonisolated func session(_ session: WCSession,
+                             activationDidCompleteWith activationState: WCSessionActivationState,
+                             error: Error?) {
         if let error {
             print("[WatchReceiveService] activation error: \(error.localizedDescription)")
         }
     }
 
-    func sessionDidBecomeInactive(_ session: WCSession) {}
+    nonisolated func sessionDidBecomeInactive(_ session: WCSession) {}
 
-    func sessionDidDeactivate(_ session: WCSession) {
+    nonisolated func sessionDidDeactivate(_ session: WCSession) {
         WCSession.default.activate()
     }
 
     /// Called when the iPhone receives a file transfer from the Watch.
-    func session(_ session: WCSession, didReceive file: WCSessionFile) {
+    nonisolated func session(_ session: WCSession, didReceive file: WCSessionFile) {
         let sourceURL = file.fileURL
         let metadata = file.metadata ?? [:]
 
@@ -63,21 +66,20 @@ extension WatchReceiveService: WCSessionDelegate {
             try FileManager.default.createDirectory(at: assetsURL,
                                                     withIntermediateDirectories: true)
             let destURL = assetsURL.appendingPathComponent("watch_\(filename)")
-            // Remove any existing file at destination
             if FileManager.default.fileExists(atPath: destURL.path) {
                 try FileManager.default.removeItem(at: destURL)
             }
             try FileManager.default.moveItem(at: sourceURL, to: destURL)
 
-            print("[WatchReceiveService] Saved watch audio to: \(destURL.path)")
+            print("[WatchReceiveService] Saved watch audio to: \(destURL.lastPathComponent)")
 
             Task { @MainActor in
-                lastReceivedFile = destURL
+                self.lastReceivedFile = destURL
             }
         } catch {
             print("[WatchReceiveService] Failed to move file: \(error.localizedDescription)")
             Task { @MainActor in
-                lastError = error.localizedDescription
+                self.lastError = error.localizedDescription
             }
         }
     }


### PR DESCRIPTION
## Summary

Two Watch connectivity fixes that together satisfy the issue #97 acceptance criterion:
> *WCSession 在 Watch 和 iPhone 模拟器 paired 配对后可激活（isReachable 可读）*

### 1. Eager WatchReceiveService initialization (`DayPageApp.swift`)

`WatchReceiveService.shared` is a lazy singleton — its `init()` calls `WCSession.default.activate()`. Without touching it early in the app lifecycle, WCSession never activates on the iPhone side, so:
- The delegate is never set
- The iPhone never receives `didReceive(file:)` callbacks
- Watch audio transfers are **silently dropped**

Fix: add `_ = WatchReceiveService.shared` in `DayPageApp.init()` alongside the other service activations.

### 2. `nonisolated` WCSessionDelegate methods (`WatchReceiveService.swift`)

`WatchReceiveService` is `@MainActor` but `WCSessionDelegate` callbacks arrive on a background thread. Having delegate methods inherit `@MainActor` isolation caused:
- Build warning: `main actor-isolated instance method cannot satisfy nonisolated requirement`
- Risk of deadlock or thread-safety violations when the callback attempts to access MainActor state synchronously from a background thread

Fix: mark all four delegate methods as `nonisolated`; use `Task { @MainActor in }` only for the `@Published` property mutations.

## Test plan
- [x] `xcodebuild -scheme DayPage build` → **BUILD SUCCEEDED** (no actor isolation warnings for WatchReceiveService)
- [ ] Pair iPhone 17 Simulator + Apple Watch Simulator → confirm `WCSession.default.isReachable` becomes `true`
- [ ] Transfer a test audio file from Watch Simulator → confirm file appears in `vault/raw/assets/`

Partially closes #97