### PR TITLE
fix: eliminate force-unwraps in VoiceService, SettingsView, BackgroundCompilationService

### DIFF
--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -705,7 +705,7 @@ struct SettingsView: View {
         let key = Secrets.resolvedOpenAIWhisperApiKey
         guard !key.isEmpty else { return }
 
-        var req = URLRequest(url: URL(string: "https://api.openai.com/v1/models")!)
+        var req = URLRequest(url: URL(staticString: "https://api.openai.com/v1/models"))
         req.setValue("Bearer \(key)", forHTTPHeaderField: "Authorization")
         req.timeoutInterval = 10
 

--- a/DayPage/Services/BackgroundCompilationService.swift
+++ b/DayPage/Services/BackgroundCompilationService.swift
@@ -155,7 +155,7 @@ final class BackgroundCompilationService {
                 DayPageLogger.shared.warn("[BGCompile] Attempt \(attempt + 1) failed: \(error.localizedDescription)")
             }
         }
-        throw lastError!
+        throw lastError ?? CompilationError.networkError("All retry attempts exhausted")
     }
 
     // MARK: - Private: Compile Eligibility Check

--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -260,7 +260,7 @@ final class VoiceService: NSObject, ObservableObject {
         // -- closing boundary
         body.append(Data("--\(boundary)--\r\n".utf8))
 
-        var request = URLRequest(url: URL(string: "https://api.openai.com/v1/audio/transcriptions")!)
+        var request = URLRequest(url: URL(staticString: "https://api.openai.com/v1/audio/transcriptions"))
         request.httpMethod = "POST"
         request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
         request.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "Content-Type")


### PR DESCRIPTION
## Summary

Closes #190

Eliminates three force-unwrap (`!`) patterns in production code:

- **`VoiceService.swift:263`** — `URL(string: "...")!` → `URL(staticString: "...")` for the Whisper transcription endpoint
- **`SettingsView.swift:708`** — `URL(string: "...")!` → `URL(staticString: "...")` for the OpenAI models connectivity test
- **`BackgroundCompilationService.swift:158`** — `throw lastError!` → `throw lastError ?? CompilationError.networkError("All retry attempts exhausted")`

### Why `URL(staticString:)`?

`URL(staticString:)` is a non-failable initializer that accepts Swift `StaticString` literals. The compiler guarantees the argument is a compile-time constant, so there is zero runtime crash risk — and no `!` in sight.

### Why the nil-coalesce on `lastError`?

The force-unwrap was logically safe (the loop only exits after ≥1 `catch` block populates `lastError`), but the compiler could not prove this. Any future refactor that adds a `break` or restructures the loop would silently introduce a crash. The nil-coalesce makes the invariant compiler-visible at zero behavioral cost.

## Test plan

- [ ] Build succeeds on device/simulator (no regression)
- [ ] Voice transcription still works end-to-end
- [ ] Settings → test Whisper connectivity still shows success/failure correctly
- [ ] Background compilation retry still reports failures correctly after exhausting retries