### PR TITLE
feat(daily): thread reply + freeform input for compiled pages

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -36,6 +36,9 @@
 		A10000022 /* EntityPageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000022 /* EntityPageService.swift */; };
 		A10000023 /* BackgroundCompilationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000023 /* BackgroundCompilationService.swift */; };
 		A10000025 /* DailyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000025 /* DailyPageView.swift */; };
+		TH0000001 /* ThreadConversationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000001 /* ThreadConversationViewModel.swift */; };
+		TH0000002 /* ThreadConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000002 /* ThreadConversationView.swift */; };
+		TH0000003 /* InlineMicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000003 /* InlineMicButton.swift */; };
 		A10000026 /* EntityPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000026 /* EntityPageView.swift */; };
 		A10000027 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000027 /* SearchService.swift */; };
 		A10000028 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000028 /* SearchView.swift */; };
@@ -187,6 +190,9 @@
 		A20000024 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A20000071 /* DayPage.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DayPage.entitlements; sourceTree = "<group>"; };
 		A20000025 /* DailyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPageView.swift; sourceTree = "<group>"; };
+		TH1000001 /* ThreadConversationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationViewModel.swift; sourceTree = "<group>"; };
+		TH1000002 /* ThreadConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationView.swift; sourceTree = "<group>"; };
+		TH1000003 /* InlineMicButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineMicButton.swift; sourceTree = "<group>"; };
 		A20000026 /* EntityPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityPageView.swift; sourceTree = "<group>"; };
 		A20000027 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		A20000028 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
@@ -546,6 +552,9 @@
 			isa = PBXGroup;
 			children = (
 				A20000025 /* DailyPageView.swift */,
+				TH1000001 /* ThreadConversationViewModel.swift */,
+				TH1000002 /* ThreadConversationView.swift */,
+				TH1000003 /* InlineMicButton.swift */,
 			);
 			path = Daily;
 			sourceTree = "<group>";
@@ -905,6 +914,9 @@
 				A10000022 /* EntityPageService.swift in Sources */,
 				A10000023 /* BackgroundCompilationService.swift in Sources */,
 				A10000025 /* DailyPageView.swift in Sources */,
+				TH0000001 /* ThreadConversationViewModel.swift in Sources */,
+				TH0000002 /* ThreadConversationView.swift in Sources */,
+				TH0000003 /* InlineMicButton.swift in Sources */,
 				A10000026 /* EntityPageView.swift in Sources */,
 				A10000027 /* SearchService.swift in Sources */,
 				A10000028 /* SearchView.swift in Sources */,

