### PR TITLE
feat(feedback): Whisper voice + image upload + AI context

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -103,6 +103,7 @@
 		FB0000001 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000001 /* FeedbackService.swift */; };
 		FB0000002 /* FeedbackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000002 /* FeedbackViewModel.swift */; };
 		FB0000003 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000003 /* FeedbackView.swift */; };
+		FB0000004 /* FeedbackContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000004 /* FeedbackContext.swift */; };
 		DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */; };
 		9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B5757B488F583231EC8F6 /* RootView.swift */; };
 		B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ED807E07C2171E9F4234B /* RecordingView.swift */; };
@@ -230,6 +231,7 @@
 		FB1000001 /* FeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackService.swift; sourceTree = "<group>"; };
 		FB1000002 /* FeedbackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewModel.swift; sourceTree = "<group>"; };
 		FB1000003 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
+		FB1000004 /* FeedbackContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackContext.swift; sourceTree = "<group>"; };
 		F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchApp.swift; sourceTree = "<group>"; };
 		C98B5757B488F583231EC8F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		B93ED807E07C2171E9F4234B /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
@@ -345,6 +347,7 @@
 			children = (
 				FB1000002 /* FeedbackViewModel.swift */,
 				FB1000003 /* FeedbackView.swift */,
+				FB1000004 /* FeedbackContext.swift */,
 			);
 			path = Feedback;
 			sourceTree = "<group>";
@@ -843,6 +846,7 @@
 				FB0000001 /* FeedbackService.swift in Sources */,
 				FB0000002 /* FeedbackViewModel.swift in Sources */,
 				FB0000003 /* FeedbackView.swift in Sources */,
