### PR TITLE
fix(#219): PhotosPicker unresponsive on iOS 26 — tap target and auto-submit fixes

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -374,14 +374,14 @@ struct InputBarV4: View {
                     onCapturePhoto()
                 }
 
-                // Photo library (multi-select)
-                ZStack {
-                    toolbarIconButton(systemImage: "photo.on.rectangle", accessibilityLabel: "相册") {}
-                    PhotosPicker(selection: $photosPickerItems, matching: .images, photoLibrary: .shared()) {
-                        Color.clear.frame(width: 44, height: 44)
-                    }
-                    .opacity(0.01)
+                // Photo library (multi-select) — the icon IS the picker's label,
+                // not a separate button stacked behind a transparent picker.
+                // The previous ZStack + opacity(0.01) overlay broke hit-testing
+                // on iOS 26.x and left the picker unreachable (#219).
+                PhotosPicker(selection: $photosPickerItems, matching: .images, photoLibrary: .shared()) {
+                    toolbarIconButtonContent(systemImage: "photo.on.rectangle")
                 }
+                .accessibilityLabel("相册")
 
                 // Location
                 toolbarIconButton(
@@ -410,13 +410,23 @@ struct InputBarV4: View {
         action: @escaping () -> Void
     ) -> some View {
         Button(action: action) {
-            Image(systemName: systemImage)
-                .font(.system(size: 20, weight: .light))
-                .foregroundStyle(tint)
-                .frame(width: 44, height: 44)
+            toolbarIconButtonContent(systemImage: systemImage, tint: tint)
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)
+    }
+
+    /// Bare icon glyph used as the visual label for both `toolbarIconButton`
+    /// (Button-wrapped) and `PhotosPicker` (its own tappable surface).
+    @ViewBuilder
+    private func toolbarIconButtonContent(
+        systemImage: String,
+        tint: Color = DSColor.onBackgroundMuted
+    ) -> some View {
+        Image(systemName: systemImage)
+            .font(.system(size: 20, weight: .light))
+            .foregroundStyle(tint)
+            .frame(width: 44, height: 44)
     }
 
     private func handleComposingMicTap() {

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -494,7 +494,11 @@ struct TodayView: View {
             pendingAttachments: viewModel.pendingAttachments,
             onFetchLocation: { viewModel.fetchLocation() },
             onClearLocation: { viewModel.clearPendingLocation() },
-            onAddPhoto: { items in viewModel.addPhotosAndSubmit(items: items) },
+            onAddPhoto: { items in
+                for item in items {
+                    viewModel.addPhotoAttachment(item: item)
+                }
+            },
             onCapturePhoto: { viewModel.startCameraCapture() },
             onRemoveAttachment: { id in viewModel.removePendingAttachment(id: id) },
             onStartVoiceRecording: { viewModel.startVoiceRecording() },


### PR DESCRIPTION
## Summary

Fixes issue #219 where the photo picker button in the input bar was unresponsive on iOS 26.x.

## Root Cause

The PhotosPicker was rendered behind a visible button using a fragile `ZStack` + `opacity(0.01)` overlay pattern:
- The visible `toolbarIconButton` had an empty action `{}` — tapping it did nothing
- The nearly-invisible PhotosPicker behind it was supposed to intercept taps, but `opacity(0.01)` broke hit-testing on iOS 26.x
- Additionally, photos were auto-submitted via `addPhotosAndSubmit` instead of being staged

## Changes

### InputBarV4.swift
- Replaced ZStack overlay pattern with direct `PhotosPicker` using a `toolbarIconButtonContent` helper as its label
- Extracted shared icon rendering helper for reuse
- Removed `opacity(0.01)` — the PhotosPicker is now the actual visible button

### TodayView.swift
- Changed `onAddPhoto` callback from `addPhotosAndSubmit` (auto-submit) to `addPhotoAttachment` (staged in pending attachments)
- Photos are now added to the pending attachments list, consistent with other attachment types

Closes #219