### PR TITLE
feat: Issue Pulse — GitHub issue status tracker

### DIFF
--- a/.issue_cache.json
+++ b/.issue_cache.json
@@ -1,0 +1,480 @@
+{
+  "close_time_count": 25,
+  "close_time_total_seconds": 440470.0,
+  "counted_closed_numbers": [
+    126,
+    132,
+    136,
+    137,
+    143,
+    150,
+    173,
+    175,
+    177,
+    181,
+    184,
+    186,
+    188,
+    190,
+    192,
+    194,
+    196,
+    198,
+    200,
+    203,
+    204,
+    208,
+    212,
+    213,
+    214
+  ],
+  "fetched_at": "2026-05-04T04:12:51+00:00",
+  "issues": {
+    "126": {
+      "assignees": [],
+      "closed_at": "2026-04-23T16:29:36Z",
+      "closed_by": "cubxxw",
+      "comments": 0,
+      "created_at": "2026-04-23T15:43:02Z",
+      "labels": [
+        "enhancement",
+        "design"
+      ],
+      "milestone": null,
+      "number": 126,
+      "state": "CLOSED",
+      "title": "feat: Replace bottom tab bar with Flomo-style hidden sidebar navigation",
+      "updated_at": "2026-04-23T16:29:36Z",
+      "url": "https://github.com/getyak/daypage/issues/126"
+    },
+    "132": {
+      "assignees": [
+        "cubxxw"
+      ],
+      "closed_at": "2026-04-25T04:11:18Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-24T13:01:46Z",
+      "labels": [
+        "bug",
+        "enhancement",
+        "P2",
+        "compilation"
+      ],
+      "milestone": "v0.2",
+      "number": 132,
+      "state": "CLOSED",
+      "title": "[Refactor] CompilationService 若干质量问题修复",
+      "updated_at": "2026-04-25T04:11:18Z",
+      "url": "https://github.com/getyak/daypage/issues/132"
+    },
+    "136": {
+      "assignees": [],
+      "closed_at": "2026-04-27T05:46:55Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-27T05:46:43Z",
+      "labels": [],
+      "milestone": null,
+      "number": 136,
+      "state": "CLOSED",
+      "title": "🚀 Linear Automation Test",
+      "updated_at": "2026-04-27T05:46:55Z",
+      "url": "https://github.com/getyak/daypage/issues/136"
+    },
+    "137": {
+      "assignees": [
+        "cubxxw"
+      ],
+      "closed_at": "2026-04-27T07:06:07Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-27T06:15:14Z",
+      "labels": [],
+      "milestone": null,
+      "number": 137,
+      "state": "CLOSED",
+      "title": "代码注释中文化 — 全部 Swift 代码注释翻译为中文",
+      "updated_at": "2026-04-27T07:06:07Z",
+      "url": "https://github.com/getyak/daypage/issues/137"
+    },
+    "143": {
+      "assignees": [],
+      "closed_at": "2026-04-29T05:10:30Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-27T10:56:07Z",
+      "labels": [
+        "enhancement",
+        "ui",
+        "P1",
+        "input",
+        "ux"
+      ],
+      "milestone": null,
+      "number": 143,
+      "state": "CLOSED",
+      "title": "Capture v2 体验优化：长按提示 / 文本-语音返回 / 附件菜单 / 设置 & 账户",
+      "updated_at": "2026-04-29T05:10:30Z",
+      "url": "https://github.com/getyak/daypage/issues/143"
+    },
+    "150": {
+      "assignees": [],
+      "closed_at": "2026-04-29T04:17:50Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-27T14:58:29Z",
+      "labels": [
+        "bug",
+        "enhancement",
+        "ui",
+        "P0",
+        "ux"
+      ],
+      "milestone": null,
+      "number": 150,
+      "state": "CLOSED",
+      "title": "🐛 Swipe animation stutter + 🏗 Zero-config feedback architecture",
+      "updated_at": "2026-04-29T04:17:50Z",
+      "url": "https://github.com/getyak/daypage/issues/150"
+    },
+    "173": {
+      "assignees": [],
+      "closed_at": "2026-04-29T07:13:24Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T06:23:31Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 173,
+      "state": "CLOSED",
+      "title": "chore: replace raw print() calls with DayPageLogger in VaultInitializer and WatchReceiveService",
+      "updated_at": "2026-04-29T07:13:24Z",
+      "url": "https://github.com/getyak/daypage/issues/173"
+    },
+    "175": {
+      "assignees": [],
+      "closed_at": "2026-04-29T07:24:08Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T06:33:40Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 175,
+      "state": "CLOSED",
+      "title": "perf/sec: WeatherService — add request timeout + avoid logging API key in URL",
+      "updated_at": "2026-04-29T07:24:08Z",
+      "url": "https://github.com/getyak/daypage/issues/175"
+    },
+    "177": {
+      "assignees": [],
+      "closed_at": "2026-04-29T07:04:55Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T06:45:04Z",
+      "labels": [
+        "bug"
+      ],
+      "milestone": null,
+      "number": 177,
+      "state": "CLOSED",
+      "title": "fix(build): iCloudConflictMonitor.swift not registered in pbxproj — iOS build broken",
+      "updated_at": "2026-04-29T07:04:55Z",
+      "url": "https://github.com/getyak/daypage/issues/177"
+    },
+    "181": {
+      "assignees": [],
+      "closed_at": "2026-04-29T07:24:43Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T07:04:12Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 181,
+      "state": "CLOSED",
+      "title": "refactor: centralize scattered UserDefaults key literals into AppSettings.Keys",
+      "updated_at": "2026-04-29T07:24:43Z",
+      "url": "https://github.com/getyak/daypage/issues/181"
+    },
+    "184": {
+      "assignees": [],
+      "closed_at": "2026-04-29T07:31:20Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T07:17:40Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 184,
+      "state": "CLOSED",
+      "title": "chore(logger): replace remaining print() with DayPageLogger in BackgroundCompilationService and CompilationService",
+      "updated_at": "2026-04-29T07:31:20Z",
+      "url": "https://github.com/getyak/daypage/issues/184"
+    },
+    "186": {
+      "assignees": [],
+      "closed_at": "2026-04-29T08:40:09Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T07:24:33Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 186,
+      "state": "CLOSED",
+      "title": "fix(feedback): use URLComponents for GitHub API URLs + add offline guard in FeedbackService",
+      "updated_at": "2026-04-29T08:40:09Z",
+      "url": "https://github.com/getyak/daypage/issues/186"
+    },
+    "188": {
+      "assignees": [],
+      "closed_at": "2026-04-29T08:45:11Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T08:40:11Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 188,
+      "state": "CLOSED",
+      "title": "perf(logger): cache ISO8601DateFormatter in DayPageLogger + only breadcrumb errors (no per-call Sentry event)",
+      "updated_at": "2026-04-29T08:45:11Z",
+      "url": "https://github.com/getyak/daypage/issues/188"
+    },
+    "190": {
+      "assignees": [],
+      "closed_at": "2026-04-29T09:00:41Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T08:47:01Z",
+      "labels": [
+        "bug"
+      ],
+      "milestone": null,
+      "number": 190,
+      "state": "CLOSED",
+      "title": "fix: eliminate force-unwraps in VoiceService, SettingsView, and BackgroundCompilationService",
+      "updated_at": "2026-04-29T09:00:41Z",
+      "url": "https://github.com/getyak/daypage/issues/190"
+    },
+    "192": {
+      "assignees": [],
+      "closed_at": "2026-04-29T09:00:27Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T08:51:44Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 192,
+      "state": "CLOSED",
+      "title": "perf: cache DateFormatter instances to avoid repeated expensive allocations",
+      "updated_at": "2026-04-29T09:00:27Z",
+      "url": "https://github.com/getyak/daypage/issues/192"
+    },
+    "194": {
+      "assignees": [],
+      "closed_at": "2026-04-29T09:34:59Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T09:03:04Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 194,
+      "state": "CLOSED",
+      "title": "perf: cache DateFormatter instances in RelativeTimeFormatter (called per memo card)",
+      "updated_at": "2026-04-29T09:34:59Z",
+      "url": "https://github.com/getyak/daypage/issues/194"
+    },
+    "196": {
+      "assignees": [],
+      "closed_at": "2026-04-29T09:34:12Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-29T09:13:28Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 196,
+      "state": "CLOSED",
+      "title": "refactor: consolidate remaining AppSettings UserDefaults keys into AppSettings.Keys",
+      "updated_at": "2026-04-29T09:34:12Z",
+      "url": "https://github.com/getyak/daypage/issues/196"
+    },
+    "198": {
+      "assignees": [],
+      "closed_at": "2026-04-29T17:06:38Z",
+      "closed_by": "kubbot",
+      "comments": 1,
+      "created_at": "2026-04-29T17:06:29Z",
+      "labels": [
+        "enhancement"
+      ],
+      "milestone": null,
+      "number": 198,
+      "state": "CLOSED",
+      "title": "[TEST] Feedback system integration test",
+      "updated_at": "2026-04-29T17:06:38Z",
+      "url": "https://github.com/getyak/daypage/issues/198"
+    },
+    "200": {
+      "assignees": [],
+      "closed_at": "2026-04-30T06:34:30Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-30T06:29:24Z",
+      "labels": [
+        "improvement"
+      ],
+      "milestone": null,
+      "number": 200,
+      "state": "CLOSED",
+      "title": "Implement compilation logic to resolve queuing bottleneck",
+      "updated_at": "2026-04-30T06:34:30Z",
+      "url": "https://github.com/getyak/daypage/issues/200"
+    },
+    "203": {
+      "assignees": [],
+      "closed_at": "2026-04-30T15:44:40Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-30T15:15:45Z",
+      "labels": [
+        "bug"
+      ],
+      "milestone": null,
+      "number": 203,
+      "state": "CLOSED",
+      "title": "Long voice transcription text truncated after sending",
+      "updated_at": "2026-04-30T15:44:40Z",
+      "url": "https://github.com/getyak/daypage/issues/203"
+    },
+    "204": {
+      "assignees": [],
+      "closed_at": "2026-05-01T04:12:37Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-04-30T15:17:01Z",
+      "labels": [
+        "bug"
+      ],
+      "milestone": null,
+      "number": 204,
+      "state": "CLOSED",
+      "title": "Pinning an item incorrectly updates its timestamp instead of keeping original time",
+      "updated_at": "2026-05-01T04:12:37Z",
+      "url": "https://github.com/getyak/daypage/issues/204"
+    },
+    "208": {
+      "assignees": [],
+      "closed_at": "2026-05-01T06:25:07Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-05-01T03:45:44Z",
+      "labels": [
+        "improvement"
+      ],
+      "milestone": null,
+      "number": 208,
+      "state": "CLOSED",
+      "title": "Optimize swipe gesture smoothness for voice/image input to match native feel",
+      "updated_at": "2026-05-01T06:25:07Z",
+      "url": "https://github.com/getyak/daypage/issues/208"
+    },
+    "212": {
+      "assignees": [],
+      "closed_at": "2026-05-01T09:56:08Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-05-01T07:19:11Z",
+      "labels": [
+        "triage"
+      ],
+      "milestone": null,
+      "number": 212,
+      "state": "CLOSED",
+      "title": "他现在点击录制语音，如果是在反馈那边 如果是单机的话 好像会一直闪烁 也就是说单机是不支持 但我希望单机后也会开始录制 然后可以继续暂停 可以参考他目前输入框…",
+      "updated_at": "2026-05-01T09:56:08Z",
+      "url": "https://github.com/getyak/daypage/issues/212"
+    },
+    "213": {
+      "assignees": [],
+      "closed_at": "2026-05-01T09:38:37Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-05-01T09:08:52Z",
+      "labels": [
+        "triage"
+      ],
+      "milestone": null,
+      "number": 213,
+      "state": "CLOSED",
+      "title": "后来觉得现在编译按钮还是隐藏掉比较好 应该还是对用户最好还是没有感觉吧 就让他自己在后台自己去编译 这样的话可能更符合用户的直觉 但现在的话他好像 他他他他就…",
+      "updated_at": "2026-05-01T09:38:37Z",
+      "url": "https://github.com/getyak/daypage/issues/213"
+    },
+    "214": {
+      "assignees": [],
+      "closed_at": "2026-05-01T10:45:34Z",
+      "closed_by": "cubxxw",
+      "comments": 1,
+      "created_at": "2026-05-01T09:11:11Z",
+      "labels": [
+        "triage"
+      ],
+      "milestone": null,
+      "number": 214,
+      "state": "CLOSED",
+      "title": "好像在提交的模式下 在feedback 这个反馈的场景下 它好像并没有一个非常好的 反馈到主页的一种方式 我希望它能有这样的一个 方式吧 或者是 把它作为一个…",
+      "updated_at": "2026-05-01T10:45:34Z",
+      "url": "https://github.com/getyak/daypage/issues/214"
+    },
+    "217": {
+      "assignees": [],
+      "closed_at": null,
+      "closed_by": null,
+      "comments": 1,
+      "created_at": "2026-05-01T10:31:40Z",
+      "labels": [
+        "triage"
+      ],
+      "milestone": null,
+      "number": 217,
+      "state": "OPEN",
+      "title": "一闪一闪的，很迷惑，就是点击一次后，感觉不稳定了深度思考优化",
+      "updated_at": "2026-05-01T10:32:07Z",
+      "url": "https://github.com/getyak/daypage/issues/217"
+    },
+    "219": {
+      "assignees": [],
+      "closed_at": null,
+      "closed_by": null,
+      "comments": 1,
+      "created_at": "2026-05-01T11:01:01Z",
+      "labels": [
+        "triage"
+      ],
+      "milestone": null,
+      "number": 219,
+      "state": "OPEN",
+      "title": "它现在好像就是我点击图片功能好像它并不被去加载图片 好像这个地方是有bug或者是有卡顿的 我希望你们帮我检查一下",
+      "updated_at": "2026-05-01T11:01:05Z",
+      "url": "https://github.com/getyak/daypage/issues/219"
+    }
+  },
+  "last_synced_at": "2026-05-04T04:12:51+00:00",
+  "repo": "getyak/daypage"
+}