+				FB0000004 /* FeedbackContext.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage/Features/Feedback/FeedbackContext.swift
+++ b/DayPage/Features/Feedback/FeedbackContext.swift
@@ -1,0 +1,122 @@
+import Foundation
+import UIKit
+
+// MARK: - FeedbackContext
+//
+// Diagnostic context attached to every feedback issue. Collected once when the
+// user starts composing so values reflect the moment the bug surfaced.
+//
+// Sent to the AI summarizer as a separate system message so it can decide
+// which fields are relevant and weave them into the body — instead of being
+// blindly appended.
+
+struct FeedbackContext {
+
+    // App
+    let appVersion: String      // e.g. "0.1.65"
+    let buildNumber: String     // e.g. "42"
+    let bundleId: String
+
+    // Device / OS
+    let osVersion: String       // e.g. "iOS 17.4"
+    let deviceModel: String     // e.g. "iPhone15,3"
+    let locale: String          // e.g. "zh_CN"
+    let timezone: String        // e.g. "Asia/Shanghai"
+
+    // Network
+    let isOnline: Bool
+
+    // User (optional — only present when signed in)
+    let userId: String?
+    let userEmail: String?
+    let loginProvider: String?
+
+    // MARK: - Capture
+
+    @MainActor
+    static func capture() -> FeedbackContext {
+        let info = Bundle.main.infoDictionary ?? [:]
+        let appVersion = (info["CFBundleShortVersionString"] as? String) ?? "?"
+        let buildNumber = (info["CFBundleVersion"] as? String) ?? "?"
+        let bundleId = Bundle.main.bundleIdentifier ?? "?"
+
+        let device = UIDevice.current
+        let osVersion = "\(device.systemName) \(device.systemVersion)"
+
+        var sysinfo = utsname()
+        uname(&sysinfo)
+        let deviceModel = withUnsafePointer(to: &sysinfo.machine) {
+            $0.withMemoryRebound(to: CChar.self, capacity: 1) { String(cString: $0) }
+        }
+
+        let locale = Locale.current.identifier
+        let timezone = TimeZone.current.identifier
+        let isOnline = NetworkMonitor.shared.isOnline
+
+        let session = AuthService.shared.session
+        let userId = session?.user.id.uuidString
+        let userEmail = session?.user.email
+        let provider: String? = {
+            guard session != nil else { return nil }
+            switch AuthService.shared.loginProvider {
+            case .apple: return "apple"
+            case .emailOTP: return "email_otp"
+            case .unknown: return "unknown"
+            }
+        }()
+
+        return FeedbackContext(
+            appVersion: appVersion,
+            buildNumber: buildNumber,
+            bundleId: bundleId,
+            osVersion: osVersion,
+            deviceModel: deviceModel,
+            locale: locale,
+            timezone: timezone,
+            isOnline: isOnline,
+            userId: userId,
+            userEmail: userEmail,
+            loginProvider: provider
+        )
+    }
+
+    // MARK: - Serialization for AI prompt
+
+    /// Emits a compact key:value block the AI can read without ambiguity.
+    /// Email is masked to limit PII exposure on the public issue tracker.
+    var promptDescription: String {
+        var lines: [String] = []
+        lines.append("appVersion: \(appVersion) (\(buildNumber))")
+        lines.append("bundleId: \(bundleId)")
+        lines.append("os: \(osVersion)")
+        lines.append("device: \(deviceModel)")
+        lines.append("locale: \(locale)")
+        lines.append("timezone: \(timezone)")
+        lines.append("online: \(isOnline)")
+        if let userId = userId {
+            lines.append("userId: \(userId)")
+        }
+        if let email = userEmail {
+            lines.append("userEmail: \(Self.maskEmail(email))")
+        }
+        if let provider = loginProvider {
+            lines.append("loginProvider: \(provider)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private static func maskEmail(_ email: String) -> String {
+        let parts = email.split(separator: "@", maxSplits: 1)
+        guard parts.count == 2 else { return email }
+        let local = parts[0]
+        let domain = parts[1]
+        let visibleLocal: String
+        if local.count <= 2 {
+            visibleLocal = String(local) + "***"
+        } else {
+            let head = local.prefix(2)
+            visibleLocal = "\(head)***"
+        }
+        return "\(visibleLocal)@\(domain)"
+    }
+}

--- a/DayPage/Features/Feedback/FeedbackView.swift
+++ b/DayPage/Features/Feedback/FeedbackView.swift
@@ -1,10 +1,15 @@
 import SwiftUI
+import PhotosUI
+import UIKit
 
 // MARK: - FeedbackView
 
 struct FeedbackView: View {
 
     @StateObject private var vm = FeedbackViewModel()
+
+    @State private var photosPickerItems: [PhotosPickerItem] = []
+    @State private var showCamera: Bool = false
 
     var body: some View {
         ZStack {
@@ -21,9 +26,8 @@ struct FeedbackView: View {
                         successView(url: url)
                     } else {
                         feedbackInputSection
-                        if vm.isReady || vm.isSubmitting || vm.isIdle && !vm.aiTitle.isEmpty {
-                            previewSection
-                        }
+                        attachmentsSection
+                        sendBar
                     }
 
                     if let err = vm.errorMessage {
@@ -38,16 +42,36 @@ struct FeedbackView: View {
                 }
                 .padding(.horizontal, 20)
             }
-        }
-        .alert("Microphone Permission Required", isPresented: $vm.showMicPermissionAlert) {
-            Button("Cancel", role: .cancel) {}
-            Button("Open Settings") {
-                if let url = URL(string: UIApplication.openSettingsURLString) {
-                    UIApplication.shared.open(url)
-                }
+
+            if vm.pressToTalkPhase == .recording
+                || vm.pressToTalkPhase == .cancelArmed
+                || vm.pressToTalkPhase == .transcribeArmed
+                || vm.pressToTalkPhase == .transcribing {
+                voiceOverlay
+                    .transition(.opacity)
             }
-        } message: {
-            Text("Please enable microphone and speech recognition access in Settings to use voice input.")
+
+            if vm.showHoldToRecordToast {
+                toast("Hold to record")
+            }
+        }
+        .sheet(isPresented: $showCamera) {
+            CameraPickerView(
+                onCapture: { image in
+                    vm.addCameraImage(image)
+                    showCamera = false
+                },
+                onCancel: { showCamera = false }
+            )
+        }
+        .onChange(of: photosPickerItems) { newItems in
+            guard !newItems.isEmpty else { return }
+            Task {
+                for item in newItems {
+                    await vm.addImage(from: item)
+                }
+                photosPickerItems = []
+            }
         }
     }
 
@@ -58,7 +82,7 @@ struct FeedbackView: View {
             Text("Feedback")
                 .font(.custom("SpaceGrotesk-Bold", size: 22))
                 .foregroundColor(DSColor.onBackgroundPrimary)
-            Text("Describe → AI summarizes → direct to GitHub")
+            Text("Describe → AI files it on GitHub for you")
                 .font(.custom("Inter-Regular", size: 13))
                 .foregroundColor(DSColor.onBackgroundSubtle)
         }
@@ -81,7 +105,7 @@ struct FeedbackView: View {
                     )
 
                 if vm.rawFeedback.isEmpty {
-                    Text("Describe a bug, feature request, or improvement…")
+                    Text("Describe a bug, feature, or improvement…")
                         .font(.custom("Inter-Regular", size: 15))
                         .foregroundColor(DSColor.onBackgroundSubtle)
                         .padding(.horizontal, 14)
@@ -97,192 +121,211 @@ struct FeedbackView: View {
                     .frame(minHeight: 140)
             }
             .frame(minHeight: 140)
+        }
+        .padding(.bottom, 16)
+    }
 
-            HStack {
-                micButton
+    // MARK: - Attachments
+
+    private var attachmentsSection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 10) {
+                PhotosPicker(
+                    selection: $photosPickerItems,
+                    maxSelectionCount: 4,
+                    matching: .images,
+                    photoLibrary: .shared()
+                ) {
+                    attachmentChip(icon: "photo.on.rectangle", label: "Photos")
+                }
+
+                Button {
+                    showCamera = true
+                } label: {
+                    attachmentChip(icon: "camera", label: "Camera")
+                }
+                .buttonStyle(.plain)
+
                 Spacer()
-                summarizeButton
             }
-        }
-        .padding(.bottom, 24)
-    }
 
-    private var micButton: some View {
-        Button {
-            vm.transcribeVoice()
-        } label: {
-            ZStack {
-                Circle()
-                    .fill(vm.isRecording ? Color.red.opacity(0.15) : DSColor.surfaceWhite)
-                    .frame(width: 40, height: 40)
-                    .overlay(
-                        Circle().stroke(
-                            vm.isRecording ? Color.red : DSColor.borderDefault,
-                            lineWidth: 1
-                        )
-                    )
-
-                Image(systemName: vm.isRecording ? "waveform" : "mic")
-                    .font(.system(size: 16, weight: .medium))
-                    .foregroundColor(vm.isRecording ? Color.red : DSColor.onBackgroundMuted)
-                    .opacity(vm.isRecording ? 1.0 : 0.7)
-                    .animation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true), value: vm.isRecording)
-            }
-        }
-        .buttonStyle(.plain)
-        .overlay(alignment: .topTrailing) {
-            if vm.isRecording {
-                Circle()
-                    .fill(Color.red)
-                    .frame(width: 8, height: 8)
-                    .offset(x: 2, y: -2)
-                    .transition(.scale.combined(with: .opacity))
-            }
-        }
-        .animation(.easeInOut(duration: 0.2), value: vm.isRecording)
-    }
-
-    private var summarizeButton: some View {
-        Button {
-            Task { await vm.summarizeWithAI() }
-        } label: {
-            HStack(spacing: 6) {
-                if vm.isSummarizing {
-                    ProgressView()
-                        .progressViewStyle(.circular)
-                        .scaleEffect(0.8)
-                        .tint(DSColor.onPrimary)
-                } else {
-                    Image(systemName: "sparkles")
-                        .font(.system(size: 13, weight: .medium))
-                }
-                Text(vm.isSummarizing ? "Summarizing…" : "AI Summarize")
-                    .font(.custom("Inter-SemiBold", size: 14))
-            }
-            .foregroundColor(.white)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-            .background(vm.isSummarizing ? DSColor.accentAmber.opacity(0.7) : DSColor.accentAmber)
-            .cornerRadius(8)
-        }
-        .disabled(vm.isSummarizing || vm.isSubmitting)
-    }
-
-    // MARK: - Preview / Editable Card
-
-    private var previewSection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            sectionLabel("Issue Preview")
-
-            VStack(alignment: .leading, spacing: 14) {
-                // Title
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Title")
-                        .font(.custom("Inter-Medium", size: 12))
-                        .foregroundColor(DSColor.onBackgroundSubtle)
-                    TextField("Issue title", text: $vm.aiTitle)
-                        .font(.custom("Inter-SemiBold", size: 15))
-                        .foregroundColor(DSColor.onBackgroundPrimary)
-                        .textFieldStyle(.plain)
-                        .padding(10)
-                        .background(DSColor.surfaceSunken)
-                        .cornerRadius(8)
-                }
-
-                // Labels
-                if !vm.aiLabels.isEmpty {
-                    VStack(alignment: .leading, spacing: 4) {
-                        Text("Labels")
-                            .font(.custom("Inter-Medium", size: 12))
-                            .foregroundColor(DSColor.onBackgroundSubtle)
-                        HStack(spacing: 6) {
-                            ForEach(vm.aiLabels, id: \.self) { label in
-                                labelChip(label)
-                            }
+            if !vm.pendingImages.isEmpty {
+                ScrollView(.horizontal, showsIndicators: false) {
+                    HStack(spacing: 8) {
+                        ForEach(vm.pendingImages) { image in
+                            imageThumb(image)
                         }
                     }
                 }
-
-                // Body
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Body")
-                        .font(.custom("Inter-Medium", size: 12))
-                        .foregroundColor(DSColor.onBackgroundSubtle)
-
-                    ZStack(alignment: .topLeading) {
-                        RoundedRectangle(cornerRadius: 8)
-                            .fill(DSColor.surfaceSunken)
-
-                        TextEditor(text: $vm.aiBody)
-                            .font(.custom("JetBrainsMono-Regular", size: 12))
-                            .foregroundColor(DSColor.onBackgroundPrimary)
-                            .scrollContentBackground(.hidden)
-                            .background(Color.clear)
-                            .padding(8)
-                            .frame(minHeight: 180)
-                    }
-                    .frame(minHeight: 180)
-                }
-
-                // Submit button
-                submitButton
             }
-            .padding(16)
-            .background(DSColor.surfaceWhite)
-            .overlay(
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(DSColor.accentBorder, lineWidth: 1)
+
+            if vm.isProcessingImage {
+                HStack(spacing: 6) {
+                    ProgressView().scaleEffect(0.7)
+                    Text("Processing image…")
+                        .font(.custom("Inter-Regular", size: 12))
+                        .foregroundColor(DSColor.onBackgroundSubtle)
+                }
+            }
+        }
+        .padding(.bottom, 16)
+    }
+
+    private func attachmentChip(icon: String, label: String) -> some View {
+        HStack(spacing: 6) {
+            Image(systemName: icon)
+                .font(.system(size: 13))
+            Text(label)
+                .font(.custom("Inter-Medium", size: 13))
+        }
+        .foregroundColor(DSColor.onBackgroundMuted)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(DSColor.surfaceWhite)
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(DSColor.borderDefault, lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func imageThumb(_ image: PendingFeedbackImage) -> some View {
+        ZStack(alignment: .topTrailing) {
+            Image(uiImage: image.thumbnail)
+                .resizable()
+                .scaledToFill()
+                .frame(width: 72, height: 72)
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 8)
+                        .stroke(DSColor.borderDefault, lineWidth: 1)
+                )
+
+            Button {
+                vm.removeImage(id: image.id)
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.system(size: 16))
+                    .foregroundColor(DSColor.onBackgroundMuted)
+                    .background(Circle().fill(DSColor.surfaceWhite))
+            }
+            .buttonStyle(.plain)
+            .offset(x: 4, y: -4)
+        }
+    }
+
+    // MARK: - Send bar (mic + send)
+
+    private var sendBar: some View {
+        HStack(spacing: 12) {
+            PressToTalkButton(
+                onPressStart: { vm.voicePressStart() },
+                onReleaseSend: { vm.voiceReleaseSendAsTranscript() },
+                onReleaseCancel: { vm.voiceReleaseCancel() },
+                onReleaseTranscribe: { vm.voiceReleaseTranscribe() },
+                onPhaseChange: { phase in vm.pressToTalkPhase = phase },
+                onTapShortRelease: { vm.voiceShortTap() },
+                size: 44
             )
-            .cornerRadius(12)
-            .surfaceElevatedShadow()
+
+            Text("Hold mic to record")
+                .font(.custom("Inter-Regular", size: 12))
+                .foregroundColor(DSColor.onBackgroundSubtle)
+
+            Spacer()
+
+            sendButton
         }
         .padding(.bottom, 24)
     }
 
-    private func labelChip(_ label: String) -> some View {
-        Text(label)
-            .font(.custom("JetBrainsMono-Regular", fixedSize: 11))
-            .foregroundColor(DSColor.accentAmber)
-            .padding(.horizontal, 8)
-            .padding(.vertical, 3)
-            .background(DSColor.accentSoft)
-            .overlay(
-                Capsule().stroke(DSColor.accentBorder, lineWidth: 1)
-            )
-            .clipShape(Capsule())
-    }
-
-    private var submitButton: some View {
+    private var sendButton: some View {
         Button {
-            Task { await vm.submitToGitHub() }
+            Task { await vm.send() }
         } label: {
-            HStack(spacing: 8) {
-                if vm.isSubmitting {
+            HStack(spacing: 6) {
+                if vm.isSending {
                     ProgressView()
                         .progressViewStyle(.circular)
                         .scaleEffect(0.8)
                         .tint(.white)
                 } else {
-                    Image(systemName: "arrow.up.circle.fill")
-                        .font(.system(size: 16))
+                    Image(systemName: "paperplane.fill")
+                        .font(.system(size: 13, weight: .medium))
                 }
-                Text(vm.isSubmitting ? "Submitting…" : "Submit to GitHub")
-                    .font(.custom("Inter-SemiBold", size: 15))
+                Text(vm.isSending ? "Sending…" : "Send")
+                    .font(.custom("Inter-SemiBold", size: 14))
             }
             .foregroundColor(.white)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 13)
-            .background(vm.isSubmitting ? DSColor.accentAmber.opacity(0.7) : DSColor.accentAmber)
-            .cornerRadius(10)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(vm.isSending ? DSColor.accentAmber.opacity(0.7) : DSColor.accentAmber)
+            .cornerRadius(8)
         }
-        .disabled(vm.isSubmitting || vm.isSummarizing)
+        .disabled(vm.isSending)
     }
 
-    // MARK: - Submitted Issues
+    // MARK: - Voice Overlay
+
+    private var voiceOverlay: some View {
+        VStack {
+            Spacer()
+            VStack(spacing: 12) {
+                Image(systemName: overlayIcon)
+                    .font(.system(size: 28))
+                    .foregroundColor(overlayColor)
+                Text(overlayLabel)
+                    .font(.custom("Inter-SemiBold", size: 14))
+                    .foregroundColor(DSColor.onBackgroundPrimary)
+                if vm.pressToTalkPhase == .recording {
+                    Text("\(vm.voiceService.elapsedSeconds)s · slide up to cancel")
+                        .font(.custom("Inter-Regular", size: 12))
+                        .foregroundColor(DSColor.onBackgroundSubtle)
+                }
+            }
+            .padding(.horizontal, 28)
+            .padding(.vertical, 22)
+            .background(DSColor.surfaceWhite)
+            .overlay(
+                RoundedRectangle(cornerRadius: 14)
+                    .stroke(DSColor.borderDefault, lineWidth: 1)
+            )
+            .cornerRadius(14)
+            .padding(.bottom, 120)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var overlayIcon: String {
+        switch vm.pressToTalkPhase {
+        case .cancelArmed: return "xmark.circle.fill"
+        case .transcribeArmed: return "text.bubble.fill"
+        case .transcribing: return "waveform"
+        default: return "mic.fill"
+        }
+    }
+
+    private var overlayColor: Color {
+        switch vm.pressToTalkPhase {
+        case .cancelArmed: return DSColor.errorRed
+        default: return DSColor.accentAmber
+        }
+    }
+
+    private var overlayLabel: String {
+        switch vm.pressToTalkPhase {
+        case .cancelArmed: return "Release to cancel"
+        case .transcribeArmed: return "Release to transcribe"
+        case .transcribing: return "Transcribing…"
+        default: return "Listening…"
+        }
+    }
+
+    // MARK: - Submitted Issues (muted styling — issue numbers de-emphasized)
 
     private var submittedIssuesSection: some View {
         VStack(alignment: .leading, spacing: 10) {
-            sectionLabel("Submitted Issues")
+            sectionLabel("Past Submissions")
 
             VStack(alignment: .leading, spacing: 0) {
                 ForEach(vm.submittedIssues) { issue in
@@ -311,23 +354,16 @@ struct FeedbackView: View {
                     .font(.custom("Inter-Medium", size: 13))
                     .foregroundColor(DSColor.onBackgroundPrimary)
                     .lineLimit(2)
-                HStack(spacing: 6) {
-                    Text("#\(issue.number)")
-                        .font(.custom("JetBrainsMono-Regular", size: 11))
-                        .foregroundColor(DSColor.accentAmber)
-                    Text("·")
-                        .foregroundColor(DSColor.onBackgroundSubtle)
-                    Text(issue.date, style: .date)
-                        .font(.custom("Inter-Regular", size: 11))
-                        .foregroundColor(DSColor.onBackgroundSubtle)
-                }
+                Text(issue.date, style: .date)
+                    .font(.custom("Inter-Regular", size: 11))
+                    .foregroundColor(DSColor.onBackgroundSubtle)
             }
             Spacer()
             if let link = URL(string: issue.url) {
                 Link(destination: link) {
                     Image(systemName: "arrow.up.right.square")
                         .font(.system(size: 14))
-                        .foregroundColor(DSColor.onBackgroundMuted)
+                        .foregroundColor(DSColor.onBackgroundSubtle)
                 }
             }
         }
@@ -338,48 +374,46 @@ struct FeedbackView: View {
     // MARK: - Success View
 
     private func successView(url: String) -> some View {
-        VStack(spacing: 20) {
+        VStack(spacing: 18) {
             Image(systemName: "checkmark.circle.fill")
-                .font(.system(size: 52))
+                .font(.system(size: 48))
                 .foregroundColor(DSColor.successGreen)
 
-            Text("Issue Created!")
-                .font(.custom("SpaceGrotesk-Bold", size: 22))
+            Text("Thanks — your feedback was received.")
+                .font(.custom("SpaceGrotesk-Bold", size: 20))
                 .foregroundColor(DSColor.onBackgroundPrimary)
-
-            Text(url)
-                .font(.custom("JetBrainsMono-Regular", size: 12))
-                .foregroundColor(DSColor.onBackgroundMuted)
                 .multilineTextAlignment(.center)
-                .lineLimit(2)
 
-            if let link = URL(string: url) {
-                Link(destination: link) {
-                    HStack(spacing: 6) {
-                        Image(systemName: "arrow.up.right.square")
-                            .font(.system(size: 14))
-                        Text("Open in GitHub")
-                            .font(.custom("Inter-SemiBold", size: 15))
+            Text("We'll take it from here.")
+                .font(.custom("Inter-Regular", size: 14))
+                .foregroundColor(DSColor.onBackgroundMuted)
+
+            HStack(spacing: 14) {
+                if let link = URL(string: url) {
+                    Link(destination: link) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "arrow.up.right.square")
+                                .font(.system(size: 12))
+                            Text("Review on GitHub")
+                                .font(.custom("Inter-Medium", size: 13))
+                        }
+                        .foregroundColor(DSColor.onBackgroundMuted)
                     }
-                    .foregroundColor(.white)
-                    .padding(.horizontal, 20)
-                    .padding(.vertical, 12)
-                    .background(DSColor.accentAmber)
-                    .cornerRadius(10)
                 }
-            }
 
-            Button("Submit Another") {
-                vm.reset()
+                Button("Submit another") {
+                    vm.reset()
+                }
+                .font(.custom("Inter-Medium", size: 13))
+                .foregroundColor(DSColor.accentAmber)
             }
-            .font(.custom("Inter-Regular", size: 14))
-            .foregroundColor(DSColor.onBackgroundMuted)
+            .padding(.top, 4)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 40)
+        .padding(.vertical, 48)
     }
 
-    // MARK: - Error Banner
+    // MARK: - Error / Toast
 
     private func errorBanner(message: String) -> some View {
         HStack(alignment: .top, spacing: 10) {
@@ -402,6 +436,20 @@ struct FeedbackView: View {
         .background(DSColor.errorSoft)
         .cornerRadius(10)
         .padding(.vertical, 8)
+    }
+
+    private func toast(_ text: String) -> some View {
+        VStack {
+            Spacer()
+            Text(text)
+                .font(.custom("Inter-Medium", size: 13))
+                .foregroundColor(.white)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .background(Color.black.opacity(0.78))
+                .clipShape(Capsule())
+                .padding(.bottom, 60)
+        }
     }
 
     // MARK: - Helpers

--- a/DayPage/Features/Feedback/FeedbackViewModel.swift
+++ b/DayPage/Features/Feedback/FeedbackViewModel.swift
@@ -1,14 +1,15 @@
 import Foundation
-import Speech
-import AVFoundation
+import SwiftUI
+import PhotosUI
+import UIKit
 
 // MARK: - FeedbackStatus
 
 enum FeedbackStatus: Equatable {
     case idle
-    case summarizing
-    case ready
-    case submitting
+    /// Single combined "AI summarize + GitHub submit" loading state — the
+    /// user sees one spinner instead of two stages.
+    case sending
     case submitted(issueURL: String)
     case error(String)
 }
@@ -24,6 +25,17 @@ struct SubmittedIssue: Codable, Identifiable {
     var id: Int { number }
 }
 
+// MARK: - PendingFeedbackImage
+
+struct PendingFeedbackImage: Identifiable {
+    let id: String = UUID().uuidString
+    let data: Data
+    let thumbnail: UIImage
+    /// Filename used when uploading to GitHub. Generated once at staging time
+    /// so re-uploads (after retry) keep a stable path.
+    let filename: String
+}
+
 // MARK: - FeedbackViewModel
 
 @MainActor
@@ -32,35 +44,37 @@ final class FeedbackViewModel: ObservableObject {
     // MARK: - Published State
 
     @Published var rawFeedback: String = ""
-    @Published var aiTitle: String = ""
-    @Published var aiBody: String = ""
-    @Published var aiLabels: [String] = []
     @Published var status: FeedbackStatus = .idle
     @Published var submittedIssues: [SubmittedIssue] = []
-    @Published var isRecording = false
-    @Published var showMicPermissionAlert = false
+
+    /// Toast: "Hold to record" — shown on a short tap of the mic.
+    @Published var showHoldToRecordToast: Bool = false
+
+    /// Pending image attachments (uploaded only at submit time).
+    @Published var pendingImages: [PendingFeedbackImage] = []
+    @Published var isProcessingImage: Bool = false
+
+    /// Voice recording mirror, exposed so the view can render an overlay.
+    @Published var pressToTalkPhase: PressToTalkPhase = .idle
 
     private let submittedIssuesKey = "submittedIssues"
 
-    // MARK: - Voice
+    // MARK: - Dependencies
 
-    private var audioEngine = AVAudioEngine()
-    private var recognitionRequest: SFSpeechAudioBufferRecognitionRequest?
-    private var recognitionTask: SFSpeechRecognitionTask?
-    private let speechRecognizer = SFSpeechRecognizer(locale: Locale.current)
+    let voiceService = VoiceService.shared
+    private var capturedContext: FeedbackContext?
 
     // MARK: - Computed
 
     var isIdle: Bool { status == .idle }
-    var isSummarizing: Bool { status == .summarizing }
-    var isReady: Bool { status == .ready }
-    var isSubmitting: Bool { status == .submitting }
-
+    var isSending: Bool {
+        if case .sending = status { return true }
+        return false
+    }
     var submittedIssueURL: String? {
         if case .submitted(let url) = status { return url }
         return nil
     }
-
     var errorMessage: String? {
         if case .error(let msg) = status { return msg }
         return nil
@@ -72,53 +86,72 @@ final class FeedbackViewModel: ObservableObject {
         loadSubmittedIssues()
     }
 
-    // MARK: - AI Summarize
+    // MARK: - Send (AI Summary + Submit, single step)
 
-    func summarizeWithAI() async {
-        guard !rawFeedback.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-            status = .error("Please enter some feedback before summarizing.")
+    /// Combined flow: capture context → ask AI to compose issue → upload images
+    /// → create GitHub issue. The UI sees one `.sending` state for the whole
+    /// chain so the user isn't asked to confirm AI output.
+    func send() async {
+        let trimmed = rawFeedback.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty || !pendingImages.isEmpty else {
+            status = .error("Please describe your feedback or attach a screenshot.")
             return
         }
 
-        status = .summarizing
+        status = .sending
+        let context = capturedContext ?? FeedbackContext.capture()
+        capturedContext = context
 
-        let apiKey = Secrets.resolvedDeepSeekApiKey
-        guard !apiKey.isEmpty else {
-            status = .error("DeepSeek API key is not configured. Set it in Settings.")
-            return
-        }
-
+        // 1. AI summarize
+        let summary: AIIssueSummary
         do {
-            let result = try await callDeepSeekForSummary(feedback: rawFeedback, apiKey: apiKey)
-            aiTitle = result.title
-            aiBody = result.body
-            aiLabels = result.labels
-            status = .ready
+            summary = try await callDeepSeekForSummary(
+                feedback: trimmed.isEmpty ? "(no text — see attached screenshots)" : trimmed,
+                context: context
+            )
         } catch {
             status = .error(error.localizedDescription)
-        }
-    }
-
-    // MARK: - Submit to GitHub
-
-    func submitToGitHub() async {
-        guard !aiTitle.isEmpty else {
-            status = .error("Issue title is empty. Run AI Summarize first.")
             return
         }
 
-        status = .submitting
+        // 2. Upload images (best effort — image upload failure shouldn't block
+        //    the issue itself, but we surface a warning by appending a note).
+        var imageMarkdown = ""
+        var uploadedAll = true
+        for image in pendingImages {
+            do {
+                let url = try await FeedbackService.shared.uploadFeedbackImage(
+                    data: image.data,
+                    filename: image.filename
+                )
+                imageMarkdown += "\n\n![\(image.filename)](\(url))"
+            } catch {
+                uploadedAll = false
+                DayPageLogger.shared.error("feedback: image upload failed: \(error)")
+            }
+        }
 
+        // 3. Compose final body: AI body + context block + screenshots
+        var body = summary.body
+        body += "\n\n---\n\n<details><summary>📱 Diagnostic context</summary>\n\n```\n\(context.promptDescription)\n```\n\n</details>"
+        if !imageMarkdown.isEmpty {
+            body += "\n\n## Screenshots" + imageMarkdown
+        }
+        if !pendingImages.isEmpty && !uploadedAll {
+            body += "\n\n> ⚠️ Some screenshots failed to upload."
+        }
+
+        // 4. Create issue
         do {
             let issue = try await FeedbackService.shared.createIssueViaBot(
-                title: aiTitle,
-                body: aiBody,
-                labels: aiLabels
+                title: summary.title,
+                body: body,
+                labels: summary.labels
             )
             let submitted = SubmittedIssue(
                 number: issue.number,
                 url: issue.htmlURL,
-                title: aiTitle,
+                title: summary.title,
                 date: Date()
             )
             submittedIssues.insert(submitted, at: 0)
@@ -129,82 +162,87 @@ final class FeedbackViewModel: ObservableObject {
         }
     }
 
-    // MARK: - Voice Transcription
+    // MARK: - Voice (Whisper press-to-talk)
 
-    func transcribeVoice() {
-        if isRecording {
-            stopRecording()
+    /// Called by PressToTalkButton when the user starts a long-press.
+    func voicePressStart() {
+        Task { await voiceService.startRecording() }
+    }
+
+    /// Long-press release in the default zone — transcribe via Whisper and
+    /// fill the input field. We deliberately do NOT auto-submit; the user
+    /// can still tweak the wording before sending.
+    func voiceReleaseSendAsTranscript() {
+        Task { await consumeRecordingAsTranscript() }
+    }
+
+    /// Long-press release after the user dragged into the cancel zone.
+    func voiceReleaseCancel() {
+        voiceService.cancelRecording()
+    }
+
+    /// Long-press release after the user dragged into the transcribe-armed
+    /// zone — same behaviour as the default in this screen (fill draft, no
+    /// submit).
+    func voiceReleaseTranscribe() {
+        Task { await consumeRecordingAsTranscript() }
+    }
+
+    /// Short tap — show "Hold to record" hint.
+    func voiceShortTap() {
+        showHoldToRecordToast = true
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 1_400_000_000)
+            self.showHoldToRecordToast = false
+        }
+    }
+
+    private func consumeRecordingAsTranscript() async {
+        guard let result = await voiceService.stopAndTranscribe() else { return }
+        defer { voiceService.reset() }
+        if let text = result.transcript, !text.isEmpty {
+            if rawFeedback.isEmpty {
+                rawFeedback = text
+            } else {
+                rawFeedback += " " + text
+            }
         } else {
-            SFSpeechRecognizer.requestAuthorization { [weak self] authStatus in
-                DispatchQueue.main.async {
-                    switch authStatus {
-                    case .authorized:
-                        self?.startRecording()
-                    case .denied, .restricted, .notDetermined:
-                        self?.showMicPermissionAlert = true
-                    @unknown default:
-                        self?.showMicPermissionAlert = true
-                    }
-                }
-            }
+            status = .error("Voice transcription failed. Check your network or OpenAI Whisper key.")
         }
     }
 
-    private func startRecording() {
-        recognitionRequest = SFSpeechAudioBufferRecognitionRequest()
-        guard let recognitionRequest else { return }
-        recognitionRequest.shouldReportPartialResults = true
+    // MARK: - Image Attachments
 
-        let audioSession = AVAudioSession.sharedInstance()
-        do {
-            try audioSession.setCategory(.record, mode: .measurement, options: .duckOthers)
-            try audioSession.setActive(true, options: .notifyOthersOnDeactivation)
-        } catch {
-            status = .error("Audio session error: \(error.localizedDescription)")
+    func addImage(from item: PhotosPickerItem) async {
+        isProcessingImage = true
+        defer { isProcessingImage = false }
+        guard let data = try? await item.loadTransferable(type: Data.self),
+              let thumb = UIImage(data: data) else {
+            status = .error("Could not load that image.")
             return
         }
-
-        let inputNode = audioEngine.inputNode
-        let recordingFormat = inputNode.outputFormat(forBus: 0)
-        inputNode.installTap(onBus: 0, bufferSize: 1024, format: recordingFormat) { buffer, _ in
-            recognitionRequest.append(buffer)
-        }
-
-        audioEngine.prepare()
-        do {
-            try audioEngine.start()
-        } catch {
-            status = .error("Audio engine error: \(error.localizedDescription)")
-            return
-        }
-
-        recognitionTask = speechRecognizer?.recognitionTask(with: recognitionRequest) { [weak self] result, error in
-            guard let self else { return }
-            if let result {
-                Task { @MainActor in
-                    self.rawFeedback = result.bestTranscription.formattedString
-                }
-            }
-            if error != nil || (result?.isFinal == true) {
-                Task { @MainActor in
-                    self.stopRecording()
-                }
-            }
-        }
-
-        isRecording = true
+        appendImage(data: data, thumbnail: thumb)
     }
 
-    private func stopRecording() {
-        audioEngine.stop()
-        audioEngine.inputNode.removeTap(onBus: 0)
-        recognitionRequest?.endAudio()
-        recognitionRequest = nil
-        recognitionTask?.cancel()
-        recognitionTask = nil
-        isRecording = false
+    func addCameraImage(_ image: UIImage) {
+        guard let data = image.jpegData(compressionQuality: 0.85) else {
+            status = .error("Could not encode that photo.")
+            return
+        }
+        appendImage(data: data, thumbnail: image)
+    }
 
-        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+    private func appendImage(data: Data, thumbnail: UIImage) {
+        let stamp = DateFormatter.feedbackImageStamp.string(from: Date())
+        let suffix = UUID().uuidString.prefix(6)
+        let filename = "IMG_\(stamp)_\(suffix).jpg"
+        pendingImages.append(
+            PendingFeedbackImage(data: data, thumbnail: thumbnail, filename: String(filename))
+        )
+    }
+
+    func removeImage(id: String) {
+        pendingImages.removeAll { $0.id == id }
     }
 
     // MARK: - Submitted Issues Persistence
@@ -224,21 +262,28 @@ final class FeedbackViewModel: ObservableObject {
 
     func reset() {
         rawFeedback = ""
-        aiTitle = ""
-        aiBody = ""
-        aiLabels = []
+        pendingImages = []
+        capturedContext = nil
         status = .idle
     }
 
-    // MARK: - Private: DeepSeek Call
+    // MARK: - DeepSeek Call
 
-    private struct AIIssueSummary {
+    fileprivate struct AIIssueSummary {
         let title: String
         let body: String
         let labels: [String]
     }
 
-    private func callDeepSeekForSummary(feedback: String, apiKey: String) async throws -> AIIssueSummary {
+    private func callDeepSeekForSummary(
+        feedback: String,
+        context: FeedbackContext
+    ) async throws -> AIIssueSummary {
+        let apiKey = Secrets.resolvedDeepSeekApiKey
+        guard !apiKey.isEmpty else {
+            throw FeedbackError.networkError("DeepSeek API key is not configured.")
+        }
+
         let baseURL = Secrets.deepSeekBaseURL.isEmpty
             ? "https://api.deepseek.com/v1"
             : Secrets.deepSeekBaseURL
@@ -255,24 +300,48 @@ final class FeedbackViewModel: ObservableObject {
         request.timeoutInterval = 60
 
         let systemPrompt = """
-        You are DayPage's feedback assistant. Convert the user's raw feedback into a well-structured GitHub issue.
-        Output ONLY a JSON object with exactly these fields:
+        You are DayPage's feedback triage assistant. The user is reporting a bug or
+        requesting an improvement. You are given the raw feedback text AND a block
+        of diagnostic context (app version, OS, device, user id, etc.). Your job:
+
+        1. Decide whether this is a bug, feature request, or improvement.
+        2. Write a short, specific issue title (≤ 80 chars). Do NOT include the
+           version number in the title — it goes in the body.
+        3. Compose a Markdown body using the appropriate sections:
+             - Bug:         ## Description, ## Steps to Reproduce, ## Expected, ## Actual, ## Environment
+             - Feature:     ## Problem, ## Proposed Solution, ## Why
+             - Improvement: ## Current behaviour, ## Suggested change, ## Why
+           Always include an "## Environment" section that lists the relevant
+           subset of the diagnostic context (app version, OS, device — user id
+           only if it helps reproduce). Don't dump the whole context block — the
+           app appends a verbatim copy below your output.
+        4. Pick 1–2 labels from: ["bug", "enhancement", "improvement"].
+
+        Output ONLY a JSON object:
         {
-          "title": "<concise issue title, max 80 chars>",
-          "body": "<markdown body with ## Description, ## Steps to Reproduce (if bug), ## Expected Behavior, ## Actual Behavior sections>",
-          "labels": ["bug" or "enhancement" or "improvement" — pick one or two that fit best]
+          "title": "...",
+          "body":  "...",
+          "labels": ["bug"]
         }
-        No extra text outside the JSON.
+        No prose outside the JSON. No markdown fences around the JSON.
+        """
+
+        let userMessage = """
+        --- USER FEEDBACK ---
+        \(feedback)
+
+        --- DIAGNOSTIC CONTEXT ---
+        \(context.promptDescription)
         """
 
         let body: [String: Any] = [
             "model": model,
             "messages": [
                 ["role": "system", "content": systemPrompt],
-                ["role": "user", "content": feedback]
+                ["role": "user", "content": userMessage]
             ],
             "max_tokens": 1024,
-            "temperature": 0.5
+            "temperature": 0.4
         ]
 
         request.httpBody = try JSONSerialization.data(withJSONObject: body)
@@ -301,7 +370,7 @@ final class FeedbackViewModel: ObservableObject {
 
         let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Extract JSON from possible markdown fences
+        // Tolerate models that wrap JSON in ```json fences.
         let jsonString: String
         if let fenceStart = trimmed.range(of: "```json\n"),
            let fenceEnd = trimmed.range(of: "\n```", range: fenceStart.upperBound ..< trimmed.endIndex) {
@@ -328,4 +397,16 @@ final class FeedbackViewModel: ObservableObject {
 
         return AIIssueSummary(title: title, body: bodyText, labels: labels)
     }
+}
+
+// MARK: - Date helper
+
+private extension DateFormatter {
+    static let feedbackImageStamp: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyyMMdd_HHmmss"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f
+    }()
 }

--- a/DayPage/Services/FeedbackService.swift
+++ b/DayPage/Services/FeedbackService.swift
@@ -104,6 +104,83 @@ final class FeedbackService {
         return try JSONDecoder().decode(GitHubIssue.self, from: data)
     }
 
+    // MARK: - Upload Feedback Image
+
+    /// Uploads a JPEG (or any binary) to the bot repo via the GitHub Contents
+    /// API and returns the public `download_url`. Path: `feedback-assets/<filename>`.
+    /// On 422 (path collision) we retry once with a `_<6char>` suffix before giving up.
+    func uploadFeedbackImage(data: Data, filename: String) async throws -> String {
+        return try await uploadFeedbackImageOnce(
+            data: data,
+            filename: filename,
+            allowRename: true
+        )
+    }
+
+    private func uploadFeedbackImageOnce(
+        data: Data,
+        filename: String,
+        allowRename: Bool
+    ) async throws -> String {
+        guard NetworkMonitor.shared.isOnline else {
+            throw FeedbackError.networkError("offline")
+        }
+
+        let path = "feedback-assets/\(filename)"
+        guard let url = repoURL(
+            owner: FeedbackService.botOwner,
+            repo: FeedbackService.botRepo,
+            path: "contents/\(path)"
+        ) else {
+            throw FeedbackError.networkError("Invalid repo URL")
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue("token \(FeedbackService.botToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 60
+
+        let payload: [String: Any] = [
+            "message": "feedback: upload \(filename)",
+            "content": data.base64EncodedString()
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: payload)
+
+        let (respData, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse else {
+            throw FeedbackError.networkError("No HTTP response")
+        }
+
+        // 422 = path already exists. Retry once with a fresh suffix.
+        if http.statusCode == 422 && allowRename {
+            let renamed = renameWithSuffix(filename)
+            return try await uploadFeedbackImageOnce(data: data, filename: renamed, allowRename: false)
+        }
+        guard http.statusCode == 200 || http.statusCode == 201 else {
+            let body = String(data: respData, encoding: .utf8) ?? ""
+            throw FeedbackError.unknownError(http.statusCode, body)
+        }
+
+        guard let json = try JSONSerialization.jsonObject(with: respData) as? [String: Any],
+              let content = json["content"] as? [String: Any],
+              let downloadURL = content["download_url"] as? String else {
+            throw FeedbackError.networkError("Upload response missing download_url")
+        }
+        return downloadURL
+    }
+
+    private func renameWithSuffix(_ filename: String) -> String {
+        let suffix = UUID().uuidString.prefix(6)
+        if let dot = filename.lastIndex(of: ".") {
+            let stem = filename[..<dot]
+            let ext = filename[dot...]
+            return "\(stem)_\(suffix)\(ext)"
+        }
+        return "\(filename)_\(suffix)"
+    }
+
     // MARK: - List Labels
 
     /// Returns all labels defined on the given repo.


### PR DESCRIPTION
## Summary
- **Voice**: replace SFSpeechRecognizer tap-toggle with `PressToTalkButton` long-press wired to `VoiceService` (OpenAI Whisper). Release fills the textbox; user can still edit before sending.
- **Screenshots**: add `PhotosPicker` (max 4) + camera button. Images upload to the bot repo via GitHub Contents API at `feedback-assets/IMG_*.jpg` and are embedded as Markdown in the issue body.
- **AI context**: new `FeedbackContext` captures app version, build, OS, device model, locale, timezone, network, user id, masked email, login provider. Passed to AI so the generated issue includes a relevant `## Environment` section; full block also appended in a `<details>` for triage.
- **One-step send**: collapse "AI Summarize" + "Submit" into a single `send()`. Single spinner, no second confirm.
- **De-emphasize issue numbers**: muted styling in the past-submissions list and a low-key "Review on GitHub" link on the success screen.

## Test plan
- [ ] Build for iPhone 17 simulator (`xcodebuild -scheme DayPage`) — passes locally.
- [ ] Long-press mic in Feedback → speak Chinese/English → release → text appears in textbox.
- [ ] Tap mic briefly → "Hold to record" toast.
- [ ] Drag up while recording → release → recording discarded.
- [ ] Add 1–4 screenshots, hit Send → Issue body shows AI summary, `## Environment`, screenshots, collapsed diagnostic block.
- [ ] Check the created issue at https://github.com/getyak/daypage/issues — title is concise, body has correct structure, image links resolve.
- [ ] Submitted-issues list: numbers muted, only title + date visible.
- [ ] Success screen: "Review on GitHub" link works, "Submit another" resets state.

## Notes
- Default `pendingImages` retry-on-422: filename gets a 6-char uuid suffix once.
- Image bytes are kept in memory only; no vault writes from the Feedback flow.
- Whisper key reads from `Secrets.resolvedOpenAIWhisperApiKey` (already wired for Today).