### PR TITLE
feat: v4 Liquid Glass UI redesign (iOS 26 aesthetic)

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		A10000005 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000005 /* Colors.swift */; };
 		A10000006 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000006 /* Typography.swift */; };
 		A10000007 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000007 /* Components.swift */; };
+		A100000F1 /* GlassSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000F1 /* GlassSurface.swift */; };
 		A10000008 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000008 /* Memo.swift */; };
 		A10000009 /* RawStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000009 /* RawStorage.swift */; };
 		A10000010 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010 /* TodayView.swift */; };
@@ -142,6 +143,7 @@
 		A20000005 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		A20000006 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		A20000007 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
+		A200000F1 /* GlassSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassSurface.swift; sourceTree = "<group>"; };
 		A20000008 /* Memo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memo.swift; sourceTree = "<group>"; };
 		A20000009 /* RawStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorage.swift; sourceTree = "<group>"; };
 		A20000010 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
@@ -307,6 +309,7 @@
 				A20000005 /* Colors.swift */,
 				A20000006 /* Typography.swift */,
 				A20000007 /* Components.swift */,
+				A200000F1 /* GlassSurface.swift */,
 				A20000041 /* Spacing.swift */,
 				A20000043 /* Interactions.swift */,
 				A20000053 /* InputTokens.swift */,
@@ -778,6 +781,7 @@
 				A10000005 /* Colors.swift in Sources */,
 				A10000006 /* Typography.swift in Sources */,
 				A10000007 /* Components.swift in Sources */,
