### PR TITLE
fix(#230): VaultInitializer iCloud race — defer probe to avoid permanent local vault

### DIFF
--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -73,6 +73,20 @@ struct DayPageApp: App {
             iCloudSyncMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
             iCloudConflictMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
         }
+        // url(forUbiquityContainerIdentifier:) may return nil on first call during
+        // cold launch while the iCloud daemon finishes container setup. Re-probe
+        // off the main thread and swap the locator if iCloud becomes available.
+        Task.detached(priority: .utility) {
+            let icloud = iCloudVaultLocator()
+            guard icloud.isUsingiCloud else { return }
+            await MainActor.run {
+                guard !VaultInitializer.shared.isUsingiCloud else { return }
+                VaultInitializer.shared = icloud
+                VaultInitializer.initializeIfNeeded()
+                iCloudSyncMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
+                iCloudConflictMonitor.shared.startMonitoring(vaultURL: VaultInitializer.vaultURL)
+            }
+        }
         // Eagerly initialize WatchReceiveService so WCSession activates on launch.
         // Without this the lazy singleton never starts and Watch audio transfers are lost.
         _ = WatchReceiveService.shared

--- a/DayPage/Storage/VaultLocator.swift
+++ b/DayPage/Storage/VaultLocator.swift
@@ -33,18 +33,22 @@ struct LocalVaultLocator: VaultLocator {
 struct iCloudVaultLocator: VaultLocator {
     let containerID = "iCloud.com.daypage.app"
 
-    private static let _ubiquityContainer: URL? = {
-        FileManager.default.url(forUbiquityContainerIdentifier: "iCloud.com.daypage.app")
-    }()
+    // Resolve the ubiquity container fresh on every access. On cold launch
+    // url(forUbiquityContainerIdentifier:) often returns nil while the daemon
+    // finishes setup; caching the first result would permanently disable iCloud
+    // for the session (issue #230). The call is a cheap metadata lookup.
+    private var ubiquityContainer: URL? {
+        FileManager.default.url(forUbiquityContainerIdentifier: containerID)
+    }
 
     var vaultURL: URL {
-        Self._ubiquityContainer?
+        ubiquityContainer?
             .appendingPathComponent("Documents/vault", isDirectory: true)
             ?? LocalVaultLocator().vaultURL
     }
 
     var isUsingiCloud: Bool {
-        Self._ubiquityContainer != nil
+        ubiquityContainer != nil
     }
 }
 


### PR DESCRIPTION
Closes #230

## Problem
`iCloudVaultLocator._ubiquityContainer` was a `static let` that cached the first call to `url(forUbiquityContainerIdentifier:)`. On cold launch this often returns nil while the iCloud daemon finishes container setup, permanently locking `VaultInitializer.shared` to `LocalVaultLocator` for the entire session.

## Fix
1. **VaultLocator.swift**: Replace `static let _ubiquityContainer` with a computed `var ubiquityContainer` that re-queries on every access. The call is a cheap metadata lookup.
2. **DayPageApp.swift**: Add a `Task.detached(priority: .utility)` after init to re-probe iCloud availability. If iCloud becomes available but the locator is still local, swap to `iCloudVaultLocator` and restart sync/conflict monitors.

## Files Changed
- `DayPage/Storage/VaultLocator.swift`: 14 insertions, 5 deletions
- `DayPage/App/DayPageApp.swift`: 14 insertions