### PR TITLE
fix(swipe): allow drag-to-close while delete panel is revealed

### DIFF
--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -11,6 +11,10 @@ import SwiftUI
 ///  - Velocity-aware snap: flick opens/closes even with small translation
 ///  - snapClose is always reachable: when trailing is open, any rightward
 ///    drag or flick collapses it (dx is relative to drag start, not screen zero)
+///  - When a panel is revealed, the underlying NavigationLink is disabled,
+///    which also blocks its `.highPriorityGesture`. The Color.clear overlay
+///    therefore re-attaches the same swipeGesture so drag-to-close keeps
+///    working while a panel is open (the overlay also handles tap-to-close).
 struct SwipeableMemoCard: View {
 
     let memo: Memo
@@ -70,12 +74,15 @@ struct SwipeableMemoCard: View {
             .drawingGroup(opaque: false, colorMode: .extendedLinear)
             .highPriorityGesture(swipeGesture)
 
-            // Invisible tap-to-close overlay: only active when a panel is open.
-            // Lives above the card so it intercepts taps independently of `.disabled`.
+            // Invisible tap/drag-to-close overlay: only active when a panel is open.
+            // Lives above the card so it intercepts both taps and drags
+            // independently of `.disabled` on the NavigationLink (which would
+            // otherwise swallow gestures attached to the disabled subtree).
             if revealedSide != nil {
                 Color.clear
                     .contentShape(Rectangle())
                     .onTapGesture { snapClose() }
+                    .highPriorityGesture(swipeGesture)
             }
         }
         .clipped()


### PR DESCRIPTION
## 问题

在 Today 列表里左滑一条 memo 露出红色「删除」面板后，往回拖拽无法把它收回去（截图见会话上下文）。只能依赖点一下卡片才能关闭，违背 iOS Mail/Reminders 的交互预期，也跟 `SwipeableMemoCard` 头部注释里写的「any rightward drag or flick collapses it」不符。

## 根因

露出面板时：

1. `NavigationLink` 加了 `.disabled(revealedSide != nil)` 来屏蔽点击导航；`.disabled()` 同时会让附在它上面的 `.highPriorityGesture(swipeGesture)` 失效（这是上一次修复 commit `22e2fc4` 已经显式确认过的行为）。
2. 上一个修复在 ZStack 里加了一层 `Color.clear` 兜住 tap-to-close，但**只接了 `.onTapGesture`**。用户在卡片上做横向拖拽时，touch 先被这层 tap 识别器吃掉，识别器因运动失败，但 drag 事件不会再向下穿透到底层（已 disabled 的）`swipeGesture`——于是卡片卡在打开状态。

## 修复

给同一层 `Color.clear` overlay 也挂上 `swipeGesture`：

```swift
if revealedSide != nil {
    Color.clear
        .contentShape(Rectangle())
        .onTapGesture { snapClose() }
        .highPriorityGesture(swipeGesture)   // ← 新增
}
```

overlay 是 `NavigationLink` 的兄弟节点而非后代，不在 `.disabled` 子树里，gesture 能正常激活；tap-to-close 与现有 snap / rubber-band / velocity 逻辑都不动，只是让"露出态"也接得到 drag。

## Test plan

- [ ] 左滑卡片露出红色删除面板
- [ ] 从可见卡片区往右拖 ≥24pt → 卡片回到关闭位（drag-to-close）
- [ ] 露出态下点击空白区域 → snapClose（tap-to-close 仍生效）
- [ ] 露出态下点击红色「删除」按钮 → 触发删除（与现状一致）
- [ ] 关闭态下点击卡片 → 进入 MemoDetailView（NavigationLink 行为未受影响）
- [ ] 右滑露出 pin 面板，左拖也能收回（leading 侧对称行为）

https://claude.ai/code/session_01Lr4RNfE8k85L7NMwXDZjbY

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lr4RNfE8k85L7NMwXDZjbY)_