### PR TITLE
chore(logger): replace print() with DayPageLogger in compilation services

### DIFF
--- a/DayPage/Services/BackgroundCompilationService.swift
+++ b/DayPage/Services/BackgroundCompilationService.swift
@@ -69,10 +69,10 @@ final class BackgroundCompilationService {
                 // 已经调度 — 没问题
                 break
             default:
-                print("[BGCompile] Schedule error: \(error.localizedDescription)")
+                DayPageLogger.shared.error("[BGCompile] Schedule error: \(error.localizedDescription)")
             }
         } catch {
-            print("[BGCompile] Schedule error: \(error.localizedDescription)")
+            DayPageLogger.shared.error("[BGCompile] Schedule error: \(error.localizedDescription)")
         }
     }
 
@@ -91,7 +91,7 @@ final class BackgroundCompilationService {
                 try await compileWithRetry(for: yesterday, trigger: "backfill")
                 sendSuccessNotification(for: yesterday)
             } catch {
-                print("[BGCompile] Backfill failed after retries: \(error.localizedDescription)")
+                DayPageLogger.shared.error("[BGCompile] Backfill failed after retries: \(error.localizedDescription)")
                 sendFailureNotification()
             }
         }
@@ -127,7 +127,7 @@ final class BackgroundCompilationService {
                 sendSuccessNotification(for: yesterday)
                 task.setTaskCompleted(success: true)
             } catch {
-                print("[BGCompile] Background compile failed after retries: \(error.localizedDescription)")
+                DayPageLogger.shared.error("[BGCompile] Background compile failed after retries: \(error.localizedDescription)")
                 transaction?.finish(status: .internalError)
                 if !Secrets.sentryDSN.isEmpty { SentrySDK.flush(timeout: 5) }
                 sendFailureNotification()
@@ -152,7 +152,7 @@ final class BackgroundCompilationService {
                 return
             } catch {
                 lastError = error
-                print("[BGCompile] Attempt \(attempt + 1) failed: \(error.localizedDescription)")
+                DayPageLogger.shared.warn("[BGCompile] Attempt \(attempt + 1) failed: \(error.localizedDescription)")
             }
         }
         throw lastError!
@@ -197,7 +197,7 @@ final class BackgroundCompilationService {
 
         center.add(request) { error in
             if let error {
-                print("[BGCompile] Notification error: \(error.localizedDescription)")
+                DayPageLogger.shared.error("[BGCompile] Notification error: \(error.localizedDescription)")
             }
         }
     }
@@ -220,7 +220,7 @@ final class BackgroundCompilationService {
 
         center.add(request) { error in
             if let error {
-                print("[BGCompile] Failure notification error: \(error.localizedDescription)")
+                DayPageLogger.shared.error("[BGCompile] Failure notification error: \(error.localizedDescription)")
             }
         }
     }

--- a/DayPage/Services/CompilationService.swift
+++ b/DayPage/Services/CompilationService.swift
@@ -383,18 +383,14 @@ final class CompilationService {
         let (data, response) = try await URLSession.shared.data(for: request)
 
         guard let http = response as? HTTPURLResponse else {
-            #if DEBUG
-            print("[DeepSeek] URL=\(url.absoluteString) status=- body=No HTTP response")
-            #endif
+            DayPageLogger.shared.error("[DeepSeek] status=- body=No HTTP response")
             throw CompilationError.networkError("No HTTP response")
         }
 
         guard http.statusCode == 200 else {
             let bodyStr = String(data: data, encoding: .utf8) ?? "(empty)"
-            #if DEBUG
             let snippet = String(bodyStr.prefix(500))
-            print("[DeepSeek] URL=\(url.absoluteString) status=\(http.statusCode) body=\(snippet)")
-            #endif
+            DayPageLogger.shared.error("[DeepSeek] status=\(http.statusCode) body=\(snippet)")
             throw CompilationError.apiError(statusCode: http.statusCode, body: bodyStr)
         }
 


### PR DESCRIPTION
## Summary

Closes #184

Replaces 9 remaining `print()` calls in the two compilation services with `DayPageLogger`, completing the work started in PR #174.

| File | Changes |
|------|---------|
| `BackgroundCompilationService.swift` | 7 `print()` → `DayPageLogger.shared.error()` / `.warn()` |
| `CompilationService.swift` | 2 `print()` (in `#if DEBUG`) → `DayPageLogger.shared.error()`, guards removed |

**Why `warn()` for retry attempts?** Each retry failure is transient — it becomes an `error()` only if all attempts are exhausted. Using `warn()` keeps Sentry noise low while still capturing the breadcrumb trail.

**Why remove `#if DEBUG` in CompilationService?** `DayPageLogger` already handles debug-vs-release gating internally, and DeepSeek HTTP errors in production are exactly what we need Sentry to capture.

## Acceptance Criteria

- [x] No `print()` calls remain in `BackgroundCompilationService.swift`
- [x] No `print()` calls remain in `CompilationService.swift`
- [x] `DayPageLogger.shared.error()` used for error-level messages
- [x] `DayPageLogger.shared.warn()` used for per-attempt retry warnings

## Test plan

- [ ] `xcodebuild -scheme DayPage build` passes
- [ ] Trigger a compilation failure (invalid API key) → error appears in Sentry breadcrumbs / Console.app log