### PR TITLE
fix(#212): feedback mic single-tap now starts recording with pause

### DIFF
--- a/DayPage/Features/Feedback/FeedbackView.swift
+++ b/DayPage/Features/Feedback/FeedbackView.swift
@@ -50,10 +50,18 @@ struct FeedbackView: View {
                 voiceOverlay
                     .transition(.opacity)
             }
-
-            if vm.showHoldToRecordToast {
-                toast("Hold to record")
-            }
+        }
+        .sheet(isPresented: $vm.isShowingVoiceRecorder) {
+            VoiceRecordingView(
+                onComplete: { result in
+                    vm.handleVoiceRecordingComplete(result: result)
+                },
+                onCancel: {
+                    vm.cancelVoiceRecording()
+                }
+            )
+            .presentationDetents([.medium])
+            .presentationDragIndicator(.hidden)
         }
         .sheet(isPresented: $showCamera) {
             CameraPickerView(
@@ -224,11 +232,11 @@ struct FeedbackView: View {
                 onReleaseCancel: { vm.voiceReleaseCancel() },
                 onReleaseTranscribe: { vm.voiceReleaseTranscribe() },
                 onPhaseChange: { phase in vm.pressToTalkPhase = phase },
-                onTapShortRelease: { vm.voiceShortTap() },
+                onTapShortRelease: { vm.startVoiceRecording() },
                 size: 44
             )
 
-            Text("Hold mic to record")
+            Text("Tap to record · hold for quick memo")
                 .font(.custom("Inter-Regular", size: 12))
                 .foregroundColor(DSColor.onBackgroundSubtle)
 
@@ -438,20 +446,6 @@ struct FeedbackView: View {
         .background(DSColor.errorSoft)
         .cornerRadius(10)
         .padding(.vertical, 8)
-    }
-
-    private func toast(_ text: String) -> some View {
-        VStack {
-            Spacer()
-            Text(text)
-                .font(.custom("Inter-Medium", size: 13))
-                .foregroundColor(.white)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(Color.black.opacity(0.78))
-                .clipShape(Capsule())
-                .padding(.bottom, 60)
-        }
     }
 
     // MARK: - Helpers

--- a/DayPage/Features/Feedback/FeedbackViewModel.swift
+++ b/DayPage/Features/Feedback/FeedbackViewModel.swift
@@ -45,8 +45,10 @@ final class FeedbackViewModel: ObservableObject {
     @Published var status: FeedbackStatus = .idle
     @Published var submittedIssues: [SubmittedIssue] = []
 
-    /// Toast: "Hold to record" — shown on a short tap of the mic.
-    @Published var showHoldToRecordToast: Bool = false
+    /// Whether the half-screen VoiceRecordingView sheet is presented.
+    /// A single tap on the mic flips this true; the sheet handles
+    /// pause/resume/save and returns a transcript via `handleVoiceRecordingComplete`.
+    @Published var isShowingVoiceRecorder: Bool = false
 
     /// Pending image attachments (uploaded only at submit time).
     @Published var pendingImages: [PendingFeedbackImage] = []
@@ -196,12 +198,33 @@ final class FeedbackViewModel: ObservableObject {
         Task { await consumeRecordingAsTranscript() }
     }
 
-    /// Short tap — show "Hold to record" hint.
-    func voiceShortTap() {
-        showHoldToRecordToast = true
-        Task { @MainActor in
-            try? await Task.sleep(nanoseconds: 1_400_000_000)
-            self.showHoldToRecordToast = false
+    /// Short tap — open the half-screen voice recorder sheet. Mirrors the
+    /// TodayView input bar so users get pause/resume/save instead of a
+    /// press-to-talk gesture.
+    func startVoiceRecording() {
+        isShowingVoiceRecorder = true
+    }
+
+    /// Dismiss the recorder sheet without keeping any audio.
+    func cancelVoiceRecording() {
+        voiceService.cancelRecording()
+        isShowingVoiceRecorder = false
+    }
+
+    /// Recorder sheet finished — append the transcript to the feedback draft.
+    /// The audio file itself is discarded; feedback is text-only.
+    func handleVoiceRecordingComplete(result: VoiceRecordingResult) {
+        isShowingVoiceRecorder = false
+        defer { voiceService.reset() }
+        if let text = result.transcript?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !text.isEmpty {
+            if rawFeedback.isEmpty {
+                rawFeedback = text
+            } else {
+                rawFeedback += " " + text
+            }
+        } else {
+            status = .error("Voice transcription failed. Check your network or OpenAI Whisper key.")
         }
     }
 


### PR DESCRIPTION
## Summary
Single-tapping the mic in FeedbackView now opens the VoiceRecordingView sheet with pause/resume, instead of showing a useless 'Hold to record' toast.

### Changes
- `voiceShortTap()` → `startVoiceRecording()` opens VoiceRecordingView sheet
- Recording complete → transcript auto-appended to feedback text
- Added `cancelVoiceRecording()` + `handleVoiceRecordingComplete()`
- Helper text updated: 'Tap to record · hold for quick memo'
- Long-press press-to-talk preserved

Closes #212