### PR TITLE
refactor: consolidate all UserDefaults keys into AppSettings.Keys

### DIFF
--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -129,9 +129,25 @@ extension AppSettings {
         static let lastSyncBannerDate = "lastSyncBannerDate"
         static let onThisDayDismissed = "onThisDayDismissedDate"
         // Runtime API keys (entered during onboarding, stored in UserDefaults)
-        static let runtimeDeepSeekKey   = "runtimeDeepSeekKey"
-        static let runtimeOpenAIKey     = "runtimeOpenAIKey"
+        static let runtimeDeepSeekKey    = "runtimeDeepSeekKey"
+        static let runtimeOpenAIKey      = "runtimeOpenAIKey"
         static let runtimeOpenWeatherKey = "runtimeOpenWeatherKey"
+        // Settings — time zone, vault, attachment
+        static let preferredTimeZone  = "preferredTimeZone"
+        static let vaultLocation      = "vaultLocation"
+        static let attachmentPolicy   = "attachmentPolicy"
+        // GitHub feedback repo
+        static let githubRepoOwner    = "githubRepoOwner"
+        static let githubRepoName     = "githubRepoName"
+        // Migration
+        static let migrationCompletedAt = "migrationCompletedAt"
+        // Appearance
+        static let themeMode          = "themeMode"
+        static let accentColor        = "accentColor"
+        static let fontSizeAdjust     = "fontSizeAdjust"
+        static let cardDensity        = "cardDensity"
+        // Input
+        static let usePressToTalk     = "usePressToTalk"
     }
 }
 
@@ -145,13 +161,11 @@ final class AppSettings: ObservableObject {
 
     // MARK: - Preferred Time Zone
 
-    private let timeZoneKey = "preferredTimeZone"
-
     /// 用于所有日期计算的时区：文件命名、编译调度和日报归属。
     /// 默认为设备时区。
     var preferredTimeZone: TimeZone {
         get {
-            guard let id = UserDefaults.standard.string(forKey: timeZoneKey),
+            guard let id = UserDefaults.standard.string(forKey: Keys.preferredTimeZone),
                   let tz = TimeZone(identifier: id) else {
                 return TimeZone.current
             }
@@ -159,24 +173,22 @@ final class AppSettings: ObservableObject {
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue.identifier, forKey: timeZoneKey)
+            UserDefaults.standard.set(newValue.identifier, forKey: Keys.preferredTimeZone)
         }
     }
 
     /// 将首选时区重置为当前设备时区。
     func resetToDeviceTimeZone() {
-        UserDefaults.standard.removeObject(forKey: timeZoneKey)
+        UserDefaults.standard.removeObject(forKey: Keys.preferredTimeZone)
         objectWillChange.send()
     }
 
     // MARK: - Vault Location
 
-    static let vaultLocationKey = "vaultLocation"
-
     /// vault 存储位置。默认为 .local。
     var vaultLocation: VaultLocation {
         get {
-            guard let raw = UserDefaults.standard.string(forKey: Self.vaultLocationKey),
+            guard let raw = UserDefaults.standard.string(forKey: Keys.vaultLocation),
                   let loc = VaultLocation(rawValue: raw) else {
                 return .local
             }
@@ -184,18 +196,16 @@ final class AppSettings: ObservableObject {
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue.rawValue, forKey: Self.vaultLocationKey)
+            UserDefaults.standard.set(newValue.rawValue, forKey: Keys.vaultLocation)
         }
     }
 
     // MARK: - Attachment Policy
 
-    static let attachmentPolicyKey = "attachmentPolicy"
-
     /// iCloud 附件的下载方式。默认为 .onDemand。
     var attachmentPolicy: AttachmentPolicy {
         get {
-            guard let raw = UserDefaults.standard.string(forKey: Self.attachmentPolicyKey),
+            guard let raw = UserDefaults.standard.string(forKey: Keys.attachmentPolicy),
                   let policy = AttachmentPolicy(rawValue: raw) else {
                 return .onDemand
             }
@@ -203,116 +213,103 @@ final class AppSettings: ObservableObject {
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue.rawValue, forKey: Self.attachmentPolicyKey)
+            UserDefaults.standard.set(newValue.rawValue, forKey: Keys.attachmentPolicy)
         }
     }
 
     // MARK: - GitHub Repo Config
 
-    static let githubRepoOwnerKey = "githubRepoOwner"
-    static let githubRepoNameKey = "githubRepoName"
-
     /// The GitHub repo owner for feedback issue creation. Defaults to "cubxxw".
     var githubRepoOwner: String {
         get {
-            UserDefaults.standard.string(forKey: Self.githubRepoOwnerKey) ?? "cubxxw"
+            UserDefaults.standard.string(forKey: Keys.githubRepoOwner) ?? "cubxxw"
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue, forKey: Self.githubRepoOwnerKey)
+            UserDefaults.standard.set(newValue, forKey: Keys.githubRepoOwner)
         }
     }
 
     /// The GitHub repo name for feedback issue creation. Defaults to "daypage".
     var githubRepoName: String {
         get {
-            UserDefaults.standard.string(forKey: Self.githubRepoNameKey) ?? "daypage"
+            UserDefaults.standard.string(forKey: Keys.githubRepoName) ?? "daypage"
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue, forKey: Self.githubRepoNameKey)
+            UserDefaults.standard.set(newValue, forKey: Keys.githubRepoName)
         }
     }
 
     // MARK: - Theme Mode
 
