### PR TITLE
fix(#229): backfill all missed days, not just yesterday

### DIFF
--- a/DayPage/Services/BackgroundCompilationService.swift
+++ b/DayPage/Services/BackgroundCompilationService.swift
@@ -25,6 +25,10 @@ final class BackgroundCompilationService {
     nonisolated static let failureNotificationCategory = "com.daypage.compilation-failed"
     nonisolated static let failureNotificationAction = "com.daypage.retry-compilation"
 
+    /// Maximum number of missed days to compile per backfill session.
+    /// Prevents API flooding when the app hasn't been opened in a long time.
+    private let maxBackfillDays = 7
+
     // MARK: - Singleton
 
     static let shared = BackgroundCompilationService()
@@ -78,21 +82,40 @@ final class BackgroundCompilationService {
 
     // MARK: - Backfill Check (call from app foreground / scenePhase .active)
 
-    /// 检查昨天的 memo 文件是否存在但没有已编译的 Daily Page。
-    /// 如果有，立即触发编译（补充遗漏的后台运行）。
+    /// Scans all raw memo files and compiles any that have no corresponding Daily Page.
+    /// Caps at `maxBackfillDays` per session to avoid API flooding.
+    /// Today's file is always excluded (not yet ready for compilation).
     func backfillIfNeeded() {
-        let yesterday = Self.calendar.date(byAdding: .day, value: -1, to: Date()) ?? Date()
-        guard shouldCompile(for: yesterday) else { return }
+        let vaultURL = VaultInitializer.vaultURL
+        let rawDir = vaultURL.appendingPathComponent("raw", isDirectory: true)
+        guard let files = try? FileManager.default.contentsOfDirectory(atPath: rawDir.path) else { return }
+
+        let formatter = Self.dateFormatter
+        formatter.timeZone = AppSettings.currentTimeZone()
+        let todayString = formatter.string(from: Date())
+
+        let missedDates: [Date] = files
+            .filter { $0.hasSuffix(".md") && $0 != "\(todayString).md" }
+            .compactMap { filename -> Date? in
+                let dateString = String(filename.dropLast(3)) // remove ".md"
+                guard let date = formatter.date(from: dateString) else { return nil }
+                return shouldCompile(for: date) ? date : nil
+            }
+            .sorted() // oldest first
+
+        guard !missedDates.isEmpty else { return }
 
         Task {
-            NotificationCenter.default.post(name: .compilationDidStart, object: nil)
-            defer { NotificationCenter.default.post(name: .compilationDidEnd, object: nil) }
-            do {
-                try await compileWithRetry(for: yesterday, trigger: "backfill")
-                sendSuccessNotification(for: yesterday)
-            } catch {
-                DayPageLogger.shared.error("[BGCompile] Backfill failed after retries: \(error.localizedDescription)")
-                sendFailureNotification()
+            for date in missedDates.prefix(maxBackfillDays) {
+                NotificationCenter.default.post(name: .compilationDidStart, object: nil)
+                defer { NotificationCenter.default.post(name: .compilationDidEnd, object: nil) }
+                do {
+                    try await compileWithRetry(for: date, trigger: "backfill")
+                    sendSuccessNotification(for: date)
+                } catch {
+                    DayPageLogger.shared.error("[BGCompile] Backfill failed for \(formatter.string(from: date)): \(error.localizedDescription)")
+                    // Continue to next date, don't abort the whole batch
+                }
             }
         }
     }


### PR DESCRIPTION
Closes #229

## Problem
`backfillIfNeeded()` only checked yesterday's raw memo file. BGAppRefreshTask is not guaranteed to run nightly — iOS throttles it aggressively. If a user writes memos for 3 days without opening the app, only D-1 was compiled on day 4; D-2 and D-3 were permanently skipped.

## Fix
- Scan ALL raw `.md` files in `vault/raw/` instead of only checking yesterday
- Exclude today's file (not ready for compilation)
- Filter via existing `shouldCompile(for:)` (checks raw exists + daily absent)
- Sort oldest-first for chronological order
- Cap at `maxBackfillDays = 7` per session to prevent API flooding
- Continue processing remaining dates even if one compilation fails

## Files Changed
- `DayPage/Services/BackgroundCompilationService.swift`: 35 insertions, 12 deletions