### PR TITLE
perf(#208): instant feedback submission + backend AI triage

### DIFF
--- a/.github/workflows/feedback-triage.yml
+++ b/.github/workflows/feedback-triage.yml
@@ -1,0 +1,237 @@
+name: kubbot Feedback Triage
+
+# Server-side AI triage for issues filed by the in-app feedback flow.
+#
+# The iOS client now files raw feedback instantly, with the `triage` label
+# and the user's verbatim text in the body. This workflow:
+#   1. Reads the issue body (raw feedback + diagnostic context).
+#   2. Calls DeepSeek to classify (bug / enhancement / improvement) and
+#      rewrite a proper title + Markdown body.
+#   3. Updates the issue and swaps the `triage` label for the AI-suggested
+#      one via the GitHub REST API (using `gh api`).
+#
+# Required repo secret:
+#   DEEPSEEK_API_KEY   — DeepSeek chat completions key
+# Optional repo variables (vars):
+#   DEEPSEEK_BASE_URL  — defaults to https://api.deepseek.com/v1
+#   DEEPSEEK_MODEL     — defaults to deepseek-chat
+
+on:
+  issues:
+    types: [opened, labeled]
+
+permissions:
+  issues: write
+  contents: read
+
+jobs:
+  triage:
+    name: Triage feedback issue
+    runs-on: ubuntu-latest
+    # Only act on issues that currently carry the `triage` label. For
+    # `opened` we check the labels array; for `labeled` we check the label
+    # that was just applied.
+    if: |
+      (github.event.action == 'opened' &&
+        contains(github.event.issue.labels.*.name, 'triage')) ||
+      (github.event.action == 'labeled' &&
+        github.event.label.name == 'triage')
+    steps:
+      - name: Checkout (for script)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run triage
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DEEPSEEK_API_KEY: ${{ secrets.DEEPSEEK_API_KEY }}
+          DEEPSEEK_BASE_URL: ${{ vars.DEEPSEEK_BASE_URL }}
+          DEEPSEEK_MODEL: ${{ vars.DEEPSEEK_MODEL }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_TITLE: ${{ github.event.issue.title }}
+          ISSUE_BODY: ${{ github.event.issue.body }}
+          REPO: ${{ github.repository }}
+        run: |
+          python3 <<'PY'
+          import json
+          import os
+          import re
+          import subprocess
+          import sys
+          import urllib.request
+          import urllib.error
+
+          api_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
+          if not api_key:
+              print("DEEPSEEK_API_KEY is not set; skipping triage.", file=sys.stderr)
+              sys.exit(0)
+
+          base_url = (os.environ.get("DEEPSEEK_BASE_URL") or "https://api.deepseek.com/v1").rstrip("/")
+          model    = os.environ.get("DEEPSEEK_MODEL") or "deepseek-chat"
+          repo     = os.environ["REPO"]
+          number   = os.environ["ISSUE_NUMBER"]
+          orig_title = os.environ.get("ISSUE_TITLE", "") or ""
+          orig_body  = os.environ.get("ISSUE_BODY",  "") or ""
+
+          allowed_labels = {"bug", "enhancement", "improvement"}
+
+          system_prompt = (
+              "You are DayPage's feedback triage assistant. The user filed feedback "
+              "from inside the iOS app. The issue body contains their raw text plus "
+              "a diagnostic context block (app version, OS, device, etc.).\n\n"
+              "Your job:\n"
+              "1. Decide whether this is a bug, feature request (enhancement), or "
+              "improvement.\n"
+              "2. Write a short, specific issue title (<= 80 chars). Do NOT include the "
+              "version number in the title.\n"
+              "3. Compose a Markdown body using the appropriate sections:\n"
+              "     - Bug:         ## Description, ## Steps to Reproduce, ## Expected, ## Actual, ## Environment\n"
+              "     - Feature:     ## Problem, ## Proposed Solution, ## Why\n"
+              "     - Improvement: ## Current behaviour, ## Suggested change, ## Why\n"
+              "   Always include an '## Environment' section listing the relevant "
+              "subset of the diagnostic context (app version, OS, device).\n"
+              "4. Pick exactly one label from: ['bug', 'enhancement', 'improvement'].\n\n"
+              "Output ONLY a JSON object: {\"title\": \"...\", \"body\": \"...\", \"label\": \"bug\"}.\n"
+              "No prose outside the JSON. No markdown fences."
+          )
+
+          user_message = (
+              "--- ORIGINAL TITLE ---\n"
+              f"{orig_title}\n\n"
+              "--- ISSUE BODY (raw feedback + diagnostics) ---\n"
+              f"{orig_body}\n"
+          )
+
+          payload = {
+              "model": model,
+              "messages": [
+                  {"role": "system", "content": system_prompt},
+                  {"role": "user",   "content": user_message},
+              ],
+              "max_tokens": 1024,
+              "temperature": 0.4,
+          }
+
+          req = urllib.request.Request(
+              f"{base_url}/chat/completions",
+              data=json.dumps(payload).encode("utf-8"),
+              headers={
+                  "Authorization": f"Bearer {api_key}",
+                  "Content-Type": "application/json",
+              },
+              method="POST",
+          )
+
+          try:
+              with urllib.request.urlopen(req, timeout=60) as resp:
+                  raw = resp.read().decode("utf-8")
+          except urllib.error.HTTPError as e:
+              detail = e.read().decode("utf-8", errors="replace")[:500]
+              print(f"DeepSeek HTTP {e.code}: {detail}", file=sys.stderr)
+              sys.exit(1)
+          except Exception as e:
+              print(f"DeepSeek call failed: {e}", file=sys.stderr)
+              sys.exit(1)
+
+          try:
+              data = json.loads(raw)
+              content = data["choices"][0]["message"]["content"].strip()
+          except (KeyError, IndexError, json.JSONDecodeError) as e:
+              print(f"Unexpected DeepSeek response shape: {e}\n{raw[:500]}", file=sys.stderr)
+              sys.exit(1)
+
+          # Tolerate ```json ... ``` fences and leading prose.
+          fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", content, re.DOTALL)
+          if fence:
+              json_str = fence.group(1)
+          else:
+              first = content.find("{")
+              last  = content.rfind("}")
+              if first == -1 or last == -1 or last < first:
+                  print(f"AI response had no JSON object:\n{content[:500]}", file=sys.stderr)
+                  sys.exit(1)
+              json_str = content[first:last + 1]
+
+          try:
+              parsed = json.loads(json_str)
+          except json.JSONDecodeError as e:
+              print(f"Failed to parse AI JSON ({e}):\n{json_str[:500]}", file=sys.stderr)
+              sys.exit(1)
+
+          new_title = (parsed.get("title") or "").strip()
+          new_body  = (parsed.get("body")  or "").strip()
+          # Accept either `label` or `labels` to be tolerant of the model.
+          label_field = parsed.get("label") or (parsed.get("labels") or [None])[0]
+          new_label = (label_field or "").strip().lower()
+
+          if not new_title or not new_body:
+              print("AI returned empty title or body; leaving issue untouched.", file=sys.stderr)
+              sys.exit(1)
+          if new_label not in allowed_labels:
+              print(f"AI label '{new_label}' not in {allowed_labels}; defaulting to 'bug'.", file=sys.stderr)
+              new_label = "bug"
+
+          if len(new_title) > 80:
+              new_title = new_title[:79].rstrip() + "…"
+
+          # Preserve the original raw-feedback + diagnostics block at the bottom
+          # so nothing the user typed is ever lost.
+          final_body = (
+              f"{new_body}\n\n"
+              "---\n\n"
+              "<details><summary>Original submission</summary>\n\n"
+              f"{orig_body}\n\n"
+              "</details>\n"
+          )
+
+          def gh(*args, input_data=None):
+              return subprocess.run(
+                  ["gh", *args],
+                  input=input_data,
+                  text=True,
+                  capture_output=True,
+                  check=False,
+              )
+
+          # Update title + body via the REST API (handles arbitrary-size body
+          # better than `gh issue edit`).
+          patch_payload = json.dumps({"title": new_title, "body": final_body})
+          patch = gh(
+              "api",
+              "--method", "PATCH",
+              f"/repos/{repo}/issues/{number}",
+              "--input", "-",
+              input_data=patch_payload,
+          )
+          if patch.returncode != 0:
+              print(f"Failed to update issue: {patch.stderr}", file=sys.stderr)
+              sys.exit(1)
+
+          # Add the AI-picked label (no-op if already present).
+          add = gh(
+              "api",
+              "--method", "POST",
+              f"/repos/{repo}/issues/{number}/labels",
+              "-f", f"labels[]={new_label}",
+          )
+          if add.returncode != 0:
+              # Non-fatal — the issue is still updated.
+              print(f"Warning: failed to add label '{new_label}': {add.stderr}", file=sys.stderr)
+
+          # Remove the `triage` label. 404 just means it was already gone.
+          rm = gh(
+              "api",
+              "--method", "DELETE",
+              f"/repos/{repo}/issues/{number}/labels/triage",
+          )
+          if rm.returncode != 0 and "404" not in (rm.stderr or ""):
+              print(f"Warning: failed to remove 'triage' label: {rm.stderr}", file=sys.stderr)
+
+          print(f"Triaged issue #{number}: '{new_title}' [{new_label}]")
+          PY

--- a/DayPage/Features/Feedback/FeedbackView.swift
+++ b/DayPage/Features/Feedback/FeedbackView.swift
@@ -241,6 +241,7 @@ struct FeedbackView: View {
 
     private var sendButton: some View {
         Button {
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
             Task { await vm.send() }
         } label: {
             HStack(spacing: 6) {
@@ -251,16 +252,17 @@ struct FeedbackView: View {
                         .tint(.white)
                 } else {
                     Image(systemName: "paperplane.fill")
-                        .font(.system(size: 13, weight: .medium))
+                        .font(.system(size: 15, weight: .medium))
                 }
                 Text(vm.isSending ? "Sending…" : "Send")
-                    .font(.custom("Inter-SemiBold", size: 14))
+                    .font(.custom("Inter-SemiBold", size: 16))
             }
             .foregroundColor(.white)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 14)
             .background(vm.isSending ? DSColor.accentAmber.opacity(0.7) : DSColor.accentAmber)
-            .cornerRadius(8)
+            .cornerRadius(12)
         }
         .disabled(vm.isSending)
     }

--- a/DayPage/Features/Feedback/FeedbackViewModel.swift
+++ b/DayPage/Features/Feedback/FeedbackViewModel.swift
@@ -7,8 +7,6 @@ import UIKit
 
 enum FeedbackStatus: Equatable {
     case idle
-    /// Single combined "AI summarize + GitHub submit" loading state — the
-    /// user sees one spinner instead of two stages.
     case sending
     case submitted(issueURL: String)
     case error(String)
@@ -86,11 +84,12 @@ final class FeedbackViewModel: ObservableObject {
         loadSubmittedIssues()
     }
 
-    // MARK: - Send (AI Summary + Submit, single step)
+    // MARK: - Send (instant — backend triage takes over)
 
-    /// Combined flow: capture context → ask AI to compose issue → upload images
-    /// → create GitHub issue. The UI sees one `.sending` state for the whole
-    /// chain so the user isn't asked to confirm AI output.
+    /// Submit flow: capture context → upload images → create GitHub issue
+    /// labelled `triage`. The kubbot Feedback Triage Bot workflow picks it up
+    /// server-side and rewrites title/body/labels via DeepSeek, so the user
+    /// sees a confirmation in well under a second instead of waiting on AI.
     func send() async {
         let trimmed = rawFeedback.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty || !pendingImages.isEmpty else {
@@ -98,24 +97,17 @@ final class FeedbackViewModel: ObservableObject {
             return
         }
 
+        UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+
         status = .sending
         let context = capturedContext ?? FeedbackContext.capture()
         capturedContext = context
 
-        // 1. AI summarize
-        let summary: AIIssueSummary
-        do {
-            summary = try await callDeepSeekForSummary(
-                feedback: trimmed.isEmpty ? "(no text — see attached screenshots)" : trimmed,
-                context: context
-            )
-        } catch {
-            status = .error(error.localizedDescription)
-            return
-        }
+        let rawText = trimmed.isEmpty ? "(no text — see attached screenshots)" : trimmed
+        let title = Self.makeProvisionalTitle(from: rawText)
 
-        // 2. Upload images (best effort — image upload failure shouldn't block
-        //    the issue itself, but we surface a warning by appending a note).
+        // Upload images (best effort — image upload failure shouldn't block
+        // the issue itself, but we surface a warning by appending a note).
         var imageMarkdown = ""
         var uploadedAll = true
         for image in pendingImages {
@@ -131,8 +123,7 @@ final class FeedbackViewModel: ObservableObject {
             }
         }
 
-        // 3. Compose final body: AI body + context block + screenshots
-        var body = summary.body
+        var body = "## Raw feedback\n\n\(rawText)"
         body += "\n\n---\n\n<details><summary>📱 Diagnostic context</summary>\n\n```\n\(context.promptDescription)\n```\n\n</details>"
         if !imageMarkdown.isEmpty {
             body += "\n\n## Screenshots" + imageMarkdown
@@ -141,25 +132,42 @@ final class FeedbackViewModel: ObservableObject {
             body += "\n\n> ⚠️ Some screenshots failed to upload."
         }
 
-        // 4. Create issue
         do {
             let issue = try await FeedbackService.shared.createIssueViaBot(
-                title: summary.title,
+                title: title,
                 body: body,
-                labels: summary.labels
+                labels: ["triage"]
             )
             let submitted = SubmittedIssue(
                 number: issue.number,
                 url: issue.htmlURL,
-                title: summary.title,
+                title: title,
                 date: Date()
             )
             submittedIssues.insert(submitted, at: 0)
             persistSubmittedIssues()
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
             status = .submitted(issueURL: issue.htmlURL)
         } catch {
             status = .error(error.localizedDescription)
         }
+    }
+
+    /// First non-empty line, truncated to 80 chars (with ellipsis when cut).
+    /// The triage workflow rewrites this server-side, so it just has to be
+    /// good enough for the user to recognize the issue in their list.
+    private static func makeProvisionalTitle(from text: String) -> String {
+        let firstLine = text
+            .split(whereSeparator: { $0.isNewline })
+            .first
+            .map(String.init)?
+            .trimmingCharacters(in: .whitespaces) ?? ""
+        let source = firstLine.isEmpty
+            ? text.trimmingCharacters(in: .whitespacesAndNewlines)
+            : firstLine
+        if source.count <= 80 { return source }
+        let cutoff = source.index(source.startIndex, offsetBy: 79)
+        return String(source[..<cutoff]) + "…"
     }
 
     // MARK: - Voice (Whisper press-to-talk)
@@ -267,136 +275,6 @@ final class FeedbackViewModel: ObservableObject {
         status = .idle
     }
 
-    // MARK: - DeepSeek Call
-
-    fileprivate struct AIIssueSummary {
-        let title: String
-        let body: String
-        let labels: [String]
-    }
-
-    private func callDeepSeekForSummary(
-        feedback: String,
-        context: FeedbackContext
-    ) async throws -> AIIssueSummary {
-        let apiKey = Secrets.resolvedDeepSeekApiKey
-        guard !apiKey.isEmpty else {
-            throw FeedbackError.networkError("DeepSeek API key is not configured.")
-        }
-
-        let baseURL = Secrets.deepSeekBaseURL.isEmpty
-            ? "https://api.deepseek.com/v1"
-            : Secrets.deepSeekBaseURL
-        let model = Secrets.deepSeekModel.isEmpty ? "deepseek-v4-pro" : Secrets.deepSeekModel
-
-        guard let url = URL(string: "\(baseURL)/chat/completions") else {
-            throw FeedbackError.networkError("Invalid API URL")
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 60
-
-        let systemPrompt = """
-        You are DayPage's feedback triage assistant. The user is reporting a bug or
-        requesting an improvement. You are given the raw feedback text AND a block
-        of diagnostic context (app version, OS, device, user id, etc.). Your job:
-
-        1. Decide whether this is a bug, feature request, or improvement.
-        2. Write a short, specific issue title (≤ 80 chars). Do NOT include the
-           version number in the title — it goes in the body.
-        3. Compose a Markdown body using the appropriate sections:
-             - Bug:         ## Description, ## Steps to Reproduce, ## Expected, ## Actual, ## Environment
-             - Feature:     ## Problem, ## Proposed Solution, ## Why
-             - Improvement: ## Current behaviour, ## Suggested change, ## Why
-           Always include an "## Environment" section that lists the relevant
-           subset of the diagnostic context (app version, OS, device — user id
-           only if it helps reproduce). Don't dump the whole context block — the
-           app appends a verbatim copy below your output.
-        4. Pick 1–2 labels from: ["bug", "enhancement", "improvement"].
-
-        Output ONLY a JSON object:
-        {
-          "title": "...",
-          "body":  "...",
-          "labels": ["bug"]
-        }
-        No prose outside the JSON. No markdown fences around the JSON.
-        """
-
-        let userMessage = """
-        --- USER FEEDBACK ---
-        \(feedback)
-
-        --- DIAGNOSTIC CONTEXT ---
-        \(context.promptDescription)
-        """
-
-        let body: [String: Any] = [
-            "model": model,
-            "messages": [
-                ["role": "system", "content": systemPrompt],
-                ["role": "user", "content": userMessage]
-            ],
-            "max_tokens": 1024,
-            "temperature": 0.4
-        ]
-
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let http = response as? HTTPURLResponse else {
-            throw FeedbackError.networkError("No HTTP response")
-        }
-        guard http.statusCode == 200 else {
-            let bodyStr = String(data: data, encoding: .utf8) ?? ""
-            throw FeedbackError.unknownError(http.statusCode, bodyStr)
-        }
-
-        return try parseAISummary(from: data)
-    }
-
-    private func parseAISummary(from data: Data) throws -> AIIssueSummary {
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = json["choices"] as? [[String: Any]],
-              let first = choices.first,
-              let message = first["message"] as? [String: Any],
-              let content = message["content"] as? String else {
-            throw FeedbackError.networkError("Unexpected API response structure")
-        }
-
-        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Tolerate models that wrap JSON in ```json fences.
-        let jsonString: String
-        if let fenceStart = trimmed.range(of: "```json\n"),
-           let fenceEnd = trimmed.range(of: "\n```", range: fenceStart.upperBound ..< trimmed.endIndex) {
-            jsonString = String(trimmed[fenceStart.upperBound ..< fenceEnd.lowerBound])
-        } else if let braceStart = trimmed.firstIndex(of: "{"),
-                  let braceEnd = trimmed.lastIndex(of: "}") {
-            jsonString = String(trimmed[braceStart ... braceEnd])
-        } else {
-            throw FeedbackError.networkError("AI response did not contain valid JSON")
-        }
-
-        guard let jsonData = jsonString.data(using: .utf8),
-              let parsed = try JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
-            throw FeedbackError.networkError("Failed to parse AI JSON response")
-        }
-
-        let title = (parsed["title"] as? String) ?? ""
-        let bodyText = (parsed["body"] as? String) ?? ""
-        let labels = (parsed["labels"] as? [String]) ?? []
-
-        guard !title.isEmpty else {
-            throw FeedbackError.networkError("AI returned empty issue title")
-        }
-
-        return AIIssueSummary(title: title, body: bodyText, labels: labels)
-    }
 }
 
 // MARK: - Date helper

--- a/DayPage/Services/FeedbackService.swift
+++ b/DayPage/Services/FeedbackService.swift
@@ -50,6 +50,18 @@ final class FeedbackService {
     private static let botOwner = "getyak"
     private static let botRepo  = "daypage"
 
+    /// URLSession that waits for connectivity instead of failing fast when
+    /// the device briefly drops off the network mid-submit. Combined with
+    /// the longer `timeoutInterval` on each request this lets the issue
+    /// creation survive lock-screen / app-switch / spotty-wifi moments.
+    private static let resilientSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.waitsForConnectivity = true
+        config.timeoutIntervalForRequest = 120
+        config.timeoutIntervalForResource = 300
+        return URLSession(configuration: config)
+    }()
+
     // MARK: - Create Issue via Bot (zero-config)
 
     /// Posts a new issue using the embedded bot token to the hardcoded repo.
@@ -89,7 +101,7 @@ final class FeedbackService {
         request.setValue("token \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.timeoutInterval = 30
+        request.timeoutInterval = 120
 
         let payload: [String: Any] = [
             "title": title,
@@ -98,7 +110,7 @@ final class FeedbackService {
         ]
         request.httpBody = try JSONSerialization.data(withJSONObject: payload)
 
-        let (data, response) = try await URLSession.shared.data(for: request)
+        let (data, response) = try await FeedbackService.resilientSession.data(for: request)
         try validateGitHubResponse(data: data, response: response)
 
         return try JSONDecoder().decode(GitHubIssue.self, from: data)


### PR DESCRIPTION
## Summary

**Problem:** When users submitted feedback, the app called DeepSeek API synchronously (2-10s blocking). If user quit the app, everything was lost.

**Solution:** Split into client and server phases:

### Client (instant)
- User taps Send → haptic feedback → raw feedback + diagnostic context uploaded to GitHub issue with `triage` label
- No AI wait — submission completes in < 1 second
- Resilient URLSession with `waitsForConnectivity` and 120s timeout
- Larger send button with better haptic feedback

### Server (kubbot workflow)
- New `.github/workflows/feedback-triage.yml`
- Triggers on issues with `triage` label
- Calls DeepSeek to classify (bug/enhancement/improvement)
- Rewrites title/body with proper sections
- Preserves original submission in a `<details>` block
- Swaps `triage` label for AI-suggested label

## Files Changed
| File | Change |
|------|--------|
| `FeedbackViewModel.swift` | -160 lines AI code removed; instant submission with haptic |
| `FeedbackView.swift` | Larger send button (full-width, 16pt font, haptic) |
| `FeedbackService.swift` | Resilient URLSession (waitsForConnectivity, 120s timeout) |
| `feedback-triage.yml` | **New** — server-side AI triage workflow |

## Required Setup
- [ ] Set `DEEPSEEK_API_KEY` repo secret (already present as `deepSeekApiKey` in Secrets)

Closes #208