### PR TITLE
fix(#204): pin memo preserves original timestamp

### DIFF
--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -75,13 +75,15 @@ struct SwipeableMemoCard: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { onPin?() }
         }) {
             VStack(spacing: 4) {
-                Image(systemName: "pin.fill").font(.system(size: 16, weight: .semibold))
-                Text("置顶").font(.custom("Inter-Medium", size: 11))
+                Image(systemName: memo.pinnedAt != nil ? "pin.slash.fill" : "pin.fill")
+                    .font(.system(size: 16, weight: .semibold))
+                Text(memo.pinnedAt != nil ? "取消置顶" : "置顶")
+                    .font(.custom("Inter-Medium", size: 11))
             }
             .foregroundColor(.white)
             .frame(width: panelW)
             .frame(maxHeight: .infinity)
-            .background(DSColor.amberArchival)
+            .background(memo.pinnedAt != nil ? DSColor.textSecondary : DSColor.amberArchival)
         }
         // Opacity is driven by scoped withAnimation in snapOpen/snapClose.
         // Removed deprecated implicit .animation(_:value:) to prevent

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -83,7 +83,7 @@ struct SwipeableMemoCard: View {
             .foregroundColor(.white)
             .frame(width: panelW)
             .frame(maxHeight: .infinity)
-            .background(memo.pinnedAt != nil ? DSColor.textSecondary : DSColor.amberArchival)
+            .background(memo.pinnedAt != nil ? DSColor.secondary : DSColor.amberArchival)
         }
         // Opacity is driven by scoped withAnimation in snapOpen/snapClose.
         // Removed deprecated implicit .animation(_:value:) to prevent

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -204,7 +204,13 @@ struct TodayView: View {
                                             memo: memo,
                                             isLast: idx == viewModel.memos.count - 1,
                                             onDelete: { viewModel.deleteMemo(memo) },
-                                            onPin: { viewModel.pinMemo(memo) }
+                                            onPin: {
+                                    if memo.pinnedAt != nil {
+                                        viewModel.unpinMemo(memo)
+                                    } else {
+                                        viewModel.pinMemo(memo)
+                                    }
+                                }
                                         )
                                         .padding(.leading, 20)
                                         .padding(.trailing, 20)

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -184,15 +184,12 @@ final class TodayViewModel: ObservableObject {
         }
     }
 
-    /// Moves a memo to the top of today's list (newest created-time wins display order).
-    /// Adjusts the memo's `created` timestamp to just before the current newest so it
-    /// appears first without changing the day boundary.
+    /// Pins a memo to the top of today's list without changing its original timestamp.
+    /// Uses a separate `pinnedAt` field for sort order; `created` remains untouched.
     func pinMemo(_ memo: Memo) {
         guard let idx = memos.firstIndex(where: { $0.id == memo.id }) else { return }
         var pinned = memos[idx]
-        // Set to one second after the current newest memo's time so it sorts first
-        let newestTime = memos.first?.created ?? Date()
-        pinned.created = max(newestTime, pinned.created) + 1
+        pinned.pinnedAt = Date()
         var updated = memos
         updated.remove(at: idx)
         updated.insert(pinned, at: 0)
@@ -203,6 +200,25 @@ final class TodayViewModel: ObservableObject {
             }
         } catch {
             submitError = "置顶失败：\(error.localizedDescription)"
+        }
+    }
+
+    /// Unpins a memo, restoring it to its natural position based on original `created` time.
+    func unpinMemo(_ memo: Memo) {
+        guard let idx = memos.firstIndex(where: { $0.id == memo.id }) else { return }
+        var unpinned = memos[idx]
+        unpinned.pinnedAt = nil
+        var updated = memos
+        updated.remove(at: idx)
+        let insertIdx = updated.firstIndex(where: { $0.created < unpinned.created }) ?? updated.endIndex
+        updated.insert(unpinned, at: insertIdx)
+        do {
+            try rewrite(memos: updated)
+            withAnimation(.easeInOut(duration: 0.25)) {
+                memos = updated
+            }
+        } catch {
+            submitError = "取消置顶失败：\(error.localizedDescription)"
         }
     }
 
