### PR TITLE
fix(#231): move iCloudConflictMonitor resolution off MainActor

### DIFF
--- a/DayPage/Services/iCloudConflictMonitor.swift
+++ b/DayPage/Services/iCloudConflictMonitor.swift
@@ -99,8 +99,9 @@ final class iCloudConflictMonitor: ObservableObject {
     // MARK: - Conflict Processing
 
     /// Scans query results for files with unresolved conflicts and triggers resolution.
+    /// Resolution runs off the main thread to avoid UI freezes on large vaults.
     private func processConflicts() {
-        guard !isResolving, let q = query else { return }
+        guard !isResolving, let q = query, let vaultURL = vaultURL else { return }
         q.disableUpdates()
         defer { q.enableUpdates() }
 
@@ -113,11 +114,16 @@ final class iCloudConflictMonitor: ObservableObject {
 
         unresolvedConflictCount = count
 
-        guard count > 0, let vaultURL = vaultURL else { return }
+        guard count > 0 else { return }
 
+        // Move resolution off MainActor. NSFileCoordinator (used inside
+        // ConflictMerger) is thread-safe. isResolving stays true until the
+        // background work completes, providing real re-entrancy protection.
         isResolving = true
-        defer { isResolving = false }
 
-        ConflictMerger.resolveConflictsIfNeeded(in: vaultURL)
+        Task.detached(priority: .utility) {
+            ConflictMerger.resolveConflictsIfNeeded(in: vaultURL)
+            await MainActor.run { self.isResolving = false }
+        }
     }
 }


### PR DESCRIPTION
Closes #231

## Problem
`iCloudConflictMonitor.processConflicts()` called `ConflictMerger.resolveConflictsIfNeeded(in:)` synchronously on `@MainActor`. For a vault with months of memos and several conflict files, this could block the UI for hundreds of milliseconds.

Additionally, `defer { isResolving = false }` fired immediately after the synchronous call returned, making the re-entrancy guard ineffective.

## Fix
- Move `ConflictMerger.resolveConflictsIfNeeded` to `Task.detached(priority: .utility)`
- `isResolving` now stays true until the background work completes
- `NSFileCoordinator` (used inside ConflictMerger) is thread-safe

## Files Changed
- `DayPage/Services/iCloudConflictMonitor.swift`: 10 insertions, 4 deletions