### PR TITLE
fix(memo): auto-embed GPS location + fix voice card scroll blocking

### DIFF
--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -543,11 +543,13 @@ struct VoiceMemoPlayerRow: View {
                         }
                 }
                 .frame(height: 24)
+                .allowsHitTesting(false)
 
                 Text(formatDur(isPlaying ? duration * playbackProgress : duration))
                     .font(DSFonts.jetBrainsMono(size: 11))
                     .foregroundColor(DSColor.inkSubtle)
                     .frame(width: 36, alignment: .trailing)
+                    .allowsHitTesting(false)
             }
             .padding(.horizontal, 14)
             .padding(.top, 14)

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -641,10 +641,14 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         submitMemoTask = Task {
             defer { isSubmitting = false }
 
-            let weatherString = await weatherService.currentWeather(at: loc)
-
-            // Derive location from first photo EXIF if no pending location
+            // Auto-fetch location for every memo when not already set by the user.
+            // Falls back silently on denial or timeout — location is best-effort metadata.
             var memoLocation: Memo.Location? = loc
+            if memoLocation == nil {
+                memoLocation = try? await locationService.currentLocation(timeout: 3)
+            }
+
+            // Derive location from first photo EXIF when GPS is still missing
             if memoLocation == nil {
                 for att in snapshotAttachments {
                     if case .photo(let r) = att,
@@ -655,6 +659,8 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                     }
                 }
             }
+
+            let weatherString = await weatherService.currentWeather(at: memoLocation)
 
             // Determine created date: prefer first photo EXIF date when text is absent
             var created = Date()


### PR DESCRIPTION
## Summary

- **Auto location embed**: Every memo (text, voice, photo) now automatically embeds GPS coordinates at submit time. `submitCombinedMemo` calls `locationService.currentLocation(timeout: 3)` when no user-set `pendingLocation` exists. Fails silently on denial/timeout — location is best-effort metadata. Photo EXIF GPS remains the third-priority fallback. Weather lookup now also receives the resolved location.

- **Voice waveform scroll fix**: Touching the waveform area of a voice memo card blocked vertical ScrollView scrolling. The waveform `ZStack` and duration `Text` in `VoiceMemoPlayerRow` were consuming touch-start events. Added `.allowsHitTesting(false)` to both decorative views so touches pass through to the parent scroll gesture recognizer.

## Files changed

- `DayPage/Features/Today/TodayViewModel.swift` — location auto-fetch in `submitCombinedMemo`
- `DayPage/Features/Today/MemoCardView.swift` — `.allowsHitTesting(false)` on waveform and duration text

## Test plan

- [ ] Submit a text memo with location permission granted → memo file contains `location:` in YAML front-matter
- [ ] Submit a text memo with location permission denied → memo saves normally, no location field (or empty)
- [ ] Swipe vertically on a voice memo card waveform area → parent list scrolls without resistance
- [ ] Tap the play button on a voice memo card → playback starts normally (hit-testing still works on the button)
- [ ] Submit a photo with GPS EXIF — location should be extracted from EXIF as fallback