@@ -232,7 +248,12 @@ final class TodayViewModel: ObservableObject {
         do {
             let loaded = try RawStorage.read(for: date)
             // Newest first
-            memos = loaded.sorted { $0.created > $1.created }
+            memos = loaded.sorted { lhs, rhs in
+            if lhs.pinnedAt != nil && rhs.pinnedAt == nil { return true }
+            if lhs.pinnedAt == nil && rhs.pinnedAt != nil { return false }
+            if let lp = lhs.pinnedAt, let rp = rhs.pinnedAt { return lp > rp }
+            return lhs.created > rhs.created
+        }
         } catch {
             errorMessage = "加载失败：\(error.localizedDescription)"
             memos = []

--- a/DayPage/Models/Memo.swift
+++ b/DayPage/Models/Memo.swift
@@ -34,6 +34,7 @@ struct Memo: Identifiable, Equatable {
     var id: UUID
     var type: MemoType
     var created: Date
+    var pinnedAt: Date? = nil
     var location: Location?
     var weather: String?
     var device: String?
@@ -46,6 +47,7 @@ struct Memo: Identifiable, Equatable {
         id: UUID = UUID(),
         type: MemoType = .text,
         created: Date = Date(),
+        pinnedAt: Date? = nil,
         location: Location? = nil,
         weather: String? = nil,
         device: String? = nil,
@@ -55,6 +57,7 @@ struct Memo: Identifiable, Equatable {
         self.id = id
         self.type = type
         self.created = created
+        self.pinnedAt = pinnedAt
         self.location = location
         self.weather = weather
         self.device = device
@@ -77,6 +80,10 @@ extension Memo {
         lines.append("id: \(id.uuidString)")
         lines.append("type: \(type.rawValue)")
         lines.append("created: \(ISO8601DateFormatter.memo.string(from: created))")
+
+        if let p = pinnedAt {
+            lines.append("pinned_at: \(ISO8601DateFormatter.memo.string(from: p))")
+        }
 
         if let loc = location {
             lines.append("location:")
@@ -162,6 +169,11 @@ extension Memo {
         let createdString = fm.scalar("created") ?? ""
         let created = ISO8601DateFormatter.memo.date(from: createdString) ?? Date()
 
+        let pinnedAt: Date? = {
+            guard let s = fm.scalar("pinned_at") else { return nil }
+            return ISO8601DateFormatter.memo.date(from: s)
+        }()
+
         var location: Location?
         if let locationMap = fm.mapping("location") {
             var loc = Location()
@@ -189,6 +201,7 @@ extension Memo {
             id: uuid,
             type: memoType,
             created: created,
+            pinnedAt: pinnedAt,
             location: location,
             weather: weather,
             device: device,


### PR DESCRIPTION
Fixes #204 — pinning a memo no longer mutates the original `created` timestamp.

## Root Cause
`pinMemo()` in TodayViewModel hacked sort order by modifying `memo.created`, changing the user-visible creation timestamp.

## Fix
Introduced a separate `pinnedAt: Date?` field for pin state:

- **Memo model** — `pinnedAt` field with full YAML serialization/deserialization
- **TodayViewModel** — `pinMemo()` sets `pinnedAt` instead of mutating `created`; new `unpinMemo()` clears it
- **TodayViewModel sort** — pinned items sort first by `pinnedAt` desc, then unpinned by `created` desc
- **TodayView** — toggles between pin/unpin based on `pinnedAt` state
- **SwipeableMemoCard** — dynamic pin/slash icon, 置顶/取消置顶 label, background color per pin state

## Files Changed
- `DayPage/Models/Memo.swift`: +13 lines
- `DayPage/Features/Today/TodayViewModel.swift`: +35/-11
- `DayPage/Features/Today/TodayView.swift`: +8/-1
- `DayPage/Features/Today/SwipeableMemoCard.swift`: +8/-3