### PR TITLE
fix(ci): restore Maestro testIDs for InputBarV4 composer

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -266,6 +266,7 @@ struct InputBarV4: View {
                 }
                 isFocused = true
             }
+            .accessibilityIdentifier("expand-text-composer")
         }
     }
 
@@ -341,6 +342,7 @@ struct InputBarV4: View {
                 .padding(.top, 14)
                 .padding(.bottom, 10)
                 .onTapGesture { isFocused = true }
+                .accessibilityIdentifier("memo-input")
 
             // Icon toolbar row
             HStack(spacing: 0) {
@@ -465,6 +467,8 @@ struct InputBarV4: View {
         }
         .buttonStyle(.plain)
         .disabled(isSubmitting || !hasContent)
+        .accessibilityLabel("发送")
+        .accessibilityIdentifier("memo-send")
     }
 
     // MARK: - Actions

--- a/flows/01_today_memo_input.yaml
+++ b/flows/01_today_memo_input.yaml
@@ -15,28 +15,29 @@ appId: com.daypage.app
 
 - takeScreenshot: today_view_loaded
 
-# 点击 "打开文字输入" 按钮展开输入行（collapsed 模式下先展开）
+# Tap the pen button on the STREAM dock to expand the text composer
+# (InputBarV4 idle dock shows mic-hero centered, pen on the right).
 - tapOn:
-    text: "写点什么"
+    id: "expand-text-composer"
     optional: true
 
-# 等待展开动画完成
+# Wait for the composer expand animation to finish
 - waitForAnimationToEnd
 
-# 点击 TextEditor（通过 accessibilityIdentifier）
+# Tap the TextField (accessibilityIdentifier="memo-input")
 - tapOn:
     id: "memo-input"
 
 - inputText: "UI测试：今天天气很好，适合写代码"
 - takeScreenshot: after_input
 
-# 验证输入的文字出现在输入框中
+# Verify the typed text is visible inside the composer
 - assertVisible: "UI测试：今天天气很好，适合写代码"
 - takeScreenshot: text_visible_in_input
 
-# 发送 memo（accessibility label "发送"）
+# Send the memo (accessibilityIdentifier="memo-send", label "发送")
 - tapOn:
-    id: "发送"
+    id: "memo-send"
     optional: true
 
 - takeScreenshot: after_send


### PR DESCRIPTION
## Summary
The Maestro UI test `01_today_memo_input` has been failing on every PR with `Element not found: Id matching regex: memo-input`. The flow was written against the old `InputBarV3` (button text "写点什么", TextEditor with `memo-input` testID, send button labeled "发送"). After the V3 → V4 STREAM-dock refactor, none of those affordances exist anymore.

This PR adds back the testIDs the flow expects and updates the YAML to match the new V4 entry path.

## Changes
- `InputBarV4.swift`
  - `accessibilityIdentifier("memo-input")` on the composer `TextField`
  - `accessibilityIdentifier("expand-text-composer")` on the pen button (idle dock right slot)
  - `accessibilityIdentifier("memo-send")` + label `"发送"` on the send button
- `flows/01_today_memo_input.yaml`
  - Tap `expand-text-composer` instead of the missing "写点什么" text
  - Tap `memo-send` instead of the missing label-based `发送`

## Test plan
- [ ] CI green on this PR (Maestro `01_today_memo_input` passes).
- [ ] Local build succeeds (`xcodebuild -scheme DayPage`).
- [ ] No visual change to end users — testIDs are invisible affordances.

## Notes
Independent of the in-flight Feedback PR (#201). This is a pre-existing CI breakage on `main`; merging this unblocks #201 and any future PR that needs CI green.