### PR TITLE
fix(#221): Apple Sign-In session not updating after authorization

### DIFF
--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -7,15 +7,18 @@ struct RootView: View {
     @ObservedObject private var appSettings = AppSettings.shared
     @State private var hasOnboarded: Bool = UserDefaults.standard.bool(forKey: AppSettings.Keys.hasOnboarded)
     @State private var authSkipped: Bool = UserDefaults.standard.bool(forKey: AppSettings.Keys.authSkipped)
+    // Drives the auth fullScreenCover. Kept as @State (not a derived computed property)
+    // so SwiftUI reliably dismisses the cover when `authService.session` flips to non-nil
+    // — see issue #221, where a derived binding occasionally failed to re-evaluate.
+    @State private var showAuthSheet: Bool = {
+        let skipped = UserDefaults.standard.bool(forKey: AppSettings.Keys.authSkipped)
+        return AuthService.shared.session == nil && !skipped
+    }()
 
     private let sidebarWidth: CGFloat = 280
 
     private var feedbackPanelWidth: CGFloat {
         min(UIScreen.main.bounds.width * 0.85, 360)
-    }
-
-    private var showAuth: Bool {
-        authService.session == nil && !authSkipped
     }
 
     /// Resolve preferredColorScheme from AppSettings.
@@ -31,14 +34,26 @@ struct RootView: View {
         Group {
             if hasOnboarded {
                 mainContent
-                    .fullScreenCover(isPresented: Binding(
-                        get: { showAuth },
-                        set: { if !$0 { authSkipped = UserDefaults.standard.bool(forKey: AppSettings.Keys.authSkipped) } }
-                    )) {
+                    .fullScreenCover(isPresented: $showAuthSheet) {
                         AuthView(onSkip: {
                             UserDefaults.standard.set(true, forKey: AppSettings.Keys.authSkipped)
                             authSkipped = true
+                            showAuthSheet = false
                         })
+                    }
+                    .onChange(of: authService.session?.user.id) { newUserID in
+                        // Sign-in success → dismiss; sign-out → present.
+                        // Keyed on user.id (UUID, Equatable) instead of `Session`
+                        // itself, which isn't guaranteed Equatable across Supabase
+                        // SDK versions.
+                        if newUserID != nil {
+                            showAuthSheet = false
+                        } else {
+                            showAuthSheet = !authSkipped
+                        }
+                    }
+                    .onChange(of: authSkipped) { skipped in
+                        if skipped { showAuthSheet = false }
                     }
             } else {
                 OnboardingView(hasOnboarded: $hasOnboarded)

--- a/DayPage/Features/Auth/AuthView.swift
+++ b/DayPage/Features/Auth/AuthView.swift
@@ -109,7 +109,19 @@ struct AuthView: View {
                 DragGesture(minimumDistance: 0)
                     .updating($applePressed) { _, state, _ in state = true }
                     .onEnded { _ in
-                        Task { try? await authService.signInWithApple() }
+                        Task {
+                            do {
+                                try await authService.signInWithApple()
+                            } catch {
+                                // AuthService already publishes the mapped DPAuthError
+                                // to `authService.error`, which the view above renders.
+                                // Catching here prevents the unhandled-error warning
+                                // and lets us debug-log the failure path explicitly.
+                                #if DEBUG
+                                print("[AuthView] Apple sign-in failed: \(error)")
+                                #endif
+                            }
+                        }
                     }
             )
 


### PR DESCRIPTION
## Summary

Fixes issue #221 where Apple Sign-In would not update the login state or navigate back to the home page after successful authorization.

## Root Cause

The `RootView` used a computed property `showAuth` derived from `@EnvironmentObject authService.session`. In certain SwiftUI rendering cycles, the computed property did not reliably trigger the fullScreenCover dismissal when `session` transitioned from nil to non-nil.

Additionally, `AuthView` used `try?` which silently swallowed errors without providing proper feedback.

## Changes

### RootView.swift
- Replaced computed `showAuth` with `@State showAuthSheet` for deterministic SwiftUI state management
- Added `onChange(of: authService.session?.user.id)` to dismiss auth sheet when session becomes available
- Added `onChange(of: authSkipped)` to dismiss auth sheet on skip

### AuthView.swift
- Replaced `try?` with proper `do/catch` in Apple sign-in handler
- Added debug logging for sign-in failure path

## Testing

- [x] Build verification pending
- [ ] Manual test: Apple Sign-In flow → home screen

Closes #221