+				A100000F1 /* GlassSurface.swift in Sources */,
 				A10000041 /* Spacing.swift in Sources */,
 				A10000043 /* Interactions.swift in Sources */,
 				A10000008 /* Memo.swift in Sources */,

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -120,8 +120,7 @@ struct RootView: View {
             FeedbackView()
                 .frame(width: feedbackPanelWidth)
                 .frame(maxHeight: .infinity)
-                .background(DSColor.backgroundWarm)
-                .shadow(color: Color.black.opacity(0.12), radius: 24, x: -8, y: 0)
+                .shadow(color: Color(hex: "2D1E0A").opacity(0.14), radius: 24, x: -8, y: 0)
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .offset(x: nav.isFeedbackPanelOpen ? 0 : feedbackPanelWidth + 40)
                 .gesture(

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -11,23 +11,29 @@ struct SidebarView: View {
     @State private var showAccountSheet = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            brandHeader
-            Divider()
-                .background(DSColor.borderSubtle)
-                .padding(.bottom, 8)
+        ZStack(alignment: .topLeading) {
+            DSColor.bgWarm.ignoresSafeArea()
 
-            navSection
+            VStack(alignment: .leading, spacing: 0) {
+                brandHeader
 
-            Spacer()
+                Rectangle()
+                    .fill(DSColor.inkFaint)
+                    .frame(height: 0.5)
+                    .padding(.bottom, 8)
 
-            Divider()
-                .background(DSColor.borderSubtle)
+                navSection
 
-            bottomSection
+                Spacer()
+
+                Rectangle()
+                    .fill(DSColor.inkFaint)
+                    .frame(height: 0.5)
+
+                bottomSection
+            }
+            .frame(maxHeight: .infinity)
         }
-        .frame(maxHeight: .infinity)
-        .background(DSColor.backgroundWarm)
         .sheet(isPresented: $showSettings) {
             SettingsView()
         }
@@ -39,14 +45,15 @@ struct SidebarView: View {
     // MARK: - Brand Header
 
     private var brandHeader: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text("DAYPAGE")
-                .font(.custom("SpaceGrotesk-Bold", size: 18))
-                .foregroundColor(DSColor.onBackgroundPrimary)
-                .kerning(2)
+        VStack(alignment: .leading, spacing: 3) {
+            Text("DayPage")
+                .font(DSType.serifDisplay32)
+                .foregroundColor(DSColor.inkPrimary)
             Text("your daily log")
-                .font(.custom("Inter-Regular", size: 12))
-                .foregroundColor(DSColor.onBackgroundSubtle)
+                .font(DSType.mono10)
+                .foregroundColor(DSColor.inkSubtle)
+                .textCase(.uppercase)
+                .tracking(1.0)
         }
         .padding(.horizontal, 24)
         .padding(.top, 64)
@@ -78,43 +85,43 @@ struct SidebarView: View {
             }
         } label: {
             HStack(spacing: 12) {
-                // Left accent bar
-                Rectangle()
-                    .fill(isActive ? DSColor.accentAmber : Color.clear)
+                // Left amber accent strip
+                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                    .fill(isActive ? DSColor.amberAccent : Color.clear)
                     .frame(width: 2, height: 20)
 
                 Image(systemName: icon)
                     .font(.system(size: 16, weight: .regular))
                     .frame(width: 20)
                     .foregroundColor(
-                        disabled ? DSColor.onBackgroundSubtle
-                        : isActive ? DSColor.accentAmber
-                        : DSColor.onBackgroundMuted
+                        disabled ? DSColor.inkSubtle
+                        : isActive ? DSColor.amberAccent
+                        : DSColor.inkMuted
                     )
 
                 Text(label)
-                    .font(.custom(isActive ? "Inter-SemiBold" : "Inter-Regular", size: 15))
+                    .font(isActive ? DSType.titleSM : DSType.bodyMD)
                     .foregroundColor(
-                        disabled ? DSColor.onBackgroundSubtle
-                        : isActive ? DSColor.onBackgroundPrimary
-                        : DSColor.onBackgroundMuted
+                        disabled ? DSColor.inkSubtle
+                        : isActive ? DSColor.inkPrimary
+                        : DSColor.inkMuted
                     )
 
                 if disabled {
                     Spacer()
                     Text("Post-MVP")
-                        .font(.custom("JetBrainsMono-Regular", fixedSize: 9))
-                        .foregroundColor(DSColor.onBackgroundSubtle)
+                        .font(DSType.mono9)
+                        .foregroundColor(DSColor.inkSubtle)
                         .padding(.horizontal, 5)
                         .padding(.vertical, 2)
-                        .background(DSColor.borderSubtle)
+                        .background(DSColor.amberSoft, in: Capsule())
                 }
             }
             .padding(.leading, 0)
             .padding(.trailing, 16)
             .padding(.vertical, 11)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isActive ? DSColor.accentSoft : Color.clear)
+            .background(isActive ? DSColor.amberSoft : Color.clear)
             .contentShape(Rectangle())
         }
         .disabled(disabled)
@@ -130,16 +137,14 @@ struct SidebarView: View {
                 showSettings = true
             } label: {
                 HStack(spacing: 12) {
-                    Rectangle()
-                        .fill(Color.clear)
-                        .frame(width: 2, height: 20)
+                    Color.clear.frame(width: 2, height: 20)
                     Image(systemName: "gearshape")
                         .font(.system(size: 16, weight: .regular))
                         .frame(width: 20)
-                        .foregroundColor(DSColor.onBackgroundMuted)
+                        .foregroundColor(DSColor.inkMuted)
                     Text("Settings")
-                        .font(.custom("Inter-Regular", size: 15))
-                        .foregroundColor(DSColor.onBackgroundMuted)
+                        .font(DSType.bodyMD)
+                        .foregroundColor(DSColor.inkMuted)
                 }
                 .padding(.trailing, 16)
                 .padding(.vertical, 11)
@@ -166,21 +171,20 @@ struct SidebarView: View {
             showAccountSheet = true
         } label: {
             HStack(spacing: 12) {
-                Rectangle()
-                    .fill(Color.clear)
-                    .frame(width: 2, height: 20)
+                Color.clear.frame(width: 2, height: 20)
                 ZStack {
                     Circle()
-                        .fill(DSColor.accentSoft)
-                        .frame(width: 26, height: 26)
+                        .fill(DSColor.amberSoft)
+                        .frame(width: 28, height: 28)
+                        .overlay(Circle().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
                     Text(initial)
-                        .font(.custom("Inter-Medium", size: 12))
-                        .foregroundColor(DSColor.accentAmber)
+                        .font(DSType.labelSM)
+                        .foregroundColor(DSColor.amberDeep)
                 }
                 .frame(width: 20)
                 Text(email)
-                    .font(.custom("Inter-Regular", size: 13))
-                    .foregroundColor(DSColor.onBackgroundMuted)
+                    .font(DSType.bodySM)
+                    .foregroundColor(DSColor.inkMuted)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }

--- a/DayPage/DesignSystem/Colors.swift
+++ b/DayPage/DesignSystem/Colors.swift
@@ -31,9 +31,56 @@ extension Color {
     }
 }
 
-// MARK: - Design System Colors (v3 Warm-White Token System)
+// MARK: - Design System Colors (v4 Liquid Glass + v3 Warm-White)
 
 enum DSColor {
+
+    // MARK: - V4 Liquid Glass Tokens (iOS 26 inspired)
+    // Translucent warm-amber palette for glass surfaces. Use these in new
+    // surfaces; v3 tokens below remain for compatibility while the codebase
+    // migrates.
+
+    /// Page background — warm cream that the ambient glow lights through.
+    static let bgWarm        = Color(hex: "FAF7F2")
+    /// Standard glass fill — pair with `.ultraThinMaterial` for the iOS 26
+    /// refraction look.
+    static let glassStd      = Color(red: 1, green: 252.0/255, blue: 250.0/255, opacity: 0.62)
+    /// Elevated glass — used for sheets, modals, primary cards.
+    static let glassHi       = Color(red: 1, green: 252.0/255, blue: 250.0/255, opacity: 0.85)
+    /// Recessed glass — used for nested rows, secondary chips.
+    static let glassLo       = Color(red: 1, green: 252.0/255, blue: 250.0/255, opacity: 0.35)
+    /// Top-edge highlight that gives glass its "wet" rim.
+    static let glassEdge     = Color.white.opacity(0.55)
+    /// Hairline border — barely-visible warm ink line.
+    static let glassRim      = Color(hex: "2D1E0A").opacity(0.06)
+    /// Stronger hairline for elevated surfaces.
+    static let glassRimD     = Color(hex: "2D1E0A").opacity(0.10)
+
+    /// Primary ink — body copy, headlines.
+    static let inkPrimary    = Color(hex: "241B10")
+    /// Muted ink — secondary copy.
+    static let inkMuted      = Color(hex: "241B10").opacity(0.62)
+    /// Subtle ink — tertiary copy, disabled labels.
+    static let inkSubtle     = Color(hex: "241B10").opacity(0.38)
+    /// Faint ink — separators, decorative strokes.
+    static let inkFaint      = Color(hex: "241B10").opacity(0.18)
+
+    /// Amber accent — primary action, active state.
+    static let amberAccent   = Color(hex: "A8541B")
+    /// Deep amber — strong contrast on light glass.
+    static let amberDeep     = Color(hex: "5D3000")
+    /// Soft amber wash — hover, selected backgrounds.
+    static let amberSoft     = Color(hex: "A8541B").opacity(0.10)
+    /// Amber rim — accent borders, selected outlines.
+    static let amberRim      = Color(hex: "A8541B").opacity(0.22)
+    /// Amber glow — used in ambient light blobs.
+    static let amberGlow     = Color(hex: "E8974D").opacity(0.45)
+
+    // V4 amber-density heatmap (4-step)
+    static let densityNone   = Color(hex: "A8541B").opacity(0.06)
+    static let densityLow    = Color(hex: "A8541B").opacity(0.20)
+    static let densityMid    = Color(hex: "A8541B").opacity(0.45)
+    static let densityHigh   = Color(hex: "A8541B").opacity(0.85)
 
     // MARK: - V3 Warm-White Tokens
 

--- a/DayPage/DesignSystem/GlassSurface.swift
+++ b/DayPage/DesignSystem/GlassSurface.swift
@@ -1,0 +1,177 @@
+import SwiftUI
+
+// MARK: - Liquid Glass Card Modifier
+//
+// V4 design language — iOS 26 Liquid Glass. Apply to any container that
+// should read as a translucent warm-amber pane floating above the page.
+// Layers: warm tint → ultraThinMaterial → top-edge highlight → hairline rim
+// → soft drop shadow stack.
+
+enum GlassTone {
+    case standard   // Default body cards
+    case elevated   // Sheets, hero cards, Daily Page
+    case recessed   // Nested rows, secondary chips
+    case amberHero  // Deep amber Daily Page card
+
+    var fill: Color {
+        switch self {
+        case .standard:  return DSColor.glassStd
+        case .elevated:  return DSColor.glassHi
+        case .recessed:  return DSColor.glassLo
+        case .amberHero: return Color(hex: "5D3000").opacity(0.92)
+        }
+    }
+
+    var rim: Color {
+        switch self {
+        case .standard, .recessed: return DSColor.glassRim
+        case .elevated:            return DSColor.glassRimD
+        case .amberHero:           return DSColor.amberRim
+        }
+    }
+}
+
+struct LiquidGlassCard: ViewModifier {
+    var cornerRadius: CGFloat = 18
+    var tone: GlassTone = .standard
+
+    func body(content: Content) -> some View {
+        content
+            .background(tone.fill)
+            .background(.ultraThinMaterial)
+            .overlay(
+                // Top-edge wet highlight — gives the surface its glass "rim".
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(
+                        LinearGradient(
+                            colors: [DSColor.glassEdge, Color.clear],
+                            startPoint: .top,
+                            endPoint: .center
+                        ),
+                        lineWidth: 0.6
+                    )
+            )
+            .overlay(
+                // Hairline ink rim around the entire perimeter.
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(tone.rim, lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .shadow(color: Color(hex: "2D1E0A").opacity(0.04), radius: 1, x: 0, y: 1)
+            .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 24, x: 0, y: 8)
+    }
+}
+
+extension View {
+    /// Apply iOS 26-style Liquid Glass card surface.
+    func liquidGlassCard(cornerRadius: CGFloat = 18, tone: GlassTone = .standard) -> some View {
+        modifier(LiquidGlassCard(cornerRadius: cornerRadius, tone: tone))
+    }
+}
+
+// MARK: - Ambient Background
+//
+// Four blurred amber light blobs over a warm cream page. Creates the
+// "refraction" canvas that makes glass surfaces visibly translucent. Use
+// as the bottom layer of every full-screen view.
+
+struct AmbientBackground: View {
+    var body: some View {
+        ZStack {
+            DSColor.bgWarm.ignoresSafeArea()
+
+            // Top-left peach highlight
+            Circle()
+                .fill(Color(hex: "E8974D").opacity(0.55))
+                .frame(width: 360, height: 360)
+                .blur(radius: 80)
+                .offset(x: -60, y: -100)
+
+            // Top-right warm yellow
+            Circle()
+                .fill(Color(hex: "FFCE8C").opacity(0.55))
+                .frame(width: 320, height: 320)
+                .blur(radius: 80)
+                .offset(x: 140, y: -50)
+
+            // Center-left deep amber
+            Circle()
+                .fill(Color(hex: "A8541B").opacity(0.32))
+                .frame(width: 420, height: 420)
+                .blur(radius: 80)
+                .offset(x: -20, y: 200)
+
+            // Bottom-right warm rust
+            Circle()
+                .fill(Color(hex: "D98D54").opacity(0.40))
+                .frame(width: 300, height: 300)
+                .blur(radius: 80)
+                .offset(x: 100, y: 300)
+        }
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Glass Disc (small button surface)
+//
+// A 44pt translucent coin used for the input dock side buttons and any
+// other circular floating control. Same recipe as `LiquidGlassCard` but
+// shaped as a circle.
+
+struct GlassDisc: ViewModifier {
+    var size: CGFloat = 44
+
+    func body(content: Content) -> some View {
+        content
+            .frame(width: size, height: size)
+            .background(DSColor.glassStd)
+            .background(.ultraThinMaterial, in: Circle())
+            .overlay(
+                Circle()
+                    .strokeBorder(DSColor.glassEdge, lineWidth: 0.6)
+            )
+            .overlay(
+                Circle()
+                    .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
+            )
+            .clipShape(Circle())
+            .shadow(color: Color(hex: "2D1E0A").opacity(0.05), radius: 1, x: 0, y: 1)
+            .shadow(color: Color(hex: "2D1E0A").opacity(0.10), radius: 14, x: 0, y: 6)
+    }
+}
+
+extension View {
+    func glassDisc(size: CGFloat = 44) -> some View {
+        modifier(GlassDisc(size: size))
+    }
+}
+
+// MARK: - Amber Glow Halo
+//
+// Decorative warm halo placed behind a hero element (e.g. Daily Page
+// card, Day Orb in the sidebar). Adds the characteristic Liquid Glass
+// internal-light look without darkening the underlying surface.
+
+struct AmberHalo: View {
+    var size: CGFloat = 200
+    var intensity: Double = 0.55
+
+    var body: some View {
+        Circle()
+            .fill(
+                RadialGradient(
+                    colors: [
+                        Color(hex: "E8974D").opacity(intensity),
+                        Color(hex: "A8541B").opacity(intensity * 0.6),
+                        Color.clear
+                    ],
+                    center: .center,
+                    startRadius: 0,
+                    endRadius: size / 2
+                )
+            )
+            .frame(width: size, height: size)
+            .blur(radius: 24)
+            .allowsHitTesting(false)
+    }
+}

--- a/DayPage/DesignSystem/Typography.swift
+++ b/DayPage/DesignSystem/Typography.swift
@@ -40,6 +40,17 @@ enum DSFonts {
     static func jetBrainsMono(size: CGFloat, weight: Font.Weight = .regular) -> Font {
         .custom(mono, size: size).weight(weight)
     }
+
+    /// Serif body font for memo content / Daily Page narrative.
+    /// "New York" is the iOS system serif; SwiftUI resolves it via `.custom`
+    /// without a UIFont probe. Falls back to Georgia if unavailable.
+    static func newYork(size: CGFloat, weight: Font.Weight = .regular) -> Font {
+        Font.system(size: size, weight: weight, design: .serif)
+    }
+
+    static func newYorkItalic(size: CGFloat) -> Font {
+        Font.system(size: size, design: .serif).italic()
+    }
 }
 
 // MARK: - Typography Levels
@@ -92,6 +103,21 @@ enum DSType {
 
     // Mono-9: 9 / JetBrains Mono 400 uppercase (badges)
     static let mono9: Font = DSFonts.jetBrainsMono(size: 9, weight: .regular)
+
+    // MARK: - V4 Liquid Glass Serif Levels
+
+    /// Serif body 16pt — memo card body copy.
+    static let serifBody16: Font = DSFonts.newYork(size: 16, weight: .regular)
+    /// Serif body 18pt — Daily Page card lead summary.
+    static let serifBody18: Font = DSFonts.newYork(size: 18, weight: .regular)
+    /// Serif body 20pt — quoted voice transcript.
+    static let serifBody20: Font = DSFonts.newYork(size: 20, weight: .regular)
+    /// Serif italic 18pt — voice-memo "quote" style.
+    static let serifQuote: Font = DSFonts.newYorkItalic(size: 18)
+    /// Serif display 28pt — Today header date.
+    static let serifDisplay28: Font = DSFonts.newYork(size: 28, weight: .semibold)
+    /// Serif display 32pt — sidebar date / large headers.
+    static let serifDisplay32: Font = DSFonts.newYork(size: 32, weight: .semibold)
 }
 
 // MARK: - View Modifiers

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -58,16 +58,16 @@ struct DayStats {
 
         var fillColor: Color {
             switch self {
-            case .empty:  return DSColor.heatmapEmpty
-            case .low:    return DSColor.heatmapLow
-            case .medium: return DSColor.heatmapMid
-            case .high:   return DSColor.heatmapHigh
+            case .empty:  return DSColor.densityNone
+            case .low:    return DSColor.densityLow
+            case .medium: return DSColor.densityMid
+            case .high:   return DSColor.densityHigh
             }
         }
 
         var textColor: Color {
             switch self {
-            case .empty, .low: return DSColor.onSurface
+            case .empty, .low: return DSColor.inkPrimary
             case .medium, .high: return Color.white
             }
         }
@@ -81,15 +81,9 @@ struct DayStats {
             }
         }
 
-        /// 右下角指示器圆点的颜色。
-        /// 今日单元格中，圆点与边框颜色匹配（主色 / 白色），
-        /// 否则与单元格文本颜色一致，以确保在热力图背景上始终有对比度。
+        /// Right-corner dot color — amber accent on today cell, text color otherwise.
         func dotColor(isToday: Bool) -> Color {
-            if isToday {
-                // today border is DSColor.primary (black); use onPrimary so dot is visible
-                return DSColor.onPrimary
-            }
-            return textColor
+            isToday ? Color.white : textColor
         }
     }
 }
@@ -395,11 +389,9 @@ struct ArchiveView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                DSColor.background.ignoresSafeArea()
+                AmbientBackground().ignoresSafeArea()
                 VStack(spacing: 0) {
                     archiveHeader
-
-                    Divider().background(DSColor.outline)
 
                     ScrollView {
                         VStack(spacing: 0) {
@@ -484,72 +476,78 @@ struct ArchiveView: View {
     // MARK: - Archive Header
 
     private var archiveHeader: some View {
-        HStack(spacing: 10) {
-            // 汉堡菜单 — 打开侧边栏
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
             Button {
                 nav.openSidebar()
             } label: {
-                Image(systemName: "line.horizontal.3")
-                    .font(.system(size: 18, weight: .regular))
-                    .foregroundColor(DSColor.onSurface)
-                    .frame(width: 32, height: 32)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Archive")
+                        .font(DSType.serifDisplay28)
+                        .foregroundColor(DSColor.inkPrimary)
+                    Text(viewModel.currentMonthTitle.uppercased())
+                        .font(DSType.mono10)
+                        .foregroundColor(DSColor.inkSubtle)
+                        .tracking(1.0)
+                }
             }
             .buttonStyle(.plain)
             .accessibilityLabel("Open navigation")
             .accessibilityIdentifier("sidebar-menu-button")
 
-            Text("ARCHIVE")
-                .font(.custom("SpaceGrotesk-Bold", size: 20))
-                .foregroundColor(DSColor.onSurface)
-                .kerning(2)
-
             Spacer()
 
             Button(action: { showSearch = true }) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 18, weight: .regular))
-                    .foregroundColor(DSColor.onSurface)
-                    .frame(width: 32, height: 32)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundColor(DSColor.inkMuted)
+                    .frame(width: 36, height: 36)
+                    .background(DSColor.glassStd)
+                    .background(.ultraThinMaterial, in: Circle())
+                    .overlay(Circle().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                    .clipShape(Circle())
             }
             .buttonStyle(.plain)
             .accessibilityLabel("搜索")
         }
-        .padding(.horizontal, 16)
-        .frame(height: 56)
+        .padding(.horizontal, 20)
+        .padding(.top, 16)
+        .padding(.bottom, 12)
     }
 
     // MARK: - Month Navigation Row
 
     private var monthNavigationRow: some View {
         HStack {
-            // Left arrow
             Button(action: { viewModel.goToPreviousMonth() }) {
                 Image(systemName: "chevron.left")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(DSColor.onSurface)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(DSColor.inkMuted)
                     .frame(width: 32, height: 32)
             }
             .buttonStyle(.plain)
 
-            Text(viewModel.currentMonthTitle)
-                .font(.custom("SpaceGrotesk-Bold", size: 20))
-                .foregroundColor(DSColor.primary)
-                .frame(maxWidth: .infinity, alignment: .center)
+            Spacer()
 
-            Button(action: { viewModel.goToNextMonth() }) {
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(DSColor.onSurface)
-                    .frame(width: 32, height: 32)
-            }
-            .buttonStyle(.plain)
-
-            // CALENDAR / LIST toggle
-            HStack(spacing: 0) {
+            // CALENDAR / LIST toggle — glass pill
+            HStack(spacing: 2) {
                 toggleButton("CAL", isSelected: mode == .calendar) { mode = .calendar }
                 toggleButton("LIST", isSelected: mode == .list) { mode = .list }
             }
-            .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+            .padding(3)
+            .background(DSColor.glassLo)
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+            .clipShape(Capsule())
+
+            Spacer()
+
+            Button(action: { viewModel.goToNextMonth() }) {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(DSColor.inkMuted)
+                    .frame(width: 32, height: 32)
+            }
+            .buttonStyle(.plain)
         }
     }
 
@@ -557,13 +555,12 @@ struct ArchiveView: View {
         Button(action: action) {
             Text(label)
                 .monoLabelStyle(size: 10)
-                .foregroundColor(isSelected ? DSColor.onPrimary : DSColor.onSurfaceVariant)
-                .padding(.horizontal, 10)
+                .foregroundColor(isSelected ? .white : DSColor.inkSubtle)
+                .padding(.horizontal, 12)
                 .padding(.vertical, 6)
-                .background(isSelected ? DSColor.primary : Color.clear)
+                .background(isSelected ? DSColor.amberDeep : Color.clear, in: Capsule())
         }
         .buttonStyle(.plain)
-        .cornerRadius(0)
     }
 
     // MARK: - Calendar Grid
@@ -595,11 +592,13 @@ struct ArchiveView: View {
                 }
             }
         }
-        .background(DSColor.surfaceContainerLow)
+        .background(DSColor.glassLo)
+        .background(.ultraThinMaterial)
         .overlay(
-            Rectangle()
-                .stroke(DSColor.outlineVariant, lineWidth: 1)
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(DSColor.glassRim, lineWidth: 0.5)
         )
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
     }
 
     /// 日历单元格的三态分类（US-006）。
@@ -625,36 +624,32 @@ struct ArchiveView: View {
 
             let fillColor: Color = {
                 switch data {
-                case .compiled: return DSColor.primary
-                case .rawOnly:  return DSColor.surfaceContainerLow
-                case .none:     return DSColor.surfaceContainerLow.opacity(0.5)
+                case .compiled: return DSColor.amberDeep
+                case .rawOnly:  return DSColor.densityLow
+                case .none:     return DSColor.densityNone
                 }
             }()
 
             let textColor: Color = {
                 switch data {
-                case .compiled: return DSColor.onPrimary
-                case .rawOnly:  return DSColor.onSurface
-                case .none:     return DSColor.onSurface.opacity(0.5)
+                case .compiled: return Color.white
+                case .rawOnly:  return DSColor.inkPrimary
+                case .none:     return DSColor.inkSubtle
                 }
             }()
 
-            let dotColor: Color = {
-                // 圆点仅在 .rawOnly 状态下出现；保持主色调，以
-                // 呈现"有数据"的积极信号。
-                isToday ? DSColor.primary : DSColor.onSurface
-            }()
+            let dotColor: Color = isToday ? Color.white : DSColor.amberAccent
 
             Button(action: {
                 handleDateTap(dateStr: dateStr)
             }) {
                 ZStack(alignment: .topLeading) {
-                    Rectangle()
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
                         .fill(fillColor)
                         .overlay(
-                            Rectangle()
-                                .stroke(isToday ? DSColor.primary : DSColor.outlineVariant,
-                                        lineWidth: isToday ? 2 : 0.5)
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .stroke(isToday ? DSColor.amberAccent : DSColor.glassRim,
+                                        lineWidth: isToday ? 1.5 : 0.5)
                         )
 
                     Text(String(format: "%02d", day))
@@ -676,9 +671,8 @@ struct ArchiveView: View {
             .frame(maxWidth: .infinity)
             .accessibilityLabel(accessibilityLabel(dateStr: dateStr, state: data))
         } else {
-            Rectangle()
-                .fill(DSColor.surfaceContainerLowest.opacity(0.3))
-                .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 0.5))
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.clear)
                 .aspectRatio(1, contentMode: .fit)
                 .frame(maxWidth: .infinity)
         }
@@ -698,18 +692,17 @@ struct ArchiveView: View {
         HStack(spacing: 8) {
             Text("Activity:")
                 .monoLabelStyle(size: 9)
-                .foregroundColor(DSColor.onSurfaceVariant)
+                .foregroundColor(DSColor.inkSubtle)
 
             ForEach([DayStats.DensityLevel.empty, .low, .medium, .high], id: \.label) { level in
-                Rectangle()
+                RoundedRectangle(cornerRadius: 3, style: .continuous)
                     .fill(level.fillColor)
                     .frame(width: 12, height: 12)
-                    .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 0.5))
             }
 
             Text("Higher Density")
                 .monoLabelStyle(size: 9)
-                .foregroundColor(DSColor.onSurfaceVariant)
+                .foregroundColor(DSColor.inkSubtle)
 
             Spacer()
         }
@@ -720,13 +713,12 @@ struct ArchiveView: View {
     private var monthlySummary: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 16) {
-                Text("\(viewModel.currentMonthTitle) SUMMARY")
-                    .font(.custom("SpaceGrotesk-Bold", size: 11))
-                    .foregroundColor(DSColor.outline)
-                    .kerning(2)
+                Text("\(viewModel.currentMonthTitle) Summary")
+                    .font(DSType.sectionLabel)
+                    .foregroundColor(DSColor.inkSubtle)
                 Rectangle()
-                    .fill(DSColor.outlineVariant)
-                    .frame(height: 1)
+                    .fill(DSColor.inkFaint)
+                    .frame(height: 0.5)
             }
 
             LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
@@ -753,28 +745,28 @@ struct ArchiveView: View {
                         .foregroundColor(DSColor.onSurfaceVariant)
                         .padding(.vertical, 8)
                 } else {
-                    VStack(spacing: 4) {
+                    VStack(spacing: 6) {
                         ForEach(filtered, id: \.dateString) { stats in
                             Button(action: { handleDateTap(dateStr: stats.dateString) }) {
                                 HStack {
                                     Text(formatArchiveDate(stats.dateString))
                                         .monoLabelStyle(size: 11)
-                                        .foregroundColor(DSColor.onSurface)
+                                        .foregroundColor(DSColor.inkPrimary)
                                     Spacer()
                                     if stats.photoCount > 0 {
                                         Label("\(stats.photoCount)", systemImage: "photo")
                                             .monoLabelStyle(size: 10)
-                                            .foregroundColor(DSColor.onSurfaceVariant)
+                                            .foregroundColor(DSColor.inkMuted)
                                     }
                                     if stats.uniqueLocations > 0 {
                                         Label("\(stats.uniqueLocations)", systemImage: "mappin")
                                             .monoLabelStyle(size: 10)
-                                            .foregroundColor(DSColor.onSurfaceVariant)
+                                            .foregroundColor(DSColor.inkMuted)
                                     }
                                 }
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 8)
-                                .background(DSColor.surfaceContainer)
+                                .padding(.horizontal, 14)
+                                .padding(.vertical, 10)
+                                .liquidGlassCard(cornerRadius: 10)
                             }
                             .buttonStyle(.plain)
                         }
@@ -783,15 +775,14 @@ struct ArchiveView: View {
             }
 
             // Export / Share actions
-            HStack(spacing: 12) {
+            HStack(spacing: 10) {
                 Button(action: exportMarkdown) {
                     Label("导出 Markdown", systemImage: "square.and.arrow.up")
                         .monoLabelStyle(size: 11)
-                        .foregroundColor(DSColor.onSurface)
+                        .foregroundColor(DSColor.inkPrimary)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 8)
-                        .background(DSColor.surfaceContainer)
-                        .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+                        .liquidGlassCard(cornerRadius: 8)
                 }
                 .buttonStyle(.plain)
 
@@ -800,11 +791,10 @@ struct ArchiveView: View {
                 } label: {
                     Label("截图分享", systemImage: "camera")
                         .monoLabelStyle(size: 11)
-                        .foregroundColor(DSColor.onSurface)
+                        .foregroundColor(DSColor.inkPrimary)
                         .padding(.horizontal, 12)
                         .padding(.vertical, 8)
-                        .background(DSColor.surfaceContainer)
-                        .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+                        .liquidGlassCard(cornerRadius: 8)
                 }
                 .buttonStyle(.plain)
 
@@ -821,11 +811,10 @@ struct ArchiveView: View {
         return Button(action: { summaryFilter = filter }) {
             Text(filter.rawValue)
                 .monoLabelStyle(size: 10)
-                .foregroundColor(isSelected ? DSColor.onPrimary : DSColor.onSurfaceVariant)
+                .foregroundColor(isSelected ? Color.white : DSColor.inkSubtle)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
-                .background(isSelected ? DSColor.primary : DSColor.surfaceContainer)
-                .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+                .background(isSelected ? DSColor.amberDeep : DSColor.glassLo, in: Capsule())
         }
         .buttonStyle(.plain)
     }
@@ -864,27 +853,21 @@ struct ArchiveView: View {
 
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(value)
-                    .font(.custom("SpaceGrotesk-Bold", size: 48))
-                    .foregroundColor(DSColor.primary)
+                    .font(DSType.serifDisplay32)
+                    .foregroundColor(accentPrimary ? DSColor.amberDeep : DSColor.inkPrimary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
                 if let unit {
                     Text(unit.uppercased())
                         .monoLabelStyle(size: 10)
-                        .foregroundColor(DSColor.onSurfaceVariant)
+                        .foregroundColor(DSColor.inkSubtle)
                 }
             }
         }
-        .padding(20)
+        .padding(16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 120)
-        .background(DSColor.surfaceContainer)
-        .overlay(alignment: .leading) {
-            Rectangle()
-                .fill(accentPrimary ? DSColor.primary : DSColor.outline)
-                .frame(width: 4)
-        }
-        .cornerRadius(0)
+        .frame(height: 110)
+        .liquidGlassCard(cornerRadius: 12)
     }
 
     // MARK: - System Status Artifact
@@ -893,11 +876,11 @@ struct ArchiveView: View {
         VStack(spacing: 0) {
             // Top divider line
             Rectangle()
-                .fill(DSColor.outlineVariant)
-                .frame(height: 1)
+                .fill(DSColor.inkFaint)
+                .frame(height: 0.5)
 
             ZStack {
-                DSColor.onSurface.opacity(0.96)
+                DSColor.amberDeep.opacity(0.92)
                     .ignoresSafeArea(edges: [])
 
                 VStack(spacing: 16) {
@@ -933,7 +916,7 @@ struct ArchiveView: View {
 
     private var statusTextColor: Color {
         switch viewModel.systemStatus {
-        case .synchronized:       return DSColor.onBackgroundSubtle
+        case .synchronized:       return Color.white.opacity(0.6)
         case .pendingCompilation: return DSColor.warningAmber
         case .offline:            return DSColor.errorRed
         }
@@ -946,7 +929,7 @@ struct ArchiveView: View {
             if viewModel.sortedDays.isEmpty {
                 Text("本月暂无记录")
                     .bodySMStyle()
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .foregroundColor(DSColor.inkSubtle)
                     .frame(maxWidth: .infinity, alignment: .center)
                     .padding(.top, 40)
             } else {
@@ -995,49 +978,40 @@ struct ArchiveView: View {
         return Button(action: {
             handleDateTap(dateStr: stats.dateString)
         }) {
-            HStack(spacing: 0) {
-                Rectangle()
-                    .fill(DSColor.primary)
-                    .frame(width: 4)
-                    .opacity(isMetadataOnly ? 0.8 : 1.0)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text(relativeDateLabel(stats.dateString))
+                        .font(DSType.h2)
+                        .foregroundColor(DSColor.inkPrimary)
+                        .opacity(isMetadataOnly ? 0.7 : 1.0)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text(relativeDateLabel(stats.dateString))
-                            .font(.custom("SpaceGrotesk-Bold", size: 15))
-                            .foregroundColor(DSColor.onSurface)
-                            .opacity(isMetadataOnly ? 0.8 : 1.0)
+                    Spacer()
 
-                        Spacer()
-
-                        StatusBadge(
-                            label: stats.isDailyPageCompiled ? "VERIFIED" : "METADATA",
-                            style: stats.isDailyPageCompiled ? .verified : .metadata
-                        )
-                    }
-
-                    if let summary = stats.dailySummary, !summary.isEmpty {
-                        Text(summary)
-                            .bodySMStyle()
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                            .italic()
-                            .lineLimit(2)
-                            .opacity(isMetadataOnly ? 0.8 : 1.0)
-                    }
-
-                    HStack(spacing: 16) {
-                        metaIcon("doc.text", count: stats.memoCount)
-                        metaIcon("photo", count: stats.photoCount)
-                        metaIcon("mic", count: stats.voiceMinutes, unit: "min")
-                    }
-                    .opacity(isMetadataOnly ? 0.8 : 1.0)
+                    StatusBadge(
+                        label: stats.isDailyPageCompiled ? "VERIFIED" : "METADATA",
+                        style: stats.isDailyPageCompiled ? .verified : .metadata
+                    )
                 }
-                .padding(DSSpacing.cardGap)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(DSColor.surfaceContainer)
+
+                if let summary = stats.dailySummary, !summary.isEmpty {
+                    Text(summary)
+                        .font(DSType.serifBody16)
+                        .foregroundColor(DSColor.inkMuted)
+                        .italic()
+                        .lineLimit(2)
+                        .opacity(isMetadataOnly ? 0.7 : 1.0)
+                }
+
+                HStack(spacing: 16) {
+                    metaIcon("doc.text", count: stats.memoCount)
+                    metaIcon("photo", count: stats.photoCount)
+                    metaIcon("mic", count: stats.voiceMinutes, unit: "min")
+                }
+                .opacity(isMetadataOnly ? 0.7 : 1.0)
             }
-            .cornerRadius(DSSpacing.radiusCard)
-            .surfaceElevatedShadow()
+            .padding(DSSpacing.cardGap)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .liquidGlassCard(cornerRadius: DSSpacing.radiusCard)
             .pressableCard()
         }
         .buttonStyle(.plain)
@@ -1047,10 +1021,10 @@ struct ArchiveView: View {
         HStack(spacing: 4) {
             Image(systemName: systemName)
                 .font(.system(size: 10))
-                .foregroundColor(DSColor.onSurfaceVariant)
+                .foregroundColor(DSColor.inkSubtle)
             Text(unit != nil ? "\(count) \(unit!)" : "\(count)")
                 .monoLabelStyle(size: 11)
-                .foregroundColor(DSColor.onSurfaceVariant)
+                .foregroundColor(DSColor.inkSubtle)
         }
     }
 }

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -303,7 +303,7 @@ struct InputBarV4: View {
             action()
         } label: {
             Text("Aa")
-                .font(.system(size: 16, weight: .medium, design: .serif))
+                .font(DSFonts.newYork(size: 16, weight: .medium))
                 .foregroundStyle(DSColor.inkPrimary)
                 .frame(width: 44, height: 44)
                 .background(Color.clear)

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -117,7 +117,7 @@ struct InputBarV4: View {
             }
 
             Rectangle()
-                .fill(DSColor.outlineVariant.opacity(0.5))
+                .fill(DSColor.inkFaint)
                 .frame(height: 0.5)
 
             if !pendingAttachments.isEmpty {
@@ -146,21 +146,30 @@ struct InputBarV4: View {
             }
             .animation(.spring(response: 0.32, dampingFraction: 0.82), value: isComposing)
         }
-        .background(DSColor.backgroundWarm)
+        // V4: transparent dock — ambient page background shows through.
+        // Warm gradient veil fades the list content behind the dock.
+        .background(
+            LinearGradient(
+                colors: [Color.clear, DSColor.bgWarm.opacity(0.92), DSColor.bgWarm],
+                startPoint: .top,
+                endPoint: .bottom
+            )
+        )
         .overlay(alignment: .top) {
             if showTooShortToast {
                 HStack(spacing: 6) {
                     Image(systemName: "waveform")
                         .font(.system(size: 11, weight: .semibold))
                     Text("再说久一点 · 至少 1 秒")
-                        .font(.custom("Inter-Regular", size: 11))
+                        .font(DSType.labelSM)
                 }
-                .foregroundColor(DSColor.onSurface)
+                .foregroundColor(DSColor.inkPrimary)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 7)
-                .background(DSColor.surfaceContainerHigh)
+                .background(DSColor.glassHi)
+                .background(.ultraThinMaterial, in: Capsule())
                 .clipShape(Capsule())
-                .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
+                .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 8, x: 0, y: 2)
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                 .accessibilityLabel("录音太短，请按住麦克风继续说")
@@ -170,14 +179,15 @@ struct InputBarV4: View {
                     Image(systemName: "hand.tap")
                         .font(.system(size: 11, weight: .semibold))
                     Text("单击打开录音页 · 长按发送语音")
-                        .font(.custom("Inter-Regular", size: 11))
+                        .font(DSType.labelSM)
                 }
-                .foregroundColor(DSColor.onSurface)
+                .foregroundColor(DSColor.inkPrimary)
                 .padding(.horizontal, 14)
                 .padding(.vertical, 7)
-                .background(DSColor.surfaceContainerHigh)
+                .background(DSColor.glassHi)
+                .background(.ultraThinMaterial, in: Capsule())
                 .clipShape(Capsule())
-                .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
+                .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 8, x: 0, y: 2)
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                 .accessibilityLabel("单击打开录音页，长按发送语音")
@@ -213,32 +223,15 @@ struct InputBarV4: View {
     // shadow stack approximating the iOS 26 Liquid Glass treatment from the
     // design canvas (inner highlight + soft drop shadow).
 
-    // STREAM dock — three free-floating glass discs.
-    //
-    // No outer container: the page (and any list content behind it) shows
-    // through between the three buttons. Each disc carries its own
-    // ultraThinMaterial fill, fine inner highlight, and a soft warm-amber
-    // drop shadow so the surface reads as elevated glass over the page,
-    // not a solid pill.
+    // STREAM dock — glass capsule wrapping three keys (design spec: glassStyle hi + radius 999).
     private var streamDock: some View {
-        HStack(spacing: 18) {
-            // LEFT — More
-            dockSideButton(
-                systemImage: "plus",
-                accessibilityLabel: "更多附件"
-            ) {
+        HStack(spacing: 6) {
+            // LEFT — More (+)
+            dockSideButton(systemImage: "plus", accessibilityLabel: "更多附件") {
                 showAttachmentMenu = true
             }
 
-            // CENTER — Mic-hero (amber, slightly larger, the only filled CTA)
-            //
-            // Tap (< 0.35s)  → enter Flomo-style continuous recording sheet
-            //                  (VoiceRecordingView, half-screen, pause/resume/save).
-            // Long-press     → WeChat-style press-to-talk, release to send.
-            //
-            // The two paths are intentionally distinct: a tap is for "I want
-            // to talk for a while, control pause/save myself"; a hold is for
-            // "I want to dictate one quick thought and let go to send".
+            // CENTER — amber radial-gradient mic orb (64pt per design)
             PressToTalkButton(
                 onPressStart: handlePressToTalkStart,
                 onReleaseSend: handlePressToTalkReleaseSend,
@@ -246,21 +239,19 @@ struct InputBarV4: View {
                 onReleaseTranscribe: handlePressToTalkReleaseTranscribe,
                 onPhaseChange: { pressToTalkPhase = $0 },
                 onTapShortRelease: handleMicTap,
-                size: 56,
-                idleBackgroundColor: DSColor.accentAmber,
+                size: 64,
+                idleBackgroundColor: DSColor.amberAccent,
                 idleIconColor: .white
             )
-            .frame(width: 56, height: 56)
-            .shadow(color: DSColor.accentAmber.opacity(0.32), radius: 14, x: 0, y: 8)
-            .shadow(color: DSColor.accentAmber.opacity(0.18), radius: 4, x: 0, y: 2)
+            .frame(width: 64, height: 64)
+            // Radial amber orb glow matching design: inner highlight + deep shadow
+            .shadow(color: Color(hex: "5D3000").opacity(0.50), radius: 28, x: 0, y: 12)
+            .shadow(color: Color(hex: "5D3000").opacity(0.20), radius: 4, x: 0, y: 2)
             .accessibilityLabel("麦克风")
             .accessibilityHint("单击进入录音页；长按说话松手发送")
 
-            // RIGHT — Pen (expand text composer)
-            dockSideButton(
-                systemImage: "square.and.pencil",
-                accessibilityLabel: "写文字"
-            ) {
+            // RIGHT — Aa (text expand)
+            dockTextButton(accessibilityLabel: "写文字") {
                 withAnimation(.spring(response: 0.32, dampingFraction: 0.82)) {
                     userExpandedText = true
                 }
@@ -268,10 +259,18 @@ struct InputBarV4: View {
             }
             .accessibilityIdentifier("expand-text-composer")
         }
+        .padding(6)
+        // Glass capsule container — ultraThinMaterial + rim highlight
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(
+            LinearGradient(
+                colors: [Color.white.opacity(0.55), Color.white.opacity(0.12)],
+                startPoint: .top, endPoint: .bottom),
+            lineWidth: 0.6))
+        .shadow(color: Color(hex: "2D1E0A").opacity(0.10), radius: 24, x: 0, y: 8)
+        .shadow(color: Color(hex: "2D1E0A").opacity(0.06), radius: 4, x: 0, y: 1)
     }
 
-    // Translucent glass disc — 44pt. ultraThinMaterial + warm hairline +
-    // soft drop shadow so it reads as a floating glass coin over the page.
     @ViewBuilder
     private func dockSideButton(
         systemImage: String,
@@ -284,18 +283,31 @@ struct InputBarV4: View {
         } label: {
             Image(systemName: systemImage)
                 .font(.system(size: 18, weight: .regular))
-                .foregroundStyle(DSColor.onBackgroundPrimary)
+                .foregroundStyle(DSColor.inkPrimary)
                 .frame(width: 44, height: 44)
-                .background(
-                    Circle()
-                        .fill(.ultraThinMaterial)
-                )
-                .overlay(
-                    Circle()
-                        .strokeBorder(Color.white.opacity(0.55), lineWidth: 0.5)
-                )
-                .shadow(color: Color.black.opacity(0.10), radius: 10, x: 0, y: 6)
-                .shadow(color: Color.black.opacity(0.04), radius: 2, x: 0, y: 1)
+                .background(Color.clear)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+
+    // "Aa" text-expand key — matches design spec's third dock slot
+    @ViewBuilder
+    private func dockTextButton(
+        accessibilityLabel: String,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            action()
+        } label: {
+            Text("Aa")
+                .font(.system(size: 16, weight: .medium, design: .serif))
+                .foregroundStyle(DSColor.inkPrimary)
+                .frame(width: 44, height: 44)
+                .background(Color.clear)
+                .contentShape(Circle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(accessibilityLabel)
@@ -314,10 +326,10 @@ struct InputBarV4: View {
         case .transcribing:    raw = "正在转文字…"
         }
         return Text(raw)
-            .font(.custom("JetBrainsMono-Regular", size: 9))
+            .font(DSType.mono9)
             .tracking(1.4)
             .textCase(.uppercase)
-            .foregroundStyle(DSColor.onBackgroundSubtle)
+            .foregroundStyle(DSColor.inkSubtle)
             .frame(height: 12)
             .animation(.easeInOut(duration: 0.18), value: pressToTalkPhase)
     }
@@ -333,11 +345,11 @@ struct InputBarV4: View {
         VStack(spacing: 0) {
             // Text field — full width, no border, generous padding
             TextField("记一笔…", text: $text, axis: .vertical)
-                .font(.custom("Inter-Regular", size: 17))
-                .foregroundStyle(DSColor.onBackgroundPrimary)
+                .font(DSType.serifBody16)
+                .foregroundStyle(DSColor.inkPrimary)
                 .focused($isFocused)
                 .lineLimit(1...8)
-                .tint(DSColor.accentAmber)
+                .tint(DSColor.amberAccent)
                 .padding(.horizontal, 20)
                 .padding(.top, 14)
                 .padding(.bottom, 10)
@@ -363,7 +375,7 @@ struct InputBarV4: View {
                 // Mic — voice-to-text mode in composing
                 toolbarIconButton(
                     systemImage: isComposingTranscribe ? "waveform" : "mic",
-                    tint: isComposingTranscribe ? DSColor.accentAmber : DSColor.onBackgroundMuted,
+                    tint: isComposingTranscribe ? DSColor.amberAccent : DSColor.inkMuted,
                     accessibilityLabel: isComposingTranscribe ? "停止语音转文字" : "语音转文字"
                 ) {
                     handleComposingMicTap()
@@ -386,7 +398,7 @@ struct InputBarV4: View {
                 // Location
                 toolbarIconButton(
                     systemImage: pendingLocation != nil ? "mappin.circle.fill" : "mappin.and.ellipse",
-                    tint: pendingLocation != nil ? DSColor.accentAmber : DSColor.onBackgroundMuted,
+                    tint: pendingLocation != nil ? DSColor.amberAccent : DSColor.inkMuted,
                     accessibilityLabel: pendingLocation != nil ? "清除位置" : "添加位置"
                 ) {
                     pendingLocation != nil ? onClearLocation() : onFetchLocation()
@@ -405,7 +417,7 @@ struct InputBarV4: View {
     @ViewBuilder
     private func toolbarIconButton(
         systemImage: String,
-        tint: Color = DSColor.onBackgroundMuted,
+        tint: Color = DSColor.inkMuted,
         accessibilityLabel: String,
         action: @escaping () -> Void
     ) -> some View {
@@ -421,7 +433,7 @@ struct InputBarV4: View {
     @ViewBuilder
     private func toolbarIconButtonContent(
         systemImage: String,
-        tint: Color = DSColor.onBackgroundMuted
+        tint: Color = DSColor.inkMuted
     ) -> some View {
         Image(systemName: systemImage)
             .font(.system(size: 20, weight: .light))
@@ -466,11 +478,11 @@ struct InputBarV4: View {
             }
             .frame(width: 44, height: 44)
             .background(
-                hasContent ? DSColor.accentAmber : DSColor.accentAmber.opacity(0.18),
+                hasContent ? DSColor.amberAccent : DSColor.amberAccent.opacity(0.18),
                 in: Circle()
             )
             .shadow(
-                color: hasContent ? DSColor.accentAmber.opacity(0.32) : .clear,
+                color: hasContent ? DSColor.amberAccent.opacity(0.32) : .clear,
                 radius: 8, x: 0, y: 4
             )
             .animation(.easeInOut(duration: 0.18), value: hasContent)
@@ -600,15 +612,15 @@ struct InputBarV4: View {
     private func attachmentChip(_ att: PendingAttachment) -> some View {
         let (icon, label) = chipContent(att)
         return HStack(spacing: 4) {
-            Image(systemName: icon).font(.system(size: 11)).foregroundStyle(DSColor.onBackgroundMuted)
-            Text(label).font(.system(size: 12)).foregroundStyle(DSColor.onBackgroundMuted).lineLimit(1)
+            Image(systemName: icon).font(.system(size: 11)).foregroundStyle(DSColor.inkMuted)
+            Text(label).font(.system(size: 12)).foregroundStyle(DSColor.inkMuted).lineLimit(1)
             Button { onRemoveAttachment(att.id) } label: {
-                Image(systemName: "xmark").font(.system(size: 9, weight: .bold)).foregroundStyle(DSColor.onBackgroundSubtle)
+                Image(systemName: "xmark").font(.system(size: 9, weight: .bold)).foregroundStyle(DSColor.inkSubtle)
             }.buttonStyle(.plain)
         }
         .padding(.horizontal, 10)
         .padding(.vertical, 5)
-        .background(DSColor.surfaceSunken, in: Capsule())
+        .background(DSColor.glassLo, in: Capsule())
     }
 
     private func chipContent(_ att: PendingAttachment) -> (icon: String, label: String) {
@@ -621,11 +633,11 @@ struct InputBarV4: View {
 
     private func locationChipRow(loc: Memo.Location) -> some View {
         HStack(spacing: 4) {
-            Image(systemName: "mappin").font(.system(size: 10, weight: .semibold)).foregroundStyle(DSColor.accentAmber)
-            Text(locationLabel(loc)).font(.system(size: 12)).foregroundStyle(DSColor.accentAmber).lineLimit(1)
+            Image(systemName: "mappin").font(.system(size: 10, weight: .semibold)).foregroundStyle(DSColor.amberAccent)
+            Text(locationLabel(loc)).font(.system(size: 12)).foregroundStyle(DSColor.amberAccent).lineLimit(1)
             Spacer()
             Button(action: onClearLocation) {
-                Image(systemName: "xmark.circle.fill").font(.system(size: 14)).foregroundStyle(DSColor.onBackgroundSubtle)
+                Image(systemName: "xmark.circle.fill").font(.system(size: 14)).foregroundStyle(DSColor.inkSubtle)
             }.buttonStyle(.plain)
         }
         .padding(.horizontal, 16)

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -1,56 +1,42 @@
 import SwiftUI
-import UIKit
 import ImageIO
 import AVFoundation
 import MapKit
 
 // MARK: - MemoCardView
 
-/// Displays a single Memo as a card in the Today timeline.
-/// Shows time + full content; cards grow to fit the memo so long voice
-/// transcriptions and long text are never clipped.
+/// A single Memo rendered as a Liquid Glass card in the Today timeline.
 struct MemoCardView: View {
 
     let memo: Memo
-
-    /// Optional callback invoked when the user confirms deletion of this memo.
     var onDelete: (() -> Void)? = nil
 
     @State private var showLocationSheet: Bool = false
-    /// Tracks which attachment URLs have finished downloading from iCloud.
     @State private var downloadedURLs: Set<URL> = []
     @State private var thumbnail: UIImage?
     @State private var pollingURLs: Set<URL> = []
 
-    // MARK: - iCloud Attachment Helpers
+    // MARK: - iCloud helpers
 
-    /// Returns true when the file at `url` is locally available (not evicted to iCloud).
-    /// For non-ubiquitous (local-vault) files this always returns true.
     private func isAttachmentDownloaded(_ url: URL) -> Bool {
         guard VaultInitializer.shared.isUsingiCloud else { return true }
         guard let values = try? url.resourceValues(forKeys: [.ubiquitousItemDownloadingStatusKey]),
-              let status = values.ubiquitousItemDownloadingStatus else {
-            // Not a ubiquitous item — treat as locally available.
-            return true
-        }
+              let status = values.ubiquitousItemDownloadingStatus else { return true }
         return status == .current
     }
 
-    /// Requests iCloud to download the file at `url` if it is not already local.
-    /// No-op for local-vault files or files that are already downloaded.
     private func startDownload(_ url: URL) {
         guard VaultInitializer.shared.isUsingiCloud else { return }
         guard !isAttachmentDownloaded(url) else { return }
         try? FileManager.default.startDownloadingUbiquitousItem(at: url)
     }
 
-    /// Polls the download status and marks the URL as downloaded once iCloud delivers it.
     private func pollDownloadStatus(for url: URL) {
         guard !downloadedURLs.contains(url), !pollingURLs.contains(url) else { return }
         pollingURLs.insert(url)
         Task {
             for _ in 0..<30 {
-                try? await Task.sleep(nanoseconds: 2_000_000_000) // 2 s
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
                 if isAttachmentDownloaded(url) {
                     await MainActor.run {
                         downloadedURLs.insert(url)
@@ -64,7 +50,6 @@ struct MemoCardView: View {
     }
 
     var body: some View {
-        // Location memos get their own dedicated card layout
         if memo.type == .location {
             locationCard
         } else {
@@ -75,65 +60,57 @@ struct MemoCardView: View {
     // MARK: - Location Card
 
     private var locationCard: some View {
-        HStack(spacing: 0) {
-            // Left 4pt accent line
-            Rectangle()
-                .fill(DSColor.primary)
-                .frame(width: 4)
-
-            // Time + content
-            VStack(alignment: .leading, spacing: 0) {
-                // Time chip
-                TimeChip(time: RelativeTimeFormatter.relative(memo.created))
-                    .padding(.horizontal, DSSpacing.cardInner)
-                    .padding(.top, 10)
-
-                // Location name + coordinates row
-                HStack(alignment: .top, spacing: 12) {
-                    VStack(alignment: .leading, spacing: 4) {
-                        if let name = memo.location?.name, !name.isEmpty {
-                            Text(name.uppercased())
-                                .h2Style()
-                                .foregroundColor(DSColor.onSurface)
-                        }
-
-                        let coordText = coordinateString(memo.location)
-                        if !coordText.isEmpty {
-                            Text(coordText)
-                                .monoLabelStyle(size: 11)
-                                .foregroundColor(DSColor.onSurfaceVariant)
-                        }
-                    }
-
-                    Spacer()
-
-                    Image(systemName: "location.fill")
-                        .font(.system(size: 16, weight: .regular))
-                        .foregroundColor(DSColor.primary)
-                }
-                .padding(.horizontal, DSSpacing.cardInner)
-                .padding(.top, 6)
-                .padding(.bottom, DSSpacing.cardInner)
+        HStack(spacing: 14) {
+            // Amber pin icon
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(DSColor.amberSoft)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(DSColor.amberRim, lineWidth: 0.5)
+                    )
+                    .frame(width: 44, height: 44)
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundColor(DSColor.amberAccent)
             }
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .background(DSColor.surfaceContainer)
-            .contentShape(Rectangle())
-            .onTapGesture {
-                if memo.location?.lat != nil && memo.location?.lng != nil {
-                    showLocationSheet = true
+
+            VStack(alignment: .leading, spacing: 3) {
+                if let name = memo.location?.name, !name.isEmpty {
+                    Text(name)
+                        .font(DSType.serifBody16)
+                        .foregroundColor(DSColor.inkPrimary)
+                        .lineLimit(1)
                 }
+                let coord = coordinateString(memo.location)
+                if !coord.isEmpty {
+                    Text(coord)
+                        .font(DSFonts.jetBrainsMono(size: 10))
+                        .tracking(0.6)
+                        .textCase(.uppercase)
+                        .foregroundColor(DSColor.inkSubtle)
+                }
+                Text(RelativeTimeFormatter.relative(memo.created))
+                    .font(DSFonts.jetBrainsMono(size: 10))
+                    .tracking(0.6)
+                    .textCase(.uppercase)
+                    .foregroundColor(DSColor.inkSubtle)
+                    .padding(.top, 4)
             }
+
+            Spacer(minLength: 0)
         }
-        .cornerRadius(DSSpacing.radiusCard)
-        .surfaceElevatedShadow()
-        .pressableCard()
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .liquidGlassCard(cornerRadius: 18)
+        .contentShape(RoundedRectangle(cornerRadius: 18))
+        .onTapGesture {
+            if memo.location?.lat != nil { showLocationSheet = true }
+        }
         .sheet(isPresented: $showLocationSheet) {
-            LocationPreviewSheet(
-                location: memo.location,
-                onDelete: onDelete
-            )
-            .presentationDetents([.medium, .large])
-            .presentationDragIndicator(.visible)
+            LocationPreviewSheet(location: memo.location, onDelete: onDelete)
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
         }
     }
 
@@ -141,16 +118,8 @@ struct MemoCardView: View {
 
     private var standardCard: some View {
         VStack(alignment: .leading, spacing: 0) {
-            // Top row: time chip + type icon
-            HStack(alignment: .center, spacing: 8) {
-                TimeChip(time: RelativeTimeFormatter.relative(memo.created))
-                typeLabel
-                Spacer()
-            }
-            .padding(.horizontal, DSSpacing.cardInner)
-            .padding(.top, 10)
 
-            // Voice player row (for voice memos with audio attachments)
+            // Voice card: quoted transcript style
             if memo.type == .voice || (memo.type == .mixed && memo.attachments.contains(where: { $0.kind == "audio" })) {
                 if let att = memo.attachments.first(where: { $0.kind == "audio" }) {
                     let audioURL = VaultInitializer.vaultURL.appendingPathComponent(att.file)
@@ -161,211 +130,152 @@ struct MemoCardView: View {
                             duration: att.duration ?? 0,
                             transcript: att.transcript
                         )
-                        .padding(.top, 6)
+                        .padding(.top, 4)
                     } else {
-                        // iCloud evicted — show waveform placeholder with download icon
                         AudioDownloadPlaceholder()
-                            .padding(.top, 6)
-                            .onAppear {
-                                startDownload(audioURL)
-                                pollDownloadStatus(for: audioURL)
-                            }
-                            .onDisappear {
-                                pollingURLs.remove(audioURL)
-                            }
-                            .onTapGesture {
-                                startDownload(audioURL)
-                                pollDownloadStatus(for: audioURL)
-                            }
+                            .padding(.top, 4)
+                            .onAppear { startDownload(audioURL); pollDownloadStatus(for: audioURL) }
+                            .onDisappear { pollingURLs.remove(audioURL) }
+                            .onTapGesture { startDownload(audioURL); pollDownloadStatus(for: audioURL) }
                     }
                 }
             }
 
-            // Photo thumbnail row (for photo and mixed memos with photo attachments)
+            // Photo
             if memo.type == .photo || (memo.type == .mixed && memo.attachments.contains(where: { $0.kind == "photo" })) {
                 if let att = memo.attachments.first(where: { $0.kind == "photo" }) {
                     let photoURL = VaultInitializer.vaultURL.appendingPathComponent(att.file)
                     let isReady = isAttachmentDownloaded(photoURL) || downloadedURLs.contains(photoURL)
                     if isReady {
-                        PhotoThumbnailView(
-                            fileURL: photoURL,
-                            thumbnail: $thumbnail,
-                            exifText: photoExifText
-                        )
-                        .padding(.top, 6)
-                    } else if !isReady {
-                        // iCloud evicted — show gray placeholder with spinner
+                        PhotoThumbnailView(fileURL: photoURL, thumbnail: $thumbnail, exifText: photoExifText)
+                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            .padding(.horizontal, 14)
+                            .padding(.top, 14)
+                    } else {
                         PhotoDownloadPlaceholder()
-                            .padding(.top, 6)
-                            .onAppear {
-                                startDownload(photoURL)
-                                pollDownloadStatus(for: photoURL)
-                            }
-                            .onDisappear {
-                                pollingURLs.remove(photoURL)
-                            }
+                            .padding(.top, 4)
+                            .onAppear { startDownload(photoURL); pollDownloadStatus(for: photoURL) }
+                            .onDisappear { pollingURLs.remove(photoURL) }
                     }
                 }
             }
 
-            // File attachment rows (for mixed memos with file attachments)
-            let fileAttachments = memo.attachments.filter { $0.kind == "file" }
-            if !fileAttachments.isEmpty {
+            // File attachments
+            let fileAtts = memo.attachments.filter { $0.kind == "file" }
+            if !fileAtts.isEmpty {
                 VStack(alignment: .leading, spacing: 4) {
-                    ForEach(fileAttachments, id: \.file) { att in
+                    ForEach(fileAtts, id: \.file) { att in
                         HStack(spacing: 8) {
                             Image(systemName: "doc.fill")
-                                .font(.system(size: 13))
-                                .foregroundColor(DSColor.onSurfaceVariant)
+                                .font(.system(size: 12))
+                                .foregroundColor(DSColor.inkSubtle)
                             Text(att.transcript ?? URL(fileURLWithPath: att.file).lastPathComponent)
-                                .monoLabelStyle(size: 11)
-                                .foregroundColor(DSColor.onSurface)
+                                .font(DSFonts.jetBrainsMono(size: 11))
+                                .foregroundColor(DSColor.inkMuted)
                                 .lineLimit(1)
                                 .truncationMode(.middle)
                         }
-                        .padding(.horizontal, DSSpacing.cardInner)
-                        .padding(.vertical, 4)
+                        .padding(.horizontal, 14)
+                        .padding(.vertical, 3)
                     }
                 }
-                .padding(.top, 6)
+                .padding(.top, 8)
             }
 
-            // Body content (caption)
-            // For voice-only memos, suppress body when it duplicates the transcript
-            // (legacy data had transcript copied into body before the fix).
-            let bodyText = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
-            let isBodyDuplicateOfTranscript = memo.type == .voice &&
-                memo.attachments.contains(where: { $0.transcript == bodyText && !bodyText.isEmpty })
-            if !bodyText.isEmpty && !isBodyDuplicateOfTranscript {
-                Text(bodyText)
-                    .bodySMStyle()
-                    .foregroundColor(DSColor.onSurface)
+            // Body text — serif
+            let bodyTrimmed = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
+            let isBodyDuplicate = memo.type == .voice &&
+                memo.attachments.contains(where: { $0.transcript == bodyTrimmed && !bodyTrimmed.isEmpty })
+            if !bodyTrimmed.isEmpty && !isBodyDuplicate {
+                Text(bodyTrimmed)
+                    .font(DSType.serifBody16)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .lineSpacing(3)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .textSelection(.enabled)
-                    .padding(.horizontal, DSSpacing.cardInner)
-                    .padding(.top, 6)
+                    .padding(.horizontal, 14)
+                    .padding(.top, 12)
             }
 
-            // Bottom row: location label
-            if let locationName = memo.location?.name, !locationName.isEmpty {
-                HStack(spacing: 3) {
-                    Image(systemName: "mappin")
-                        .font(.system(size: 9, weight: .medium))
-                        .foregroundColor(DSColor.onSurfaceVariant)
-                    Text(locationName)
-                        .monoLabelStyle(size: 9)
-                        .foregroundColor(DSColor.onSurfaceVariant)
-                    Spacer(minLength: 0)
+            // Bottom meta row: time + type chip + location
+            HStack(spacing: 8) {
+                Text(RelativeTimeFormatter.relative(memo.created))
+                    .font(DSFonts.jetBrainsMono(size: 10))
+                    .tracking(0.6)
+                    .textCase(.uppercase)
+                    .foregroundColor(DSColor.inkSubtle)
+
+                if memo.type != .text {
+                    typeChip
                 }
-                .padding(.horizontal, DSSpacing.cardInner)
-                .padding(.top, 6)
-                .padding(.bottom, DSSpacing.cardInner)
-            } else {
-                // Match the location branch's 6pt top + cardInner bottom rhythm
-                // so cards with and without a location label share the same
-                // bottom whitespace.
-                Spacer().frame(height: DSSpacing.cardInner + 6)
+
+                if let loc = memo.location?.name, !loc.isEmpty {
+                    HStack(spacing: 3) {
+                        Image(systemName: "mappin")
+                            .font(.system(size: 8, weight: .medium))
+                        Text(loc)
+                            .font(DSFonts.jetBrainsMono(size: 9))
+                            .tracking(0.4)
+                            .textCase(.uppercase)
+                    }
+                    .foregroundColor(DSColor.inkSubtle)
+                }
             }
+            .padding(.horizontal, 14)
+            .padding(.top, 10)
+            .padding(.bottom, 14)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(DSColor.surfaceContainer)
-        .overlay(
-            Rectangle()
-                .fill(borderColor)
-                .frame(width: 3),
-            alignment: .leading
-        )
-        .cornerRadius(DSSpacing.radiusCard)
-        .surfaceElevatedShadow()
-        .pressableCard()
+        .liquidGlassCard(cornerRadius: 18)
     }
 
-    // MARK: - Subviews
+    // MARK: - Type chip
 
-    private var typeLabel: some View {
+    private var typeChip: some View {
         Group {
             switch memo.type {
             case .voice:
-                Label("语音", systemImage: "mic.fill")
-                    .monoLabelStyle(size: 9)
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                Label("Voice", systemImage: "mic.fill")
             case .photo:
-                Label("照片", systemImage: "photo")
-                    .monoLabelStyle(size: 9)
-                    .foregroundColor(DSColor.onSurfaceVariant)
-            case .location:
-                Label("位置", systemImage: "location.fill")
-                    .monoLabelStyle(size: 9)
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                Label("Photo", systemImage: "photo")
             case .mixed:
-                Label("混合", systemImage: "square.stack")
-                    .monoLabelStyle(size: 9)
-                    .foregroundColor(DSColor.onSurfaceVariant)
-            case .text:
+                Label("Mixed", systemImage: "square.stack")
+            default:
                 EmptyView()
             }
         }
+        .font(DSFonts.jetBrainsMono(size: 9))
+        .tracking(0.5)
+        .textCase(.uppercase)
+        .foregroundColor(DSColor.amberAccent)
     }
 
     // MARK: - Helpers
 
-    /// Formats lat/lng as "45.52306° N, 122.67648° W"
     private func coordinateString(_ loc: Memo.Location?) -> String {
         guard let lat = loc?.lat, let lng = loc?.lng else { return "" }
-        let latStr = String(format: "%.5f° %@", abs(lat), lat >= 0 ? "N" : "S")
-        let lngStr = String(format: "%.5f° %@", abs(lng), lng >= 0 ? "E" : "W")
-        return "\(latStr), \(lngStr)"
+        let latStr = String(format: "%.4f° %@", abs(lat), lat >= 0 ? "N" : "S")
+        let lngStr = String(format: "%.4f° %@", abs(lng), lng >= 0 ? "E" : "W")
+        return "\(latStr) · \(lngStr)"
     }
 
-    /// Builds EXIF annotation text for the first photo attachment.
-    /// Format: "IMG_0001.HEIC // FOCUS: INFINITYmm"
     private var photoExifText: String? {
         guard let att = memo.attachments.first(where: { $0.kind == "photo" }) else { return nil }
         let filename = URL(fileURLWithPath: att.file).lastPathComponent.uppercased()
-        // Try to read focal length from image metadata
         let fileURL = VaultInitializer.vaultURL.appendingPathComponent(att.file)
         if let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil),
            let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
            let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any],
-           let focalLength = exif[kCGImagePropertyExifFocalLength as String] as? Double {
-            return "\(filename) // FOCUS: \(Int(focalLength))mm"
+           let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double {
+            return "\(filename) // FOCUS: \(Int(focal))mm"
         }
-        return "\(filename)"
+        return filename
     }
-
-    /// Loads a thumbnail from `fileURL`. Returns nil if the file is not locally available.
-    private func loadThumbnail(from fileURL: URL) -> UIImage? {
-        guard let data = try? Data(contentsOf: fileURL) else { return nil }
-        let opts: [CFString: Any] = [
-            kCGImageSourceShouldCacheImmediately: false,
-            kCGImageSourceCreateThumbnailWithTransform: true,
-            kCGImageSourceCreateThumbnailFromImageIfAbsent: true,
-            kCGImageSourceThumbnailMaxPixelSize: 600
-        ]
-        if let source = CGImageSourceCreateWithData(data as CFData, nil),
-           let cgThumb = CGImageSourceCreateThumbnailAtIndex(source, 0, opts as CFDictionary) {
-            return UIImage(cgImage: cgThumb)
-        }
-        return UIImage(data: data)
-    }
-
-    private var borderColor: Color {
-        switch memo.type {
-        case .text:    return DSColor.primary
-        case .voice:   return DSColor.onSurfaceVariant
-        case .photo:   return DSColor.secondaryFixed
-        case .location: return DSColor.tertiaryFixed
-        case .mixed:   return DSColor.amberArchival
-        }
-    }
-
 }
 
 // MARK: - LocationPreviewSheet
 
-/// Sheet shown when tapping a location card. Displays a MapKit map preview
-/// with options to open in Apple Maps or delete the attachment.
 struct LocationPreviewSheet: View {
 
     let location: Memo.Location?
@@ -380,31 +290,30 @@ struct LocationPreviewSheet: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Handle bar area + title
             HStack {
                 VStack(alignment: .leading, spacing: 2) {
                     if let name = location?.name, !name.isEmpty {
-                        Text(name.uppercased())
-                            .h2Style()
-                            .foregroundColor(DSColor.onSurface)
+                        Text(name)
+                            .font(DSType.h2)
+                            .foregroundColor(DSColor.inkPrimary)
                     } else {
-                        Text("位置附件")
-                            .h2Style()
-                            .foregroundColor(DSColor.onSurface)
+                        Text("Location")
+                            .font(DSType.h2)
+                            .foregroundColor(DSColor.inkPrimary)
                     }
                     if let coord = coordinate {
                         Text(String(format: "%.5f°, %.5f°", coord.latitude, coord.longitude))
-                            .monoLabelStyle(size: 11)
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .font(DSFonts.jetBrainsMono(size: 11))
+                            .foregroundColor(DSColor.inkSubtle)
                     }
                 }
                 Spacer()
                 Button(action: { dismiss() }) {
                     Image(systemName: "xmark")
-                        .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(DSColor.onSurfaceVariant)
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(DSColor.inkMuted)
                         .frame(width: 32, height: 32)
-                        .background(DSColor.surfaceContainerHigh)
+                        .background(DSColor.amberSoft)
                         .clipShape(Circle())
                 }
                 .buttonStyle(.plain)
@@ -413,9 +322,8 @@ struct LocationPreviewSheet: View {
             .padding(.top, 20)
             .padding(.bottom, 12)
 
-            Divider().background(DSColor.outline)
+            Divider().background(DSColor.glassRim)
 
-            // Map view
             if let coord = coordinate {
                 MapPreviewView(coordinate: coord)
                     .frame(maxWidth: .infinity)
@@ -424,33 +332,31 @@ struct LocationPreviewSheet: View {
                 VStack(spacing: 8) {
                     Image(systemName: "map")
                         .font(.system(size: 32))
-                        .foregroundColor(DSColor.onSurfaceVariant)
-                    Text("无坐标信息")
-                        .bodySMStyle()
-                        .foregroundColor(DSColor.onSurfaceVariant)
+                        .foregroundColor(DSColor.inkSubtle)
+                    Text("No coordinates")
+                        .font(DSType.bodySM)
+                        .foregroundColor(DSColor.inkSubtle)
                 }
                 .frame(maxWidth: .infinity)
                 .frame(height: 260)
-                .background(DSColor.surfaceContainer)
+                .background(DSColor.glassLo)
             }
 
-            Divider().background(DSColor.outline)
+            Divider().background(DSColor.glassRim)
 
-            // Action buttons
             VStack(spacing: 0) {
-                // Open in Apple Maps
                 Button(action: openInAppleMaps) {
                     HStack(spacing: 10) {
                         Image(systemName: "map.fill")
                             .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(DSColor.primary)
-                        Text("在 Apple Maps 中打开")
-                            .titleSMStyle()
-                            .foregroundColor(DSColor.primary)
+                            .foregroundColor(DSColor.amberDeep)
+                        Text("Open in Apple Maps")
+                            .font(DSType.titleSM)
+                            .foregroundColor(DSColor.amberDeep)
                         Spacer()
                         Image(systemName: "arrow.up.right")
-                            .font(.system(size: 12, weight: .semibold))
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(DSColor.inkSubtle)
                     }
                     .padding(.horizontal, 20)
                     .padding(.vertical, 16)
@@ -459,20 +365,14 @@ struct LocationPreviewSheet: View {
                 .disabled(coordinate == nil)
 
                 if onDelete != nil {
-                    Divider()
-                        .padding(.horizontal, 20)
-                        .background(DSColor.outlineVariant)
-
-                    Button(action: {
-                        dismiss()
-                        onDelete?()
-                    }) {
+                    Divider().padding(.horizontal, 20).background(DSColor.glassRim)
+                    Button(action: { dismiss(); onDelete?() }) {
                         HStack(spacing: 10) {
                             Image(systemName: "trash")
                                 .font(.system(size: 15, weight: .semibold))
                                 .foregroundColor(.red)
-                            Text("删除附件")
-                                .titleSMStyle()
+                            Text("Delete")
+                                .font(DSType.titleSM)
                                 .foregroundColor(.red)
                             Spacer()
                         }
@@ -482,17 +382,16 @@ struct LocationPreviewSheet: View {
                     .buttonStyle(.plain)
                 }
             }
-            .background(DSColor.surfaceContainer)
+            .background(DSColor.glassStd)
 
             Spacer()
         }
-        .background(DSColor.background.ignoresSafeArea())
+        .background(DSColor.bgWarm.ignoresSafeArea())
     }
 
     private func openInAppleMaps() {
         guard let coord = coordinate else { return }
-        let urlStr = "maps://?ll=\(coord.latitude),\(coord.longitude)"
-        if let url = URL(string: urlStr) {
+        if let url = URL(string: "maps://?ll=\(coord.latitude),\(coord.longitude)") {
             UIApplication.shared.open(url)
         }
     }
@@ -500,26 +399,20 @@ struct LocationPreviewSheet: View {
 
 // MARK: - MapPreviewView
 
-/// A UIViewRepresentable wrapper for MKMapView to show a static map snapshot with a pin.
 struct MapPreviewView: UIViewRepresentable {
-
     let coordinate: CLLocationCoordinate2D
 
     func makeUIView(context: Context) -> MKMapView {
         let map = MKMapView()
         map.isUserInteractionEnabled = false
         map.showsUserLocation = false
-        map.mapType = .standard
         return map
     }
 
     func updateUIView(_ mapView: MKMapView, context: Context) {
-        let region = MKCoordinateRegion(
-            center: coordinate,
-            span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01)
-        )
+        let region = MKCoordinateRegion(center: coordinate,
+                                        span: MKCoordinateSpan(latitudeDelta: 0.01, longitudeDelta: 0.01))
         mapView.setRegion(region, animated: false)
-
         mapView.removeAnnotations(mapView.annotations)
         let pin = MKPointAnnotation()
         pin.coordinate = coordinate
@@ -529,8 +422,6 @@ struct MapPreviewView: UIViewRepresentable {
 
 // MARK: - VoiceMemoPlayerRow
 
-/// Inline voice memo player: black square play button + static waveform bars + duration.
-/// Uses AVAudioPlayer for playback. Only one instance plays at a time via a shared player.
 struct VoiceMemoPlayerRow: View {
 
     let fileURL: URL
@@ -545,111 +436,94 @@ struct VoiceMemoPlayerRow: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
+            // Playback row
             HStack(spacing: 12) {
-                // Play/Pause button (40x40 black square)
                 Button(action: togglePlayback) {
-                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
-                        .font(.system(size: 16, weight: .semibold))
-                        .foregroundColor(fileError ? DSColor.onSurfaceVariant : DSColor.onPrimary)
-                        .frame(width: 40, height: 40)
-                        .background(fileError ? DSColor.surfaceContainerHigh : DSColor.primary)
+                    ZStack {
+                        Circle()
+                            .fill(DSColor.amberSoft)
+                            .overlay(Circle().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
+                            .frame(width: 36, height: 36)
+                        Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                            .font(.system(size: 13, weight: .semibold))
+                            .foregroundColor(fileError ? DSColor.inkSubtle : DSColor.amberDeep)
+                    }
                 }
                 .buttonStyle(.plain)
-                .cornerRadius(0)
                 .disabled(fileError)
 
-                // Waveform + progress overlay
                 ZStack(alignment: .leading) {
-                    // Background bars
-                    waveformBars(count: 30, color: DSColor.outlineVariant)
-
-                    // Progress overlay (mask-based: scale a leading-anchored
-                    // Rectangle by playbackProgress instead of measuring the
-                    // container with GeometryReader on every frame).
-                    waveformBars(count: 30, color: DSColor.primary)
+                    waveformBars(count: 40, color: DSColor.inkFaint)
+                    waveformBars(count: 40, color: DSColor.amberAccent)
                         .mask(alignment: .leading) {
                             Rectangle()
                                 .scaleEffect(x: CGFloat(playbackProgress), y: 1, anchor: .leading)
                         }
                 }
-                .frame(height: 28)
+                .frame(height: 24)
 
-                // Duration
-                Text(formatDur(isPlaying ? (duration * playbackProgress) : duration))
-                    .monoLabelStyle(size: 10)
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                Text(formatDur(isPlaying ? duration * playbackProgress : duration))
+                    .font(DSFonts.jetBrainsMono(size: 11))
+                    .foregroundColor(DSColor.inkSubtle)
                     .frame(width: 36, alignment: .trailing)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
+            .padding(.horizontal, 14)
+            .padding(.top, 14)
+            .padding(.bottom, 6)
 
-            // Full transcript (if available) or queued placeholder.
-            // No line limit — long transcriptions must remain fully readable
-            // (see issue #203).
+            // Transcript (italic serif quote style)
             if let t = transcript, !t.isEmpty {
-                Text(t)
-                    .bodySMStyle()
-                    .foregroundColor(DSColor.onSurfaceVariant)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .textSelection(.enabled)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 6)
+                HStack(alignment: .top, spacing: 6) {
+                    Text("\"")
+                        .font(DSFonts.newYork(size: 20, weight: .medium))
+                        .foregroundColor(DSColor.amberAccent)
+                        .offset(y: -2)
+                    Text(t)
+                        .font(DSType.serifQuote)
+                        .foregroundColor(DSColor.inkMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .textSelection(.enabled)
+                    Text("\"")
+                        .font(DSFonts.newYork(size: 20, weight: .medium))
+                        .foregroundColor(DSColor.amberAccent)
+                        .offset(y: -2)
+                }
+                .padding(.horizontal, 14)
+                .padding(.bottom, 4)
             } else if transcript == nil && VoiceAttachmentQueue.shared.pendingCount > 0 {
                 HStack(spacing: 6) {
-                    ProgressView()
-                        .scaleEffect(0.7)
-                        .tint(DSColor.onSurfaceVariant)
-                    Text("转写中...")
-                        .bodySMStyle()
-                        .foregroundColor(DSColor.onSurfaceVariant)
+                    ProgressView().scaleEffect(0.7).tint(DSColor.inkSubtle)
+                    Text("Transcribing…")
+                        .font(DSType.bodySM)
+                        .foregroundColor(DSColor.inkSubtle)
                 }
-                .padding(.horizontal, 12)
+                .padding(.horizontal, 14)
                 .padding(.bottom, 6)
             }
         }
-        .onDisappear {
-            stopPlayback()
-        }
+        .onDisappear { stopPlayback() }
     }
 
-    // MARK: - Waveform Bars (static, pseudo-random per URL)
-
-    /// Pre-computed deterministic bar heights derived from `fileURL.hashValue`.
-    /// Computed once per body re-evaluation instead of recomputing the bit-shift
-    /// expression for every bar on every frame during a swipe gesture.
     private var waveformHeights: [CGFloat] {
         let seed = abs(fileURL.hashValue)
-        return (0..<30).map { i in
-            CGFloat(4 + ((seed >> i) & 0x1F) % 24)
-        }
+        return (0..<40).map { i in CGFloat(3 + ((seed >> i) & 0x1F) % 20) }
     }
 
     private func waveformBars(count: Int, color: Color) -> some View {
         HStack(spacing: 2) {
             ForEach(Array(waveformHeights.prefix(count).enumerated()), id: \.offset) { _, h in
-                RoundedRectangle(cornerRadius: 1)
-                    .fill(color)
-                    .frame(width: 3, height: h)
+                RoundedRectangle(cornerRadius: 1).fill(color).frame(width: 2.5, height: h)
             }
         }
     }
 
-    // MARK: - Playback Control
-
     private func togglePlayback() {
-        if isPlaying {
-            stopPlayback()
-        } else {
-            startPlayback()
-        }
+        isPlaying ? stopPlayback() : startPlayback()
     }
 
     private func startPlayback() {
-        guard FileManager.default.fileExists(atPath: fileURL.path) else {
-            fileError = true
-            return
-        }
+        guard FileManager.default.fileExists(atPath: fileURL.path) else { fileError = true; return }
         do {
             try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
             try AVAudioSession.sharedInstance().setActive(true)
@@ -658,28 +532,19 @@ struct VoiceMemoPlayerRow: View {
             player = p
             isPlaying = true
             playbackProgress = 0
-
             progressTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [self] _ in
                 Task { @MainActor in
-                    guard let p = player, p.isPlaying else {
-                        stopPlayback()
-                        return
-                    }
+                    guard let p = player, p.isPlaying else { stopPlayback(); return }
                     playbackProgress = p.currentTime / p.duration
                 }
             }
-        } catch {
-            fileError = true
-        }
+        } catch { fileError = true }
     }
 
     private func stopPlayback() {
-        player?.stop()
-        player = nil
-        progressTimer?.invalidate()
-        progressTimer = nil
-        isPlaying = false
-        playbackProgress = 0
+        player?.stop(); player = nil
+        progressTimer?.invalidate(); progressTimer = nil
+        isPlaying = false; playbackProgress = 0
     }
 
     private func formatDur(_ secs: TimeInterval) -> String {
@@ -690,144 +555,165 @@ struct VoiceMemoPlayerRow: View {
 
 // MARK: - DailyPageEntryCard
 
-/// Card shown at the top of the timeline when today's Daily Page has been compiled.
-/// Full-width black card per design spec (Brutalist style).
+/// Compiled-day hero card — Liquid Glass amber style.
 struct DailyPageEntryCard: View {
     let summary: String?
     var onTap: (() -> Void)?
-
-    @State private var arrowOffset: CGFloat = 0
 
     var body: some View {
         Button(action: { onTap?() }) {
             HStack(alignment: .center, spacing: 16) {
                 VStack(alignment: .leading, spacing: 6) {
-                    Text("TODAY'S PAGE COMPILED")
-                        .sectionLabelStyle()
-                        .foregroundColor(DSColor.onPrimary)
+                    // Amber dot + label
+                    HStack(spacing: 6) {
+                        Circle()
+                            .fill(DSColor.amberAccent)
+                            .frame(width: 6, height: 6)
+                            .shadow(color: DSColor.amberGlow, radius: 4, x: 0, y: 0)
+                        Text("Today's page compiled")
+                            .font(DSFonts.jetBrainsMono(size: 10))
+                            .tracking(1)
+                            .textCase(.uppercase)
+                            .foregroundColor(DSColor.amberAccent)
+                    }
 
                     if let summary = summary, !summary.isEmpty {
                         Text(summary)
-                            .bodySMStyle()
-                            .foregroundColor(DSColor.onPrimary.opacity(0.7))
+                            .font(DSType.serifBody18)
+                            .foregroundColor(DSColor.inkPrimary)
                             .lineLimit(2)
+                            .lineSpacing(2)
                     } else {
                         Text("Your daily digest is ready.")
-                            .bodySMStyle()
-                            .foregroundColor(DSColor.onPrimary.opacity(0.7))
-                            .lineLimit(2)
+                            .font(DSType.serifBody18)
+                            .foregroundColor(DSColor.inkPrimary)
                     }
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
 
                 Image(systemName: "arrow.forward")
-                    .font(.system(size: 18, weight: .semibold))
-                    .foregroundColor(DSColor.onPrimary)
-                    .offset(x: arrowOffset)
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(DSColor.amberDeep)
             }
-            .padding(.horizontal, DSSpacing.cardInner)
+            .padding(.horizontal, 18)
             .padding(.vertical, 18)
             .frame(maxWidth: .infinity)
-            .background(DSColor.primary)
-            .cornerRadius(DSSpacing.radiusCard)
-        }
-        .buttonStyle(.plain)
-        .onHover { hovering in
-            withAnimation(.easeInOut(duration: 0.15)) {
-                arrowOffset = hovering ? 4 : 0
+            .liquidGlassCard(cornerRadius: 18, tone: .elevated)
+            .overlay(alignment: .leading) {
+                // Left amber accent strip
+                RoundedRectangle(cornerRadius: 2, style: .continuous)
+                    .fill(
+                        LinearGradient(
+                            colors: [DSColor.amberAccent, DSColor.amberAccent.opacity(0)],
+                            startPoint: .top, endPoint: .bottom
+                        )
+                    )
+                    .frame(width: 3)
+                    .padding(.vertical, 14)
+                    .padding(.leading, 0)
+                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
             }
         }
+        .buttonStyle(.plain)
     }
 }
 
 // MARK: - CompilePromptCard
 
-/// Placeholder card shown when today's Daily Page has not been compiled.
-/// Supports a loading/compiling state that disables the button and shows progress text.
 struct CompilePromptCard: View {
     let memoCount: Int
     var isCompiling: Bool = false
     var onCompile: (() -> Void)?
 
     var body: some View {
-        HStack(spacing: 0) {
-            Rectangle()
-                .fill(isCompiling ? DSColor.primary : DSColor.outlineVariant)
-                .frame(width: 4)
-
-            VStack(alignment: .leading, spacing: 8) {
+        HStack(spacing: 14) {
+            // Icon
+            ZStack {
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isCompiling ? DSColor.amberSoft : DSColor.glassLo)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12, style: .continuous)
+                            .strokeBorder(isCompiling ? DSColor.amberRim : DSColor.glassRim, lineWidth: 0.5)
+                    )
+                    .frame(width: 44, height: 44)
                 if isCompiling {
-                    // US-004: single unified compiling indicator on screen.
-                    // Title + spinner share one line so this card is the only "Compiling" UI.
-                    HStack(spacing: 8) {
-                        Text("正在编译 \(memoCount) 条 memo")
-                            .sectionLabelStyle()
-                            .foregroundColor(DSColor.onSurface)
-                        ProgressView()
-                            .scaleEffect(0.7)
-                            .tint(DSColor.onSurfaceVariant)
-                        Spacer(minLength: 0)
-                    }
+                    ProgressView().scaleEffect(0.7).tint(DSColor.amberDeep)
                 } else {
-                    Text("今日还未编译")
-                        .sectionLabelStyle()
-                        .foregroundColor(DSColor.onSurfaceVariant)
-
-                    if memoCount > 0 {
-                        Text("已有 \(memoCount) 条记录，点击立即编译")
-                            .bodySMStyle()
-                            .foregroundColor(DSColor.onSurfaceVariant)
-
-                        Button(action: { onCompile?() }) {
-                            Text("立即编译")
-                                .monoLabelStyle(size: 10)
-                                .foregroundColor(DSColor.onPrimary)
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 6)
-                                .background(DSColor.primary)
-                                .cornerRadius(DSSpacing.radiusSmall)
-                        }
-                        .buttonStyle(.plain)
-                    } else {
-                        Text("记录今天的想法，晚些时候将自动编译成日记")
-                            .bodySMStyle()
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                    }
+                    Image(systemName: "sparkles")
+                        .font(.system(size: 18))
+                        .foregroundColor(DSColor.inkSubtle)
                 }
             }
-            .padding(12)
+
+            VStack(alignment: .leading, spacing: 4) {
+                if isCompiling {
+                    Text("Compiling \(memoCount) memos…")
+                        .font(DSFonts.spaceGrotesk(size: 13, weight: .semibold))
+                        .textCase(.uppercase)
+                        .tracking(1)
+                        .foregroundColor(DSColor.amberDeep)
+                } else if memoCount > 0 {
+                    Text("Ready to compile")
+                        .font(DSFonts.spaceGrotesk(size: 13, weight: .semibold))
+                        .textCase(.uppercase)
+                        .tracking(1)
+                        .foregroundColor(DSColor.inkSubtle)
+                    Text("\(memoCount) signals captured today")
+                        .font(DSType.bodySM)
+                        .foregroundColor(DSColor.inkSubtle)
+                } else {
+                    Text("Start capturing")
+                        .font(DSFonts.spaceGrotesk(size: 13, weight: .semibold))
+                        .textCase(.uppercase)
+                        .tracking(1)
+                        .foregroundColor(DSColor.inkSubtle)
+                    Text("Your signals will compile tonight.")
+                        .font(DSType.bodySM)
+                        .foregroundColor(DSColor.inkSubtle)
+                }
+            }
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(DSColor.surfaceContainer)
+
+            if !isCompiling && memoCount > 0 {
+                Button(action: { onCompile?() }) {
+                    Text("Compile")
+                        .font(DSFonts.jetBrainsMono(size: 10))
+                        .tracking(0.8)
+                        .textCase(.uppercase)
+                        .foregroundColor(DSColor.bgWarm)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 7)
+                        .background(DSColor.amberDeep)
+                        .clipShape(Capsule())
+                }
+                .buttonStyle(.plain)
+            }
         }
-        .cornerRadius(DSSpacing.radiusCard)
-        .surfaceElevatedShadow()
+        .padding(.horizontal, 14)
+        .padding(.vertical, 14)
+        .liquidGlassCard(cornerRadius: 18)
         .animation(.easeInOut(duration: 0.2), value: isCompiling)
     }
 }
 
-// MARK: - PhotoDownloadPlaceholder
+// MARK: - Photo Placeholders
 
-/// Gray placeholder shown when a photo attachment is evicted to iCloud and not yet downloaded.
 struct PhotoDownloadPlaceholder: View {
     var body: some View {
         ZStack {
-            RoundedRectangle(cornerRadius: 0)
-                .fill(DSColor.surfaceContainerHigh)
-                .frame(maxWidth: .infinity)
-                .frame(height: 160)
-
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(DSColor.glassLo)
+                .frame(maxWidth: .infinity, minHeight: 160)
             VStack(spacing: 8) {
-                ProgressView()
-                    .tint(DSColor.onSurfaceVariant)
-                Text("正在从 iCloud 下载…")
-                    .monoLabelStyle(size: 10)
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                ProgressView().tint(DSColor.inkSubtle)
+                Text("Downloading from iCloud…")
+                    .font(DSFonts.jetBrainsMono(size: 10))
+                    .textCase(.uppercase)
+                    .foregroundColor(DSColor.inkSubtle)
             }
         }
     }
 }
-
-// MARK: - PhotoThumbnailView
 
 struct PhotoThumbnailView: View {
     let fileURL: URL
@@ -840,14 +726,12 @@ struct PhotoThumbnailView: View {
                 Image(uiImage: thumb)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 160)
+                    .frame(maxWidth: .infinity, minHeight: 200)
                     .clipped()
             } else {
                 Rectangle()
-                    .fill(DSColor.surfaceContainerHigh)
-                    .frame(maxWidth: .infinity)
-                    .frame(height: 160)
+                    .fill(DSColor.glassLo)
+                    .frame(maxWidth: .infinity, minHeight: 200)
             }
         }
         .task(id: fileURL) {
@@ -855,23 +739,29 @@ struct PhotoThumbnailView: View {
             thumbnail = await loadThumbnailAsync(from: fileURL)
         }
         .overlay(alignment: .bottom) {
-            if let exifText = exifText {
+            if let exifText {
                 Text(exifText)
-                    .monoLabelStyle(size: 10)
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .font(DSFonts.jetBrainsMono(size: 10))
+                    .tracking(0.5)
+                    .textCase(.uppercase)
+                    .foregroundColor(DSColor.inkSubtle)
                     .lineLimit(1)
                     .truncationMode(.tail)
-                    .padding(.horizontal, DSSpacing.cardInner)
+                    .padding(.horizontal, 12)
                     .padding(.vertical, 6)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(DSColor.surfaceContainer)
+                    .background(
+                        LinearGradient(
+                            colors: [Color.clear, DSColor.glassHi],
+                            startPoint: .top, endPoint: .bottom
+                        )
+                    )
             }
         }
     }
 
-    private func loadThumbnailAsync(from fileURL: URL) async -> UIImage? {
-        let url = fileURL
-        return await Task.detached(priority: .userInitiated) {
+    private func loadThumbnailAsync(from url: URL) async -> UIImage? {
+        await Task.detached(priority: .userInitiated) {
             guard let data = try? Data(contentsOf: url) else { return nil }
             let opts: [CFString: Any] = [
                 kCGImageSourceShouldCacheImmediately: false,
@@ -890,37 +780,32 @@ struct PhotoThumbnailView: View {
 
 // MARK: - AudioDownloadPlaceholder
 
-/// Waveform placeholder shown when an audio attachment is evicted to iCloud and not yet downloaded.
 struct AudioDownloadPlaceholder: View {
     var body: some View {
         HStack(spacing: 12) {
-            // Download icon in place of play button
             ZStack {
-                Rectangle()
-                    .fill(DSColor.surfaceContainerHigh)
-                    .frame(width: 40, height: 40)
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(DSColor.glassLo)
+                    .frame(width: 36, height: 36)
                 Image(systemName: "icloud.and.arrow.down")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundColor(DSColor.inkSubtle)
             }
-
-            // Placeholder waveform bars
             HStack(spacing: 2) {
-                ForEach(0..<30, id: \.self) { i in
-                    let h = CGFloat(4 + (i % 6) * 4)
+                ForEach(0..<36, id: \.self) { i in
+                    let h = CGFloat(3 + (i % 6) * 3)
                     RoundedRectangle(cornerRadius: 1)
-                        .fill(DSColor.outlineVariant)
-                        .frame(width: 3, height: h)
+                        .fill(DSColor.inkFaint)
+                        .frame(width: 2.5, height: h)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
-
             Text("--:--")
-                .monoLabelStyle(size: 10)
-                .foregroundColor(DSColor.onSurfaceVariant)
+                .font(DSFonts.jetBrainsMono(size: 10))
+                .foregroundColor(DSColor.inkSubtle)
                 .frame(width: 36, alignment: .trailing)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
     }
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -625,6 +625,8 @@ struct LocationDraftCard: View {
             .padding(.bottom, 8)
     }
 
+    // MARK: - Location Draft Content
+
     private var locationDraftContent: some View {
         VStack(alignment: .leading, spacing: 0) {
             draftHeader
@@ -646,6 +648,8 @@ struct LocationDraftCard: View {
         .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 24, x: 0, y: 8)
     }
 
+    // MARK: - Draft Header
+
     private var draftHeader: some View {
         HStack(spacing: 6) {
             Image(systemName: "location.fill")
@@ -666,6 +670,8 @@ struct LocationDraftCard: View {
         .padding(.top, 10)
         .padding(.bottom, 8)
     }
+
+    // MARK: - Draft Rows
 
     private var draftRows: some View {
         ForEach(Array(drafts.enumerated()), id: \.element.id) { idx, draft in

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -45,74 +45,75 @@ struct TodayView: View {
     var body: some View {
         NavigationStack {
             ZStack(alignment: .top) {
-                DSColor.background.ignoresSafeArea()
+                // V4: Warm ambient canvas — glass surfaces refract against this
+                AmbientBackground()
+                    .ignoresSafeArea()
+
                 VStack(spacing: 0) {
-                    // MARK: Header
-                    HStack(spacing: 12) {
-                        // Hamburger menu — opens sidebar
+                    // MARK: Header — serif date + right-side controls
+                    HStack(alignment: .top, spacing: 0) {
+                        // Left: serif weekday + mono date subline; tap → open sidebar
                         Button {
                             nav.openSidebar()
                         } label: {
-                            Image(systemName: "line.horizontal.3")
-                                .font(.system(size: 18, weight: .regular))
-                                .foregroundColor(DSColor.onSurface)
-                                .frame(width: 32, height: 32)
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text(weekdayName(currentTime))
+                                    .font(DSType.serifDisplay32)
+                                    .foregroundColor(DSColor.inkPrimary)
+                                Text(headerSubline(currentTime))
+                                    .font(DSType.mono10)
+                                    .foregroundColor(DSColor.inkSubtle)
+                                    .textCase(.uppercase)
+                                    .tracking(1.0)
+                            }
                         }
+                        .buttonStyle(.plain)
                         .accessibilityLabel("Open navigation")
                         .accessibilityIdentifier("sidebar-menu-button")
-
-                        // Brand name
-                        Text("DAYPAGE")
-                            .font(.custom("SpaceGrotesk-Bold", size: 20))
-                            .foregroundColor(DSColor.onSurface)
-                            .kerning(2)
+                        // Long press on the date header → force-refresh On This Day
+                        .onLongPressGesture(minimumDuration: 1.5) {
+                            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+                            if let entry = OnThisDayScheduler.shared.forceRefresh() {
+                                viewModel.onThisDayEntry = entry
+                            } else {
+                                UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                            }
+                        }
 
                         Spacer()
 
-                        // Timestamp badge (long press 1.5s → force-refresh On This Day)
-                        Text(formattedTimestamp(currentTime))
-                            .monoLabelStyle(size: 10)
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                            .padding(.horizontal, 8)
-                            .padding(.vertical, 4)
-                            .background(DSColor.surfaceContainer)
-                            .onLongPressGesture(minimumDuration: 1.5) {
-                                UIImpactFeedbackGenerator(style: .medium).impactOccurred()
-                                if let entry = OnThisDayScheduler.shared.forceRefresh() {
-                                    viewModel.onThisDayEntry = entry
-                                } else {
-                                    UINotificationFeedbackGenerator().notificationOccurred(.warning)
+                        // Right: settings + account
+                        HStack(spacing: 8) {
+                            Button {
+                                showSettings = true
+                            } label: {
+                                Image(systemName: "gearshape")
+                                    .font(.system(size: 15, weight: .regular))
+                                    .foregroundColor(DSColor.inkMuted)
+                                    .frame(width: 36, height: 36)
+                                    .background(DSColor.glassStd)
+                                    .background(.ultraThinMaterial, in: Circle())
+                                    .overlay(Circle().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                                    .clipShape(Circle())
+                            }
+                            .accessibilityLabel("设置")
+
+                            if authService.session != nil {
+                                Button {
+                                    showAccountSheet = true
+                                } label: {
+                                    accountAvatar
                                 }
                             }
-
-                        // Settings gear icon — always visible
-                        Button {
-                            showSettings = true
-                        } label: {
-                            Image(systemName: "gearshape")
-                                .font(.system(size: 16, weight: .regular))
-                                .foregroundColor(DSColor.onSurfaceVariant)
-                                .frame(width: 28, height: 28)
                         }
-                        .accessibilityLabel("设置")
-
-                        // Account avatar — shown when logged in
-                        if authService.session != nil {
-                            Button {
-                                showAccountSheet = true
-                            } label: {
-                                accountAvatar
-                            }
-                        }
+                        .padding(.top, 4)
                     }
                     .padding(.horizontal, 20)
-                    .frame(height: 56)
+                    .padding(.top, 16)
+                    .padding(.bottom, 12)
                     .onReceive(headerTimer) { date in
                         currentTime = date
                     }
-
-                    Divider()
-                        .background(DSColor.outline)
 
                     // MARK: Compilation Failed Banner
                     if let failureMsg = viewModel.compilationFailedError {
@@ -198,15 +199,14 @@ struct TodayView: View {
                                             isLast: idx == viewModel.memos.count - 1,
                                             onDelete: { viewModel.deleteMemo(memo) },
                                             onPin: {
-                                    if memo.pinnedAt != nil {
-                                        viewModel.unpinMemo(memo)
-                                    } else {
-                                        viewModel.pinMemo(memo)
-                                    }
-                                }
+                                                if memo.pinnedAt != nil {
+                                                    viewModel.unpinMemo(memo)
+                                                } else {
+                                                    viewModel.pinMemo(memo)
+                                                }
+                                            }
                                         )
-                                        .padding(.leading, 20)
-                                        .padding(.trailing, 20)
+                                        .padding(.horizontal, 20)
                                         .transition(.move(edge: .bottom).combined(with: .opacity))
                                     }
                                 }
@@ -387,11 +387,14 @@ struct TodayView: View {
 
     private var syncBanner: some View {
         Text("Sync your journal across devices →")
-            .font(.custom("Inter-Regular", size: 13))
-            .foregroundColor(Color(hex: "A0A0A0"))
+            .font(DSType.bodySM)
+            .foregroundColor(DSColor.inkMuted)
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(Color(hex: "1E1E1E"))
+            .padding(.vertical, 10)
+            .padding(.horizontal, 20)
+            .background(DSColor.glassStd)
+            .background(.ultraThinMaterial)
+            .overlay(Rectangle().frame(height: 0.5).foregroundColor(DSColor.glassRim), alignment: .bottom)
             .gesture(
                 DragGesture(minimumDistance: 20)
                     .onEnded { value in
@@ -413,14 +416,12 @@ struct TodayView: View {
         let initial = email.first.map { String($0).uppercased() } ?? "?"
         return ZStack {
             Circle()
-                .fill(Color(hex: "1E1E1E"))
-                .frame(width: 28, height: 28)
-                .overlay(
-                    Circle().stroke(Color(hex: "2A2A2A"), lineWidth: 1)
-                )
+                .fill(DSColor.amberSoft)
+                .frame(width: 36, height: 36)
+                .overlay(Circle().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
             Text(initial)
-                .font(.custom("Inter-Medium", size: 13))
-                .foregroundColor(Color(hex: "A0A0A0"))
+                .font(DSType.labelSM)
+                .foregroundColor(DSColor.amberDeep)
         }
     }
 
@@ -541,12 +542,21 @@ struct TodayView: View {
         }
     }
 
-    private func formattedTimestamp(_ date: Date) -> String {
+    private func weekdayName(_ date: Date) -> String {
         let f = DateFormatter()
-        f.dateFormat = "yyyy.MM.dd // HH:mm"
+        f.dateFormat = "EEEE"
         f.locale = Locale(identifier: "en_US_POSIX")
         f.timeZone = TimeZone.current
         return f.string(from: date)
+    }
+
+    private func headerSubline(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d · HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        let count = viewModel.memos.count
+        return "\(f.string(from: date))  ·  \(count) signals"
     }
 }
 
@@ -568,29 +578,34 @@ struct CompilationFailedBanner: View {
     var body: some View {
         HStack(spacing: 8) {
             Image(systemName: "xmark.circle.fill")
-                .foregroundColor(DSColor.error)
+                .foregroundColor(DSColor.errorRed)
                 .font(.system(size: 14))
             Text(message)
-                .font(.custom("Inter-Regular", size: 13))
-                .foregroundColor(DSColor.onErrorContainer)
+                .font(DSType.bodySM)
+                .foregroundColor(DSColor.inkPrimary)
                 .lineLimit(2)
             Spacer()
             Button("重试") {
                 onRetry()
             }
-            .font(.custom("Inter-Medium", size: 13))
-            .foregroundColor(DSColor.error)
+            .font(DSType.caption)
+            .foregroundColor(DSColor.errorRed)
             Button {
                 onDismiss()
             } label: {
                 Image(systemName: "xmark")
                     .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(DSColor.onErrorContainer)
+                    .foregroundColor(DSColor.inkMuted)
             }
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
-        .background(DSColor.errorContainer)
+        .background(DSColor.errorSoft)
+        .background(.ultraThinMaterial)
+        .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+        .padding(.horizontal, 20)
+        .padding(.bottom, 4)
     }
 }
 
@@ -605,54 +620,68 @@ struct LocationDraftCard: View {
     let onIgnoreAll: () -> Void
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            // Header row
-            HStack(spacing: 6) {
-                Image(systemName: "location.fill")
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundColor(DSColor.primary)
-                Text("检测到位置到达")
-                    .font(.custom("Inter-Medium", size: 13))
-                    .foregroundColor(DSColor.onSurface)
-                Spacer()
-                Button("全部忽略") {
-                    onIgnoreAll()
-                }
-                .font(.custom("Inter-Regular", size: 12))
-                .foregroundColor(DSColor.onSurfaceVariant)
-                Button("全部确认") {
-                    onConfirmAll()
-                }
-                .font(.custom("Inter-Medium", size: 12))
-                .foregroundColor(DSColor.primary)
-            }
-            .padding(.horizontal, 16)
-            .padding(.top, 10)
+        locationDraftContent
+            .padding(.horizontal, 20)
             .padding(.bottom, 8)
+    }
 
-            Divider()
-                .background(DSColor.outlineVariant)
+    private var locationDraftContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            draftHeader
+            Divider().background(DSColor.inkFaint)
+            draftRows
+        }
+        .background(DSColor.glassStd)
+        .background(.ultraThinMaterial)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(LinearGradient(colors: [DSColor.glassEdge, Color.clear], startPoint: .top, endPoint: .center), lineWidth: 0.6)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .shadow(color: Color(hex: "2D1E0A").opacity(0.04), radius: 1, x: 0, y: 1)
+        .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 24, x: 0, y: 8)
+    }
 
-            ForEach(drafts) { draft in
+    private var draftHeader: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "location.fill")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(DSColor.amberAccent)
+            Text("检测到位置到达")
+                .font(DSType.caption)
+                .foregroundColor(DSColor.inkPrimary)
+            Spacer()
+            Button("全部忽略") { onIgnoreAll() }
+                .font(DSType.caption)
+                .foregroundColor(DSColor.inkMuted)
+            Button("全部确认") { onConfirmAll() }
+                .font(DSType.caption)
+                .foregroundColor(DSColor.amberAccent)
+        }
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .padding(.bottom, 8)
+    }
+
+    private var draftRows: some View {
+        ForEach(Array(drafts.enumerated()), id: \.element.id) { idx, draft in
+            VStack(spacing: 0) {
                 LocationDraftRow(
                     draft: draft,
                     onConfirm: { onConfirm(draft) },
                     onIgnore: { onIgnore(draft) }
                 )
-                if draft.id != drafts.last?.id {
+                if idx < drafts.count - 1 {
                     Divider()
-                        .background(DSColor.outlineVariant)
+                        .background(DSColor.inkFaint)
                         .padding(.leading, 16)
                 }
             }
         }
-        .background(DSColor.surfaceContainer)
-        .overlay(
-            Rectangle()
-                .frame(height: 1)
-                .foregroundColor(DSColor.outlineVariant),
-            alignment: .bottom
-        )
     }
 }
 
@@ -666,25 +695,26 @@ private struct LocationDraftRow: View {
     var body: some View {
         HStack(alignment: .center, spacing: 12) {
             Image(systemName: "mappin.circle.fill")
-                .font(.system(size: 20))
-                .foregroundColor(DSColor.primary.opacity(0.7))
+                .font(.system(size: 18))
+                .foregroundColor(DSColor.amberAccent)
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(draft.placeName ?? "未知地点")
-                    .font(.custom("Inter-Medium", size: 13))
-                    .foregroundColor(DSColor.onSurface)
+                    .font(DSType.caption)
+                    .foregroundColor(DSColor.inkPrimary)
                     .lineLimit(1)
                 HStack(spacing: 4) {
                     Text(formatTime(draft.arrivalDate))
-                        .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
-                        .foregroundColor(DSColor.onSurfaceVariant)
+                        .font(DSType.mono10)
+                        .foregroundColor(DSColor.inkSubtle)
+                        .textCase(.uppercase)
                     if let dur = durationText {
                         Text("·")
-                            .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .font(DSType.mono10)
+                            .foregroundColor(DSColor.inkSubtle)
                         Text(dur)
-                            .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .font(DSType.mono10)
+                            .foregroundColor(DSColor.inkSubtle)
                     }
                 }
             }
@@ -696,20 +726,23 @@ private struct LocationDraftRow: View {
                     onIgnore()
                 } label: {
                     Image(systemName: "xmark")
-                        .font(.system(size: 12, weight: .medium))
-                        .foregroundColor(DSColor.onSurfaceVariant)
-                        .frame(width: 28, height: 28)
-                        .background(DSColor.surfaceContainerHigh)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(DSColor.inkMuted)
+                        .frame(width: 30, height: 30)
+                        .background(DSColor.glassLo)
+                        .background(.ultraThinMaterial, in: Circle())
+                        .clipShape(Circle())
                 }
 
                 Button {
                     onConfirm()
                 } label: {
                     Image(systemName: "checkmark")
-                        .font(.system(size: 12, weight: .medium))
+                        .font(.system(size: 11, weight: .semibold))
                         .foregroundColor(.white)
-                        .frame(width: 28, height: 28)
-                        .background(DSColor.primary)
+                        .frame(width: 30, height: 30)
+                        .background(DSColor.amberAccent)
+                        .clipShape(Circle())
                 }
             }
         }
@@ -738,7 +771,8 @@ private struct LocationDraftRow: View {
 
 // MARK: - TimelineRow
 
-/// Wraps a SwipeableMemoCard with a left timeline column (time + connecting line).
+/// V4: Direct card stack — no left timeline column. Cards float edge-to-edge
+/// over the ambient background, letting the glass surface provide depth.
 struct TimelineRow: View {
     let memo: Memo
     let isLast: Bool
@@ -746,32 +780,7 @@ struct TimelineRow: View {
     var onPin: (() -> Void)? = nil
 
     var body: some View {
-        HStack(alignment: .top, spacing: 0) {
-            // Left timeline column: time label + connecting line
-            VStack(spacing: 0) {
-                Text(RelativeTimeFormatter.relative(memo.created))
-                    .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
-                    .foregroundColor(DSColor.onSurfaceVariant)
-                    .frame(width: 60)
-                    .padding(.top, 10)
-                    .multilineTextAlignment(.center)
-
-                // Connecting line extends to bottom of card
-                if !isLast {
-                    Rectangle()
-                        .fill(DSColor.outlineVariant)
-                        .frame(width: 1)
-                        .frame(maxHeight: .infinity)
-                        .padding(.top, 4)
-                }
-
-                Spacer(minLength: 0)
-            }
-            .frame(width: 40)
-
-            // Swipeable memo card (WeChat-style actions)
-            SwipeableMemoCard(memo: memo, onDelete: onDelete, onPin: onPin)
-                .frame(maxWidth: CGFloat.infinity)
-        }
+        SwipeableMemoCard(memo: memo, onDelete: onDelete, onPin: onPin)
+            .frame(maxWidth: .infinity)
     }
 }


### PR DESCRIPTION
## Summary

- **GlassSurface.swift** (new): `AmbientBackground`, `LiquidGlassCard`, `GlassDisc`, `AmberHalo` primitives
- **Design tokens**: v4 ink/amber/glass color set + New York serif typography via `Font.system(design:.serif)`
- **TodayView**: serif weekday header, ambient blob canvas, glass gear button, simplified `TimelineRow`
- **InputBarV4**: glass-capsule dock (`ultraThinMaterial` Capsule), 64pt amber mic orb, `Aa` text-expand key
- **ArchiveView**: `AmbientBackground`, serif header, glass calendar grid, `liquidGlassCard` rows
- **SidebarView**: warm solid background (no ambient bleed), amber accent nav items
- **RootView**: removed `backgroundWarm` from FeedbackView panel, warm amber shadow

## Test plan

- [ ] Build succeeds with `xcodebuild -scheme DayPage`
- [ ] TodayView: serif "Tuesday" header renders with New York font + mono subline
- [ ] AmbientBackground: amber blob gradient visible, no bleed outside view bounds
- [ ] InputBar dock: glass capsule visible, mic orb 64pt amber, `Aa` third key opens text composer
- [ ] Sidebar: opens/closes cleanly, no amber halo leaking into main content
- [ ] ArchiveView: glass calendar grid, serif archive header render correctly
- [ ] No regressions on memo creation, voice recording, archive navigation