### PR TITLE
fix(#239): prevent raw memo data loss during iCloud conflict resolution

### DIFF
--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -124,6 +124,7 @@ final class TodayViewModel: ObservableObject {
         self.date = date
         observeCompilationFailure()
         observeOnThisDay()
+        observeConflictResolution()
     }
 
     private func observeCompilationFailure() {
@@ -164,6 +165,20 @@ final class TodayViewModel: ObservableObject {
         ) { [weak self] notification in
             Task { @MainActor [weak self] in
                 self?.onThisDayEntry = notification.object as? OnThisDayEntry
+            }
+        }
+    }
+
+    /// Reloads memos whenever iCloud conflict resolution rewrites today's raw file.
+    /// Without this observer the UI shows stale in-memory memos after a merge.
+    private func observeConflictResolution() {
+        NotificationCenter.default.addObserver(
+            forName: .vaultConflictResolved,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.load()
             }
         }
     }
@@ -682,7 +697,7 @@ final class TodayViewModel: ObservableObject {
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd"
         formatter.locale = Locale(identifier: "en_US_POSIX")
-        formatter.timeZone = TimeZone.current
+        formatter.timeZone = AppSettings.currentTimeZone()
         let dateStr = formatter.string(from: date)
         return VaultInitializer.vaultURL
             .appendingPathComponent("wiki")

--- a/DayPage/Services/ConflictMerger.swift
+++ b/DayPage/Services/ConflictMerger.swift
@@ -154,11 +154,29 @@ enum ConflictMerger {
 
         if isRaw {
             var original = parseMemos(from: originalData)
+            let beforeCount = original.count
             for version in conflictVersions {
                 if let conflictData = try? Data(contentsOf: version.url) {
                     let conflictMemos = parseMemos(from: conflictData)
                     original = mergeRawMemos(original: original, conflict: conflictMemos)
+                } else {
+                    DayPageLogger.log(
+                        level: "WARN",
+                        message: "[ConflictMerger] Could not read conflict version for \(primaryURL.lastPathComponent) — version skipped, memos in that version may be lost"
+                    )
                 }
+            }
+            let afterCount = original.count
+            let crumb = Breadcrumb()
+            crumb.category = "conflict_merger"
+            crumb.message = "merged \(primaryURL.lastPathComponent): \(beforeCount) primary + conflict versions → \(afterCount) memos"
+            crumb.level = afterCount < beforeCount ? .warning : .info
+            SentrySDK.addBreadcrumb(crumb)
+            if afterCount < beforeCount {
+                DayPageLogger.log(
+                    level: "WARN",
+                    message: "[ConflictMerger] Memo count decreased after merge of \(primaryURL.lastPathComponent): \(beforeCount) → \(afterCount)"
+                )
             }
             let merged = original.map { $0.toMarkdown() }.joined(separator: RawStorage.memoSeparator)
             try writeMerged(data: Data(merged.utf8), to: primaryURL)

--- a/DayPage/Storage/RawStorage.swift
+++ b/DayPage/Storage/RawStorage.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Sentry
 
 // MARK: - RawStorage
 
@@ -62,6 +63,12 @@ enum RawStorage {
             }
 
             try atomicWrite(string: combined, to: url)
+
+            let crumb = Breadcrumb()
+            crumb.category = "rawstorage"
+            crumb.message = "append memo \(memo.id) to \(url.lastPathComponent)"
+            crumb.level = .info
+            SentrySDK.addBreadcrumb(crumb)
         }
     }
 
@@ -71,10 +78,25 @@ enum RawStorage {
     /// 如果文件不存在或不包含有效的 memo，返回空数组。
     static func read(for date: Date) throws -> [Memo] {
         let url = fileURL(for: date)
-        guard FileManager.default.fileExists(atPath: url.path) else { return [] }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            let crumb = Breadcrumb()
+            crumb.category = "rawstorage"
+            crumb.message = "read: file not found \(url.lastPathComponent)"
+            crumb.level = .warning
+            SentrySDK.addBreadcrumb(crumb)
+            return []
+        }
 
         let content = try String(contentsOf: url, encoding: .utf8)
-        return parse(fileContent: content)
+        let memos = parse(fileContent: content)
+
+        let crumb = Breadcrumb()
+        crumb.category = "rawstorage"
+        crumb.message = "read \(memos.count) memos from \(url.lastPathComponent)"
+        crumb.level = .info
+        SentrySDK.addBreadcrumb(crumb)
+
+        return memos
     }
 
     // MARK: - Parsing


### PR DESCRIPTION
Closes #239

## Root Cause

Two compounding bugs caused yesterday's memos to appear missing:

**Bug A — Missing reload after conflict resolution (primary cause)**
`TodayViewModel` never observed `vaultConflictResolved`. When `ConflictMerger` resolved an iCloud conflict and rewrote the raw `.md` file on disk, the UI kept showing the stale in-memory `memos` array. If the file arrived from iCloud *after* the initial `load()` call (e.g. the user opened the app before iCloud had finished syncing), the UI would show 0 memos even though data was safely on disk.

**Bug B — Timezone mismatch in `dailyPageURL`**
`dailyPageURL(for:)` used `TimeZone.current` while `RawStorage.fileURL(for:)` uses `AppSettings.currentTimeZone()`. For the affected user (Asia/Vientiane, UTC+7) who had set a preferred timezone, raw files were keyed to the preferred timezone date but the compiled daily page check used the device timezone date — they could diverge across a midnight boundary, making the page appear uncompiled and suppressing the full memo view.

## Fix

- `TodayViewModel.observeConflictResolution()`: new observer that calls `load()` on `vaultConflictResolved` — same pattern as the existing `compilationDidFail` observer
- `dailyPageURL(for:)`: changed `TimeZone.current` → `AppSettings.currentTimeZone()` to match `RawStorage`
- `ConflictMerger.resolveMDConflict`: logs `WARN` when memo count decreases after merge; logs `WARN` when a conflict version cannot be read (instead of silently skipping it)

## Observability

Added Sentry breadcrumbs to:
- `RawStorage.append()` — records memo ID and target file
- `RawStorage.read()` — records memo count read or "file not found"
- `ConflictMerger.resolveMDConflict()` — records before/after memo count with `.warning` level if count decreased

These breadcrumbs will appear in the Sentry issue trail for any future occurrence.

## Test Plan
- [ ] Submit memos on device A → kill app → open on device B → verify iCloud conflict is resolved and memos appear without requiring manual refresh
- [ ] Set preferred timezone ≠ device timezone, submit memos near midnight → verify memos file and daily page use the same date
- [ ] Verify Sentry breadcrumbs appear for normal append/read operations (check Sentry > Issues > Breadcrumbs)
- [ ] Verify no regression: memos submitted today still appear immediately after tapping Send

🤖 Generated with [Claude Code](https://claude.com/claude-code)