--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -4,7 +4,7 @@ import SwiftUI
 
 struct EmptyStateView: View {
     let title: LocalizedStringKey
-    var subtitle: LocalizedStringKey?
+    var subtitle: String?
     var ctaLabel: String?
     var ctaAction: (() -> Void)?
     var showOrbAccent: Bool = false

--- a/DayPage/Features/Daily/DailyPageView.swift
+++ b/DayPage/Features/Daily/DailyPageView.swift
@@ -160,6 +160,12 @@ struct DailyPageView: View {
     @State private var recompileError: String? = nil
     @State private var showEditMetadata: Bool = false
 
+    // Thread conversation state — keyed by question string
+    @State private var threadVMs: [String: ThreadConversationViewModel] = [:]
+    // Freeform input area
+    @State private var freeformDraft: String = ""
+    @State private var freeformVM: ThreadConversationViewModel? = nil
+
     var body: some View {
         NavigationStack {
             ZStack {
@@ -822,44 +828,118 @@ struct DailyPageView: View {
         }
     }
 
-    // MARK: - Threads (AI Follow-up)
+    // MARK: - Threads (AI Follow-up) — expandable conversation cards
 
     private func threadsSection(model: DailyPageModel) -> some View {
-        VStack(alignment: .leading, spacing: 16) {
+        VStack(alignment: .leading, spacing: 12) {
             Text("THREADS")
                 .sectionLabelStyle()
                 .foregroundColor(DSColor.outline)
 
-            let columns = [GridItem(.flexible()), GridItem(.flexible())]
-            LazyVGrid(columns: columns, spacing: 12) {
-                ForEach(model.followUpQuestions, id: \.self) { question in
-                    Button(action: {
-                        dismiss()
-                        onReturnToToday?(question)
-                    }) {
-                        VStack(alignment: .leading, spacing: 16) {
-                            Text(question)
-                                .bodySMStyle()
-                                .foregroundColor(DSColor.onSurface)
-                                .multilineTextAlignment(.leading)
-                                .frame(maxWidth: .infinity, alignment: .leading)
+            ForEach(model.followUpQuestions, id: \.self) { question in
+                threadCard(question: question, compiledText: model.rawContent)
+            }
 
-                            HStack(spacing: 4) {
-                                Text("CONTINUE")
-                                    .monoLabelStyle(size: 10)
-                                    .foregroundColor(DSColor.amberArchival)
-                                Image(systemName: "arrow.right")
-                                    .font(.system(size: 10))
-                                    .foregroundColor(DSColor.amberArchival)
-                            }
-                        }
-                        .padding(DSSpacing.cardInner)
-                        .background(DSColor.surfaceContainerHigh)
-                        .cornerRadius(DSSpacing.radiusCard)
+            freeformInputArea(compiledText: model.rawContent)
+        }
+    }
+
+    /// Returns (creating if needed) the VM for a given question and renders an expandable card.
+    private func threadCard(question: String, compiledText: String) -> some View {
+        let vm = threadVM(for: question, compiledText: compiledText)
+        return ThreadConversationView(vm: vm)
+            .onTapGesture {
+                // First tap expands and fires the initial question.
+                guard !vm.isExpanded else { return }
+                withAnimation(.spring(response: 0.3, dampingFraction: 0.82)) {
+                    // Collapse all other threads and freeform before expanding.
+                    for key in threadVMs.keys where key != question {
+                        threadVMs[key]?.isExpanded = false
                     }
-                    .buttonStyle(.plain)
+                    freeformVM?.isExpanded = false
+                    vm.isExpanded = true
+                }
+                if vm.messages.isEmpty {
+                    Task { await vm.send(userMessage: question) }
                 }
             }
+    }
+
+    private func threadVM(for question: String, compiledText: String) -> ThreadConversationViewModel {
+        if let existing = threadVMs[question] { return existing }
+        let dateParser = DateFormatter()
+        dateParser.dateFormat = "yyyy-MM-dd"
+        dateParser.locale = Locale(identifier: "en_US_POSIX")
+        let date = dateParser.date(from: dateString) ?? Date()
+        let vm = ThreadConversationViewModel(question: question, compiledPageText: compiledText, date: date)
+        Task { await vm.loadHistory() }
+        threadVMs[question] = vm
+        return vm
+    }
+
+    // MARK: - Freeform input area
+
+    private func freeformInputArea(compiledText: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Freeform VM thread card (visible only after first send)
+            if let fvm = freeformVM, !fvm.messages.isEmpty {
+                ThreadConversationView(vm: fvm)
+            }
+
+            // Input bar
+            HStack(spacing: 8) {
+                TextField("你想聊什么…", text: $freeformDraft)
+                    .font(DSType.bodySM)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .submitLabel(.send)
+                    .onSubmit { sendFreeform(compiledText: compiledText) }
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 9)
+                    .background(DSColor.amberSoft.opacity(0.5))
+                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+
+                InlineMicButton { transcript in freeformDraft = transcript }
+
+                Button(action: { sendFreeform(compiledText: compiledText) }) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 24))
+                        .foregroundColor(canSendFreeform ? DSColor.amberAccent : DSColor.inkSubtle)
+                }
+                .buttonStyle(.plain)
+                .disabled(!canSendFreeform)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(DSColor.surfaceContainerHigh.opacity(0.8))
+            .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        }
+    }
+
+    private var canSendFreeform: Bool {
+        !freeformDraft.trimmingCharacters(in: .whitespaces).isEmpty
+            && !(freeformVM?.isStreaming ?? false)
+    }
+
+    private func sendFreeform(compiledText: String) {
+        let text = freeformDraft.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return }
+        freeformDraft = ""
+
+        if freeformVM == nil {
+            let dateParser = DateFormatter()
+            dateParser.dateFormat = "yyyy-MM-dd"
+            dateParser.locale = Locale(identifier: "en_US_POSIX")
+            let date = dateParser.date(from: dateString) ?? Date()
+            let vm = ThreadConversationViewModel(question: nil, compiledPageText: compiledText, date: date)
+            freeformVM = vm
+            Task {
+                await vm.loadHistory()
+                vm.isExpanded = true
+                await vm.send(userMessage: text)
+            }
+        } else {
+            freeformVM?.isExpanded = true
+            Task { await freeformVM?.send(userMessage: text) }
         }
     }
 

--- a/DayPage/Features/Daily/InlineMicButton.swift
+++ b/DayPage/Features/Daily/InlineMicButton.swift
@@ -1,0 +1,148 @@
+import SwiftUI
+import AVFoundation
+
+// MARK: - InlineMicButton
+
+/// Compact long-press mic button for inline use inside conversation input bars.
+/// Long-press to record → release to transcribe via Whisper → fires onTranscript.
+/// Keeps its own AVAudioRecorder so it does not share state with VoiceService.
+struct InlineMicButton: View {
+
+    let onTranscript: (String) -> Void
+
+    @State private var isRecording = false
+    @State private var isTranscribing = false
+    @State private var recorder: AVAudioRecorder?
+    @State private var tempURL: URL?
+    @State private var pulseScale: CGFloat = 1.0
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack {
+            if isTranscribing {
+                ProgressView()
+                    .progressViewStyle(.circular)
+                    .scaleEffect(0.7)
+                    .tint(DSColor.amberAccent)
+                    .frame(width: 32, height: 32)
+            } else {
+                Circle()
+                    .fill(isRecording ? DSColor.amberAccent : DSColor.amberSoft)
+                    .frame(width: 32, height: 32)
+                    .overlay(
+                        Image(systemName: isRecording ? "mic.fill" : "mic")
+                            .font(.system(size: 14, weight: .medium))
+                            .foregroundColor(isRecording ? .white : DSColor.amberAccent)
+                    )
+                    .scaleEffect(pulseScale)
+            }
+        }
+        .frame(width: 32, height: 32)
+        .gesture(longPressGesture)
+        .accessibilityLabel(isRecording ? "松开停止录音" : "长按录音")
+        .accessibilityHint("长按开始录音，松手后自动转写为文字")
+    }
+
+    // MARK: - Gesture
+
+    /// LongPressGesture fires on press-down; a DragGesture with minimumDistance 0
+    /// catches the finger-up event to stop recording.
+    private var longPressGesture: some Gesture {
+        LongPressGesture(minimumDuration: 0.25)
+            .onEnded { _ in Task { await startRecording() } }
+            .simultaneously(with:
+                DragGesture(minimumDistance: 0)
+                    .onEnded { _ in
+                        guard isRecording else { return }
+                        Task { await stopAndTranscribe() }
+                    }
+            )
+    }
+
+    // MARK: - Recording control
+
+    private func startRecording() async {
+        guard !isRecording, !isTranscribing else { return }
+
+        guard await requestMicPermission() else { return }
+
+        do {
+            let session = AVAudioSession.sharedInstance()
+            try session.setCategory(.record, mode: .default, options: [])
+            try session.setActive(true)
+        } catch { return }
+
+        let url = makeTempURL()
+        let settings: [String: Any] = [
+            AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
+            AVSampleRateKey: 44_100,
+            AVNumberOfChannelsKey: 1,
+            AVEncoderAudioQualityKey: AVAudioQuality.high.rawValue
+        ]
+
+        guard let rec = try? AVAudioRecorder(url: url, settings: settings) else {
+            try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            return
+        }
+        rec.record()
+        recorder = rec
+        tempURL = url
+
+        withAnimation(.easeOut(duration: 0.15)) { isRecording = true }
+        // Animate pulse only while recording.
+        withAnimation(Animation.easeInOut(duration: 0.55).repeatForever(autoreverses: true)) {
+            pulseScale = 1.18
+        }
+    }
+
+    private func stopAndTranscribe() async {
+        guard isRecording, let rec = recorder, let url = tempURL else { return }
+
+        rec.stop()
+        recorder = nil
+        withAnimation(.easeOut(duration: 0.15)) {
+            isRecording = false
+            pulseScale = 1.0
+        }
+
+        try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+
+        // Discard clips that are probably accidental taps (< 4 KB).
+        let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        guard size > 4_096 else { cleanupTemp(url); return }
+
+        isTranscribing = true
+        defer { isTranscribing = false; cleanupTemp(url) }
+
+        if let text = await VoiceService.shared.transcribeAudio(at: url), !text.isEmpty {
+            onTranscript(text)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func requestMicPermission() async -> Bool {
+        let status = AVAudioSession.sharedInstance().recordPermission
+        switch status {
+        case .granted: return true
+        case .denied:  return false
+        case .undetermined:
+            return await withCheckedContinuation { cont in
+                AVAudioSession.sharedInstance().requestRecordPermission { cont.resume(returning: $0) }
+            }
+        @unknown default: return false
+        }
+    }
+
+    private func makeTempURL() -> URL {
+        let stamp = Int(Date().timeIntervalSince1970)
+        return FileManager.default.temporaryDirectory
+            .appendingPathComponent("inline_mic_\(stamp).m4a")
+    }
+
+    private func cleanupTemp(_ url: URL) {
+        try? FileManager.default.removeItem(at: url)
+        tempURL = nil
+    }
+}

--- a/DayPage/Features/Daily/ThreadConversationView.swift
+++ b/DayPage/Features/Daily/ThreadConversationView.swift
@@ -1,0 +1,247 @@
+import SwiftUI
+
+// MARK: - ThreadConversationView
+
+/// Expandable card that renders a single AI follow-up thread.
+/// Shows the question header, the message history, a streaming indicator,
+/// and (after the first AI reply) an input row for follow-up questions.
+struct ThreadConversationView: View {
+
+    @ObservedObject var vm: ThreadConversationViewModel
+
+    @State private var followUpDraft: String = ""
+    @FocusState private var inputFocused: Bool
+
+    // MARK: - Body
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            questionHeader
+                .padding(.horizontal, 16)
+                .padding(.top, 14)
+                .padding(.bottom, 12)
+
+            if vm.isExpanded {
+                expandedContent
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .background(DSColor.surfaceContainerHigh)
+        .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+        .animation(.spring(response: 0.3, dampingFraction: 0.82), value: vm.isExpanded)
+    }
+
+    // MARK: - Question header
+
+    private var questionHeader: some View {
+        HStack(alignment: .top, spacing: 10) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(DSColor.amberAccent)
+                .frame(width: 3, height: 20)
+
+            Text(vm.question ?? "自由追问")
+                .font(DSType.serifBody16)
+                .foregroundColor(DSColor.inkPrimary)
+                .lineLimit(vm.isExpanded ? nil : 2)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: toggleExpanded) {
+                Image(systemName: vm.isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(DSColor.inkMuted)
+                    .frame(width: 28, height: 28)
+                    .background(DSColor.amberSoft, in: Circle())
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    // MARK: - Expanded content
+
+    private var expandedContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Rectangle()
+                .fill(DSColor.glassRimD)
+                .frame(height: 0.5)
+                .padding(.horizontal, 16)
+                .padding(.bottom, 8)
+
+            if !vm.messages.isEmpty {
+                messagesScrollView
+                    .padding(.bottom, 4)
+            }
+
+            if vm.isStreaming {
+                streamingRow
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+                    .transition(.opacity)
+            }
+
+            if let err = vm.error {
+                Text(err)
+                    .font(DSType.bodySM)
+                    .foregroundColor(DSColor.error)
+                    .padding(.horizontal, 16)
+                    .padding(.bottom, 8)
+            }
+
+            let hasReply = vm.messages.contains { $0.role == "assistant" }
+            if hasReply && !vm.isStreaming {
+                followUpInputRow
+                    .padding(.horizontal, 12)
+                    .padding(.bottom, 12)
+                    .transition(.opacity)
+                    .animation(.easeIn(duration: 0.2), value: hasReply)
+            }
+        }
+    }
+
+    // MARK: - Messages scroll view
+
+    private var messagesScrollView: some View {
+        ScrollView(.vertical, showsIndicators: false) {
+            LazyVStack(alignment: .leading, spacing: 8) {
+                ForEach(vm.messages) { msg in
+                    MessageBubble(message: msg)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+        }
+        .frame(maxHeight: 280)
+    }
+
+    // MARK: - Streaming row
+
+    private var streamingRow: some View {
+        HStack(alignment: .top, spacing: 8) {
+            aiBadge
+
+            VStack(alignment: .leading, spacing: 4) {
+                if !vm.streamingText.isEmpty {
+                    Text(vm.streamingText)
+                        .font(DSType.serifBody16)
+                        .foregroundColor(DSColor.inkPrimary)
+                        .lineSpacing(5)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                TypingIndicator()
+            }
+        }
+    }
+
+    // MARK: - Follow-up input row
+
+    private var followUpInputRow: some View {
+        HStack(spacing: 6) {
+            TextField("继续追问…", text: $followUpDraft)
+                .font(DSType.bodySM)
+                .foregroundColor(DSColor.inkPrimary)
+                .focused($inputFocused)
+                .submitLabel(.send)
+                .onSubmit { sendFollowUp() }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(DSColor.amberSoft.opacity(0.6))
+                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+            InlineMicButton { transcript in followUpDraft = transcript }
+
+            Button(action: sendFollowUp) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 22))
+                    .foregroundColor(canSend ? DSColor.amberAccent : DSColor.inkSubtle)
+            }
+            .buttonStyle(.plain)
+            .disabled(!canSend)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var canSend: Bool {
+        !followUpDraft.trimmingCharacters(in: .whitespaces).isEmpty && !vm.isStreaming
+    }
+
+    private var aiBadge: some View {
+        Text("AI")
+            .font(DSFonts.jetBrainsMono(size: 9, weight: .medium))
+            .foregroundColor(DSColor.amberDeep)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(DSColor.amberSoft)
+            .clipShape(Capsule())
+    }
+
+    private func toggleExpanded() {
+        withAnimation(.spring(response: 0.3, dampingFraction: 0.82)) {
+            vm.isExpanded.toggle()
+        }
+    }
+
+    private func sendFollowUp() {
+        let text = followUpDraft.trimmingCharacters(in: .whitespaces)
+        guard !text.isEmpty else { return }
+        followUpDraft = ""
+        inputFocused = false
+        Task { await vm.send(userMessage: text) }
+    }
+}
+
+// MARK: - MessageBubble
+
+private struct MessageBubble: View {
+    let message: ThreadConversationViewModel.Message
+
+    private var isUser: Bool { message.role == "user" }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 0) {
+            if isUser { Spacer(minLength: 44) }
+
+            Text(message.text)
+                .font(DSType.serifBody16)
+                .foregroundColor(isUser ? DSColor.amberDeep : DSColor.inkPrimary)
+                .lineSpacing(5)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(
+                    isUser ? DSColor.amberSoft : DSColor.surfaceContainerLowest,
+                    in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .strokeBorder(
+                            isUser ? DSColor.amberRim : DSColor.glassRim,
+                            lineWidth: 0.5
+                        )
+                )
+
+            if !isUser { Spacer(minLength: 44) }
+        }
+    }
+}
+
+// MARK: - TypingIndicator
+
+/// Three-dot bounce animation shown while the AI is streaming.
+private struct TypingIndicator: View {
+
+    @State private var phase: Int = 0
+
+    private let animationTimer = Timer.publish(every: 0.28, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        HStack(spacing: 3) {
+            ForEach(0..<3, id: \.self) { i in
+                Circle()
+                    .fill(DSColor.amberAccent.opacity(i == phase ? 1.0 : 0.3))
+                    .frame(width: 5, height: 5)
+                    .scaleEffect(i == phase ? 1.3 : 1.0)
+                    .animation(.easeInOut(duration: 0.22), value: phase)
+            }
+        }
+        .onReceive(animationTimer) { _ in phase = (phase + 1) % 3 }
+    }
+}

--- a/DayPage/Features/Daily/ThreadConversationViewModel.swift
+++ b/DayPage/Features/Daily/ThreadConversationViewModel.swift
@@ -1,0 +1,292 @@
+import Foundation
+import SwiftUI
+
+// MARK: - ThreadConversationViewModel
+
+/// Drives a single question-and-answer thread embedded in a Daily Page.
+/// Handles streaming AI replies and persists conversations to vault/threads/YYYY-MM-DD.md.
+@MainActor
+final class ThreadConversationViewModel: ObservableObject, Identifiable {
+
+    // MARK: - Public identity
+
+    let id: String
+    let question: String?          // nil for freeform entries
+    let compiledPageText: String
+    let date: Date
+
+    // MARK: - Message model
+
+    struct Message: Identifiable {
+        let id = UUID()
+        let role: String           // "user" | "assistant"
+        var text: String
+    }
+
+    // MARK: - Published state
+
+    @Published var messages: [Message] = []
+    @Published var streamingText: String = ""
+    @Published var isStreaming: Bool = false
+    @Published var error: String? = nil
+    @Published var isExpanded: Bool = false
+
+    // MARK: - Private formatters
+
+    private let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f
+    }()
+
+    private let iso8601Formatter: ISO8601DateFormatter = {
+        let f = ISO8601DateFormatter()
+        f.formatOptions = [.withInternetDateTime]
+        return f
+    }()
+
+    // MARK: - Init
+
+    init(question: String?, compiledPageText: String, date: Date) {
+        self.question = question
+        self.compiledPageText = compiledPageText
+        self.date = date
+        // Stable ID: use question text for preset threads, UUID for freeform.
+        self.id = question ?? UUID().uuidString
+    }
+
+    // MARK: - Load history
+
+    /// Reads vault/threads/YYYY-MM-DD.md and restores the matching conversation block.
+    func loadHistory() async {
+        let fileURL = threadsFileURL()
+        guard FileManager.default.fileExists(atPath: fileURL.path),
+              let content = try? String(contentsOf: fileURL, encoding: .utf8) else { return }
+
+        let questionKey = question ?? "(freeform)"
+        let blocks = content
+            .components(separatedBy: "\n\n---\n\n")
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+        for block in blocks {
+            let blockQuestion = extractFrontmatterValue(key: "question", from: block)
+            guard blockQuestion == questionKey else { continue }
+            let parsed = parseMessages(from: block)
+            if !parsed.isEmpty { messages = parsed }
+            return
+        }
+    }
+
+    // MARK: - Send
+
+    /// Appends a user message and streams the AI reply.
+    func send(userMessage: String) async {
+        let trimmed = userMessage.trimmingCharacters(in: .whitespaces)
+        guard !trimmed.isEmpty, !isStreaming else { return }
+
+        messages.append(Message(role: "user", text: trimmed))
+        error = nil
+
+        let apiMessages = buildAPIMessages()
+        do {
+            try await streamReply(apiMessages: apiMessages)
+        } catch {
+            self.error = error.localizedDescription
+        }
+    }
+
+    // MARK: - Streaming reply
+
+    private func streamReply(apiMessages: [[String: String]]) async throws {
+        let apiKey = Secrets.resolvedDeepSeekApiKey
+        guard !apiKey.isEmpty else { throw ThreadError.missingApiKey }
+
+        let baseURL = Secrets.deepSeekBaseURL.isEmpty ? "https://api.deepseek.com/v1" : Secrets.deepSeekBaseURL
+        let model = Secrets.deepSeekModel.isEmpty ? "deepseek-chat" : Secrets.deepSeekModel
+
+        guard let url = URL(string: "\(baseURL)/chat/completions") else {
+            throw ThreadError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = 60
+
+        var allMessages: [[String: String]] = [["role": "system", "content": buildSystemPrompt()]]
+        allMessages.append(contentsOf: apiMessages)
+
+        let body: [String: Any] = [
+            "model": model,
+            "messages": allMessages,
+            "max_tokens": 512,
+            "temperature": 0.8,
+            "stream": true
+        ]
+
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        isStreaming = true
+        streamingText = ""
+        // Guarantee cleanup on every exit path — success, throw, or cancellation.
+        defer {
+            isStreaming = false
+            streamingText = ""
+        }
+
+        let (asyncBytes, response) = try await URLSession.shared.bytes(for: request)
+
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            throw ThreadError.apiError(statusCode: http.statusCode)
+        }
+
+        for try await line in asyncBytes.lines {
+            guard line.hasPrefix("data: ") else { continue }
+            let payload = String(line.dropFirst(6))
+            if payload == "[DONE]" { break }
+
+            guard let jsonData = payload.data(using: .utf8),
+                  let json = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                  let choices = json["choices"] as? [[String: Any]],
+                  let delta = choices.first?["delta"] as? [String: Any],
+                  let chunk = delta["content"] as? String else { continue }
+
+            streamingText += chunk
+        }
+
+        // Capture before defer clears it.
+        let finalText = streamingText
+
+        if !finalText.isEmpty {
+            messages.append(Message(role: "assistant", text: finalText))
+        }
+        persist()
+    }
+
+    // MARK: - Persist
+
+    /// Writes this thread's block into vault/threads/YYYY-MM-DD.md,
+    /// replacing a previous block with the same question if one exists.
+    private func persist() {
+        guard !messages.isEmpty else { return }
+
+        let fileURL = threadsFileURL()
+        let dir = fileURL.deletingLastPathComponent()
+        if !FileManager.default.fileExists(atPath: dir.path) {
+            try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        }
+
+        let questionKey = question ?? "(freeform)"
+        let newBlock = serializeBlock()
+
+        var blocks = (try? String(contentsOf: fileURL, encoding: .utf8))?
+            .components(separatedBy: "\n\n---\n\n")
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+            ?? []
+
+        var replaced = false
+        for i in blocks.indices {
+            if extractFrontmatterValue(key: "question", from: blocks[i]) == questionKey {
+                blocks[i] = newBlock
+                replaced = true
+                break
+            }
+        }
+        if !replaced { blocks.append(newBlock) }
+
+        let combined = blocks.joined(separator: "\n\n---\n\n")
+        try? RawStorage.atomicWrite(string: combined, to: fileURL)
+    }
+
+    // MARK: - File URL
+
+    private func threadsFileURL() -> URL {
+        let dateString = dateFormatter.string(from: date)
+        return VaultInitializer.vaultURL
+            .appendingPathComponent("threads")
+            .appendingPathComponent("\(dateString).md")
+    }
+
+    // MARK: - Serialisation / parsing
+
+    private func serializeBlock() -> String {
+        let questionKey = question ?? "(freeform)"
+        let timestamp = iso8601Formatter.string(from: Date())
+        var lines = ["---", "question: \(questionKey)", "timestamp: \(timestamp)", "---"]
+        for msg in messages {
+            let roleLabel = msg.role == "assistant" ? "ai" : "user"
+            lines.append("\(roleLabel): \(msg.text)")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    private func parseMessages(from block: String) -> [Message] {
+        var result: [Message] = []
+        var closingDelimiters = 0
+
+        for line in block.components(separatedBy: "\n") {
+            let t = line.trimmingCharacters(in: .whitespaces)
+            if t == "---" { closingDelimiters += 1; continue }
+            guard closingDelimiters >= 2 else { continue }
+
+            if t.hasPrefix("user: ") {
+                result.append(Message(role: "user", text: String(t.dropFirst(6))))
+            } else if t.hasPrefix("ai: ") {
+                result.append(Message(role: "assistant", text: String(t.dropFirst(4))))
+            }
+        }
+        return result
+    }
+
+    private func extractFrontmatterValue(key: String, from block: String) -> String? {
+        let prefix = "\(key): "
+        for line in block.components(separatedBy: "\n") {
+            let t = line.trimmingCharacters(in: .whitespaces)
+            if t.hasPrefix(prefix) { return String(t.dropFirst(prefix.count)) }
+        }
+        return nil
+    }
+
+    // MARK: - API helpers
+
+    private func buildAPIMessages() -> [[String: String]] {
+        messages.map { msg in
+            ["role": msg.role == "assistant" ? "assistant" : "user", "content": msg.text]
+        }
+    }
+
+    private func buildSystemPrompt() -> String {
+        let dateString = dateFormatter.string(from: date)
+        let maxChars = 3_000
+        let pageText = compiledPageText.count > maxChars
+            ? String(compiledPageText.prefix(maxChars)) + "..."
+            : compiledPageText
+
+        return """
+        你是用户的个人反思助手。以下是用户今天（\(dateString)）的日记内容：
+
+        \(pageText)
+
+        请基于日记内容回答用户的追问。回答简洁、有温度，100字以内。用第二人称（"你"）。不要重复问题本身。
+        """
+    }
+}
+
+// MARK: - ThreadError
+
+private enum ThreadError: LocalizedError {
+    case missingApiKey
+    case invalidURL
+    case apiError(statusCode: Int)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingApiKey:      return "AI Key 未配置"
+        case .invalidURL:         return "API URL 无效"
+        case .apiError(let code): return "API 错误 \(code)"
+        }
+    }
+}

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -241,9 +241,15 @@ struct MemoCardView: View {
                     .lineSpacing(6)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .textSelection(.enabled)
                     .padding(.horizontal, 14)
                     .padding(.top, 12)
+                    .contextMenu {
+                        Button {
+                            UIPasteboard.general.string = bodyTrimmed
+                        } label: {
+                            Label("复制", systemImage: "doc.on.doc")
+                        }
+                    }
             }
 
             // Bottom meta row: time + type chip + location
@@ -560,7 +566,13 @@ struct VoiceMemoPlayerRow: View {
                         .foregroundColor(DSColor.inkMuted)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
-                        .textSelection(.enabled)
+                        .contextMenu {
+                            Button {
+                                UIPasteboard.general.string = t
+                            } label: {
+                                Label("复制", systemImage: "doc.on.doc")
+                            }
+                        }
                     Text("\"")
                         .font(DSFonts.serif(size: 20, weight: .medium))
                         .foregroundColor(DSColor.amberAccent)

--- a/DayPage/Resources/L10n.swift
+++ b/DayPage/Resources/L10n.swift
@@ -6,29 +6,27 @@ enum L10n {
     enum Empty {
         // Today Blank
         static let todayBlankTitle      = LocalizedStringKey("empty.today.blank.title")
-        static let todayBlankSubtitle   = LocalizedStringKey("empty.today.blank.subtitle")
+        static let todayBlankSubtitle   = NSLocalizedString("empty.today.blank.subtitle", comment: "")
         static let todayBlankCta        = NSLocalizedString("empty.today.blank.cta", comment: "")
 
         // Today No Signals
         static let todayNoSignalsTitle    = LocalizedStringKey("empty.today.no_signals.title")
-        static let todayNoSignalsSubtitle = LocalizedStringKey("empty.today.no_signals.subtitle")
+        static let todayNoSignalsSubtitle = NSLocalizedString("empty.today.no_signals.subtitle", comment: "")
 
         // Compile Locked
         static let compileLockedTitle = LocalizedStringKey("empty.compile_locked.title")
-        static func compileLockedSubtitle(count: Int) -> LocalizedStringKey {
-            LocalizedStringKey(
-                String(format: NSLocalizedString("empty.compile_locked.subtitle", comment: ""), count)
-            )
+        static func compileLockedSubtitle(count: Int) -> String {
+            String(format: NSLocalizedString("empty.compile_locked.subtitle", comment: ""), count)
         }
 
         // Archive Day Empty
         static let archiveDayTitle    = LocalizedStringKey("empty.archive_day.title")
-        static let archiveDaySubtitle = LocalizedStringKey("empty.archive_day.subtitle")
+        static let archiveDaySubtitle = NSLocalizedString("empty.archive_day.subtitle", comment: "")
         static let archiveDayCta      = NSLocalizedString("empty.archive_day.cta", comment: "")
 
         // Mic Permission Denied
         static let micDeniedTitle    = LocalizedStringKey("empty.mic_denied.title")
-        static let micDeniedSubtitle = LocalizedStringKey("empty.mic_denied.subtitle")
+        static let micDeniedSubtitle = NSLocalizedString("empty.mic_denied.subtitle", comment: "")
         static let micDeniedCta      = NSLocalizedString("empty.mic_denied.cta", comment: "")
     }
 


### PR DESCRIPTION
## Summary

- **Thread reply**: each question card in a compiled Daily Page can be tapped to expand an inline AI conversation. Replies stream via DeepSeek SSE, conversation persists to `vault/threads/YYYY-MM-DD.md`.
- **Freeform input**: a lightweight input bar (text field + inline mic button) at the bottom of the compiled page lets users ask anything beyond the preset questions.
- **Bug fix — localization**: compile-locked empty state was displaying raw keys like `empty.compile_locked.title`. Root cause: `LocalizedStringKey(formattedString)` triggers a second lookup that fails. Fixed by changing subtitle constants to `NSLocalizedString`/`String`.
- **Bug fix — scroll**: `ScrollView` scroll was blocked when finger landed on a voice transcript or body text area. Root cause: `.textSelection(.enabled)` injects a UIKit `UIPanGestureRecognizer` that wins priority over the scroll gesture. Replaced with `.contextMenu` copy action.
- **Bug fix (Evaluator)**: `isStreaming` could get permanently stuck `true` if a network error fired mid-stream. Added `defer { isStreaming = false; streamingText = "" }` to all exit paths in `streamReply`.
- **Bug fix (Evaluator)**: `AVAudioSession` was left active if `AVAudioRecorder` init failed in `InlineMicButton`, muting other app audio. Added `setActive(false)` in the guard-else path.
- **Bug fix (Evaluator)**: multiple Thread cards could expand simultaneously. `threadCard` onTapGesture now collapses all other VMs before expanding the tapped one.

## New files

| File | Purpose |
|------|---------|
| `Features/Daily/ThreadConversationViewModel.swift` | `@MainActor ObservableObject` — SSE streaming, message model, vault persistence, history loading |
| `Features/Daily/ThreadConversationView.swift` | SwiftUI card — typing indicator, message bubbles, fold/unfold, freeform input integration |
| `Features/Daily/InlineMicButton.swift` | Long-press mic → Whisper transcription, self-contained `AVAudioRecorder` |

## Test plan

- [ ] Compile-locked empty state shows translated text (not raw key)
- [ ] Tap a thread card → expands, sends initial question, streams reply
- [ ] Tapping a second card collapses the first
- [ ] Network error during streaming → error label shown, send button re-enabled immediately
- [ ] Long-press mic in freeform bar → amber pulse, release → transcript fills input
- [ ] Scrolling over voice transcript area works normally (no scroll block)
- [ ] Thread conversation persists across view dismissal + return (vault/threads/)