### PR TITLE
fix(today): UX overhaul — voice display, history scroll, layout, share, a11y

### DIFF
--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -89,8 +89,13 @@ struct MemoDetailView: View {
 
                     // MARK: Serif Body (view or edit)
                     let bodyTrimmed = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
-                    let isBodyDuplicate = memo.type == .voice &&
-                        memo.attachments.contains(where: { $0.transcript == bodyTrimmed && !bodyTrimmed.isEmpty })
+                    let hasAudio = memo.attachments.contains(where: { $0.kind == "audio" })
+                    let isBodyDuplicate = hasAudio &&
+                        memo.attachments.contains(where: { att in
+                            att.kind == "audio" &&
+                            att.transcript?.trimmingCharacters(in: .whitespacesAndNewlines) == bodyTrimmed &&
+                            !bodyTrimmed.isEmpty
+                        })
 
                     if isEditingBody {
                         VStack(alignment: .leading, spacing: 10) {

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -747,6 +747,7 @@ struct InputBarV4: View {
             return
         }
         onSubmit()
+        isFocused = false
         transition(to: .collapsing)
     }
 

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -222,8 +222,17 @@ struct MemoCardView: View {
 
             // Body text — serif
             let bodyTrimmed = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
-            let isBodyDuplicate = memo.type == .voice &&
-                memo.attachments.contains(where: { $0.transcript == bodyTrimmed && !bodyTrimmed.isEmpty })
+            // Suppress body text when it is identical to an audio transcript
+            // already shown in the VoiceMemoPlayerRow above.  The old check used
+            // `memo.type == .voice`, which missed `.mixed` memos containing audio
+            // + text; now we look for any audio attachment kind. (#US-016)
+            let hasAudio = memo.attachments.contains(where: { $0.kind == "audio" })
+            let isBodyDuplicate = hasAudio &&
+                memo.attachments.contains(where: { att in
+                    att.kind == "audio" &&
+                    att.transcript?.trimmingCharacters(in: .whitespacesAndNewlines) == bodyTrimmed &&
+                    !bodyTrimmed.isEmpty
+                })
             if !bodyTrimmed.isEmpty && !isBodyDuplicate {
                 // Render-only polish: CJK/Latin spacing; does not modify vault file.
                 Text(CJKTextPolish.polish(bodyTrimmed))
@@ -267,6 +276,34 @@ struct MemoCardView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .liquidGlassCard(cornerRadius: 18)
+        // Share context menu — long-press the card to share its text content.
+        // Mirrors the accessibility actions already registered on
+        // SwipeableMemoCard so VoiceOver and sighted users have consistent access.
+        .contextMenu {
+            let shareText = shareableText
+            if !shareText.isEmpty {
+                ShareLink(item: shareText) {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                }
+            }
+        }
+    }
+
+    // MARK: - Share text
+
+    /// Builds a plain-text representation of the memo suitable for sharing.
+    /// Prefers the voice transcript when present; falls back to body text.
+    private var shareableText: String {
+        // For voice/mixed memos, use the transcript if available.
+        if let att = memo.attachments.first(where: { $0.kind == "audio" }),
+           let transcript = att.transcript, !transcript.isEmpty {
+            let body = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
+            if body.isEmpty || body == transcript {
+                return transcript
+            }
+            return "\(transcript)\n\n\(body)"
+        }
+        return memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Type chip

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -51,7 +51,7 @@ struct SwipeableMemoCard: View {
     private var accessibilityMemoLabel: String {
         let prefix = memo.body.prefix(50)
         let trimmed = prefix.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.isEmpty ? "备忘录" : "备忘录：\(trimmed)"
+        return trimmed.isEmpty ? "Memo" : "Memo: \(trimmed)"
     }
 
     var body: some View {
@@ -85,10 +85,10 @@ struct SwipeableMemoCard: View {
         // MARK: VoiceOver support — expose swipe actions as named accessibility actions
         // so users who rely on VoiceOver can invoke Delete / Pin without gestures.
         .accessibilityLabel(accessibilityMemoLabel)
-        .accessibilityAction(named: "删除") {
+        .accessibilityAction(named: "Delete") {
             onDelete?()
         }
-        .accessibilityAction(named: memo.pinnedAt != nil ? "取消置顶" : "置顶") {
+        .accessibilityAction(named: memo.pinnedAt != nil ? "Unpin" : "Pin") {
             onPin?()
         }
     }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -100,7 +100,7 @@ struct TodayView: View {
                                 .overlay(Circle().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
                                 .clipShape(Circle())
                         }
-                        .accessibilityLabel("设置")
+                        .accessibilityLabel("Settings")
                         .padding(.top, 4)
                     }
                     .padding(.horizontal, 20)
@@ -330,6 +330,9 @@ struct TodayView: View {
             }
             .onChange(of: voiceQueue.pendingCount) { count in
                 updateVoiceQueueBanner(count: count)
+                // When a transcription finishes (count drops), reload memos so the
+                // newly-written transcript appears in the card without user intervention.
+                viewModel.load()
             }
             // Reload when app returns from background to correct the active date (midnight crossover).
             .onChange(of: scenePhase) { phase in
@@ -535,8 +538,10 @@ struct TodayView: View {
         if !viewModel.memos.isEmpty && !viewModel.isLoading {
             switch viewModel.fallbackContent {
             case .yesterdayDailyPage(let page):
+                earlierDivider
                 yesterdaySection(page).padding(.top, 8)
             case .weekRecap(let entries):
+                earlierDivider
                 WeeklyRecapSection(entries: entries) { dateString in
                     onThisDayDateString = dateString
                 }
@@ -545,6 +550,29 @@ struct TodayView: View {
                 EmptyView()
             }
         }
+    }
+
+    // MARK: - Earlier Divider
+
+    /// Horizontal rule with "EARLIER" label that visually separates today's
+    /// memo list from the history supplement section.
+    private var earlierDivider: some View {
+        HStack(spacing: 0) {
+            Rectangle()
+                .fill(DSColor.inkFaint)
+                .frame(height: 0.5)
+            Text("EARLIER")
+                .font(DSType.mono10)
+                .tracking(1.0)
+                .foregroundColor(DSColor.inkSubtle)
+                .padding(.horizontal, 8)
+            Rectangle()
+                .fill(DSColor.inkFaint)
+                .frame(height: 0.5)
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 24)
+        .padding(.bottom, 4)
     }
 
     @ViewBuilder
@@ -605,7 +633,7 @@ struct TodayView: View {
                         .background(DSColor.accentAmber)
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("重新编译")
+                .accessibilityLabel("Recompile")
             }
 
             DailyPageEntryCard(
@@ -735,21 +763,45 @@ struct TodayView: View {
         }
     }
 
-    private func weekdayName(_ date: Date) -> String {
+    private static let weekdayFmt: DateFormatter = {
         let f = DateFormatter()
         f.dateFormat = "EEEE"
         f.locale = Locale(identifier: "en_US_POSIX")
         f.timeZone = TimeZone.current
-        return f.string(from: date)
+        return f
+    }()
+
+    private static let headerDateFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f
+    }()
+
+    private static let headerTimeFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f
+    }()
+
+    private func weekdayName(_ date: Date) -> String {
+        Self.weekdayFmt.string(from: date)
     }
 
     private func headerSubline(_ date: Date) -> String {
-        let f = DateFormatter()
-        f.dateFormat = "MMM d · HH:mm"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone.current
         let count = viewModel.memos.count
-        return "\(f.string(from: date))  ·  \(count) signals"
+        let dateStr = Self.headerDateFmt.string(from: date)
+        switch count {
+        case 0:
+            return "\(dateStr)  ·  \(Self.headerTimeFmt.string(from: date))"
+        case 1:
+            return "\(dateStr)  ·  1 note"
+        default:
+            return "\(dateStr)  ·  \(count) notes"
+        }
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -55,6 +55,7 @@ struct TodayView: View {
 
                 VStack(spacing: 0) {
                     // MARK: Header — serif date + right-side controls
+                    // Note: animation on this VStack drives the orbHero enter/exit transition.
                     HStack(alignment: .top, spacing: 0) {
                         // Left: serif weekday + mono date subline; tap → open sidebar
                         Button {
@@ -152,7 +153,14 @@ struct TodayView: View {
                     }
 
                     // MARK: Day Orb Hero — serif date + mono kicker + orb
-                    orbHero
+                    // Hide when memos exist: the header already shows the date,
+                    // and the 140pt orb wastes prime content space once there
+                    // are signals in the timeline. (#US-016)
+                    if viewModel.memos.isEmpty {
+                        orbHero
+                            .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
+                            .animation(.easeOut(duration: 0.22), value: viewModel.memos.isEmpty)
+                    }
 
                     // MARK: Timeline
                     // Plain ScrollView — no GeometryReader. The previous wrapper
@@ -210,6 +218,11 @@ struct TodayView: View {
                                     .transition(.move(edge: .bottom).combined(with: .opacity))
                                 }
                             }
+
+                            // History supplement — shown at the bottom when today
+                            // already has memos, so the user can still scroll down
+                            // to yesterday's page or the weekly recap. (#US-016)
+                            historySupplement
 
                             // Loading indicator
                             if viewModel.isLoading {
@@ -491,8 +504,10 @@ struct TodayView: View {
         }
     }
 
+    // MARK: - Yesterday Section (shared by fallback and supplement paths)
+
     @ViewBuilder
-    private func yesterdayDailyPageFallback(_ page: DailyPageModel) -> some View {
+    private func yesterdaySection(_ page: DailyPageModel) -> some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("YESTERDAY")
                 .font(DSType.mono10)
@@ -508,6 +523,33 @@ struct TodayView: View {
             )
             .padding(.horizontal, 20)
         }
+    }
+
+    // MARK: - History Supplement (memos present — shown at timeline bottom)
+
+    /// When today already has memos we still show yesterday's compiled page or
+    /// the weekly recap at the bottom of the scroll, so the user can pull down
+    /// to see history. (#US-016)
+    @ViewBuilder
+    private var historySupplement: some View {
+        if !viewModel.memos.isEmpty && !viewModel.isLoading {
+            switch viewModel.fallbackContent {
+            case .yesterdayDailyPage(let page):
+                yesterdaySection(page).padding(.top, 8)
+            case .weekRecap(let entries):
+                WeeklyRecapSection(entries: entries) { dateString in
+                    onThisDayDateString = dateString
+                }
+                .padding(.top, 8)
+            default:
+                EmptyView()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func yesterdayDailyPageFallback(_ page: DailyPageModel) -> some View {
+        yesterdaySection(page)
     }
 
     @ViewBuilder

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -11,7 +11,7 @@
 
 /* Compile Locked */
 "empty.compile_locked.title" = "Not enough to compile.";
-"empty.compile_locked.subtitle" = "You have %d memo(s). Reach 3 to unlock daily compilation.";
+"empty.compile_locked.subtitle" = "%d of 3 memos captured. Keep going to unlock daily compilation.";
 
 /* Archive Day Empty */
 "empty.archive_day.title" = "No page for this day.";


### PR DESCRIPTION
## Summary

7-round Generator→Evaluator→Reviewer agent-teams iteration addressing all user-reported Today page issues:

- **Voice memo garbled/duplicate display** — `isBodyDuplicate` now checks `att.kind=="audio"` instead of `memo.type==.voice`, covering `.mixed` memos; applied to both `MemoCardView` and `MemoDetailView`
- **History content lost when today has memos** — new `historySupplement` renders yesterday's compiled daily-page or weekly recap at the bottom of the scroll, restoring "pull down to see history"; guarded by `!isLoading` to prevent flash; EARLIER hairline divider separates it from today's content
- **orbHero wastes screen space when data exists** — 140pt orb collapses with opacity+scale transition scoped only to that block; header serif date always visible for context
- **No share button** — long-press any text/voice/mixed card → native iOS share sheet; `shareableText` prefers audio transcript, falls back to body, combines both when they differ
- **Keyboard doesn't dismiss on submit** — `InputBarV4.handleSend()` now sets `isFocused = false` before collapse animation
- **Transcript auto-refresh** — `voiceQueue.pendingCount onChange` calls `viewModel.load()` so transcription results appear automatically without re-foregrounding the app
- **Accessibility** — `accessibilityLabel` and `accessibilityAction` strings unified to English across `TodayView` and `SwipeableMemoCard`; `headerSubline` DateFormatters promoted to `static let` to avoid per-render allocation

## Test plan

- [ ] Record a voice memo → transcript appears in card without tapping into detail view
- [ ] Record a voice memo → wait for transcription → transcript appears in card automatically (no re-open needed)
- [ ] Submit a memo → keyboard dismisses immediately
- [ ] With memos present, scroll down → EARLIER section with yesterday's daily page or weekly recap appears
- [ ] With memos present, Day Orb hero is hidden; header shows "N notes"
- [ ] Long-press a memo card → share sheet appears with correct text
- [ ] Enable VoiceOver → Settings button reads "Settings", swipe actions read "Delete"/"Pin"/"Unpin"
- [ ] Delete all today's memos → Day Orb hero reappears with smooth fade-in animation