### PR TITLE
fix(#227): replace memo separator with HTML comment to prevent body --- collision

### DIFF
--- a/DayPage/Storage/RawStorage.swift
+++ b/DayPage/Storage/RawStorage.swift
@@ -3,7 +3,7 @@ import Foundation
 // MARK: - RawStorage
 
 /// 读取和写入 Memo 记录到 vault/raw/YYYY-MM-DD.md 文件。
-/// 同一天文件中的多条 memo 由 "\n\n---\n\n" 分隔。
+/// 同一天文件中的多条 memo 由 memoSeparator 分隔。
 /// 所有写入都是原子的：先写入临时文件，再重命名。
 enum RawStorage {
 
@@ -19,7 +19,12 @@ enum RawStorage {
     // MARK: - Separator
 
     /// 同一天文件内 memo 之间使用的精确分隔符。
-    static let memoSeparator = "\n\n---\n\n"
+    /// 使用 HTML 注释而非裸 "---"，避免与 YAML frontmatter 闭合符及
+    /// 用户正文中可能出现的 "---" 冲突（issue #227）。
+    static let memoSeparator = "\n\n<!-- daypage-memo-separator -->\n\n"
+
+    /// 历史分隔符（v1）。仍然保留以便向后兼容已有 vault 文件的解析。
+    static let legacyMemoSeparator = "\n\n---\n\n"
 
     // MARK: - URL helpers
 
@@ -75,10 +80,34 @@ enum RawStorage {
     // MARK: - Parsing
 
     /// Splits file content on the memo separator and parses each block into a Memo.
+    ///
+    /// 兼容性策略（issue #227）：
+    /// 1. 若文件含**当前**分隔符 → 新格式，按当前分隔符切分。
+    /// 2. 否则先尝试将整个文件当作单条 memo 解析 — 这覆盖了所有
+    ///    新格式单 memo 文件，以及旧格式的单 memo 文件（两者磁盘
+    ///    表示相同）。若成功且整段被一条 memo 完整消费，返回该结果。
+    /// 3. 否则回退到历史分隔符 "\n\n---\n\n"，处理旧 vault 文件。
+    /// 该策略既保证旧文件可读，又避免新格式 memo 正文中偶尔出现的
+    /// "---" 被错误切分。
     static func parse(fileContent: String) -> [Memo] {
-        // Split on the separator
-        let blocks = fileContent.components(separatedBy: memoSeparator)
-        return blocks.compactMap { block in
+        if fileContent.contains(memoSeparator) {
+            return splitAndParse(fileContent, separator: memoSeparator)
+        }
+
+        let trimmed = fileContent.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty, let single = Memo.fromMarkdown(trimmed) {
+            return [single]
+        }
+
+        if fileContent.contains(legacyMemoSeparator) {
+            return splitAndParse(fileContent, separator: legacyMemoSeparator)
+        }
+
+        return []
+    }
+
+    private static func splitAndParse(_ content: String, separator: String) -> [Memo] {
+        content.components(separatedBy: separator).compactMap { block -> Memo? in
             let trimmed = block.trimmingCharacters(in: .whitespacesAndNewlines)
             guard !trimmed.isEmpty else { return nil }
             return Memo.fromMarkdown(trimmed)

--- a/DayPageTests/RawStorageTests.swift
+++ b/DayPageTests/RawStorageTests.swift
@@ -143,6 +143,67 @@ final class RawStorageTests: XCTestCase {
         XCTAssertEqual(memos.count, 2)
     }
 
+    // MARK: - issue #227: memo body containing --- must round-trip
+
+    /// A memo whose body contains a triple-dash line must serialize and parse back
+    /// without being dropped. Before #227 the legacy "\n\n---\n\n" separator
+    /// collided with the YAML frontmatter delimiter and silently lost the memo.
+    func testParse_memoBodyContainingTripleDash_roundtrips() throws {
+        let body = "before\n\n---\n\nafter"
+        let memo = makeMemo(body: body)
+        try RawStorage.append(memo)
+
+        let memos = try RawStorage.read(for: memo.created)
+        XCTAssertEqual(memos.count, 1, "Memo with '---' in body must not be dropped")
+        XCTAssertEqual(memos.first?.body, body, "Body containing '---' must round-trip exactly")
+    }
+
+    /// Two memos written through append/read must round-trip when one of them
+    /// contains a "---" line in its body.
+    func testParse_multipleMemosOneWithTripleDash_allReadBack() throws {
+        let date = Date()
+        var m1 = makeMemo(body: "regular memo")
+        m1.created = date
+        var m2 = makeMemo(body: "with separator-like content\n\n---\n\nstill same memo")
+        m2.created = date
+        var m3 = makeMemo(body: "third memo")
+        m3.created = date
+
+        try RawStorage.append(m1)
+        try RawStorage.append(m2)
+        try RawStorage.append(m3)
+
+        let memos = try RawStorage.read(for: date)
+        XCTAssertEqual(memos.count, 3, "All three memos must be read back")
+        let bodies = memos.map { $0.body }
+        XCTAssertTrue(bodies.contains("regular memo"))
+        XCTAssertTrue(bodies.contains("with separator-like content\n\n---\n\nstill same memo"))
+        XCTAssertTrue(bodies.contains("third memo"))
+    }
+
+    /// A vault file written by an older app version using the legacy "\n\n---\n\n"
+    /// separator must still be parseable so existing users don't lose data.
+    func testParse_oldSeparator_backwardCompatible() {
+        let legacyContent = validMemoBlock() + "\n\n---\n\n" + validMemoBlock()
+        let memos = RawStorage.parse(fileContent: legacyContent)
+        XCTAssertEqual(memos.count, 2, "Files using the legacy separator must still parse")
+    }
+
+    /// The new HTML-comment separator must split memos correctly.
+    func testParse_newSeparator_correctlySplits() {
+        let content = validMemoBlock() + RawStorage.memoSeparator + validMemoBlock() + RawStorage.memoSeparator + validMemoBlock()
+        let memos = RawStorage.parse(fileContent: content)
+        XCTAssertEqual(memos.count, 3, "New separator must split all memos")
+    }
+
+    /// The current separator must not be the legacy one — guards against accidental revert.
+    func testMemoSeparator_isNotLegacyTripleDash() {
+        XCTAssertNotEqual(RawStorage.memoSeparator, "\n\n---\n\n",
+                          "Separator must not be the legacy bare '---' (collides with YAML frontmatter)")
+        XCTAssertTrue(RawStorage.memoSeparator.contains("daypage-memo-separator"),
+                      "Separator should be a unique HTML-comment marker")
+    }
+
     // MARK: - fileURL
 
     func testFileURL_isUnderRawDirectory() {


### PR DESCRIPTION
## Problem

The legacy inter-memo separator `\n\n---\n\n` collided with:
1. YAML frontmatter closing delimiter (also `---`)
2. User-typed `---` in memo body

User memos containing `---` on a line were silently dropped because `fromMarkdown()` found the wrong closing `---`.

## Fix

- **New separator**: `\n\n<!-- daypage-memo-separator -->\n\n` — a unique HTML comment that cannot appear in natural writing
- **Backward compatibility**: `parse()` falls back to the legacy `\n\n---\n\n` separator for existing vault files written by older app versions
- **Single-memo files**: Both new and old format single-memo files parse without separator
- **Guard test**: Ensures the separator constant cannot be accidentally reverted to the legacy triple-dash

## Files Changed

- `DayPage/Storage/RawStorage.swift` — changed `memoSeparator`, added `legacyMemoSeparator`, rewrote `parse()` with fallback logic
- `DayPageTests/RawStorageTests.swift` — added 5 test cases for body-with-`---`, multi-memo, backward compat, new separator, and guard

## Tests Added

- `testParse_memoBodyContainingTripleDash_roundtrips` — memo with `---` in body round-trips
- `testParse_multipleMemosOneWithTripleDash_allReadBack` — 3 memos, one with `---`, all recoverable
- `testParse_oldSeparator_backwardCompatible` — legacy vault files still parse
- `testParse_newSeparator_correctlySplits` — new separator splits all memos
- `testMemoSeparator_isNotLegacyTripleDash` — guard against accidental revert

Closes #227