--- a/ISSUE_STATUS.md
+++ b/ISSUE_STATUS.md
@@ -1,0 +1,56 @@
+# 📡 Issue Pulse — Status Dashboard
+**Repository:** [`getyak/daypage`](https://github.com/getyak/daypage)  
+**Last update:** `2026-05-04T04:12:51+00:00`  
+**Generated:** `2026-05-04T04:12:51+00:00`
+
+---
+
+## 🔴 Open Issues
+
+| # | Title | Labels | Assignees | Milestone | 💬 | Created | Updated | Age (created) | Stale (updated) |
+|---|---|---|---|---|---|---|---|---|---|
+| #217 | [一闪一闪的，很迷惑，就是点击一次后，感觉不稳定了深度思考优化](https://github.com/getyak/daypage/issues/217) | `triage` | — | — | 1 | 2026-05-01 | 2026-05-01 | 2d | 2d |
+| #219 | [它现在好像就是我点击图片功能好像它并不被去加载图片 好像这个地方是有bug或者是有卡顿的 我希望你们帮我检查一下](https://github.com/getyak/daypage/issues/219) | `triage` | — | — | 1 | 2026-05-01 | 2026-05-01 | 2d | 2d |
+
+## 🟢 Recently Closed
+
+| # | Title | Closed by | Closed |
+|---|---|---|---|
+| #214 | [好像在提交的模式下 在feedback 这个反馈的场景下 它好像并没有一个非常好的 反馈到主页的一种方式 我希望它能有这样的一个 方式吧 或者是 把它作为一个…](https://github.com/getyak/daypage/issues/214) | cubxxw | 2026-05-01 |
+| #212 | [他现在点击录制语音，如果是在反馈那边 如果是单机的话 好像会一直闪烁 也就是说单机是不支持 但我希望单机后也会开始录制 然后可以继续暂停 可以参考他目前输入框…](https://github.com/getyak/daypage/issues/212) | cubxxw | 2026-05-01 |
+| #213 | [后来觉得现在编译按钮还是隐藏掉比较好 应该还是对用户最好还是没有感觉吧 就让他自己在后台自己去编译 这样的话可能更符合用户的直觉 但现在的话他好像 他他他他就…](https://github.com/getyak/daypage/issues/213) | cubxxw | 2026-05-01 |
+| #208 | [Optimize swipe gesture smoothness for voice/image input to match native feel](https://github.com/getyak/daypage/issues/208) | cubxxw | 2026-05-01 |
+| #204 | [Pinning an item incorrectly updates its timestamp instead of keeping original time](https://github.com/getyak/daypage/issues/204) | cubxxw | 2026-05-01 |
+| #203 | [Long voice transcription text truncated after sending](https://github.com/getyak/daypage/issues/203) | cubxxw | 2026-04-30 |
+| #200 | [Implement compilation logic to resolve queuing bottleneck](https://github.com/getyak/daypage/issues/200) | cubxxw | 2026-04-30 |
+| #198 | [[TEST] Feedback system integration test](https://github.com/getyak/daypage/issues/198) | kubbot | 2026-04-29 |
+| #194 | [perf: cache DateFormatter instances in RelativeTimeFormatter (called per memo card)](https://github.com/getyak/daypage/issues/194) | cubxxw | 2026-04-29 |
+| #196 | [refactor: consolidate remaining AppSettings UserDefaults keys into AppSettings.Keys](https://github.com/getyak/daypage/issues/196) | cubxxw | 2026-04-29 |
+| #190 | [fix: eliminate force-unwraps in VoiceService, SettingsView, and BackgroundCompilationService](https://github.com/getyak/daypage/issues/190) | cubxxw | 2026-04-29 |
+| #192 | [perf: cache DateFormatter instances to avoid repeated expensive allocations](https://github.com/getyak/daypage/issues/192) | cubxxw | 2026-04-29 |
+| #188 | [perf(logger): cache ISO8601DateFormatter in DayPageLogger + only breadcrumb errors (no per-call Sentry event)](https://github.com/getyak/daypage/issues/188) | cubxxw | 2026-04-29 |
+| #186 | [fix(feedback): use URLComponents for GitHub API URLs + add offline guard in FeedbackService](https://github.com/getyak/daypage/issues/186) | cubxxw | 2026-04-29 |
+| #184 | [chore(logger): replace remaining print() with DayPageLogger in BackgroundCompilationService and CompilationService](https://github.com/getyak/daypage/issues/184) | cubxxw | 2026-04-29 |
+| #181 | [refactor: centralize scattered UserDefaults key literals into AppSettings.Keys](https://github.com/getyak/daypage/issues/181) | cubxxw | 2026-04-29 |
+| #175 | [perf/sec: WeatherService — add request timeout + avoid logging API key in URL](https://github.com/getyak/daypage/issues/175) | cubxxw | 2026-04-29 |
+| #173 | [chore: replace raw print() calls with DayPageLogger in VaultInitializer and WatchReceiveService](https://github.com/getyak/daypage/issues/173) | cubxxw | 2026-04-29 |
+| #177 | [fix(build): iCloudConflictMonitor.swift not registered in pbxproj — iOS build broken](https://github.com/getyak/daypage/issues/177) | cubxxw | 2026-04-29 |
+| #143 | [Capture v2 体验优化：长按提示 / 文本-语音返回 / 附件菜单 / 设置 & 账户](https://github.com/getyak/daypage/issues/143) | cubxxw | 2026-04-29 |
+| #150 | [🐛 Swipe animation stutter + 🏗 Zero-config feedback architecture](https://github.com/getyak/daypage/issues/150) | cubxxw | 2026-04-29 |
+| #137 | [代码注释中文化 — 全部 Swift 代码注释翻译为中文](https://github.com/getyak/daypage/issues/137) | cubxxw | 2026-04-27 |
+| #136 | [🚀 Linear Automation Test](https://github.com/getyak/daypage/issues/136) | cubxxw | 2026-04-27 |
+| #132 | [[Refactor] CompilationService 若干质量问题修复](https://github.com/getyak/daypage/issues/132) | cubxxw | 2026-04-25 |
+| #126 | [feat: Replace bottom tab bar with Flomo-style hidden sidebar navigation](https://github.com/getyak/daypage/issues/126) | cubxxw | 2026-04-23 |
+
+## 📈 Stats
+
+- 🔴 Open: **2**
+- 🟢 Closed (recent window): **25**
+- Σ Tracked total: **27**
+- ⏱️ Avg time to close (rolling): **0.2 days**
+- 🚨 Stale open by last activity (>30d): **0**
+- 📅 Oldest open by creation: **2d**
+
+---
+
+_Legend: ⚠️ no activity >7 days · 🚨 no activity >30 days_

--- a/issue_pulse/README.md
+++ b/issue_pulse/README.md
@@ -1,0 +1,177 @@
+# 📡 Issue Pulse
+
+A small Python tool that tracks the state of GitHub issues for a repository,
+caches snapshots locally, detects state transitions between scans, and renders
+a clean Markdown dashboard.
+
+Default target repo: **`getyak/daypage`**.
+
+## Requirements
+
+- Python 3.10+
+- [`gh` CLI](https://cli.github.com/) authenticated against GitHub
+  (`gh auth status` should report a logged-in account)
+
+No third-party Python packages are needed — only the standard library.
+
+## Layout
+
+```
+issue_pulse/
+  __init__.py
+  config.py          # default repo, paths, thresholds (env-overridable)
+  tracker.py         # gh CLI calls, cache I/O, diff detection, incremental sync
+  display.py         # ISSUE_STATUS.md rendering
+  cli.py             # scan / status / watch / diff
+  pyproject.toml     # `pip install .` → `issue-pulse` entry point
+  README.md
+  tests/
+    test_tracker.py  # tracker + display unit tests (gh mocked)
+    test_cli.py      # CLI tests (tracker.scan mocked)
+```
+
+Generated artefacts live alongside the package (override paths via env vars):
+
+- `.issue_cache.json`      — last fetched snapshot (atomic JSON write)
+- `issue_changelog.log`    — append-only JSONL log of every state change
+- `ISSUE_STATUS.md`        — the human-readable dashboard
+
+## Install
+
+Install as a CLI from the package dir:
+
+```bash
+pip install ./issue_pulse
+issue-pulse scan
+```
+
+Or run directly from the repo root without installing:
+
+```bash
+python3 -m issue_pulse.cli scan
+```
+
+## Usage
+
+```bash
+# Query GitHub, refresh the cache, and regenerate ISSUE_STATUS.md
+issue-pulse scan
+
+# Force a full sync (bypass incremental delta)
+issue-pulse scan --full
+
+# Print the current dashboard to stdout
+issue-pulse status
+
+# Show the most recent state changes from the changelog
+issue-pulse diff --limit 30
+
+# Poll on an interval (default 300s) — auto-backs off on errors
+issue-pulse watch --interval 600
+
+# Override the default repo
+issue-pulse --repo someone/other-repo scan
+```
+
+## Sync strategy
+
+- **First run** — full sync: fetches all OPEN issues plus the most recent
+  N CLOSED issues (`RECENT_CLOSED_LIMIT`).
+- **Subsequent runs** — incremental: queries only issues with
+  `updated:>=<last_synced_at - 5m>` and overlays them on the cached
+  snapshot. Falls back to full sync if the cache is older than
+  `INCREMENTAL_MAX_AGE_DAYS` (7 by default) or if `--full` is passed.
+
+## What it tracks
+
+For each issue: `number`, `title`, `state`, `labels`, `assignees`,
+`milestone`, `comments`, `created_at`, `updated_at`, `closed_at`,
+`closed_by`, `url`.
+
+`closed_by` is resolved from the GitHub REST timeline endpoint
+(`repos/{owner}/{repo}/issues/{n}/timeline`) — `gh issue view --json closedBy`
+does **not** exist. Lookups for newly-closed issues run in parallel
+(`ThreadPoolExecutor`, default 5 workers).
+
+State transitions detected and written to the changelog:
+
+| Kind               | Trigger                                                                       |
+| ------------------ | ----------------------------------------------------------------------------- |
+| `opened`           | issue appeared in this scan and is OPEN                                       |
+| `closed`           | issue was OPEN previously and CLOSED was observed via API                     |
+| `reopened`         | issue was CLOSED previously, OPEN now                                         |
+| `labels_changed`   | label set differs (with added/removed list)                                   |
+| `unknown_dropped`  | issue dropped out of the open window without a confirmed CLOSED observation   |
+
+`unknown_dropped` exists so the tool never fabricates a "closed" event
+just because an issue scrolled past the fetch window.
+
+## Dashboard
+
+`ISSUE_STATUS.md` includes:
+
+- header with repo, fetch timestamp, generation timestamp
+- 🔴 **Open Issues** — table sorted by age, with assignees, milestone,
+  comment count, ⚠️ for >7 days no activity and 🚨 for >30 days
+  no activity (staleness is by `updated_at`, not `created_at`)
+- 🟢 **Recently Closed** — most recent N closed issues with `closed_by`
+- 📈 **Stats** — open/closed counts, total, avg time to close (rolling),
+  stale count, oldest open issue by creation
+
+Average time-to-close is computed from a **persistent rolling counter**
+stored in `.issue_cache.json` (`close_time_total_seconds`,
+`close_time_count`), not just the visible 25-issue window — so the metric
+remains meaningful across many scans.
+
+## Testing
+
+```bash
+python3 -m pytest issue_pulse/tests/ -v
+# or:
+python3 -m unittest discover -s issue_pulse/tests -v
+```
+
+The suite covers cache round-trip, change detection, display formatting,
+incremental sync, rolling stats, and `gh` CLI invocation — all with
+network calls mocked.
+
+## Configuration
+
+Tweak `issue_pulse/config.py` or set environment variables:
+
+| Setting                       | Env var          | Default                       |
+| ----------------------------- | ---------------- | ----------------------------- |
+| `DEFAULT_REPO`                | `IP_REPO`        | `getyak/daypage`              |
+| `CACHE_PATH`                  | `IP_CACHE_PATH`  | `<repo>/.issue_cache.json`    |
+| `CHANGELOG_PATH`              | `IP_CHANGELOG`   | `<repo>/issue_changelog.log`  |
+| `OUTPUT_PATH`                 | `IP_OUTPUT`      | `<repo>/ISSUE_STATUS.md`      |
+| `REFRESH_INTERVAL_SECONDS`    | —                | `300`                         |
+| `WARNING_THRESHOLD_DAYS`      | —                | `7`                           |
+| `STALE_THRESHOLD_DAYS`        | —                | `30`                          |
+| `RECENT_CLOSED_LIMIT`         | —                | `25`                          |
+| `ISSUE_FETCH_LIMIT`           | —                | `500` (see below)             |
+| `CLOSED_BY_MAX_WORKERS`       | —                | `5`                           |
+| `INCREMENTAL_MAX_AGE_DAYS`    | —                | `7`                           |
+
+### Note on the 500-issue fetch cap
+
+`ISSUE_FETCH_LIMIT = 500` is a hard ceiling on how many issues we ask
+`gh issue list` to return per request. For most repos this is far more
+than needed; for very large repos with thousands of open issues, lift
+this cap in `config.py`. The incremental sync path mitigates this in
+day-to-day use because each delta query only fetches issues touched
+since the last scan.
+
+## Error handling
+
+- `gh` failures (auth, rate limit, network) raise a `RuntimeError` and
+  are surfaced as a non-zero exit from `issue-pulse scan`.
+- `issue-pulse watch` keeps running on errors and uses **exponential
+  backoff** (`interval × 2^(consecutive_errors-1)`, capped at
+  `max(interval × 8, 600)` seconds).
+- Missing or corrupt cache files are treated as "first run" — the next
+  scan rebuilds the cache.
+- Cache writes are atomic (`tempfile` + `os.replace`) so an interrupted
+  scan cannot leave a half-written file.
+- URLs returned by `gh` are validated against the
+  `https://github.com/` prefix; anything else is dropped.

--- a/issue_pulse/__init__.py
+++ b/issue_pulse/__init__.py
@@ -1,0 +1,3 @@
+"""Issue Pulse — GitHub issue status tracker."""
+
+__version__ = "0.1.0"

--- a/issue_pulse/__main__.py
+++ b/issue_pulse/__main__.py
@@ -1,0 +1,5 @@
+"""Allow running `python3 -m issue_pulse` as a shorthand."""
+
+from issue_pulse.cli import main
+
+main()

--- a/issue_pulse/cli.py
+++ b/issue_pulse/cli.py
@@ -1,0 +1,171 @@
+"""Command-line interface for Issue Pulse.
+
+Subcommands:
+    scan    — query GitHub, update cache, regenerate ISSUE_STATUS.md
+    status  — print the current dashboard to the terminal
+    watch   — repeatedly scan on an interval
+    diff    — show changes since the last scan (from the changelog)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import time
+from pathlib import Path
+
+from . import config
+from .display import write_dashboard
+from .tracker import scan
+
+
+_KIND_MARKERS: dict[str, str] = {
+    "opened": "✨",
+    "reopened": "🔁",
+    "closed": "✅",
+    "labels_changed": "🏷️ ",
+    "unknown_dropped": "❓",
+}
+
+
+def _print_summary(repo: str, scan_result: tuple) -> None:
+    open_issues, closed_issues, changes = scan_result
+    print(f"[issue-pulse] repo={repo}")
+    print(f"  open    : {len(open_issues)}")
+    print(f"  closed  : {len(closed_issues)} (recent window)")
+    print(f"  changes : {len(changes)}")
+    for change in changes:
+        marker = _KIND_MARKERS.get(change.kind, "•")
+        title = change.title[:60]
+        print(f"    {marker} #{change.number} {change.kind:<16} {title}")
+
+
+def cmd_scan(args: argparse.Namespace) -> int:
+    try:
+        result = scan(repo=args.repo, force_full=getattr(args, "full", False))
+    except RuntimeError as exc:
+        print(f"[issue-pulse] scan failed: {exc}", file=sys.stderr)
+        return 2
+    _print_summary(args.repo, result)
+    out_path = write_dashboard(repo=args.repo)
+    print(f"[issue-pulse] wrote {out_path}")
+    return 0
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    path: Path = config.OUTPUT_PATH
+    if not path.exists():
+        print(
+            "[issue-pulse] no dashboard yet — run `python -m issue_pulse.cli scan` first",
+            file=sys.stderr,
+        )
+        return 1
+    sys.stdout.write(path.read_text(encoding="utf-8"))
+    return 0
+
+
+def cmd_watch(args: argparse.Namespace) -> int:
+    interval = max(10, int(args.interval))
+    print(f"[issue-pulse] watching {args.repo} every {interval}s — Ctrl+C to stop")
+    consecutive_errors = 0
+    max_backoff = max(interval * 8, 600)
+    try:
+        while True:
+            try:
+                result = scan(repo=args.repo)
+                _print_summary(args.repo, result)
+                write_dashboard(repo=args.repo)
+                consecutive_errors = 0
+                sleep_for = interval
+            except RuntimeError as exc:
+                consecutive_errors += 1
+                # Exponential backoff: interval * 2^(n-1), capped.
+                sleep_for = min(interval * (2 ** (consecutive_errors - 1)), max_backoff)
+                print(
+                    f"[issue-pulse] scan failed (#{consecutive_errors}, backing off {sleep_for}s): {exc}",
+                    file=sys.stderr,
+                )
+            time.sleep(sleep_for)
+    except KeyboardInterrupt:
+        print("\n[issue-pulse] stopped")
+        return 0
+
+
+def cmd_diff(args: argparse.Namespace) -> int:
+    path: Path = config.CHANGELOG_PATH
+    if not path.exists():
+        print("[issue-pulse] no changelog yet — run a scan first")
+        return 0
+    lines = path.read_text(encoding="utf-8").splitlines()
+    tail = lines[-args.limit:] if args.limit > 0 else lines
+    if not tail:
+        print("[issue-pulse] changelog is empty")
+        return 0
+    for raw in tail:
+        try:
+            entry = json.loads(raw)
+        except json.JSONDecodeError:
+            continue
+        ts = entry.get("timestamp", "")
+        kind = entry.get("kind", "?")
+        number = entry.get("number", "?")
+        title = entry.get("title", "")
+        detail = entry.get("detail", "")
+        print(f"{ts}  {kind:<16} #{number}  {title}  ({detail})")
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="issue-pulse",
+        description="Track GitHub issue status for a repository.",
+    )
+    parser.add_argument(
+        "--repo",
+        default=config.DEFAULT_REPO,
+        help=f"Repo in OWNER/NAME form (default: {config.DEFAULT_REPO})",
+    )
+
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    scan_p = sub.add_parser("scan", help="Query GitHub, update cache, regenerate dashboard")
+    scan_p.add_argument(
+        "--full",
+        action="store_true",
+        help="Force a full sync instead of incremental delta",
+    )
+    sub.add_parser("status", help="Print the current dashboard markdown")
+
+    watch = sub.add_parser("watch", help="Poll repeatedly")
+    watch.add_argument(
+        "--interval",
+        type=int,
+        default=config.REFRESH_INTERVAL_SECONDS,
+        help=f"Seconds between polls (default: {config.REFRESH_INTERVAL_SECONDS})",
+    )
+
+    diff = sub.add_parser("diff", help="Show recent changes from the changelog")
+    diff.add_argument(
+        "--limit", type=int, default=20, help="How many recent entries to show",
+    )
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    if args.command == "scan":
+        return cmd_scan(args)
+    if args.command == "status":
+        return cmd_status(args)
+    if args.command == "watch":
+        return cmd_watch(args)
+    if args.command == "diff":
+        return cmd_diff(args)
+    parser.print_help()
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/issue_pulse/config.py
+++ b/issue_pulse/config.py
@@ -1,0 +1,66 @@
+"""Configuration constants for Issue Pulse.
+
+Env-var overrides (read at import time):
+    IP_REPO                — default repository (OWNER/NAME)
+    IP_CACHE_PATH          — path to the JSON cache file
+    IP_CHANGELOG           — path to the JSONL changelog
+    IP_OUTPUT              — path to the rendered dashboard
+    IP_STALE_DAYS          — staleness threshold (days) for 🚨 marker
+    IP_WARNING_DAYS        — warning threshold (days) for ⚠️ marker
+    IP_CLOSED_LIMIT        — recent closed issues to fetch/display
+    IP_INCREMENTAL_MAX_AGE — max cache age (days) before forcing full sync
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def _int_from_env(name: str, default: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError:
+        return default
+
+
+DEFAULT_REPO: str = os.environ.get("IP_REPO", "getyak/daypage")
+REFRESH_INTERVAL_SECONDS: int = 300
+STALE_THRESHOLD_DAYS: int = _int_from_env("IP_STALE_DAYS", 30)
+WARNING_THRESHOLD_DAYS: int = _int_from_env("IP_WARNING_DAYS", 7)
+
+# Paths are anchored to this package directory so the tool works from any cwd.
+PACKAGE_DIR: Path = Path(__file__).resolve().parent
+ROOT_DIR: Path = PACKAGE_DIR.parent
+
+
+def _path_from_env(name: str, default: Path) -> Path:
+    raw = os.environ.get(name)
+    return Path(raw).expanduser() if raw else default
+
+
+CACHE_PATH: Path = _path_from_env("IP_CACHE_PATH", ROOT_DIR / ".issue_cache.json")
+CHANGELOG_PATH: Path = _path_from_env("IP_CHANGELOG", ROOT_DIR / "issue_changelog.log")
+OUTPUT_PATH: Path = _path_from_env("IP_OUTPUT", ROOT_DIR / "ISSUE_STATUS.md")
+
+# How many recently-closed issues to fetch and display.
+RECENT_CLOSED_LIMIT: int = _int_from_env("IP_CLOSED_LIMIT", 25)
+# Hard cap on how many issues to request from the GitHub API per state.
+# This is a deliberate ceiling to keep scans bounded; very large repos may
+# need to lift it. See README for details.
+ISSUE_FETCH_LIMIT: int = 500
+
+# Concurrency for per-issue lookups (closed_by) on newly-closed issues.
+CLOSED_BY_MAX_WORKERS: int = 5
+
+# Incremental-sync window: if cache.last_synced_at is older than this many
+# days, fall back to a full scan rather than relying on a delta query.
+INCREMENTAL_MAX_AGE_DAYS: int = _int_from_env("IP_INCREMENTAL_MAX_AGE", 7)
+
+# Prune closed issues older than this from the persisted cache to bound size.
+CLOSED_CACHE_RETENTION_DAYS: int = 90
+
+# Cap on the rolling-counter "counted" set persisted to disk.
+COUNTED_CLOSED_CAP: int = 1000

--- a/issue_pulse/display.py
+++ b/issue_pulse/display.py
@@ -1,0 +1,280 @@
+"""Status dashboard generator.
+
+Renders ISSUE_STATUS.md from the cache produced by `tracker.py`.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from . import config
+from .tracker import Issue, load_cache
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+
+
+def _days_since(ts: str | None, now: datetime) -> int | None:
+    parsed = _parse_iso(ts)
+    if parsed is None:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return (now - parsed).days
+
+
+def _urgency_marker(days: int | None) -> str:
+    if days is None:
+        return ""
+    if days >= config.STALE_THRESHOLD_DAYS:
+        return "🚨"
+    if days >= config.WARNING_THRESHOLD_DAYS:
+        return "⚠️"
+    return ""
+
+
+def _escape_md(text: str) -> str:
+    """Escape characters that would break a markdown table cell."""
+    return text.replace("|", "\\|").replace("\n", " ").strip()
+
+
+def _format_labels(labels: Iterable[str]) -> str:
+    items = [f"`{lbl}`" for lbl in labels if lbl]
+    return ", ".join(items) if items else "—"
+
+
+def _format_assignees(assignees: Iterable[str]) -> str:
+    items = [f"@{a}" for a in assignees if a]
+    return ", ".join(items) if items else "—"
+
+
+def _format_short_date(ts: str | None) -> str:
+    parsed = _parse_iso(ts)
+    if parsed is None:
+        return "—"
+    return parsed.strftime("%Y-%m-%d")
+
+
+# ---------------------------------------------------------------------------
+# Stats
+# ---------------------------------------------------------------------------
+
+def compute_stats(
+    open_issues: list[Issue],
+    closed_issues: list[Issue],
+    now: datetime | None = None,
+    rolling_total_seconds: float | None = None,
+    rolling_count: int | None = None,
+) -> dict[str, float | int]:
+    """Compute summary stats over the cached issues.
+
+    Staleness is measured by `updated_at` (last activity) rather than
+    `created_at`, so a still-discussed issue isn't flagged as stale.
+
+    If `rolling_total_seconds` and `rolling_count` are provided, avg
+    time-to-close is computed from that persistent counter; otherwise it
+    falls back to the in-window closed issues.
+    """
+    now = now or datetime.now(timezone.utc)
+    stale = 0
+    for issue in open_issues:
+        # Prefer updated_at; fall back to created_at if missing.
+        days = _days_since(issue.updated_at or issue.created_at, now)
+        if days is not None and days >= config.STALE_THRESHOLD_DAYS:
+            stale += 1
+
+    if rolling_count and rolling_total_seconds is not None and rolling_count > 0:
+        avg_close_days = (rolling_total_seconds / rolling_count) / 86400
+    else:
+        durations: list[float] = []
+        for issue in closed_issues:
+            created = _parse_iso(issue.created_at)
+            closed = _parse_iso(issue.closed_at)
+            if created and closed:
+                if created.tzinfo is None:
+                    created = created.replace(tzinfo=timezone.utc)
+                if closed.tzinfo is None:
+                    closed = closed.replace(tzinfo=timezone.utc)
+                durations.append((closed - created).total_seconds() / 86400)
+        avg_close_days = sum(durations) / len(durations) if durations else 0.0
+
+    # Also expose oldest-by-creation, since "age by creation" is still useful.
+    oldest_age = 0
+    for issue in open_issues:
+        days = _days_since(issue.created_at, now)
+        if days is not None and days > oldest_age:
+            oldest_age = days
+
+    return {
+        "open_count": len(open_issues),
+        "closed_count": len(closed_issues),
+        "total": len(open_issues) + len(closed_issues),
+        "avg_close_days": round(avg_close_days, 2),
+        "stale_count": stale,
+        "oldest_open_age_days": oldest_age,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Markdown rendering
+# ---------------------------------------------------------------------------
+
+def render_open_table(open_issues: list[Issue], now: datetime) -> str:
+    if not open_issues:
+        return "_No open issues — inbox zero._\n"
+
+    sorted_issues = sorted(
+        open_issues,
+        key=lambda i: _parse_iso(i.created_at) or datetime.min.replace(tzinfo=timezone.utc),
+    )
+
+    lines = [
+        "| # | Title | Labels | Assignees | Milestone | 💬 | Created | Updated | Age (created) | Stale (updated) |",
+        "|---|---|---|---|---|---|---|---|---|---|",
+    ]
+    for issue in sorted_issues:
+        age_days = _days_since(issue.created_at, now)
+        stale_days = _days_since(issue.updated_at or issue.created_at, now)
+        marker = _urgency_marker(stale_days)
+        age_text = f"{age_days}d" if age_days is not None else "—"
+        stale_text = f"{marker} {stale_days}d".strip() if stale_days is not None else "—"
+        title = _escape_md(issue.title)
+        title_cell = f"[{title}]({issue.url})" if issue.url else title
+        lines.append(
+            f"| #{issue.number} "
+            f"| {title_cell} "
+            f"| {_format_labels(issue.labels)} "
+            f"| {_format_assignees(issue.assignees)} "
+            f"| {issue.milestone or '—'} "
+            f"| {issue.comments} "
+            f"| {_format_short_date(issue.created_at)} "
+            f"| {_format_short_date(issue.updated_at)} "
+            f"| {age_text} "
+            f"| {stale_text} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_closed_table(closed_issues: list[Issue]) -> str:
+    if not closed_issues:
+        return "_No recently-closed issues._\n"
+
+    sorted_issues = sorted(
+        closed_issues,
+        key=lambda i: _parse_iso(i.closed_at) or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )[: config.RECENT_CLOSED_LIMIT]
+
+    lines = [
+        "| # | Title | Closed by | Closed |",
+        "|---|---|---|---|",
+    ]
+    for issue in sorted_issues:
+        title = _escape_md(issue.title)
+        title_cell = f"[{title}]({issue.url})" if issue.url else title
+        lines.append(
+            f"| #{issue.number} "
+            f"| {title_cell} "
+            f"| {issue.closed_by or '—'} "
+            f"| {_format_short_date(issue.closed_at)} |"
+        )
+    return "\n".join(lines) + "\n"
+
+
+def render_stats(stats: dict[str, float | int]) -> str:
+    return (
+        f"- 🔴 Open: **{stats['open_count']}**\n"
+        f"- 🟢 Closed (recent window): **{stats['closed_count']}**\n"
+        f"- Σ Tracked total: **{stats['total']}**\n"
+        f"- ⏱️ Avg time to close (rolling): **{stats['avg_close_days']} days**\n"
+        f"- 🚨 Stale open by last activity (>{config.STALE_THRESHOLD_DAYS}d): **{stats['stale_count']}**\n"
+        f"- 📅 Oldest open by creation: **{stats['oldest_open_age_days']}d**\n"
+    )
+
+
+def render_dashboard(
+    repo: str,
+    open_issues: list[Issue],
+    closed_issues: list[Issue],
+    fetched_at: str | None = None,
+    now: datetime | None = None,
+    rolling_total_seconds: float | None = None,
+    rolling_count: int | None = None,
+) -> str:
+    """Render the full ISSUE_STATUS.md content as a string."""
+    now = now or datetime.now(timezone.utc)
+    stats = compute_stats(
+        open_issues,
+        closed_issues,
+        now=now,
+        rolling_total_seconds=rolling_total_seconds,
+        rolling_count=rolling_count,
+    )
+    fetched_display = fetched_at or now.isoformat(timespec="seconds")
+
+    parts = [
+        "# 📡 Issue Pulse — Status Dashboard\n",
+        f"**Repository:** [`{repo}`](https://github.com/{repo})  \n",
+        f"**Last update:** `{fetched_display}`  \n",
+        f"**Generated:** `{now.isoformat(timespec='seconds')}`\n",
+        "\n---\n",
+        "\n## 🔴 Open Issues\n\n",
+        render_open_table(open_issues, now),
+        "\n## 🟢 Recently Closed\n\n",
+        render_closed_table(closed_issues),
+        "\n## 📈 Stats\n\n",
+        render_stats(stats),
+        "\n---\n\n",
+        "_Legend: ⚠️ no activity >7 days · 🚨 no activity >30 days_\n",
+    ]
+    return "".join(parts)
+
+
+def write_dashboard(
+    output_path: Path = config.OUTPUT_PATH,
+    cache_path: Path = config.CACHE_PATH,
+    repo: str | None = None,
+) -> Path:
+    """Read the cache and write the rendered dashboard to disk."""
+    cache: dict[str, Any] = load_cache(cache_path)
+    repo_name = repo or cache.get("repo") or config.DEFAULT_REPO
+
+    open_issues: list[Issue] = []
+    closed_issues: list[Issue] = []
+    for raw in (cache.get("issues") or {}).values():
+        try:
+            issue = Issue.from_dict(raw)
+        except (KeyError, TypeError, ValueError):
+            continue
+        if issue.state == "OPEN":
+            open_issues.append(issue)
+        else:
+            closed_issues.append(issue)
+
+    rolling_total = float(cache.get("close_time_total_seconds") or 0.0)
+    rolling_count = int(cache.get("close_time_count") or 0)
+
+    content = render_dashboard(
+        repo=repo_name,
+        open_issues=open_issues,
+        closed_issues=closed_issues,
+        fetched_at=cache.get("fetched_at"),
+        rolling_total_seconds=rolling_total,
+        rolling_count=rolling_count,
+    )
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_text(content, encoding="utf-8")
+    return output_path

--- a/issue_pulse/tests/test_cli.py
+++ b/issue_pulse/tests/test_cli.py
@@ -1,0 +1,115 @@
+"""Tests for issue_pulse.cli — `tracker.scan` is mocked.
+
+Run with:  python -m unittest issue_pulse.tests.test_cli
+"""
+from __future__ import annotations
+
+import io
+import json
+import unittest
+from contextlib import redirect_stdout, redirect_stderr
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from issue_pulse import cli, config, tracker
+
+
+def _make_change(kind: str = "opened", number: int = 1) -> tracker.StateChange:
+    return tracker.StateChange(
+        number=number, title="hello", kind=kind, detail="", timestamp="2026-05-04T00:00:00Z",
+    )
+
+
+class CliScanTests(unittest.TestCase):
+    def test_scan_success_prints_summary_and_writes_dashboard(self) -> None:
+        result = ([], [], [_make_change("opened", 1), _make_change("closed", 2)])
+        with mock.patch("issue_pulse.cli.scan", return_value=result), \
+             mock.patch("issue_pulse.cli.write_dashboard", return_value=Path("/tmp/x.md")) as wrote:
+            buf = io.StringIO()
+            with redirect_stdout(buf):
+                rc = cli.main(["--repo", "x/y", "scan"])
+        self.assertEqual(rc, 0)
+        wrote.assert_called_once_with(repo="x/y")
+        out = buf.getvalue()
+        self.assertIn("opened", out)
+        self.assertIn("closed", out)
+        self.assertIn("repo=x/y", out)
+
+    def test_scan_failure_returns_exit_code_2(self) -> None:
+        with mock.patch("issue_pulse.cli.scan", side_effect=RuntimeError("auth fail")):
+            err = io.StringIO()
+            with redirect_stderr(err):
+                rc = cli.main(["--repo", "x/y", "scan"])
+        self.assertEqual(rc, 2)
+        self.assertIn("auth fail", err.getvalue())
+
+    def test_scan_full_flag_passed_through(self) -> None:
+        with mock.patch("issue_pulse.cli.scan", return_value=([], [], [])) as scanned, \
+             mock.patch("issue_pulse.cli.write_dashboard", return_value=Path("/tmp/x.md")):
+            with redirect_stdout(io.StringIO()):
+                cli.main(["--repo", "x/y", "scan", "--full"])
+        self.assertTrue(scanned.call_args.kwargs.get("force_full"))
+
+
+class CliStatusTests(unittest.TestCase):
+    def test_status_missing_dashboard_returns_1(self) -> None:
+        with TemporaryDirectory() as tmp:
+            with mock.patch.object(config, "OUTPUT_PATH", Path(tmp) / "missing.md"):
+                err = io.StringIO()
+                with redirect_stderr(err):
+                    rc = cli.main(["status"])
+        self.assertEqual(rc, 1)
+        self.assertIn("no dashboard yet", err.getvalue())
+
+    def test_status_prints_dashboard(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "dash.md"
+            path.write_text("# Hello\n", encoding="utf-8")
+            with mock.patch.object(config, "OUTPUT_PATH", path):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    rc = cli.main(["status"])
+        self.assertEqual(rc, 0)
+        self.assertIn("# Hello", buf.getvalue())
+
+
+class CliDiffTests(unittest.TestCase):
+    def test_diff_no_changelog(self) -> None:
+        with TemporaryDirectory() as tmp:
+            with mock.patch.object(config, "CHANGELOG_PATH", Path(tmp) / "no.log"):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    rc = cli.main(["diff"])
+        self.assertEqual(rc, 0)
+        self.assertIn("no changelog yet", buf.getvalue())
+
+    def test_diff_prints_recent(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "log.jsonl"
+            entries = [
+                {"timestamp": "t1", "kind": "opened", "number": 1, "title": "a", "detail": ""},
+                {"timestamp": "t2", "kind": "closed", "number": 2, "title": "b", "detail": "by=x"},
+            ]
+            path.write_text("\n".join(json.dumps(e) for e in entries) + "\n", encoding="utf-8")
+            with mock.patch.object(config, "CHANGELOG_PATH", path):
+                buf = io.StringIO()
+                with redirect_stdout(buf):
+                    rc = cli.main(["diff", "--limit", "1"])
+        self.assertEqual(rc, 0)
+        out = buf.getvalue()
+        # --limit 1 → only the last entry (closed #2)
+        self.assertIn("#2", out)
+        self.assertIn("closed", out)
+        self.assertNotIn("#1", out)
+
+
+class CliMarkerMapTests(unittest.TestCase):
+    def test_marker_map_uses_opened_not_new(self) -> None:
+        self.assertIn("opened", cli._KIND_MARKERS)
+        self.assertNotIn("new", cli._KIND_MARKERS)
+        self.assertIn("unknown_dropped", cli._KIND_MARKERS)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/issue_pulse/tests/test_tracker.py
+++ b/issue_pulse/tests/test_tracker.py
@@ -1,0 +1,391 @@
+"""Tests for issue_pulse.tracker and issue_pulse.display.
+
+Run with:  python -m unittest issue_pulse.tests.test_tracker
+"""
+from __future__ import annotations
+
+import json
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from unittest import mock
+
+from issue_pulse import display, tracker
+
+
+def _issue(
+    number: int,
+    state: str = "OPEN",
+    title: str = "Sample issue",
+    labels: list[str] | None = None,
+    created_days_ago: int = 1,
+    updated_days_ago: int | None = None,
+    closed_days_ago: int | None = None,
+    closed_by: str | None = None,
+    assignees: list[str] | None = None,
+    milestone: str | None = None,
+    comments: int = 0,
+) -> tracker.Issue:
+    now = datetime.now(timezone.utc)
+    created = (now - timedelta(days=created_days_ago)).isoformat(timespec="seconds")
+    updated_ago = updated_days_ago if updated_days_ago is not None else created_days_ago
+    updated = (now - timedelta(days=updated_ago)).isoformat(timespec="seconds")
+    closed = (
+        (now - timedelta(days=closed_days_ago)).isoformat(timespec="seconds")
+        if closed_days_ago is not None
+        else None
+    )
+    return tracker.Issue(
+        number=number,
+        title=title,
+        state=state,
+        labels=labels or [],
+        created_at=created,
+        updated_at=updated,
+        closed_at=closed,
+        closed_by=closed_by,
+        url=f"https://github.com/example/repo/issues/{number}",
+        assignees=assignees or [],
+        milestone=milestone,
+        comments=comments,
+    )
+
+
+class CacheRoundTripTests(unittest.TestCase):
+    def test_save_and_load(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "cache.json"
+            payload = {
+                "repo": "example/repo",
+                "fetched_at": "2026-05-04T00:00:00+00:00",
+                "issues": {"1": _issue(1).to_dict()},
+            }
+            tracker.save_cache(payload, path)
+            self.assertTrue(path.exists())
+            loaded = tracker.load_cache(path)
+            self.assertEqual(loaded["repo"], "example/repo")
+            self.assertIn("1", loaded["issues"])
+            # New skeleton keys should be present after load.
+            self.assertIn("last_synced_at", loaded)
+            self.assertIn("close_time_total_seconds", loaded)
+            self.assertIn("close_time_count", loaded)
+            self.assertIn("counted_closed_numbers", loaded)
+
+    def test_load_missing_returns_skeleton(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "missing.json"
+            data = tracker.load_cache(path)
+            self.assertIsNone(data["repo"])
+            self.assertIsNone(data["fetched_at"])
+            self.assertEqual(data["issues"], {})
+            self.assertEqual(data["close_time_count"], 0)
+
+    def test_load_corrupt_returns_skeleton(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "corrupt.json"
+            path.write_text("{not json", encoding="utf-8")
+            data = tracker.load_cache(path)
+            self.assertEqual(data["issues"], {})
+
+    def test_save_is_atomic(self) -> None:
+        with TemporaryDirectory() as tmp:
+            path = Path(tmp) / "cache.json"
+            tracker.save_cache({"issues": {"1": _issue(1).to_dict()}}, path)
+            tracker.save_cache({"issues": {"2": _issue(2).to_dict()}}, path)
+            data = json.loads(path.read_text(encoding="utf-8"))
+            leftover = list(Path(tmp).glob(".issue_cache.*"))
+            self.assertEqual(leftover, [])
+            self.assertIn("2", data["issues"])
+
+
+class DiffDetectionTests(unittest.TestCase):
+    def test_new_open_issue(self) -> None:
+        prev: dict[int, tracker.Issue] = {}
+        curr = {1: _issue(1)}
+        changes = tracker.diff_issues(prev, curr)
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].kind, "opened")
+
+    def test_open_to_closed(self) -> None:
+        prev = {1: _issue(1, state="OPEN")}
+        curr = {1: _issue(1, state="CLOSED", closed_days_ago=0, closed_by="alice")}
+        changes = tracker.diff_issues(prev, curr, confirmed_closed={1})
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].kind, "closed")
+        self.assertIn("alice", changes[0].detail)
+
+    def test_reopened(self) -> None:
+        prev = {1: _issue(1, state="CLOSED", closed_days_ago=2)}
+        curr = {1: _issue(1, state="OPEN")}
+        changes = tracker.diff_issues(prev, curr)
+        self.assertEqual(changes[0].kind, "reopened")
+
+    def test_label_change(self) -> None:
+        prev = {1: _issue(1, labels=["bug"])}
+        curr = {1: _issue(1, labels=["bug", "p1"])}
+        changes = tracker.diff_issues(prev, curr)
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].kind, "labels_changed")
+        self.assertIn("+p1", changes[0].detail)
+
+    def test_no_change(self) -> None:
+        prev = {1: _issue(1, labels=["bug"])}
+        curr = {1: _issue(1, labels=["bug"])}
+        curr[1].created_at = prev[1].created_at
+        curr[1].updated_at = prev[1].updated_at
+        changes = tracker.diff_issues(prev, curr)
+        self.assertEqual(changes, [])
+
+    def test_dropped_open_issue_is_unknown_not_closed(self) -> None:
+        prev = {1: _issue(1, state="OPEN")}
+        curr: dict[int, tracker.Issue] = {}
+        changes = tracker.diff_issues(prev, curr, confirmed_closed=set())
+        self.assertEqual(len(changes), 1)
+        self.assertEqual(changes[0].kind, "unknown_dropped")
+
+    def test_dropped_open_issue_confirmed_closed(self) -> None:
+        prev = {1: _issue(1, state="OPEN")}
+        curr: dict[int, tracker.Issue] = {}
+        changes = tracker.diff_issues(prev, curr, confirmed_closed={1})
+        self.assertEqual(changes[0].kind, "closed")
+
+
+class DisplayFormattingTests(unittest.TestCase):
+    def test_render_open_table_includes_urgency_markers(self) -> None:
+        # Stale by `updated_at` triggers markers.
+        old = _issue(1, title="Old issue", created_days_ago=40, updated_days_ago=40)
+        warn = _issue(2, title="Warn issue", created_days_ago=10, updated_days_ago=10)
+        fresh = _issue(3, title="Fresh issue", created_days_ago=1, updated_days_ago=1)
+        now = datetime.now(timezone.utc)
+        out = display.render_open_table([old, warn, fresh], now)
+        self.assertIn("🚨", out)
+        self.assertIn("⚠️", out)
+        self.assertIn("Fresh issue", out)
+
+    def test_recent_activity_resets_staleness(self) -> None:
+        # Created long ago but updated recently — should NOT be flagged stale.
+        active = _issue(1, created_days_ago=100, updated_days_ago=1)
+        stats = display.compute_stats([active], [])
+        self.assertEqual(stats["stale_count"], 0)
+        # But oldest_open_age_days reflects creation.
+        self.assertGreaterEqual(stats["oldest_open_age_days"], 100)
+
+    def test_render_closed_table_handles_empty(self) -> None:
+        out = display.render_closed_table([])
+        self.assertIn("No recently-closed", out)
+
+    def test_render_dashboard_contains_sections(self) -> None:
+        opens = [_issue(10, title="Open A", assignees=["alice"], milestone="v1", comments=3)]
+        closes = [_issue(11, state="CLOSED", title="Closed A", closed_days_ago=1, closed_by="bob")]
+        md = display.render_dashboard(
+            repo="example/repo",
+            open_issues=opens,
+            closed_issues=closes,
+        )
+        self.assertIn("# 📡 Issue Pulse", md)
+        self.assertIn("## 🔴 Open Issues", md)
+        self.assertIn("## 🟢 Recently Closed", md)
+        self.assertIn("## 📈 Stats", md)
+        self.assertIn("example/repo", md)
+        self.assertIn("Open A", md)
+        self.assertIn("Closed A", md)
+        self.assertIn("bob", md)
+        self.assertIn("@alice", md)
+        self.assertIn("v1", md)
+
+    def test_compute_stats_uses_rolling_counter(self) -> None:
+        opens = [_issue(1, created_days_ago=40, updated_days_ago=40)]
+        closes: list[tracker.Issue] = []
+        # Provide a rolling counter: 2 closed issues averaging 4 days each.
+        stats = display.compute_stats(
+            opens, closes,
+            rolling_total_seconds=8 * 86400,
+            rolling_count=2,
+        )
+        self.assertEqual(stats["avg_close_days"], 4.0)
+        self.assertEqual(stats["stale_count"], 1)
+
+    def test_escape_pipe_in_title(self) -> None:
+        issue = _issue(99, title="Pipe | in title")
+        out = display.render_open_table([issue], datetime.now(timezone.utc))
+        self.assertIn("Pipe \\| in title", out)
+
+
+class GhMockingTests(unittest.TestCase):
+    def test_fetch_issues_parses_gh_output(self) -> None:
+        sample = json.dumps([
+            {
+                "number": 7,
+                "title": "Hello",
+                "state": "OPEN",
+                "labels": [{"name": "bug"}, {"name": "p1"}],
+                "createdAt": "2026-05-01T10:00:00Z",
+                "updatedAt": "2026-05-01T10:00:00Z",
+                "closedAt": None,
+                "url": "https://github.com/example/repo/issues/7",
+                "assignees": [{"login": "alice"}],
+                "milestone": {"title": "v2"},
+                "comments": 4,
+            }
+        ])
+        with mock.patch.object(tracker, "_run_gh", return_value=sample) as mocked:
+            issues = tracker.fetch_issues("example/repo", state="open")
+            mocked.assert_called_once()
+        self.assertEqual(len(issues), 1)
+        issue = issues[0]
+        self.assertEqual(issue.number, 7)
+        self.assertEqual(issue.labels, ["bug", "p1"])
+        self.assertEqual(issue.assignees, ["alice"])
+        self.assertEqual(issue.milestone, "v2")
+        self.assertEqual(issue.comments, 4)
+
+    def test_fetch_issues_drops_non_github_url(self) -> None:
+        sample = json.dumps([{
+            "number": 1, "title": "x", "state": "OPEN",
+            "labels": [], "createdAt": "", "updatedAt": "",
+            "closedAt": None, "url": "https://evil.example/issues/1",
+            "assignees": [], "milestone": None, "comments": 0,
+        }])
+        with mock.patch.object(tracker, "_run_gh", return_value=sample):
+            issues = tracker.fetch_issues("example/repo", state="open")
+        self.assertEqual(issues[0].url, "")
+
+    def test_fetch_issues_passes_search(self) -> None:
+        with mock.patch.object(tracker, "_run_gh", return_value="[]") as mocked:
+            tracker.fetch_issues("example/repo", state="all", search="updated:>=2026-04-01")
+        args = mocked.call_args[0][0]
+        self.assertIn("--search", args)
+        self.assertIn("updated:>=2026-04-01", args)
+
+    def test_fetch_closed_by_uses_timeline_api(self) -> None:
+        timeline = json.dumps([
+            {"event": "labeled", "actor": {"login": "x"}},
+            {"event": "closed", "actor": {"login": "alice"}},
+        ])
+        with mock.patch.object(tracker, "_run_gh", return_value=timeline) as mocked:
+            who = tracker.fetch_closed_by("example/repo", 42)
+        # The call must hit the REST timeline endpoint.
+        args = mocked.call_args[0][0]
+        self.assertEqual(args[0], "api")
+        self.assertIn("repos/example/repo/issues/42/timeline", args[1])
+        self.assertEqual(who, "alice")
+
+    def test_fetch_closed_by_falls_back_to_pr_author(self) -> None:
+        timeline = json.dumps([
+            {
+                "event": "cross-referenced",
+                "source": {
+                    "issue": {
+                        "pull_request": {"url": "..."},
+                        "user": {"login": "carol"},
+                    }
+                }
+            },
+        ])
+        with mock.patch.object(tracker, "_run_gh", return_value=timeline):
+            who = tracker.fetch_closed_by("example/repo", 42)
+        self.assertEqual(who, "PR by carol")
+
+    def test_fetch_closed_by_returns_none_on_error(self) -> None:
+        with mock.patch.object(tracker, "_run_gh", side_effect=RuntimeError("fail")):
+            self.assertIsNone(tracker.fetch_closed_by("example/repo", 1))
+
+    def test_run_gh_handles_failure(self) -> None:
+        with mock.patch("subprocess.run") as mocked:
+            from subprocess import CalledProcessError
+            mocked.side_effect = CalledProcessError(
+                returncode=1, cmd=["gh"], stderr="boom",
+            )
+            with self.assertRaises(RuntimeError) as ctx:
+                tracker._run_gh(["issue", "list"])
+            self.assertIn("boom", str(ctx.exception))
+
+
+class RollingCounterTests(unittest.TestCase):
+    def test_counter_accumulates_unique_closures(self) -> None:
+        cache = {
+            "close_time_total_seconds": 0.0,
+            "close_time_count": 0,
+            "counted_closed_numbers": [],
+        }
+        closed = [
+            _issue(1, state="CLOSED", created_days_ago=10, closed_days_ago=8),
+            _issue(2, state="CLOSED", created_days_ago=5, closed_days_ago=3),
+        ]
+        tracker._update_close_time_counter(cache, closed)
+        self.assertEqual(cache["close_time_count"], 2)
+        # Re-running with the same set must NOT double-count.
+        tracker._update_close_time_counter(cache, closed)
+        self.assertEqual(cache["close_time_count"], 2)
+
+        # Adding a brand-new closure increments by 1.
+        closed.append(_issue(3, state="CLOSED", created_days_ago=4, closed_days_ago=1))
+        tracker._update_close_time_counter(cache, closed)
+        self.assertEqual(cache["close_time_count"], 3)
+
+
+class IncrementalSyncTests(unittest.TestCase):
+    def test_first_run_does_full_sync(self) -> None:
+        with TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "cache.json"
+            changelog = Path(tmp) / "log.jsonl"
+            with mock.patch.object(tracker, "fetch_issues", return_value=[]) as fetched, \
+                 mock.patch.object(tracker, "_populate_closed_by_parallel"):
+                tracker.scan(repo="x/y", cache_path=cache_path, changelog_path=changelog)
+            # First run must fetch open + closed (2 calls), no `--search`.
+            calls = fetched.call_args_list
+            self.assertEqual(len(calls), 2)
+            for call in calls:
+                self.assertNotIn("search", call.kwargs)
+
+    def test_subsequent_run_uses_incremental(self) -> None:
+        with TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "cache.json"
+            changelog = Path(tmp) / "log.jsonl"
+            now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            seed = {
+                "repo": "x/y",
+                "fetched_at": now_iso,
+                "last_synced_at": now_iso,
+                "issues": {"1": _issue(1).to_dict()},
+                "close_time_total_seconds": 0.0,
+                "close_time_count": 0,
+                "counted_closed_numbers": [],
+            }
+            tracker.save_cache(seed, cache_path)
+
+            with mock.patch.object(tracker, "fetch_issues", return_value=[]) as fetched, \
+                 mock.patch.object(tracker, "_populate_closed_by_parallel"):
+                tracker.scan(repo="x/y", cache_path=cache_path, changelog_path=changelog)
+            # Incremental: exactly 1 call, with a `search` kwarg.
+            self.assertEqual(len(fetched.call_args_list), 1)
+            call = fetched.call_args_list[0]
+            self.assertIn("search", call.kwargs)
+            self.assertTrue(call.kwargs["search"].startswith("updated:>="))
+
+    def test_force_full_overrides_incremental(self) -> None:
+        with TemporaryDirectory() as tmp:
+            cache_path = Path(tmp) / "cache.json"
+            changelog = Path(tmp) / "log.jsonl"
+            now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+            seed = {
+                "repo": "x/y",
+                "fetched_at": now_iso,
+                "last_synced_at": now_iso,
+                "issues": {"1": _issue(1).to_dict()},
+            }
+            tracker.save_cache(seed, cache_path)
+            with mock.patch.object(tracker, "fetch_issues", return_value=[]) as fetched, \
+                 mock.patch.object(tracker, "_populate_closed_by_parallel"):
+                tracker.scan(
+                    repo="x/y",
+                    cache_path=cache_path,
+                    changelog_path=changelog,
+                    force_full=True,
+                )
+            self.assertEqual(len(fetched.call_args_list), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/issue_pulse/tracker.py
+++ b/issue_pulse/tracker.py
@@ -1,0 +1,614 @@
+"""Issue tracking engine.
+
+Queries GitHub via the `gh` CLI, caches results to a JSON file, and
+detects state transitions (open <-> closed, label changes) by diffing
+against the previous cache.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+from . import config
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclass
+class Issue:
+    """A snapshot of a single GitHub issue."""
+
+    number: int
+    title: str
+    state: str  # "OPEN" or "CLOSED"
+    labels: list[str] = field(default_factory=list)
+    created_at: str = ""
+    updated_at: str = ""
+    closed_at: str | None = None
+    closed_by: str | None = None
+    url: str = ""
+    assignees: list[str] = field(default_factory=list)
+    milestone: str | None = None
+    comments: int = 0
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "state": self.state,
+            "labels": list(self.labels),
+            "created_at": self.created_at,
+            "updated_at": self.updated_at,
+            "closed_at": self.closed_at,
+            "closed_by": self.closed_by,
+            "url": self.url,
+            "assignees": list(self.assignees),
+            "milestone": self.milestone,
+            "comments": self.comments,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "Issue":
+        return cls(
+            number=int(data["number"]),
+            title=str(data.get("title", "")),
+            state=str(data.get("state", "OPEN")).upper(),
+            labels=list(data.get("labels", [])),
+            created_at=str(data.get("created_at", "")),
+            updated_at=str(data.get("updated_at", "")),
+            closed_at=data.get("closed_at"),
+            closed_by=data.get("closed_by"),
+            url=str(data.get("url", "")),
+            assignees=list(data.get("assignees", [])),
+            milestone=data.get("milestone"),
+            comments=int(data.get("comments", 0) or 0),
+        )
+
+
+@dataclass
+class StateChange:
+    """A single state transition between two cache snapshots."""
+
+    number: int
+    title: str
+    # "opened" | "closed" | "reopened" | "labels_changed" | "unknown_dropped"
+    kind: str
+    detail: str = ""
+    timestamp: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "number": self.number,
+            "title": self.title,
+            "kind": self.kind,
+            "detail": self.detail,
+            "timestamp": self.timestamp,
+        }
+
+
+# ---------------------------------------------------------------------------
+# gh CLI calls
+# ---------------------------------------------------------------------------
+
+_ISSUE_FIELDS = (
+    "number,title,state,labels,createdAt,updatedAt,closedAt,url,"
+    "assignees,milestone,comments"
+)
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run a `gh` command and return stdout. Raises RuntimeError on failure."""
+    # Paginated API calls (timeline, etc.) can be much slower than a single
+    # `gh issue list`, so give them a longer budget.
+    timeout = 120 if "--paginate" in args else 60
+    try:
+        result = subprocess.run(
+            ["gh", *args],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("gh CLI not found on PATH") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise RuntimeError(f"gh command timed out: {' '.join(args)}") from exc
+    except subprocess.CalledProcessError as exc:
+        stderr = (exc.stderr or "").strip()
+        raise RuntimeError(f"gh command failed ({exc.returncode}): {stderr}") from exc
+    return result.stdout
+
+
+def _normalize(raw: dict[str, Any]) -> Issue:
+    """Convert a raw `gh issue list --json` record to our Issue model."""
+    labels = [lbl.get("name", "") for lbl in raw.get("labels") or [] if lbl.get("name")]
+    assignees = [
+        a.get("login", "")
+        for a in raw.get("assignees") or []
+        if a.get("login")
+    ]
+    milestone_raw = raw.get("milestone")
+    milestone = None
+    if isinstance(milestone_raw, dict):
+        milestone = milestone_raw.get("title") or None
+    comments_raw = raw.get("comments")
+    if isinstance(comments_raw, list):
+        comments_count = len(comments_raw)
+    elif isinstance(comments_raw, int):
+        comments_count = comments_raw
+    else:
+        comments_count = 0
+    url = str(raw.get("url", ""))
+    if url and not url.startswith("https://github.com/"):
+        # Defensive: drop anything that isn't a real GitHub URL.
+        url = ""
+    return Issue(
+        number=int(raw["number"]),
+        title=str(raw.get("title", "")),
+        state=str(raw.get("state", "OPEN")).upper(),
+        labels=labels,
+        created_at=str(raw.get("createdAt", "")),
+        updated_at=str(raw.get("updatedAt", "")),
+        closed_at=raw.get("closedAt") or None,
+        closed_by=None,  # filled in lazily for newly-closed issues
+        url=url,
+        assignees=assignees,
+        milestone=milestone,
+        comments=comments_count,
+    )
+
+
+def fetch_issues(
+    repo: str,
+    state: str,
+    limit: int = config.ISSUE_FETCH_LIMIT,
+    search: str | None = None,
+) -> list[Issue]:
+    """Fetch issues from GitHub for the given repo + state ("open"|"closed"|"all").
+
+    If `search` is provided, it's passed to `gh issue list --search` and
+    typically restricts results to a time window (e.g. "updated:>=2026-04-01").
+    """
+    args = [
+        "issue", "list",
+        "--repo", repo,
+        "--state", state,
+        "--limit", str(limit),
+        "--json", _ISSUE_FIELDS,
+    ]
+    if search:
+        args.extend(["--search", search])
+    out = _run_gh(args)
+    try:
+        records = json.loads(out)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Could not parse gh JSON output: {exc}") from exc
+    return [_normalize(r) for r in records]
+
+
+def fetch_closed_by(repo: str, number: int) -> str | None:
+    """Look up who closed an issue. Returns None on error or if not closed.
+
+    Uses the GitHub REST timeline endpoint via `gh api` because
+    `gh issue view --json closedByPullRequestsReferences,timelineItems`
+    is not actually a supported field set.
+    """
+    try:
+        out = _run_gh([
+            "api",
+            f"repos/{repo}/issues/{number}/timeline",
+            "--paginate",
+        ])
+    except RuntimeError:
+        return None
+    try:
+        items = json.loads(out)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(items, list):
+        return None
+
+    pr_author: str | None = None
+    last_closer: str | None = None
+
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        event = item.get("event")
+        if event == "closed":
+            actor = item.get("actor") or {}
+            login = actor.get("login")
+            if login:
+                last_closer = str(login)
+        elif event == "cross-referenced":
+            source = item.get("source") or {}
+            issue_obj = source.get("issue") or {}
+            if issue_obj.get("pull_request"):
+                user = issue_obj.get("user") or {}
+                login = user.get("login")
+                if login and pr_author is None:
+                    pr_author = str(login)
+
+    if last_closer:
+        return last_closer
+    if pr_author:
+        return f"PR by {pr_author}"
+    return None
+
+
+def _populate_closed_by_parallel(
+    repo: str,
+    issues: list[Issue],
+    max_workers: int = config.CLOSED_BY_MAX_WORKERS,
+) -> None:
+    """Fill in `closed_by` for the given issues, in parallel."""
+    if not issues:
+        return
+    workers = max(1, min(max_workers, len(issues)))
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = {
+            pool.submit(fetch_closed_by, repo, issue.number): issue
+            for issue in issues
+        }
+        for fut in as_completed(futures):
+            issue = futures[fut]
+            try:
+                issue.closed_by = fut.result()
+            except Exception:
+                issue.closed_by = None
+
+
+# ---------------------------------------------------------------------------
+# Cache I/O
+# ---------------------------------------------------------------------------
+
+_CACHE_SKELETON: dict[str, Any] = {
+    "repo": None,
+    "fetched_at": None,
+    "last_synced_at": None,
+    "issues": {},
+    # Persistent rolling counter for avg-time-to-close.
+    "close_time_total_seconds": 0.0,
+    "close_time_count": 0,
+    # Numbers we've already counted in the rolling avg, to avoid double-counting.
+    "counted_closed_numbers": [],
+}
+
+
+def _skeleton() -> dict[str, Any]:
+    data = dict(_CACHE_SKELETON)
+    data["issues"] = {}
+    data["counted_closed_numbers"] = []
+    return data
+
+
+def load_cache(path: Path = config.CACHE_PATH) -> dict[str, Any]:
+    """Load the JSON cache file. Returns an empty skeleton on missing/invalid."""
+    if not path.exists():
+        return _skeleton()
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return _skeleton()
+    if not isinstance(data, dict):
+        return _skeleton()
+    for key, value in _CACHE_SKELETON.items():
+        if key not in data:
+            data[key] = value if not isinstance(value, (dict, list)) else type(value)()
+    return data
+
+
+def save_cache(data: dict[str, Any], path: Path = config.CACHE_PATH) -> None:
+    """Atomically persist the cache to disk."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(data, indent=2, ensure_ascii=False, sort_keys=True)
+    fd, tmp_name = tempfile.mkstemp(prefix=".issue_cache.", dir=str(path.parent))
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(payload)
+        os.replace(tmp_name, path)
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+
+# ---------------------------------------------------------------------------
+# Diffing
+# ---------------------------------------------------------------------------
+
+def diff_issues(
+    previous: dict[int, Issue],
+    current: dict[int, Issue],
+    *,
+    confirmed_closed: set[int] | None = None,
+) -> list[StateChange]:
+    """Compare two {number: Issue} maps and return state changes.
+
+    `confirmed_closed` lists issue numbers that we positively know are closed
+    (because the API just returned state=CLOSED for them). Issues that simply
+    drop out of the fetch window are emitted as `unknown_dropped`, not
+    `closed`, to avoid false-positive closure events.
+    """
+    confirmed_closed = confirmed_closed or set()
+    changes: list[StateChange] = []
+    now = datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+    for number, issue in current.items():
+        prev = previous.get(number)
+        if prev is None:
+            kind = "opened" if issue.state == "OPEN" else "closed"
+            changes.append(StateChange(
+                number=issue.number,
+                title=issue.title,
+                kind=kind,
+                detail=f"state={issue.state}",
+                timestamp=now,
+            ))
+            continue
+
+        if prev.state != issue.state:
+            if issue.state == "CLOSED":
+                kind = "closed"
+                detail = f"closed_by={issue.closed_by or 'unknown'}"
+            else:
+                kind = "reopened"
+                detail = "reopened"
+            changes.append(StateChange(
+                number=issue.number,
+                title=issue.title,
+                kind=kind,
+                detail=detail,
+                timestamp=now,
+            ))
+            continue
+
+        if set(prev.labels) != set(issue.labels):
+            added = sorted(set(issue.labels) - set(prev.labels))
+            removed = sorted(set(prev.labels) - set(issue.labels))
+            parts: list[str] = []
+            if added:
+                parts.append(f"+{','.join(added)}")
+            if removed:
+                parts.append(f"-{','.join(removed)}")
+            changes.append(StateChange(
+                number=issue.number,
+                title=issue.title,
+                kind="labels_changed",
+                detail=" ".join(parts),
+                timestamp=now,
+            ))
+
+    for number, issue in previous.items():
+        if number in current:
+            continue
+        if issue.state != "OPEN":
+            # Already closed in the prev snapshot; dropping out is expected.
+            continue
+        if number in confirmed_closed:
+            changes.append(StateChange(
+                number=issue.number,
+                title=issue.title,
+                kind="closed",
+                detail="confirmed via API",
+                timestamp=now,
+            ))
+        else:
+            # Don't claim it's closed — we genuinely don't know.
+            changes.append(StateChange(
+                number=issue.number,
+                title=issue.title,
+                kind="unknown_dropped",
+                detail="dropped from open window without observed close",
+                timestamp=now,
+            ))
+    return changes
+
+
+def append_changelog(
+    changes: Iterable[StateChange],
+    path: Path = config.CHANGELOG_PATH,
+) -> None:
+    """Append change records as one JSON object per line."""
+    changes = list(changes)
+    if not changes:
+        return
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as fh:
+        for change in changes:
+            fh.write(json.dumps(change.to_dict(), ensure_ascii=False) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Rolling avg-time-to-close
+# ---------------------------------------------------------------------------
+
+def _parse_iso(ts: str | None) -> datetime | None:
+    if not ts:
+        return None
+    try:
+        if ts.endswith("Z"):
+            ts = ts[:-1] + "+00:00"
+        return datetime.fromisoformat(ts)
+    except ValueError:
+        return None
+
+
+def _update_close_time_counter(
+    cache: dict[str, Any],
+    closed_issues: list[Issue],
+) -> None:
+    """Add any newly-observed closed issues to the persistent rolling counter."""
+    counted = set(cache.get("counted_closed_numbers") or [])
+    total_seconds = float(cache.get("close_time_total_seconds") or 0.0)
+    count = int(cache.get("close_time_count") or 0)
+    for issue in closed_issues:
+        if issue.number in counted:
+            continue
+        created = _parse_iso(issue.created_at)
+        closed = _parse_iso(issue.closed_at)
+        if not created or not closed:
+            continue
+        if created.tzinfo is None:
+            created = created.replace(tzinfo=timezone.utc)
+        if closed.tzinfo is None:
+            closed = closed.replace(tzinfo=timezone.utc)
+        seconds = (closed - created).total_seconds()
+        if seconds < 0:
+            continue
+        total_seconds += seconds
+        count += 1
+        counted.add(issue.number)
+    cache["close_time_total_seconds"] = total_seconds
+    cache["close_time_count"] = count
+    # Cap the persisted "counted" set to the last N entries (highest issue
+    # numbers ≈ most recent). The sum and count remain accurate; only the
+    # dedupe set is bounded so the JSON file doesn't grow unboundedly.
+    counted_sorted = sorted(counted)
+    if len(counted_sorted) > config.COUNTED_CLOSED_CAP:
+        counted_sorted = counted_sorted[-config.COUNTED_CLOSED_CAP:]
+    cache["counted_closed_numbers"] = counted_sorted
+
+
+def _prune_closed_issues(
+    current_map: dict[int, "Issue"],
+    retention_days: int = config.CLOSED_CACHE_RETENTION_DAYS,
+) -> dict[int, "Issue"]:
+    """Drop closed issues older than `retention_days` to bound cache size."""
+    cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+    pruned: dict[int, Issue] = {}
+    for number, issue in current_map.items():
+        if issue.state == "CLOSED":
+            closed = _parse_iso(issue.closed_at)
+            if closed is not None:
+                if closed.tzinfo is None:
+                    closed = closed.replace(tzinfo=timezone.utc)
+                if closed < cutoff:
+                    continue
+        pruned[number] = issue
+    return pruned
+
+
+# ---------------------------------------------------------------------------
+# Orchestration
+# ---------------------------------------------------------------------------
+
+def _should_use_incremental(cache: dict[str, Any]) -> bool:
+    last_synced = _parse_iso(cache.get("last_synced_at"))
+    if last_synced is None:
+        return False
+    if last_synced.tzinfo is None:
+        last_synced = last_synced.replace(tzinfo=timezone.utc)
+    age = datetime.now(timezone.utc) - last_synced
+    if age > timedelta(days=config.INCREMENTAL_MAX_AGE_DAYS):
+        return False
+    if not cache.get("issues"):
+        return False
+    return True
+
+
+def scan(
+    repo: str = config.DEFAULT_REPO,
+    cache_path: Path = config.CACHE_PATH,
+    changelog_path: Path = config.CHANGELOG_PATH,
+    *,
+    force_full: bool = False,
+) -> tuple[list[Issue], list[Issue], list[StateChange]]:
+    """Fetch issues, diff, persist, and return results.
+
+    Strategy:
+      - First run (or stale cache): full sync of open + recent closed.
+      - Subsequent runs: delta query for issues updated since `last_synced_at`,
+        merged on top of the previous snapshot.
+
+    Returns:
+        (open_issues, closed_issues, state_changes)
+    """
+    cache = load_cache(cache_path)
+    previous_map: dict[int, Issue] = {}
+    for num_str, raw in (cache.get("issues") or {}).items():
+        try:
+            previous_map[int(num_str)] = Issue.from_dict(raw)
+        except (ValueError, KeyError, TypeError):
+            continue
+
+    use_incremental = (not force_full) and _should_use_incremental(cache)
+
+    if use_incremental:
+        last_synced = _parse_iso(cache.get("last_synced_at"))
+        assert last_synced is not None
+        # Subtract a small overlap to avoid missing edits at the boundary.
+        delta_since = (last_synced - timedelta(minutes=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        delta = fetch_issues(
+            repo,
+            state="all",
+            search=f"updated:>={delta_since}",
+        )
+        # Start from the previous snapshot, overlay deltas.
+        current_map: dict[int, Issue] = {n: i for n, i in previous_map.items()}
+        for issue in delta:
+            current_map[issue.number] = issue
+        # Closed-window for display: use what we have in cache + delta.
+        closed_issues = [i for i in current_map.values() if i.state == "CLOSED"]
+        open_issues = [i for i in current_map.values() if i.state == "OPEN"]
+    else:
+        open_issues = fetch_issues(repo, state="open")
+        closed_issues = fetch_issues(repo, state="closed", limit=config.RECENT_CLOSED_LIMIT)
+        current_map = {i.number: i for i in open_issues}
+        for issue in closed_issues:
+            current_map[issue.number] = issue
+
+    # Identify newly-closed issues (state transitioned to CLOSED since prev).
+    newly_closed: list[Issue] = []
+    for issue in current_map.values():
+        if issue.state != "CLOSED":
+            continue
+        prev = previous_map.get(issue.number)
+        if prev is None or prev.state != "CLOSED" or not prev.closed_by:
+            newly_closed.append(issue)
+        else:
+            issue.closed_by = prev.closed_by
+
+    _populate_closed_by_parallel(repo, newly_closed)
+
+    confirmed_closed = {i.number for i in current_map.values() if i.state == "CLOSED"}
+    changes = diff_issues(previous_map, current_map, confirmed_closed=confirmed_closed)
+
+    # Update persistent rolling counter for avg time-to-close.
+    _update_close_time_counter(cache, [i for i in current_map.values() if i.state == "CLOSED"])
+
+    now_iso = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    persisted_map = _prune_closed_issues(current_map)
+    cache_payload = {
+        "repo": repo,
+        "fetched_at": now_iso,
+        "last_synced_at": now_iso,
+        "issues": {str(num): iss.to_dict() for num, iss in persisted_map.items()},
+        "close_time_total_seconds": cache.get("close_time_total_seconds", 0.0),
+        "close_time_count": cache.get("close_time_count", 0),
+        "counted_closed_numbers": cache.get("counted_closed_numbers", []),
+    }
+    save_cache(cache_payload, cache_path)
+    append_changelog(changes, changelog_path)
+
+    # Re-derive the returned lists from the merged map so callers see all
+    # tracked open issues, not just what came back in this delta.
+    open_issues = [i for i in current_map.values() if i.state == "OPEN"]
+    closed_issues_out = [i for i in current_map.values() if i.state == "CLOSED"]
+    closed_issues_out.sort(
+        key=lambda i: _parse_iso(i.closed_at) or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+    return open_issues, closed_issues_out[: config.RECENT_CLOSED_LIMIT], changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,33 @@
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "issue-pulse"
+version = "0.2.0"
+description = "Track GitHub issue state for a repository — incremental sync, JSON cache, Markdown dashboard."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [
+    { name = "DayPage" },
+]
+keywords = ["github", "issues", "tracker", "dashboard"]
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Topic :: Software Development :: Bug Tracking",
+]
+
+# No third-party deps — issue-pulse uses only the standard library and
+# shells out to the `gh` CLI.
+dependencies = []
+
+[project.scripts]
+issue-pulse = "issue_pulse.cli:main"
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["issue_pulse*"]


### PR DESCRIPTION
## Overview

**Issue Pulse** is a Python-based GitHub issue tracking system that lives in a Claude Code worktree. It monitors issues via the `gh` CLI and generates a real-time Markdown dashboard showing open/closed status with rich metadata.

## How It Works

```
gh issue list → scan() → diff vs cache → changelog + ISSUE_STATUS.md
```

- Incremental sync: delta queries via `--search updated:>=...`, full sync on first run or stale cache
- State change detection: open↔closed↔reopened, label changes, unknown drops
- Parallel closed_by: ThreadPoolExecutor (max_workers=5)
- Rolling stats: bounded counter for avg time-to-close
- Cache pruning: closed issues older than 90d auto-pruned

## Dashboard Output

### Open Issues table
| # | Title | Labels | Assignees | Milestone | 💬 | Created | Updated | Age | Stale |

### Closed Issues table
| # | Title | Closed by | Closed |

### Stats
Open/Closed/Total counts, rolling avg close time, stale count, oldest open

## CLI Commands

```bash
python3 -m issue_pulse scan      # full scan + generate dashboard
python3 -m issue_pulse watch     # poll mode with exp backoff
python3 -m issue_pulse diff      # show state changes since last scan
python3 -m issue_pulse report    # terminal summary
```

## Configuration (12 env vars)

| Var | Default | Description |
|-----|---------|-------------|
| IP_REPO | getyak/daypage | Target repository |
| IP_STALE_DAYS | 30 | Staleness threshold |
| IP_WARNING_DAYS | 7 | Warning threshold |
| IP_CLOSED_LIMIT | 25 | Closed issues to fetch |
| IP_INCREMENTAL_MAX_AGE | 7 | Days before forcing full sync |
| IP_CACHE_PATH | .issue_cache.json | Cache file path |
| IP_CHANGELOG | issue_changelog.log | Changelog path |
| IP_OUTPUT | ISSUE_STATUS.md | Dashboard output path |

## Quality

- 36 unit tests all passing
- Built via 3-round Supervisor-Executor agent iteration (74 → 92/100)

## Files

```
issue_pulse/
├── tracker.py          # Core engine
├── display.py          # Dashboard generator
├── cli.py              # CLI interface
├── config.py           # Config + env overrides
├── __main__.py         # python3 -m issue_pulse entry
├── README.md
└── tests/
    ├── test_tracker.py # 30+ tests
    ├── test_cli.py     # CLI tests
    └── __init__.py
pyproject.toml           # Package config
ISSUE_STATUS.md          # Generated dashboard sample
.issue_cache.json        # Incremental cache
```

## Next Steps
- Add as `.claude/commands/issue-pulse.md` slash command
- Optional cron job for auto-refresh
- Consider GitHub Actions for push-triggered updates
