### PR TITLE
perf: cache DateFormatter instances in ArchiveView and BackgroundCompilationService

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -958,24 +958,29 @@ struct ArchiveView: View {
         .padding(.top, 8)
     }
 
+    private static let isoParser: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    private static let monthDayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMMM d"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
     /// 将 "yyyy-MM-dd" 转换为 "APRIL 14"（MMMM d, en_US, 全大写）。
     private func formatArchiveDate(_ dateString: String) -> String {
-        let parser = DateFormatter()
-        parser.dateFormat = "yyyy-MM-dd"
-        parser.locale = Locale(identifier: "en_US_POSIX")
-        guard let date = parser.date(from: dateString) else { return dateString }
-        let formatter = DateFormatter()
-        formatter.dateFormat = "MMMM d"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        return formatter.string(from: date).uppercased()
+        guard let date = Self.isoParser.date(from: dateString) else { return dateString }
+        return Self.monthDayFormatter.string(from: date).uppercased()
     }
 
     /// 人性化日期标签：TODAY / YESTERDAY / N DAYS AGO / APRIL 14。
     private func relativeDateLabel(_ dateString: String) -> String {
-        let parser = DateFormatter()
-        parser.dateFormat = "yyyy-MM-dd"
-        parser.locale = Locale(identifier: "en_US_POSIX")
-        guard let date = parser.date(from: dateString) else { return dateString }
+        guard let date = Self.isoParser.date(from: dateString) else { return dateString }
         let cal = Calendar.current
         let now = Date()
         if cal.isDateInToday(date) { return "TODAY" }

--- a/DayPage/Services/BackgroundCompilationService.swift
+++ b/DayPage/Services/BackgroundCompilationService.swift
@@ -160,16 +160,20 @@ final class BackgroundCompilationService {
 
     // MARK: - Private: Compile Eligibility Check
 
+    private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
     /// 如果 `date` 存在 raw memo 文件且尚未编译 Daily Page，则返回 true。
     private func shouldCompile(for date: Date) -> Bool {
         let rawURL = RawStorage.fileURL(for: date)
         guard FileManager.default.fileExists(atPath: rawURL.path) else { return false }
 
-        let formatter = DateFormatter()
-        formatter.dateFormat = "yyyy-MM-dd"
-        formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = AppSettings.currentTimeZone()
-        let dateString = formatter.string(from: date)
+        Self.dateFormatter.timeZone = AppSettings.currentTimeZone()
+        let dateString = Self.dateFormatter.string(from: date)
 
         let dailyURL = VaultInitializer.vaultURL
             .appendingPathComponent("wiki")


### PR DESCRIPTION
## Summary

Closes #192

`DateFormatter` is expensive to initialize — locale, calendar, and timezone setup each allocate internal state. Two hot call-paths were allocating fresh instances on every invocation:

### `ArchiveView.swift`
`formatArchiveDate(_:)` and `relativeDateLabel(_:)` are called for every row in the archive list. Each allocated 2 `DateFormatter` objects → O(2n) allocations per scroll/refresh.

**Fix**: Extract into two `private static let` constants (`isoParser` + `monthDayFormatter`) initialized once and reused for all rows.

### `BackgroundCompilationService.swift`
`shouldCompile(for:)` allocated a fresh formatter on every eligibility check (called at app foreground and in background task).

**Fix**: Extract into `private static let dateFormatter`. The timezone is set before each use via `Self.dateFormatter.timeZone = AppSettings.currentTimeZone()` so user timezone changes are always respected.

> Note: `DateFormatter` is thread-safe for concurrent reads on iOS 7+ per Apple docs. The timezone mutation in `shouldCompile` is safe because it runs on `@MainActor`.

## Test plan

- [ ] Archive list renders correctly (dates show "TODAY", "YESTERDAY", "N DAYS AGO", "APRIL 14" as before)
- [ ] Archive list scrolls smoothly with many entries
- [ ] Background compilation eligibility check still generates correct `yyyy-MM-dd` filenames in user timezone
- [ ] Changing timezone in Settings → background compilation still uses the new timezone