### PR TITLE
fix(#251): hide sync banner after login, clear authSkipped flag

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -399,15 +399,23 @@ struct TodayView: View {
             .onAppear {
                 evaluateSyncBanner()
             }
+            .onChange(of: authService.session) { _ in
+                evaluateSyncBanner()
+            }
         }
     }
 
     // MARK: - Sync Banner Logic
 
     private func evaluateSyncBanner() {
+        // If user is already authenticated, never show the banner
+        guard authService.session == nil else {
+            showSyncBanner = false
+            return
+        }
         let saveCount = UserDefaults.standard.integer(forKey: AppSettings.Keys.memoSaveCount)
         let authSkipped = UserDefaults.standard.bool(forKey: AppSettings.Keys.authSkipped)
-        guard saveCount >= 3, authService.session == nil, authSkipped else { return }
+        guard saveCount >= 3, authSkipped else { return }
         let lastShown = UserDefaults.standard.object(forKey: AppSettings.Keys.lastSyncBannerDate) as? Date
         let sevenDays: TimeInterval = 7 * 24 * 3600
         if let last = lastShown, Date().timeIntervalSince(last) < sevenDays { return }

--- a/DayPage/Services/AuthService.swift
+++ b/DayPage/Services/AuthService.swift
@@ -190,6 +190,9 @@ final class AuthService: NSObject, ObservableObject {
                 await MainActor.run {
                     self.session = session
                     if let session {
+                        // User authenticated — clear the "skip" flag so the sync
+                        // banner doesn't persist from pre-login state (GH #251).
+                        UserDefaults.standard.set(false, forKey: AppSettings.Keys.authSkipped)
                         let sentryUser = Sentry.User(userId: session.user.id.uuidString)
                         SentrySDK.setUser(sentryUser)
                         DayPageLogger.shared.info("[AuthService] Auth event: \(String(describing: event)), session expires: \(session.expiresAt)")


### PR DESCRIPTION
## Summary

Fixes #251 — the "Sync your journal across devices →" banner persisted even after the user successfully logged in.

## Root Cause

1. The `authSkipped` UserDefaults flag was never reset when a user authenticated, so the banner logic still saw the pre-login skip state
2. `evaluateSyncBanner()` was only called on `.onAppear` — it never re-evaluated when auth state changed mid-session
3. When session became non-nil, the guard simply returned early without explicitly hiding the already-visible banner

## Fix

- **AuthService.swift**: Reset `authSkipped` to `false` in `authStateChanges` listener when a session is established
- **TodayView.swift**: Add `.onChange(of: authService.session)` to re-evaluate banner on auth state transitions
- **TodayView.swift**: Make `evaluateSyncBanner()` explicitly set `showSyncBanner = false` when user is authenticated (instead of silently returning)

Closes #251