### PR TITLE
fix(today): kill 2-4s page-wide jitter (GeometryReader feedback loop)

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -321,9 +321,12 @@ struct InputBarV4: View {
             .accessibilityIdentifier("expand-text-composer")
         }
         .padding(6)
-        // Glass capsule — matchedGeometryEffect on the whole HStack so SwiftUI
-        // interpolates position, size, and corner radius to the card shape.
-        .matchedGeometryEffect(id: MorphID.surface, in: morphNS)
+        // NOTE: matchedGeometryEffect was removed — the idle Capsule and the
+        // composing RoundedRectangle (20pt) cannot be linearly interpolated
+        // by SwiftUI as a single shape, and sharing one ID across two
+        // mutually-exclusive branches caused the layout system to re-measure
+        // both candidates on every body re-evaluation. The branches simply
+        // cross-fade now via the existing isComposing condition. (#258)
         .background(.ultraThinMaterial, in: Capsule())
         .overlay(Capsule().strokeBorder(
             LinearGradient(
@@ -565,9 +568,7 @@ struct InputBarV4: View {
                 .animation(.easeInOut(duration: 0.15), value: templateSuffix.isEmpty)
             }
         }
-        // Card — matchedGeometryEffect on the whole VStack mirrors the surface
-        // geometry from the idle capsule for a continuous positional morph.
-        .matchedGeometryEffect(id: MorphID.surface, in: morphNS)
+        // NOTE: matchedGeometryEffect removed — see streamDockMorph for context. (#258)
         .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
         .overlay(
             RoundedRectangle(cornerRadius: 20, style: .continuous)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -154,94 +154,102 @@ struct TodayView: View {
                     // MARK: Day Orb Hero — serif date + mono kicker + orb
                     orbHero
 
-                    // MARK: Timeline (75% of available space)
-                    GeometryReader { geo in
-                        ScrollView {
-                            LazyVStack(spacing: 8) {
-                                // OnThisDayCard removed — relocation tracked in follow-up issue (US-015)
-                                // WeeklyRecapSection removed — relocation tracked in follow-up issue (US-015)
+                    // MARK: Timeline
+                    // Plain ScrollView — no GeometryReader. The previous wrapper
+                    // (`GeometryReader { ScrollView { ... }.frame(minHeight: geo.size.height * 0.75) }
+                    // .frame(maxHeight: geo.size.height)`) created a layout
+                    // feedback loop: GeometryReader sized itself from the parent
+                    // VStack's leftover space, then constrained the ScrollView's
+                    // intrinsic content to ≥75% of that space. When sibling rows
+                    // (banners, orb hero, compile area, input bar) republished
+                    // their @Published state, the VStack's leftover changed,
+                    // GeometryReader handed back a new size, and the whole tree
+                    // measured again — manifesting as a 2–4 s page-wide jitter
+                    // on real devices. (#258)
+                    ScrollView {
+                        LazyVStack(spacing: 8) {
+                            // OnThisDayCard removed — relocation tracked in follow-up issue (US-015)
+                            // WeeklyRecapSection removed — relocation tracked in follow-up issue (US-015)
 
-                                // Daily Page entry card (post-compile). Auto-compile runs
-                                // silently on load; users swipe left to reveal a manual
-                                // "重新编译" action when the AI output needs a redo.
-                                if viewModel.isDailyPageCompiled {
-                                    swipeableDailyPageCard
-                                        .padding(.horizontal, 20)
-                                }
+                            // Daily Page entry card (post-compile). Auto-compile runs
+                            // silently on load; users swipe left to reveal a manual
+                            // "重新编译" action when the AI output needs a redo.
+                            if viewModel.isDailyPageCompiled {
+                                swipeableDailyPageCard
+                                    .padding(.horizontal, 20)
+                            }
 
-                                // Memo cards (reverse-chronological)
-                                if viewModel.memos.isEmpty && !viewModel.isLoading {
-                                    let hasOnboarded = UserDefaults.standard.bool(forKey: AppSettings.Keys.hasOnboarded)
-                                    if !hasOnboarded {
-                                        EmptyStateView.todayBlank {
-                                            // focus is implicit — the input bar is always visible below
-                                        }
-                                        .padding(.top, 48)
-                                        .padding(.horizontal, 20)
-                                    } else {
-                                        fallbackContentView
-                                            .padding(.top, 24)
+                            // Memo cards (reverse-chronological)
+                            if viewModel.memos.isEmpty && !viewModel.isLoading {
+                                let hasOnboarded = UserDefaults.standard.bool(forKey: AppSettings.Keys.hasOnboarded)
+                                if !hasOnboarded {
+                                    EmptyStateView.todayBlank {
+                                        // focus is implicit — the input bar is always visible below
                                     }
+                                    .padding(.top, 48)
+                                    .padding(.horizontal, 20)
                                 } else {
-                                    ForEach(Array(viewModel.memos.enumerated()), id: \.element.id) { idx, memo in
-                                        TimelineRow(
-                                            memo: memo,
-                                            isLast: idx == viewModel.memos.count - 1,
-                                            onDelete: { viewModel.deleteMemo(memo) },
-                                            onPin: {
-                                                if memo.pinnedAt != nil {
-                                                    viewModel.unpinMemo(memo)
-                                                } else {
-                                                    viewModel.pinMemo(memo)
-                                                }
+                                    fallbackContentView
+                                        .padding(.top, 24)
+                                }
+                            } else {
+                                ForEach(Array(viewModel.memos.enumerated()), id: \.element.id) { idx, memo in
+                                    TimelineRow(
+                                        memo: memo,
+                                        isLast: idx == viewModel.memos.count - 1,
+                                        onDelete: { viewModel.deleteMemo(memo) },
+                                        onPin: {
+                                            if memo.pinnedAt != nil {
+                                                viewModel.unpinMemo(memo)
+                                            } else {
+                                                viewModel.pinMemo(memo)
                                             }
-                                        )
-                                        .padding(.horizontal, 20)
-                                        .transition(.move(edge: .bottom).combined(with: .opacity))
-                                    }
+                                        }
+                                    )
+                                    .padding(.horizontal, 20)
+                                    .transition(.move(edge: .bottom).combined(with: .opacity))
                                 }
-
-                                // Loading indicator
-                                if viewModel.isLoading {
-                                    HStack {
-                                        Spacer()
-                                        ProgressView()
-                                            .tint(DSColor.onSurfaceVariant)
-                                        Spacer()
-                                    }
-                                    .padding(.vertical, 20)
-                                }
-
-                                // Load error message
-                                if let error = viewModel.errorMessage {
-                                    Text(error)
-                                        .bodySMStyle()
-                                        .foregroundColor(DSColor.error)
-                                        .padding(.horizontal, 20)
-                                }
-
-                                Spacer(minLength: 16)
                             }
-                            .padding(.top, 12)
-                            .frame(minHeight: geo.size.height * 0.75)
+
+                            // Loading indicator
+                            if viewModel.isLoading {
+                                HStack {
+                                    Spacer()
+                                    ProgressView()
+                                        .tint(DSColor.onSurfaceVariant)
+                                    Spacer()
+                                }
+                                .padding(.vertical, 20)
+                            }
+
+                            // Load error message
+                            if let error = viewModel.errorMessage {
+                                Text(error)
+                                    .bodySMStyle()
+                                    .foregroundColor(DSColor.error)
+                                    .padding(.horizontal, 20)
+                            }
+
+                            Spacer(minLength: 16)
                         }
-                        // US-010: Vignette gradient at the bottom edge fades timeline
-                        // content behind the composer dock, so cards appear to recede
-                        // rather than abruptly stopping at the input bar boundary.
-                        .mask(
-                            VStack(spacing: 0) {
-                                Rectangle()
-                                LinearGradient(
-                                    colors: [Color.black, Color.clear],
-                                    startPoint: .top,
-                                    endPoint: .bottom
-                                )
-                                .frame(height: 40)
-                            }
-                        )
-                        .coordinateSpace(name: "todayScroll")
-                        .frame(maxHeight: geo.size.height)
+                        .padding(.top, 12)
                     }
+                    // US-010: Vignette gradient at the bottom edge fades timeline
+                    // content behind the composer dock, so cards appear to recede
+                    // rather than abruptly stopping at the input bar boundary.
+                    .mask(
+                        VStack(spacing: 0) {
+                            Rectangle()
+                            LinearGradient(
+                                colors: [Color.black, Color.clear],
+                                startPoint: .top,
+                                endPoint: .bottom
+                            )
+                            .frame(height: 40)
+                        }
+                    )
+                    .coordinateSpace(name: "todayScroll")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                     // MARK: Compile Area
                     // Shows a locked hint when signals < 3, or the compile


### PR DESCRIPTION
## Summary

Real-device users reported the entire Today page periodically yanking toward the top-left and snapping back every **2–4 seconds**. Two compounding layout bugs caused it; both fixed here.

### Root cause #1 — GeometryReader feedback loop (primary)

`TodayView` wrapped its timeline in:

```swift
GeometryReader { geo in
    ScrollView { LazyVStack { ... }.frame(minHeight: geo.size.height * 0.75) }
    .frame(maxHeight: geo.size.height)
}
```

The `GeometryReader` sized itself from the parent `VStack`'s leftover space, then constrained the `ScrollView`'s intrinsic content **back** against that same dimension. Any sibling republishing `@Published` state — `CompilationFailedBanner`, `LocationDraftCard`, `pendingAttachments.count`, `voiceQueue.pendingCount`, the compile area's locked/ready toggle — shifted the leftover space, the `GeometryReader` handed back a new size, the `ScrollView` re-measured, and the whole subtree reflowed. With iCloud sync events firing on real devices, this produced the 2–4 s page-wide jitter.

Replaced with a plain `ScrollView` sized via `.frame(maxWidth: .infinity, maxHeight: .infinity)`. SwiftUI computes the layout naturally; no feedback path.

### Root cause #2 — `matchedGeometryEffect` ID shared by incompatible shapes (secondary)

`InputBarV4` attached `matchedGeometryEffect(id: .surface, in: morphNS)` to **both** the idle Capsule and the composing RoundedRectangle (20 pt corner). The shapes can't be linearly interpolated as a single geometry, and sharing one ID across two mutually-exclusive branches forced SwiftUI to keep re-measuring both candidates on every `body` re-evaluation.

Removed the modifier from both branches. They cross-fade naturally via the existing `if isComposing` condition; the `.surface` case in `MorphID` is kept (still referenced for orb persistence in future work) but no longer attached.

## Test plan

- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [x] iPhone 17 simulator: launch app, take screenshots at t+4 s / t+6 s / t+8 s on the Today page → visually identical (MD5 differences come only from `DayOrbView`'s ±3.5 % breathing `scaleEffect`, hairline subpixel)
- [ ] **Real device verification** — please confirm 2–4 s page-wide jitter is gone
- [ ] Verify Composer still expands smoothly when tapping the "Aa" pen and collapses on chevron-down (cross-fade replaces the previous matched-geometry morph; functionally equivalent)

## What this PR does NOT change

- No business logic, no data storage / vault format
- No public API surface (`InputBarV4` init signature unchanged)
- No design system changes — Liquid Glass styling, ambient background, mic dock visuals all preserved