### PR TITLE
fix(#217): UI flickering caused by broad implicit animation modifiers

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -208,7 +208,6 @@ struct TodayView: View {
                                         .padding(.leading, 20)
                                         .padding(.trailing, 20)
                                         .transition(.move(edge: .bottom).combined(with: .opacity))
-                                        .animation(.spring(response: 0.3, dampingFraction: 0.85), value: viewModel.memos.count)
                                     }
                                 }
 
@@ -258,23 +257,28 @@ struct TodayView: View {
                     // just the input bar.
                     inputBarV4
                 }
-                // Submit error toast
+                // Submit error toast — scoped animation lives on the overlay
+                // container so only the toast itself animates, not the whole
+                // ZStack tree. (#217)
                 .overlay(alignment: .top) {
-                    if let err = viewModel.submitError {
-                        Text(err)
-                            .bodySMStyle()
-                            .foregroundColor(DSColor.onError)
-                            .padding(.horizontal, 16)
-                            .padding(.vertical, 10)
-                            .background(DSColor.error)
-                            .padding(.top, 8)
-                            .transition(.move(edge: .top).combined(with: .opacity))
-                            .onAppear {
-                                DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
-                                    viewModel.submitError = nil
+                    ZStack(alignment: .top) {
+                        if let err = viewModel.submitError {
+                            Text(err)
+                                .bodySMStyle()
+                                .foregroundColor(DSColor.onError)
+                                .padding(.horizontal, 16)
+                                .padding(.vertical, 10)
+                                .background(DSColor.error)
+                                .padding(.top, 8)
+                                .transition(.move(edge: .top).combined(with: .opacity))
+                                .onAppear {
+                                    DispatchQueue.main.asyncAfter(deadline: .now() + 3) {
+                                        viewModel.submitError = nil
+                                    }
                                 }
-                            }
+                        }
                     }
+                    .animation(.easeInOut(duration: 0.25), value: viewModel.submitError)
                 }
             }
             .navigationBarHidden(true)
@@ -285,7 +289,6 @@ struct TodayView: View {
             .onChange(of: voiceQueue.pendingCount) { count in
                 updateVoiceQueueBanner(count: count)
             }
-            .animation(.easeInOut(duration: 0.25), value: viewModel.submitError)
             // Daily Page full-screen sheet
             .fullScreenCover(isPresented: $showDailyPage) {
                 let dateStr: String = {


### PR DESCRIPTION
## Summary

Fixes issue #217 where the Today view UI flickered/jittered, especially after any interaction (clicking, submitting, loading).

## Root Cause

Two implicit `.animation()` modifiers were applied too broadly:

1. **ForEach TimelineRow (line 211)**: `.animation(.spring(...), value: viewModel.memos.count)` was on every row in the ForEach loop. When memos loaded/changed, SwiftUI re-animated ALL rows simultaneously — causing visible jitter across the entire timeline.

2. **Body ZStack (line 288)**: `.animation(.easeInOut(...), value: viewModel.submitError)` was on the entire body ZStack. Every time `submitError` toggled, the entire view hierarchy re-animated, causing layout shifts and flickering.

## Changes

### TodayView.swift
- **Removed** `.animation(.spring(...), value: viewModel.memos.count)` from each ForEach TimelineRow — this was the primary cause of flickering
- **Scoped** `submitError` animation to an inner overlay ZStack instead of the outer body ZStack — only the error toast animates, not the entire view tree
- Preserved intentional `.transition` modifiers on rows (for list insertion) and all scoped animations in InputBarV4, CompileFooterButton, and SwipeableMemoCard

## Technical Details

The anti-pattern was placing an implicit `.animation()` modifier on individual views inside a `ForEach`, keyed to a collection count. This causes every existing row to animate every time the count changes — even rows that didn't change. The correct approach is to use `.transition()` for insertion/removal and scoped animations for specific state-driven visual changes.

Closes #217