-    private let themeModeKey = "themeMode"
-
     var themeMode: ThemeMode {
         get {
-            guard let raw = UserDefaults.standard.string(forKey: themeModeKey),
+            guard let raw = UserDefaults.standard.string(forKey: Keys.themeMode),
                   let mode = ThemeMode(rawValue: raw) else { return .system }
             return mode
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue.rawValue, forKey: themeModeKey)
+            UserDefaults.standard.set(newValue.rawValue, forKey: Keys.themeMode)
         }
     }
 
     // MARK: - Accent Color
 
-    private let accentColorKey = "accentColor"
-
     var accentColor: AccentColorOption {
         get {
-            guard let raw = UserDefaults.standard.string(forKey: accentColorKey),
+            guard let raw = UserDefaults.standard.string(forKey: Keys.accentColor),
                   let color = AccentColorOption(rawValue: raw) else { return .amber }
             return color
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue.rawValue, forKey: accentColorKey)
+            UserDefaults.standard.set(newValue.rawValue, forKey: Keys.accentColor)
         }
     }
 
     // MARK: - Font Size Adjust
 
-    private let fontSizeAdjustKey = "fontSizeAdjust"
-
     var fontSizeAdjust: FontSizeAdjust {
         get {
-            guard let raw = UserDefaults.standard.string(forKey: fontSizeAdjustKey),
+            guard let raw = UserDefaults.standard.string(forKey: Keys.fontSizeAdjust),
                   let adjust = FontSizeAdjust(rawValue: raw) else { return .normal }
             return adjust
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue.rawValue, forKey: fontSizeAdjustKey)
+            UserDefaults.standard.set(newValue.rawValue, forKey: Keys.fontSizeAdjust)
         }
     }
 
     // MARK: - Card Density
 
-    private let cardDensityKey = "cardDensity"
-
     var cardDensity: CardDensity {
         get {
-            guard let raw = UserDefaults.standard.string(forKey: cardDensityKey),
+            guard let raw = UserDefaults.standard.string(forKey: Keys.cardDensity),
                   let density = CardDensity(rawValue: raw) else { return .comfortable }
             return density
         }
         set {
             objectWillChange.send()
-            UserDefaults.standard.set(newValue.rawValue, forKey: cardDensityKey)
+            UserDefaults.standard.set(newValue.rawValue, forKey: Keys.cardDensity)
         }
     }
 
     // MARK: - Migration Completed At
 
