### PR TITLE
fix(#214): feedback as right-side slide-in panel, not full tab

### DIFF
--- a/DayPage/App/AppNavigationModel.swift
+++ b/DayPage/App/AppNavigationModel.swift
@@ -16,6 +16,7 @@ final class AppNavigationModel: ObservableObject {
 
     @Published var selectedTab: AppTab = .today
     @Published var isSidebarOpen: Bool = false
+    @Published var isFeedbackPanelOpen: Bool = false
 
     init() {}
 
@@ -34,5 +35,18 @@ final class AppNavigationModel: ObservableObject {
     func navigate(to tab: AppTab) {
         selectedTab = tab
         closeSidebar()
+    }
+
+    func openFeedbackPanel() {
+        closeSidebar()
+        withAnimation(.spring(response: 0.38, dampingFraction: 0.86)) {
+            isFeedbackPanelOpen = true
+        }
+    }
+
+    func closeFeedbackPanel() {
+        withAnimation(.spring(response: 0.32, dampingFraction: 0.90)) {
+            isFeedbackPanelOpen = false
+        }
     }
 }

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -10,6 +10,10 @@ struct RootView: View {
 
     private let sidebarWidth: CGFloat = 280
 
+    private var feedbackPanelWidth: CGFloat {
+        min(UIScreen.main.bounds.width * 0.85, 360)
+    }
+
     private var showAuth: Bool {
         authService.session == nil && !authSkipped
     }
@@ -62,10 +66,6 @@ struct RootView: View {
                     .opacity(nav.selectedTab == .archive ? 1 : 0)
                     .allowsHitTesting(nav.selectedTab == .archive && !nav.isSidebarOpen)
 
-                FeedbackView()
-                    .opacity(nav.selectedTab == .feedback ? 1 : 0)
-                    .allowsHitTesting(nav.selectedTab == .feedback && !nav.isSidebarOpen)
-
                 GraphView()
                     .opacity(nav.selectedTab == .graph ? 1 : 0)
                     .allowsHitTesting(nav.selectedTab == .graph && !nav.isSidebarOpen)
@@ -92,6 +92,33 @@ struct RootView: View {
                 .ignoresSafeArea()
                 .shadow(color: Color.black.opacity(0.10), radius: 20, x: 6, y: 0)
                 .offset(x: nav.isSidebarOpen ? 0 : -sidebarWidth)
+
+            // Right-side feedback panel — overlay + sliding panel
+            if nav.isFeedbackPanelOpen {
+                Color.black.opacity(0.28)
+                    .ignoresSafeArea()
+                    .onTapGesture { nav.closeFeedbackPanel() }
+                    .transition(.opacity)
+                    .zIndex(1)
+            }
+
+            FeedbackView()
+                .frame(width: feedbackPanelWidth)
+                .frame(maxHeight: .infinity)
+                .background(DSColor.backgroundWarm)
+                .shadow(color: Color.black.opacity(0.12), radius: 24, x: -8, y: 0)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+                .offset(x: nav.isFeedbackPanelOpen ? 0 : feedbackPanelWidth + 40)
+                .gesture(
+                    DragGesture(minimumDistance: 20)
+                        .onEnded { value in
+                            if value.translation.width > 60 {
+                                nav.closeFeedbackPanel()
+                            }
+                        }
+                )
+                .allowsHitTesting(nav.isFeedbackPanelOpen)
+                .zIndex(2)
         }
         // 边缘滑动打开：仅在拖动从左侧 40pt 以内开始时触发
         .gesture(

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -71,7 +71,11 @@ struct SidebarView: View {
 
         Button {
             guard !disabled else { return }
-            nav.navigate(to: tab)
+            if tab == .feedback {
+                nav.openFeedbackPanel()
+            } else {
+                nav.navigate(to: tab)
+            }
         } label: {
             HStack(spacing: 12) {
                 // Left accent bar


### PR DESCRIPTION
## Summary
FeedbackView no longer takes over the full screen. It now slides in from the right as a lightweight panel, keeping the main Today content visible and central.

### Changes
- **AppNavigationModel**: Add `isFeedbackPanelOpen`, `openFeedbackPanel()`, `closeFeedbackPanel()`
- **RootView**: Remove FeedbackView from tab stack, add right-side sliding panel with overlay
- **SidebarView**: Feedback nav item opens panel instead of tab switch

### UX
- Panel width: min(85% screen, 360pt)
- Semi-transparent overlay behind panel
- Tap overlay or swipe right >60pt to dismiss
- Panel state preserved across open/close

Closes #214