### PR TITLE
fix(today): never truncate voice transcripts in memo cards (#203)

### DIFF
--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -7,7 +7,8 @@ import MapKit
 // MARK: - MemoCardView
 
 /// Displays a single Memo as a card in the Today timeline.
-/// Shows time + content preview with expand/collapse for long text.
+/// Shows time + full content; cards grow to fit the memo so long voice
+/// transcriptions and long text are never clipped.
 struct MemoCardView: View {
 
     let memo: Memo
@@ -15,15 +16,11 @@ struct MemoCardView: View {
     /// Optional callback invoked when the user confirms deletion of this memo.
     var onDelete: (() -> Void)? = nil
 
-    @State private var isExpanded: Bool = false
     @State private var showLocationSheet: Bool = false
     /// Tracks which attachment URLs have finished downloading from iCloud.
     @State private var downloadedURLs: Set<URL> = []
     @State private var thumbnail: UIImage?
     @State private var pollingURLs: Set<URL> = []
-
-    // Maximum lines when collapsed
-    private let previewLineLimit = 4
 
     // MARK: - iCloud Attachment Helpers
 
@@ -243,43 +240,33 @@ struct MemoCardView: View {
                 Text(bodyText)
                     .bodySMStyle()
                     .foregroundColor(DSColor.onSurface)
-                    .lineLimit(isExpanded ? nil : previewLineLimit)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
                     .padding(.horizontal, DSSpacing.cardInner)
                     .padding(.top, 6)
             }
 
-            // Bottom row: location label + expand toggle
-            HStack(alignment: .center, spacing: 8) {
-                if let locationName = memo.location?.name, !locationName.isEmpty {
-                    HStack(spacing: 3) {
-                        Image(systemName: "mappin")
-                            .font(.system(size: 9, weight: .medium))
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                        Text(locationName)
-                            .monoLabelStyle(size: 9)
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                    }
+            // Bottom row: location label
+            if let locationName = memo.location?.name, !locationName.isEmpty {
+                HStack(spacing: 3) {
+                    Image(systemName: "mappin")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(DSColor.onSurfaceVariant)
+                    Text(locationName)
+                        .monoLabelStyle(size: 9)
+                        .foregroundColor(DSColor.onSurfaceVariant)
+                    Spacer(minLength: 0)
                 }
-
-                Spacer()
-
-                // Expand/collapse button for long content
-                if needsExpansionButton {
-                    Button(action: {
-                        withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
-                            isExpanded.toggle()
-                        }
-                    }) {
-                        Text(isExpanded ? "收起" : "展开")
-                            .monoLabelStyle(size: 9)
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                    }
-                    .buttonStyle(.plain)
-                }
+                .padding(.horizontal, DSSpacing.cardInner)
+                .padding(.top, 6)
+                .padding(.bottom, DSSpacing.cardInner)
+            } else {
+                // Match the location branch's 6pt top + cardInner bottom rhythm
+                // so cards with and without a location label share the same
+                // bottom whitespace.
+                Spacer().frame(height: DSSpacing.cardInner + 6)
             }
-            .padding(.horizontal, DSSpacing.cardInner)
-            .padding(.top, 6)
-            .padding(.bottom, DSSpacing.cardInner)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(DSColor.surfaceContainer)
@@ -373,17 +360,6 @@ struct MemoCardView: View {
         }
     }
 
-    /// Whether the body is long enough to need an expand button.
-    private var needsExpansionButton: Bool {
-        let body = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !body.isEmpty else { return false }
-        // Suppress for voice memos where body is a legacy duplicate of transcript.
-        let isDuplicate = memo.type == .voice &&
-            memo.attachments.contains(where: { $0.transcript == body })
-        guard !isDuplicate else { return false }
-        let lineCount = body.components(separatedBy: "\n").count
-        return lineCount > previewLineLimit || body.count > 200
-    }
 }
 
 // MARK: - LocationPreviewSheet
@@ -605,12 +581,16 @@ struct VoiceMemoPlayerRow: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
 
-            // Transcript preview (if available) or queued placeholder
+            // Full transcript (if available) or queued placeholder.
+            // No line limit — long transcriptions must remain fully readable
+            // (see issue #203).
             if let t = transcript, !t.isEmpty {
                 Text(t)
                     .bodySMStyle()
                     .foregroundColor(DSColor.onSurfaceVariant)
-                    .lineLimit(2)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .textSelection(.enabled)
                     .padding(.horizontal, 12)
                     .padding(.bottom, 6)
             } else if transcript == nil && VoiceAttachmentQueue.shared.pendingCount > 0 {


### PR DESCRIPTION
## Summary

Fixes #203 — long voice transcriptions were being cut off in the Today timeline memo cards.

DayPage is a per-day capture journal: daily entries are short, self-authored, and the user just dictated them. Hiding text behind a "展开" button is friction, not affordance. Cards now grow to fit the full memo so every transcribed word is visible at a glance.

## What changed

`DayPage/Features/Today/MemoCardView.swift`:

- **Memo body**: removed `lineLimit(isExpanded ? nil : previewLineLimit)` (was clipping at 4 lines / 200 chars)
- **VoiceMemoPlayerRow transcript**: removed `lineLimit(2)`
- Both `Text` views now use `.fixedSize(horizontal: false, vertical: true)` + `.frame(maxWidth: .infinity, alignment: .leading)` so SwiftUI sizes each card by content height
- Added `.textSelection(.enabled)` so users can select and copy long transcripts
- Removed the now-unused expand/collapse button, `@State isExpanded`, `previewLineLimit` constant, and `needsExpansionButton` computed property
- Preserved the 26pt bottom rhythm when no location label is present so cards with/without location share consistent whitespace

Net diff: **+29 / −49 lines** — net deletion. Less code, fewer states, fewer interactions.

## Why full-expand instead of "show more"

Discussed during implementation: a per-day capture app doesn't accumulate enough memos for "霸屏" to be a real risk. Folding adds a click between the user and their own words — wrong tradeoff for this product. Twitter-style fold/unfold makes sense for infinite social feeds, not daily journals.

## Quality gates

- BUILD: `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` — **BUILD SUCCEEDED**
- Independent evaluator review (separate code-reviewer agent, no shared context): **47/50**
  - Modified path: 10/10 (no padding regression — measured 26pt → 26pt equivalent)
  - Code cleanup: 10/10 (zero residual references to removed symbols)
- Public API of `MemoCardView` (`memo`, `onDelete`) unchanged — no impact on `SwipeableMemoCard.swift` callsite

## Test plan

- [ ] Build on iPhone 17 simulator (iOS 16+)
- [ ] Record a long voice memo (>30s, transcribed >500 chars)
- [ ] Verify transcript fully visible in both memo card body and audio player row
- [ ] Verify short memos still render compactly with no extra whitespace
- [ ] Verify text selection (long-press) works on transcript text
- [ ] Verify cards with and without location labels have consistent bottom padding
- [ ] Verify scrolling through a day with mixed-length memos is smooth

Closes #203
