### PR TITLE
perf(logger): cache ISO8601DateFormatter + remove per-error Sentry event

### DIFF
--- a/DayPage/Services/DayPageLogger.swift
+++ b/DayPage/Services/DayPageLogger.swift
@@ -9,6 +9,13 @@ final class DayPageLogger {
     private nonisolated static let queue = DispatchQueue(label: "com.daypage.logger", qos: .utility)
     private let maxFileSize: Int = 1_048_576 // 1 MB
 
+    // Shared formatter — ISO8601DateFormatter init is expensive; reuse across all calls.
+    private nonisolated static let formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        return f
+    }()
+
     private var logURL: URL {
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
         let logsDir = docs.appendingPathComponent("vault/logs", isDirectory: true)
@@ -23,7 +30,8 @@ final class DayPageLogger {
         let crumb = Breadcrumb(level: .error, category: "app")
         crumb.message = message
         SentrySDK.addBreadcrumb(crumb)
-        SentrySDK.capture(message: message) { $0.setLevel(SentryLevel.error) }
+        // Breadcrumb only — no per-call SentrySDK.capture(). Call sites that need a
+        // full Sentry event (unhandled exceptions) should invoke SentrySDK directly.
     }
 
     func warn(_ message: String, file: String = #file, line: Int = #line) {
@@ -41,7 +49,7 @@ final class DayPageLogger {
     }
 
     private func write(level: String, message: String, file: String, line: Int) {
-        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let timestamp = Self.formatter.string(from: Date())
         let shortFile = (file as NSString).lastPathComponent
         let entry = "[\(timestamp)] [\(level)] \(shortFile):\(line) — \(message)\n"
         let url = logURL
@@ -51,11 +59,12 @@ final class DayPageLogger {
         }
     }
 
-    // Callable from any actor context (nonisolated enum, background threads, WCSessionDelegate).
-    // Routes through the shared serial queue for thread-safe writes; Sentry breadcrumbs are skipped for off-actor calls.
+    // Callable from any actor context (nonisolated, background threads, WCSessionDelegate).
+    // Routes through the shared serial queue for thread-safe writes; Sentry breadcrumbs
+    // are skipped for off-actor calls.
     nonisolated static func log(level: String, message: String,
                                 file: String = #file, line: Int = #line) {
-        let timestamp = ISO8601DateFormatter().string(from: Date())
+        let timestamp = formatter.string(from: Date())
         let shortFile = (file as NSString).lastPathComponent
         let entry = "[\(timestamp)] [\(level)] \(shortFile):\(line) — \(message)\n"
         Self.queue.async {


### PR DESCRIPTION
## Summary

Closes #188

Two improvements to \`DayPageLogger.swift\`:

### 1. Shared \`ISO8601DateFormatter\` (perf)

\`DateFormatter\` / \`ISO8601DateFormatter\` initialization parses locale, timezone, and calendar — it is one of the more expensive Foundation allocations. The previous code called \`ISO8601DateFormatter()\` inline on every log call in both the \`@MainActor\` \`write()\` path and the \`nonisolated static log()\` path.

The fix extracts a single \`private nonisolated static let formatter\` initialized once at first use. Both code paths now share the same instance.

### 2. Remove \`SentrySDK.capture(message:)\` from \`error()\` (cost + noise)

The previous \`error()\` called both \`SentrySDK.addBreadcrumb\` **and** \`SentrySDK.capture(message:)\`. This means every \`DayPageLogger.shared.error()\` call — including per-retry compilation failures and notification delivery errors — sent a full Sentry **event** consuming quota and triggering alerts.

Breadcrumbs are the correct mechanism for operational error logging; they appear in the breadcrumb trail attached to any subsequent Sentry event without burning event quota. Call sites that need an explicit Sentry event can call \`SentrySDK.capture\` directly.

## Test plan

- [ ] \`xcodebuild -scheme DayPage build\` passes
- [ ] Trigger a compilation failure → Sentry breadcrumb appears, no standalone Sentry event fired
- [ ] Log file (\`vault/logs/app.log\`) still written with correct ISO 8601 timestamps