### PR TITLE
fix(auth): Apple Sign-In race condition — login page fails to dismiss

### DIFF
--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -41,16 +41,26 @@ struct RootView: View {
                             showAuthSheet = false
                         })
                     }
-                    .onChange(of: authService.session?.user.id) { newUserID in
-                        // Sign-in success → dismiss; sign-out → present.
-                        // Keyed on user.id (UUID, Equatable) instead of `Session`
-                        // itself, which isn't guaranteed Equatable across Supabase
-                        // SDK versions.
-                        if newUserID != nil {
+                    .onChange(of: authService.session != nil) { hasSession in
+                        // Watch the stable boolean rather than session?.user.id.
+                        // During Supabase's internal signedIn transition the listener
+                        // can emit a transient nil session, causing user.id to flash
+                        // nil→UUID→nil→UUID and toggle showAuthSheet twice (RC1).
+                        // `session != nil` is monotonically stable per sign-in event.
+                        if hasSession {
                             showAuthSheet = false
                         } else {
                             showAuthSheet = !authSkipped
                         }
+                    }
+                    .onAppear {
+                        // The @State initializer captures session synchronously at
+                        // view construction time. If AuthService's async listener
+                        // hasn't delivered the restored session yet, showAuthSheet
+                        // starts as true even for already-signed-in users. Re-check
+                        // once the view appears by which time the listener has
+                        // typically fired (RC3 — lazy re-check path).
+                        if authService.session != nil { showAuthSheet = false }
                     }
                     .onChange(of: authSkipped) { skipped in
                         if skipped { showAuthSheet = false }

--- a/DayPage/Services/AuthService.swift
+++ b/DayPage/Services/AuthService.swift
@@ -229,10 +229,16 @@ final class AuthService: NSObject, ObservableObject {
                 KeychainHelper.set(email, forKey: Self.appleEmailKey)
             }
 
-            session = try await supabase.auth.signInWithIdToken(
+            // Do NOT assign to self.session here. The authStateChanges listener
+            // is the single source of truth for session state; assigning directly
+            // would create a second write path that races with the listener's
+            // nil→session→nil flash during Supabase's internal state transition (RC1).
+            // Clear isLoading before the listener's session update triggers SwiftUI
+            // diffing so the ProgressView overlay is already gone when onChange fires (RC3).
+            isLoading = false
+            _ = try await supabase.auth.signInWithIdToken(
                 credentials: .init(provider: .apple, idToken: identityToken)
             )
-            isLoading = false
         } catch let asError as ASAuthorizationError where asError.code == .canceled {
             isLoading = false
         } catch {


### PR DESCRIPTION
## Bug

After user completes Apple Sign-In, the login page (AuthView) does NOT dismiss. User stays stuck on the login screen seeing a loading spinner, instead of transitioning to the main app.

## Root Cause

Three race conditions interact to cause this bug:

| # | Race Condition | Effect |
|---|---------------|--------|
| RC1 | `session` written by TWO paths: `signInWithIdToken` return value AND `authStateChanges` listener. During Supabase's internal `signedIn` transition, the listener can emit a **transient nil session** | `session?.user.id` flashes `nil→UUID→nil→UUID`, toggling `showAuthSheet` and re-presenting the cover |
| RC2 | ASAuthorizationController system dialog may dismiss the `fullScreenCover` | Cover re-presents after dialog completes, before session is set |
| RC3 | `isLoading` remains `true` when `session` is set, blocking cover dismissal animation | ProgressView overlay persists, user thinks login failed |

## Fix (2 files, +24 -8 lines)

### 1. AuthService.swift — Single source of truth for session

```
BEFORE: session = try await signInWithIdToken(...)
         isLoading = false

AFTER:  isLoading = false              // clear BEFORE session update
        _ = try await signInWithIdToken(...)  // trust listener only
```

**Fixes RC1**: Eliminates the second write path to `session`. The `authStateChanges` listener is now the sole writer, so session transitions are monotonic.

**Fixes RC3**: `isLoading = false` runs before the listener fires, so the ProgressView is gone when the cover starts dismissing.

### 2. RootView.swift — Stable boolean onChange + lazy re-check

```
BEFORE: .onChange(of: authService.session?.user.id) { newUserID in ... }

AFTER:  .onChange(of: authService.session != nil) { hasSession in ... }
        .onAppear { if authService.session != nil { showAuthSheet = false } }
```

**Fixes RC1**: `session != nil` is a stable `Bool` (false→true once on sign-in). SwiftUI's `onChange` deduplicates equal values, so spurious `true→true` deliveries from the listener are ignored.

**Fixes RC2**: `.onAppear` re-checks session after the async listener delivers the restored session (handles the case where `@State` initializer runs before listener fires).

## Data Flow (After Fix)

```
User taps Apple → AuthService.signInWithApple()
  → requestAppleAuthorization() → system dialog
  → isLoading = false (clear before any session update)
  → signInWithIdToken() → Supabase emits signedIn
  → authStateChanges listener: self.session = newSession
  → RootView.onChange(hasSession=true): showAuthSheet = false
  → fullScreenCover dismisses → user sees mainContent ✓
```

## Verification

- [x] Single writer for `session` (authStateChanges listener only)
- [x] `isLoading` cleared before session update
- [x] onChange uses stable boolean, not optional chain 
- [x] onAppear handles lazy session restore
- [ ] Build verification pending (CI)