-    static let migrationCompletedAtKey = "migrationCompletedAt"
-
     /// 迁移到 iCloud 的完成日期。未迁移时为 nil。
     var migrationCompletedAt: Date? {
         get {
-            UserDefaults.standard.object(forKey: Self.migrationCompletedAtKey) as? Date
+            UserDefaults.standard.object(forKey: Keys.migrationCompletedAt) as? Date
         }
         set {
             objectWillChange.send()
             if let date = newValue {
-                UserDefaults.standard.set(date, forKey: Self.migrationCompletedAtKey)
+                UserDefaults.standard.set(date, forKey: Keys.migrationCompletedAt)
             } else {
-                UserDefaults.standard.removeObject(forKey: Self.migrationCompletedAtKey)
+                UserDefaults.standard.removeObject(forKey: Keys.migrationCompletedAt)
             }
         }
     }
@@ -322,7 +319,7 @@ final class AppSettings: ObservableObject {
     /// 直接从 UserDefaults 读取首选时区，无需 @MainActor 上下文。
     /// 在同步、非隔离的代码路径中使用此方法（例如 RawStorage、静态格式化器）。
     nonisolated static func currentTimeZone() -> TimeZone {
-        guard let id = UserDefaults.standard.string(forKey: "preferredTimeZone"),
+        guard let id = UserDefaults.standard.string(forKey: Keys.preferredTimeZone),
               let tz = TimeZone(identifier: id) else {
             return TimeZone.current
         }
@@ -332,7 +329,7 @@ final class AppSettings: ObservableObject {
     /// 直接从 UserDefaults 读取附件策略，无需 @MainActor 上下文。
     /// 在 VaultInitializer 或其他非隔离代码中使用。
     nonisolated static func currentAttachmentPolicy() -> AttachmentPolicy {
-        guard let raw = UserDefaults.standard.string(forKey: "attachmentPolicy"),
+        guard let raw = UserDefaults.standard.string(forKey: Keys.attachmentPolicy),
               let policy = AttachmentPolicy(rawValue: raw) else {
             return .onDemand
         }
@@ -342,7 +339,7 @@ final class AppSettings: ObservableObject {
     /// 直接从 UserDefaults 读取 vault 位置，无需 @MainActor 上下文。
     /// 在 VaultInitializer 或其他非隔离代码中使用。
     nonisolated static func currentVaultLocation() -> VaultLocation {
-        guard let raw = UserDefaults.standard.string(forKey: "vaultLocation"),
+        guard let raw = UserDefaults.standard.string(forKey: Keys.vaultLocation),
               let loc = VaultLocation(rawValue: raw) else {
             return .local
         }

--- a/DayPage/Features/Feedback/FeedbackViewModel.swift
+++ b/DayPage/Features/Feedback/FeedbackViewModel.swift
@@ -27,13 +27,13 @@ final class FeedbackViewModel: ObservableObject {
     // MARK: - Repo Config (UserDefaults)
 
     var repoOwner: String {
-        get { UserDefaults.standard.string(forKey: AppSettings.githubRepoOwnerKey) ?? "cubxxw" }
-        set { UserDefaults.standard.set(newValue, forKey: AppSettings.githubRepoOwnerKey) }
+        get { UserDefaults.standard.string(forKey: AppSettings.Keys.githubRepoOwner) ?? "cubxxw" }
+        set { UserDefaults.standard.set(newValue, forKey: AppSettings.Keys.githubRepoOwner) }
     }
 
     var repoName: String {
-        get { UserDefaults.standard.string(forKey: AppSettings.githubRepoNameKey) ?? "daypage" }
-        set { UserDefaults.standard.set(newValue, forKey: AppSettings.githubRepoNameKey) }
+        get { UserDefaults.standard.string(forKey: AppSettings.Keys.githubRepoName) ?? "daypage" }
+        set { UserDefaults.standard.set(newValue, forKey: AppSettings.Keys.githubRepoName) }
     }
 
     // MARK: - Token (Keychain)

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -34,7 +34,7 @@ struct SettingsView: View {
     @StateObject private var syncMonitor = iCloudSyncMonitor.shared
 
     // Press-to-talk fallback toggle (US-008).
-    @AppStorage("usePressToTalk") private var usePressToTalk: Bool = true
+    @AppStorage(AppSettings.Keys.usePressToTalk) private var usePressToTalk: Bool = true
 
     // API key editing sheet
     @State private var editingKeyName: String = ""

--- a/DayPageTests/VaultMigrationServiceTests.swift
+++ b/DayPageTests/VaultMigrationServiceTests.swift
@@ -16,14 +16,14 @@ final class VaultMigrationServiceTests: XCTestCase {
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try? fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
         // Clear previous migration state
-        UserDefaults.standard.removeObject(forKey: AppSettings.migrationCompletedAtKey)
-        UserDefaults.standard.removeObject(forKey: AppSettings.vaultLocationKey)
+        UserDefaults.standard.removeObject(forKey: AppSettings.Keys.migrationCompletedAt)
+        UserDefaults.standard.removeObject(forKey: AppSettings.Keys.vaultLocation)
     }
 
     override func tearDown() {
         try? fm.removeItem(at: tempDir)
-        UserDefaults.standard.removeObject(forKey: AppSettings.migrationCompletedAtKey)
-        UserDefaults.standard.removeObject(forKey: AppSettings.vaultLocationKey)
+        UserDefaults.standard.removeObject(forKey: AppSettings.Keys.migrationCompletedAt)
+        UserDefaults.standard.removeObject(forKey: AppSettings.Keys.vaultLocation)
         super.tearDown()
     }
 
@@ -168,8 +168,8 @@ final class VaultMigrationServiceTests: XCTestCase {
     /// When vault doesn't exist (common in Simulator where Documents/vault is absent),
     /// deleteLocalBackup should not throw and must clear migrationCompletedAt.
     func testDeleteLocalBackup_whenVaultAbsent_clearsMigrationDate() async throws {
-        UserDefaults.standard.set(Date(), forKey: AppSettings.migrationCompletedAtKey)
-        XCTAssertNotNil(UserDefaults.standard.object(forKey: AppSettings.migrationCompletedAtKey))
+        UserDefaults.standard.set(Date(), forKey: AppSettings.Keys.migrationCompletedAt)
+        XCTAssertNotNil(UserDefaults.standard.object(forKey: AppSettings.Keys.migrationCompletedAt))
 
         let service = await VaultMigrationService.shared
         try await MainActor.run {
@@ -177,7 +177,7 @@ final class VaultMigrationServiceTests: XCTestCase {
         }
 
         XCTAssertNil(
-            UserDefaults.standard.object(forKey: AppSettings.migrationCompletedAtKey),
+            UserDefaults.standard.object(forKey: AppSettings.Keys.migrationCompletedAt),
             "migrationCompletedAt must be cleared even when vault directory was absent"
         )
     }
@@ -185,7 +185,7 @@ final class VaultMigrationServiceTests: XCTestCase {
     /// deleteLocalBackup clears migrationCompletedAt regardless of how old the date is.
     func testDeleteLocalBackup_clearsMigrationDate_regardlessOfAge() async throws {
         let oldDate = Date(timeIntervalSinceNow: -40 * 24 * 3600) // 40 days ago
-        UserDefaults.standard.set(oldDate, forKey: AppSettings.migrationCompletedAtKey)
+        UserDefaults.standard.set(oldDate, forKey: AppSettings.Keys.migrationCompletedAt)
 
         let service = await VaultMigrationService.shared
         await MainActor.run {
@@ -193,14 +193,14 @@ final class VaultMigrationServiceTests: XCTestCase {
         }
 
         XCTAssertNil(
-            UserDefaults.standard.object(forKey: AppSettings.migrationCompletedAtKey),
+            UserDefaults.standard.object(forKey: AppSettings.Keys.migrationCompletedAt),
             "migrationCompletedAt must be nil after deleteLocalBackup for a 40-day-old migration"
         )
     }
 
     /// When migrationCompletedAt is already nil, deleteLocalBackup must not crash.
     func testDeleteLocalBackup_whenNoPriorMigration_doesNotThrow() async throws {
-        UserDefaults.standard.removeObject(forKey: AppSettings.migrationCompletedAtKey)
+        UserDefaults.standard.removeObject(forKey: AppSettings.Keys.migrationCompletedAt)
 
         let service = await VaultMigrationService.shared
         try await MainActor.run {
@@ -222,7 +222,7 @@ final class VaultMigrationServiceTests: XCTestCase {
         )
 
         XCTAssertNotNil(
-            UserDefaults.standard.object(forKey: AppSettings.migrationCompletedAtKey),
+            UserDefaults.standard.object(forKey: AppSettings.Keys.migrationCompletedAt),
             "migrationCompletedAt must be set after successful migration"
         )
 
@@ -233,7 +233,7 @@ final class VaultMigrationServiceTests: XCTestCase {
         }
 
         XCTAssertNil(
-            UserDefaults.standard.object(forKey: AppSettings.migrationCompletedAtKey),
+            UserDefaults.standard.object(forKey: AppSettings.Keys.migrationCompletedAt),
             "migrationCompletedAt must be cleared after deleteLocalBackup"
         )
     }


### PR DESCRIPTION
## Summary

Closes #196

Extends the `AppSettings.Keys` enum (introduced in PR #182) to cover **every** remaining UserDefaults key in the codebase. `AppSettings.Keys` is now the single authoritative list of all UserDefaults keys used by the app — a typo in a key string will produce a compile error instead of silently creating an orphaned preference entry.

### New keys added to `AppSettings.Keys`

| Key constant | UserDefaults string |
|---|---|
| `preferredTimeZone` | `"preferredTimeZone"` |
| `vaultLocation` | `"vaultLocation"` |
| `attachmentPolicy` | `"attachmentPolicy"` |
| `githubRepoOwner` | `"githubRepoOwner"` |
| `githubRepoName` | `"githubRepoName"` |
| `migrationCompletedAt` | `"migrationCompletedAt"` |
| `themeMode` | `"themeMode"` |
| `accentColor` | `"accentColor"` |
| `fontSizeAdjust` | `"fontSizeAdjust"` |
| `cardDensity` | `"cardDensity"` |
| `usePressToTalk` | `"usePressToTalk"` |

### Files changed

- **`AppSettings.swift`** — remove 10 scattered `private let`/`static let ...Key` constants from the class body; replace all `forKey:` usages and the 3 bare string literals in `currentTimeZone()` / `currentAttachmentPolicy()` / `currentVaultLocation()`
- **`FeedbackViewModel.swift`** — `AppSettings.githubRepoOwnerKey` → `AppSettings.Keys.githubRepoOwner`
- **`SettingsView.swift`** — `@AppStorage("usePressToTalk")` → `@AppStorage(AppSettings.Keys.usePressToTalk)`
- **`VaultMigrationServiceTests.swift`** — `AppSettings.migrationCompletedAtKey` → `AppSettings.Keys.migrationCompletedAt`, `AppSettings.vaultLocationKey` → `AppSettings.Keys.vaultLocation`

**No behavioral change** — all string values are identical to the constants they replace.

## Test plan

- [ ] All existing tests pass (VaultMigrationServiceTests, RawStorageTests)
- [ ] Settings persist correctly across app restarts (timezone, theme, vault location)
- [ ] Feedback repo owner/name persists correctly
- [ ] `@AppStorage(AppSettings.Keys.usePressToTalk)` toggle works in Settings