### PR TITLE
docs(prd): V5 Codex — 跨端 AI 知识系统终极形态蓝图

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,9 +172,38 @@ Icon
 crash.log
 
 # -----------------------------------------------------------------------------
-# Node（如果未来加 JS 工具链如 swift-format 通过 npm 装）
+# Node / pnpm / Next.js / Web 端构建产物
 # -----------------------------------------------------------------------------
 node_modules/
+.pnpm-store/
+.pnpm-debug.log*
+
+# Next.js
+.next/
+out/
+next-env.d.ts
+
+# Turbopack / Turborepo
+.turbo/
+
+# Drizzle
+drizzle/meta/
+
+# Supabase 本地（数据库快照不入仓，但 migrations/seed/config 入仓）
+web/supabase/.branches/
+web/supabase/.temp/
+supabase/.branches/
+supabase/.temp/
+
+# 测试 / 覆盖率
+coverage/
+.nyc_output/
+
+# Vercel
+.vercel/
+
+# TypeScript 增量构建
+*.tsbuildinfo
 
 # -----------------------------------------------------------------------------
 # Python（scripts/ 下的辅助脚本，例如 update_testflight_changelog.py）

--- a/archive/2026-05-10-today-composer-liquid/prd-root.json
+++ b/archive/2026-05-10-today-composer-liquid/prd-root.json
@@ -1,0 +1,331 @@
+{
+  "project": "DayPage",
+  "branchName": "ralph/today-composer-liquid-refinement",
+  "description": "Today \u4e3b\u9875\u6781\u7b80\u4f18\u96c5\u91cd\u5851 + Composer 3.0 Liquid Composition Surface \u2014 \u6574\u5408 issue #252 + #250: \u5220 GlassTabBar, AmbientBackground \u7eaf\u5316, Day Orb \u6536\u655b, \u7a7a\u6570\u636e\u56de\u9000\u6808, i18n \u4fee\u590d + L10n.swift, composerState \u72b6\u6001\u673a, Liquid Morph, 5 \u5f62\u6001 Adaptive Send, keyboard-attached toolbar, drag handle, 5 \u7ea7 haptics, Context Spotlight Strip, Smart Templates, Lens Strip, Caret Spotlight, Status Strip",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "i18n \u8d44\u6e90\u5f7b\u67e5\uff1alproj target membership + L10n.swift \u5f3a\u7c7b\u578b\u679a\u4e3e",
+      "description": "As a \u7528\u6237, I want \u4e3b\u9875\u6587\u6848\u663e\u793a\u4e2d\u6587/\u82f1\u6587\u7ffb\u8bd1\u800c\u975e\u539f\u59cb key, so that \u622a\u56fe\u4e0d\u518d\u51fa\u73b0 'empty.today.no_signals.title' \u8fd9\u7c7b\u66b4\u9732\u5b57\u7b26\u4e32.",
+      "acceptanceCriteria": [
+        "Xcode DayPage target Build Phases Copy Bundle Resources \u5305\u542b zh-Hans.lproj \u548c en.lproj",
+        "Xcode Project Localizations \u542f\u7528 Chinese (Simplified) \u4e0e English",
+        "Info.plist \u542b CFBundleDevelopmentRegion=zh-Hans \u4e0e CFBundleLocalizations=[zh-Hans, en]",
+        "\u65b0\u589e DayPage/Resources/L10n.swift \u63d0\u4f9b L10n.Empty.todayNoSignalsTitle \u5f3a\u7c7b\u578b\u8bbf\u95ee\u5668",
+        "EmptyStateView.todayNoSignals() \u6539\u7528 L10n.Empty.* \u800c\u975e\u88f8\u5b57\u9762\u91cf",
+        "\u4e2d\u82f1\u6587\u7cfb\u7edf\u8bed\u8a00\u5207\u6362\u540e hero \u4e0b\u65b9\u6587\u6848\u6b63\u786e\u53d8\u5316",
+        "grep -rn 'LocalizedStringKey(\"' DayPage/ \u8f93\u51fa\u4e3a 0 (\u9664 L10n.swift)",
+        "xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build \u901a\u8fc7",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "AmbientBackground \u7eaf\u5316\uff1a\u5220 4 \u56e2\u6696\u8272\u5149\u6591\uff0c\u9ed8\u8ba4\u4ec5 cream \u5e95",
+      "description": "As a \u7528\u6237, I want \u4e3b\u9875\u80cc\u666f\u63a5\u8fd1\u7eaf\u8272\u5976\u6cb9\u7eb8\u611f, so that \u89c6\u89c9\u951a\u70b9\u56de\u5230\u5b57\u672c\u8eab, \u4e0d\u518d\u50cf AI \u6f14\u793a\u7a3f.",
+      "acceptanceCriteria": [
+        "DayPage/DesignSystem/GlassSurface.swift AmbientBackground \u9ed8\u8ba4\u4ec5\u6e32\u67d3 DSColor.bgWarm (FAF7F2)",
+        "4 \u56e2 amber blob \u7528 @AppStorage('debug.ambientBlobs') \u5305\u8d77\u6765, \u9ed8\u8ba4 false",
+        "TodayView, DailyPageView, MemoDetailView \u663e\u5f0f\u4e0d\u4f20\u5f00\u5173, \u4f7f\u7528\u9ed8\u8ba4\u7eaf\u8272\u884c\u4e3a",
+        "iPhone 17 Simulator \u622a\u56fe\u4e0e\u6539\u52a8\u524d\u5e76\u6392\u9971\u548c\u5ea6\u8089\u773c\u660e\u663e\u4e0b\u964d",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Day Orb \u6536\u655b\uff1asize 140pt + halo opacity 0.15 + orbFill \u00d70.5",
+      "description": "As a \u7528\u6237, I want Day Orb \u4ece\u4e2d\u592e\u5de8\u5927\u7425\u73c0\u7403\u53d8\u4e3a\u7eb8\u4e0a\u4e00\u679a\u8f7b\u6655, so that serif \u65e5\u671f 'Friday MAY 8' \u6210\u4e3a\u89c6\u89c9\u4e3b\u89d2.",
+      "acceptanceCriteria": [
+        "DayPage/Features/Today/DayOrbView.swift halo \u900f\u660e\u5ea6\u4ece 0.4 \u6539\u4e3a 0.15",
+        "orbFill gradient stops \u900f\u660e\u5ea6\u5168\u90e8 \u00d70.5",
+        "DayOrbView \u66b4\u9732 size: CGFloat = 140 \u4e0e haloOpacity: CGFloat = 0.15 \u53c2\u6570",
+        "TodayView \u8c03\u7528\u5904\u663e\u5f0f\u4f20 size: 140",
+        "\u547c\u5438\u52a8\u753b\u5e45\u5ea6 \u00d70.7",
+        "iPhone 17 Simulator \u622a\u56fe\u4e0e\u6539\u52a8\u524d\u5e76\u6392 orb \u660e\u663e\u6536\u655b",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-002 (AmbientBackground \u7eaf\u5316\u5148\u843d\u5730)"
+    },
+    {
+      "id": "US-004",
+      "title": "\u5220\u9664 GlassTabBar\uff0c\u8d26\u53f7\u5934\u50cf\u8fc1\u5165\u8bbe\u7f6e sheet\uff0c\u53f3\u4e0a\u4ec5\u7559\u9f7f\u8f6e",
+      "description": "As a \u7528\u6237, I want \u9876\u90e8\u4e0d\u518d\u51fa\u73b0 [Today \u25be] pill \u548c\u7425\u73c0\u8272\u5934\u50cf, so that \u6574\u9875\u53ea\u6709 sidebar \u4e00\u5957\u5bfc\u822a\u8bed\u8a00, \u89c6\u89c9\u4e00\u81f4.",
+      "acceptanceCriteria": [
+        "\u5220\u9664 DayPage/Components/GlassTabBar.swift",
+        "\u4ece RootView.swift / TodayView.swift / AppNavigationModel.swift \u4e2d\u79fb\u9664\u6240\u6709 GlassTabBar / AppTab \u5f15\u7528",
+        "TodayView \u9876\u90e8\u8d26\u53f7\u5934\u50cf (36pt \u5b9e\u5fc3\u7425\u73c0\u5706) \u79fb\u9664, \u8d26\u53f7\u5165\u53e3\u79fb\u5230\u8bbe\u7f6e sheet \u9876\u90e8",
+        "TodayView \u9876\u90e8\u53f3\u4fa7\u4ec5\u4fdd\u7559\u9f7f\u8f6e\u6309\u94ae (28pt \u73bb\u7483\u5706)",
+        "Archive / Graph \u5207\u6362\u901a\u8fc7 sidebar \u5b8c\u6210, \u56de\u5f52 path \u65e0\u6b67\u4e49",
+        "grep -rn 'GlassTabBar' DayPage/ \u8f93\u51fa\u4e3a 0",
+        "xcodebuild build \u901a\u8fc7",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 4,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "TodayViewModel \u65b0\u589e TodayFallback \u679a\u4e3e\u4e0e fallbackContent \u8ba1\u7b97\u5c5e\u6027",
+      "description": "As a \u5f00\u53d1\u8005, I want TodayViewModel \u66b4\u9732 fallback \u5185\u5bb9\u9009\u62e9, so that TodayView \u5728\u4eca\u65e5 0 memo \u65f6\u80fd\u6309\u4f18\u5148\u7ea7\u6e32\u67d3\u5b58\u91cf\u5185\u5bb9\u5361.",
+      "acceptanceCriteria": [
+        "TodayViewModel \u65b0\u589e enum TodayFallback { case yesterdayDailyPage(DailyPage), onThisDay([Memo]), weekRecap(WeekStats), pureEmpty }",
+        "TodayViewModel.fallbackContent: TodayFallback \u8ba1\u7b97\u5c5e\u6027\u6309 yesterdayDailyPage > onThisDay > weekRecap > pureEmpty \u4f18\u5148\u7ea7\u8fd4\u56de",
+        "\u4f18\u5148\u7ea7\u786c\u7f16\u7801\u4e0d\u53ef\u914d\u7f6e",
+        "\u65b0\u589e DayPageTests/TodayViewModelTests.swift \u8986\u76d6 4 \u79cd fallback \u72b6\u6001",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 5,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-001 (i18n \u4fee\u590d, \u5426\u5219 fallback \u6587\u6848\u4e5f\u4f1a\u66b4\u9732 key)"
+    },
+    {
+      "id": "US-006",
+      "title": "\u590d\u6d3b OnThisDayCard \u4e0e WeeklyRecapSection\uff0cTodayView \u63a5\u5165 fallback \u6e32\u67d3",
+      "description": "As a \u7528\u6237, I want \u5373\u4f7f\u4eca\u5929\u6ca1\u8bb0, \u4e3b\u9875\u4e5f\u80fd\u5c55\u793a\u6628\u65e5 Daily Page / On This Day / \u672c\u5468\u56de\u987e\u4e2d\u7684\u4e00\u5f20\u5f15\u5b50\u5361, so that Today \u4e3b\u9875\u6c38\u4e0d\u7a7a\u767d.",
+      "acceptanceCriteria": [
+        "TodayView \u5728 memos.isEmpty && !isLoading \u65f6\u6309 viewModel.fallbackContent \u6e32\u67d3\u5bf9\u5e94\u5361",
+        "yesterdayDailyPage \u590d\u7528 DailyPageEntryCard",
+        "onThisDay \u590d\u7528 OnThisDayCard.swift (\u590d\u6d3b\u5f53\u524d\u7981\u7528\u5f15\u7528)",
+        "weekRecap \u590d\u6d3b WeeklyRecapSection.swift \u5e76\u63a5\u5165",
+        "pureEmpty \u4ec5\u663e\u793a hero \u4e0b\u65b9\u4e00\u53e5\u5c0f\u5b57 (\u4e0d\u518d\u72ec\u5360\u6574\u5c4f)",
+        "\u4e09\u79cd fallback \u5361\u70b9\u51fb\u884c\u4e3a: \u6628\u65e5\u5361\u8fdb\u5165 DailyPageView, OnThisDay \u8fdb\u5165 MemoDetailView, WeekRecap \u8fdb\u5165 ArchiveView \u5468\u6a21\u5f0f",
+        "\u539f EmptyStateView.todayNoSignals() \u9000\u5316\u4e3a\u5355\u884c\u5c0f\u5b57",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 6,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-005 (fallbackContent \u8ba1\u7b97\u5c5e\u6027)"
+    },
+    {
+      "id": "US-007",
+      "title": "InputBarV4 \u5f15\u5165 ComposerState \u72b6\u6001\u673a\u66ff\u6362 userExpandedText",
+      "description": "As a \u5f00\u53d1\u8005, I want \u7528 composerState: .idle / .expanding / .open / .collapsing \u66ff\u6362 userExpandedText: Bool, so that 12 \u4e2a\u7b7e\u540d\u65f6\u523b\u4e2d\u8fc7\u6e21\u90a3\u4e00\u62cd\u80fd\u88ab\u7cbe\u786e\u63a7\u5236.",
+      "acceptanceCriteria": [
+        "InputBarV4.swift \u65b0\u589e enum ComposerState: Equatable { case idle, expanding, open, collapsing }",
+        "\u5220\u9664 userExpandedText: Bool, \u6240\u6709\u5f15\u7528\u8fc1\u79fb\u5230 state == .open || state == .expanding",
+        "\u72b6\u6001\u8f6c\u79fb\u51fd\u6570 transition(to: ComposerState) \u96c6\u4e2d\u7ba1\u7406, \u6bcf\u6b21\u8f6c\u79fb\u89e6\u53d1\u5bf9\u5e94 haptic \u4e0e animation",
+        "expanding / collapsing \u6301\u7eed\u65f6\u95f4 = .spring(response: 0.42, dampingFraction: 0.78)",
+        ".expanding / .collapsing \u671f\u95f4\u7981\u6b62\u63a5\u53d7\u65b0\u7684\u72b6\u6001\u5207\u6362 (\u9632\u6296)",
+        "\u65b0\u589e DayPageTests/ComposerStateMachineTests.swift \u8986\u76d6\u6240\u6709\u5408\u6cd5/\u975e\u6cd5\u8f6c\u79fb",
+        "xcodebuild build \u901a\u8fc7",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 7,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-008",
+      "title": "Liquid Morph: idle \u73bb\u7483\u80f6\u56ca matchedGeometryEffect \u751f\u957f\u6210 composition card",
+      "description": "As a \u7528\u6237, I want \u4ece idle \u4e09\u69fd\u80f6\u56ca\u5230 composing \u5361\u7247\u770b\u5230\u5f62\u6001\u5ef6\u7eed\u800c\u975e\u4e24\u4e2a view \u5207\u6362, so that \u5207\u6362\u6709\u4eea\u5f0f\u611f.",
+      "acceptanceCriteria": [
+        "\u7528 matchedGeometryEffect(id: 'composer.surface', in: namespace) \u628a idle \u80f6\u56ca morph \u6210 composing \u5706\u89d2\u77e9\u5f62",
+        "\u9ea6\u514b\u98ce orb \u4e0d\u6d88\u5931: 64x64 \u7f29\u5230 28x28 \u5e76\u5de6\u79fb\u5230\u5361\u7247\u5de6\u4e0b\u89d2\u4f5c\u4e3a\u5207\u56de\u8bed\u97f3\u5165\u53e3",
+        "Aa \u6309\u94ae\u6de1\u51fa = TextField caret \u6de1\u5165 (\u540c\u4f4d\u7f6e\u4ea4\u53c9\u6de1\u5165 200ms)",
+        "\u6574\u6bb5\u52a8\u753b .spring(response: 0.42, dampingFraction: 0.78)",
+        "\u52a8\u753b\u8d77\u70b9\u89e6\u53d1 UIImpactFeedbackGenerator(.soft)",
+        "\u5f55\u5c4f\u9a8c\u8bc1\u4efb\u610f\u4e00\u5e27\u622a\u56fe\u53d6\u51fa\u6765\u5f62\u72b6\u90fd\u80fd\u89e3\u91ca\u4ece\u54ea\u6765",
+        "Reduced Motion \u5f00\u542f\u65f6\u964d\u7ea7\u4e3a\u7b80\u5355 fade (0.2s)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 8,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-007 (ComposerState \u72b6\u6001\u673a)"
+    },
+    {
+      "id": "US-009",
+      "title": "Adaptive Send Affordance\uff1a\u53d1\u9001\u6309\u94ae 5 \u5f62\u6001 (\u7a7a/\u6587\u672c/\u6587\u672c+\u56fe/\u4f4d\u7f6e/\u591a\u6a21\u6001)",
+      "description": "As a \u7528\u6237, I want \u53d1\u9001\u6309\u94ae\u6839\u636e draft \u5f62\u6001\u53d8\u5f62, so that \u6211\u80fd\u4ece\u56fe\u5f62\u4e0a\u8bfb\u51fa\u73b0\u5728\u53d1\u9001\u4f1a\u505a\u4ec0\u4e48.",
+      "acceptanceCriteria": [
+        "\u7a7a\u6001: \u6d45\u8272 mic.fill \u5706\u73af (\u67d4\u5149\u547c\u5438 1.6s/cycle), accessibilityLabel='\u6309\u4f4f\u8bf4'",
+        "\u4ec5\u6587\u672c\u6001: \u5b9e\u5fc3\u7425\u73c0 arrow.up, accessibilityLabel='\u53d1\u9001'",
+        "\u6587\u672c+\u7167\u7247\u6001: camera.fill + arrow.up \u590d\u5408, accessibilityLabel='\u8bb0\u4e0b\u8fd9\u4e00\u523b'",
+        "\u4ec5\u4f4d\u7f6e\u6001: mappin.and.arrow.up, accessibilityLabel='\u6807\u8bb0\u6b64\u5904'",
+        "\u591a\u6a21\u6001\u6001: \u7425\u73c0 ring \u5e26\u5149\u6655\u8109\u52a8 (1.6s), accessibilityLabel='\u53d1\u9001 N \u9879'",
+        "\u7a7a\u6001\u660e\u786e\u4e0d\u518d\u7528 18% \u900f\u660e\u7425\u73c0\u5706",
+        "\u5f62\u6001\u5207\u6362 .spring(response: 0.32, dampingFraction: 0.8)",
+        "VoiceOver \u6717\u8bfb\u5bf9\u5e94 label",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 9,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-007 (ComposerState \u72b6\u6001\u673a)"
+    },
+    {
+      "id": "US-010",
+      "title": "Composer \u5de5\u5177\u680f\u8fc1\u79fb\u5230 keyboard-attached (.toolbar placement: .keyboard)",
+      "description": "As a \u7528\u6237, I want \u5de5\u5177\u680f\u8ddf\u952e\u76d8\u4e00\u8d77\u6d6e\u8d77, so that \u4e0d\u518d\u5f62\u6210\u952e\u76d8+\u5de5\u5177\u680f\u53cc\u5c42\u5806\u53e0.",
+      "acceptanceCriteria": [
+        "\u5de5\u5177\u680f\u8fc1\u79fb\u5230 .toolbar { ToolbarItemGroup(placement: .keyboard) { ... } }",
+        "\u5361\u7247\u672c\u4f53\u505c\u5728\u753b\u9762\u4e2d\u6bb5, \u4e0b\u65b9\u53ef\u89c1 timeline (\u5e26 vignette \u6e10\u9690\u906e\u7f69)",
+        "\u952e\u76d8\u6536\u8d77\u65f6\u5de5\u5177\u680f\u8ddf\u968f\u6d88\u5931, \u65e0\u6b8b\u7559\u9ad8\u5ea6\u5360\u4f4d",
+        "iPad \u6a2a\u5c4f\u952e\u76d8\u5de5\u5177\u680f\u4e0d\u6ea2\u51fa",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 10,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-007"
+    },
+    {
+      "id": "US-011",
+      "title": "Drag-to-Collapse Handle: \u5361\u7247\u9876 36x4 capsule \u4e0a\u6ed1\u6536\u8d77",
+      "description": "As a \u7528\u6237, I want \u5361\u7247\u9876\u8fb9\u4e00\u4e2a 36x4 capsule handle \u4e0a\u6ed1\u53ef\u6536\u8d77, so that \u4e0e iOS sheet \u8bed\u8a00\u4e00\u81f4.",
+      "acceptanceCriteria": [
+        "\u5361\u7247\u9876\u90e8\u5c45\u4e2d 36x4 \u7070\u8272 capsule",
+        "\u4e0a\u6ed1\u8ddd\u79bb > 32pt \u89e6\u53d1 transition(to: .collapsing) \u7136\u540e\u56de .idle",
+        "\u5355\u51fb handle \u7b49\u4ef7\u4e0a\u6ed1 (accessibility)",
+        "\u6298\u53e0\u52a8\u753b\u4e0e morph \u53cd\u5411\u64ad\u653e",
+        "\u6298\u53e0\u89e6\u53d1 .medium impact",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 11,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-007 + US-008"
+    },
+    {
+      "id": "US-012",
+      "title": "Haptics.swift \u6269\u5c55 5 \u7ea7\u89e6\u611f\u9636\u68af\u5e76\u63a5\u5165 Composer \u6d41\u7a0b",
+      "description": "As a \u7528\u6237, I want \u4e0d\u540c\u52a8\u4f5c\u89e6\u53d1\u4e0d\u540c\u5f3a\u5ea6\u7684\u89e6\u611f, so that Composer \u6709\u6750\u8d28\u611f.",
+      "acceptanceCriteria": [
+        "DayPage/DesignSystem/Haptics.swift \u66b4\u9732 5 \u7ea7 API: .soft / .rigid(intensity:) / .medium / .light / .success / .warning",
+        "\u70b9 dock \u4efb\u610f\u952e\u89e6\u53d1 .soft impact",
+        "Caret \u9996\u6b21\u51fa\u73b0 0.15s \u5ef6\u8fdf\u540e\u89e6\u53d1 .rigid 0.3 \u5f3a\u5ea6",
+        "\u6dfb\u52a0\u9644\u4ef6\u89e6\u53d1 .medium",
+        "\u5220\u9664\u9644\u4ef6\u89e6\u53d1 .light",
+        "\u53d1\u9001\u6210\u529f\u89e6\u53d1 .success notification",
+        "\u5f55\u97f3\u592a\u77ed/\u9519\u8bef\u89e6\u53d1 .warning notification",
+        "\u81f3\u5c11 4 \u7ea7\u5728 Composer \u6d41\u7a0b\u4e2d\u88ab\u5b9e\u9645\u89e6\u53d1",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 12,
+      "passes": true,
+      "notes": "\u53ef\u5e76\u884c\u4e8e US-007 ~ US-011"
+    },
+    {
+      "id": "US-013",
+      "title": "ComposerContextProvider \u670d\u52a1\uff1a\u805a\u5408 Weather/Location/lastMemo/Pasteboard",
+      "description": "As a \u5f00\u53d1\u8005, I want \u4e00\u4e2a ComposerContextProvider \u805a\u5408\u6240\u6709\u4e0a\u4e0b\u6587\u6e90, so that Spotlight Strip \u80fd\u62ff\u5230\u7edf\u4e00\u7684 chip \u6570\u636e.",
+      "acceptanceCriteria": [
+        "\u65b0\u589e DayPage/Services/ComposerContextProvider.swift @MainActor final class",
+        "\u6574\u5408 WeatherService / LocationService / viewModel.memos.last / UIPasteboard.general",
+        "\u66b4\u9732 var chips: [ContextChip] \u8ba1\u7b97\u5c5e\u6027",
+        "ContextChip \u7c7b\u578b: .weather(temp, condition) / .location(short) / .timeRitual(emoji, text) / .lastMemoTail(snippet) / .smartPaste(value)",
+        "lastMemoTail \u8ba1\u7b97\u7f13\u5b58 60s \u907f\u514d\u91cd\u590d\u8bfb vault",
+        "\u65b0\u589e DayPageTests/ComposerContextProviderTests.swift",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 13,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-014",
+      "title": "Context Spotlight Strip: TextField \u4e0a\u65b9\u6a2a\u5411 chip \u5e26",
+      "description": "As a \u7528\u6237, I want TextField \u4e0a\u65b9\u4e00\u6761\u6a2a\u5411 chip \u5e26\u663e\u793a\u5929\u6c14/\u4f4d\u7f6e/\u4e0a\u4e00\u6761\u5c3e\u5df4/\u667a\u80fd\u7c98\u8d34, so that \u7a7a Composer \u4e5f\u6709\u73b0\u5728\u5199\u4ec0\u4e48\u7684\u5f15\u5b50.",
+      "acceptanceCriteria": [
+        "Spotlight Strip \u6a2a\u5411\u6eda\u52a8, \u6bcf\u4e2a chip 28pt \u9ad8, \u73bb\u7483\u6750\u8d28",
+        "\u6570\u636e\u6e90\u8d70 ComposerContextProvider.chips",
+        "\u70b9\u51fb chip \u5bf9\u5e94\u5185\u5bb9\u585e\u5165 draft (\u4f4d\u7f6e\u585e Memo.Location, \u65f6\u95f4\u585e prompt, \u4e0a\u4e00\u6761\u5c3e\u5df4\u585e\u5f15\u7528\u5757, \u526a\u8d34\u677f\u585e\u6587\u672c)",
+        "\u89e6\u6478\u8f6f\u89e6\u611f .soft 0.4",
+        "\u7a7a Composer \u81f3\u5c11 3 \u6761 chip",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 14,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-013"
+    },
+    {
+      "id": "US-015",
+      "title": "Smart Templates: 12 \u6761\u65f6\u6bb5\u6a21\u677f hardcode",
+      "description": "As a \u7528\u6237, I want \u7a7a Composer \u663e\u793a 1 \u884c\u65f6\u6bb5\u6a21\u677f, so that \u6211\u80fd\u4e00\u952e\u5f97\u5230\u4eca\u5929\u600e\u4e48\u5199\u7684\u5f15\u5b50.",
+      "acceptanceCriteria": [
+        "12 \u6761 hardcode \u6a21\u677f\u6309\u65f6\u6bb5\u6620\u5c04: 06-11 \u6668/\u4eca\u5929/\u9192\u6765; 11-17 \u521a\u624d/\u4e2d\u5348/\u60f3\u6cd5; 17-22 \u6700\u67d0\u523b/\u603b\u7ed3/\u660e\u5929; 22-06 \u56de\u770b/\u672a\u5b8c/\u68a6",
+        "\u4ec5\u5728 text.isEmpty && pendingAttachments.isEmpty \u65f6\u663e\u793a",
+        "\u70b9\u51fb \u6a21\u677f\u6587\u5b57\u585e\u5165 TextField, placeholder \u9ad8\u4eae (.foregroundStyle(.secondary))",
+        "caret \u5b9a\u4f4d\u5230 placeholder \u8d77\u70b9",
+        "\u7528\u6237\u5f00\u59cb\u6253\u5b57\u540e placeholder \u6d88\u5931",
+        "\u4e0d\u5f15\u5165\u914d\u7f6e\u6587\u4ef6 / \u8bbe\u7f6e\u9879",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 15,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-016",
+      "title": "Inline Lens Strip: \u6700\u8fd1 4 \u5f20\u7167\u7247\u7f29\u7565\u56fe (\u61d2\u52a0\u8f7d\u76f8\u518c\u6743\u9650)",
+      "description": "As a \u7528\u6237, I want TextField \u4e0b\u65b9\u4e00\u6761 56x56 \u5706\u89d2\u7f29\u7565\u56fe\u5e26, so that \u6211\u80fd\u4e00\u952e\u9644\u52a0\u6700\u8fd1 24h \u5185\u7684\u7167\u7247, \u65e0\u9700\u8df3 PhotosPicker.",
+      "acceptanceCriteria": [
+        "\u7b2c\u4e00\u6b21\u5c55\u5f00 Composer \u65f6 prompt PHPhotoLibrary.requestAuthorization(for: .readWrite)",
+        "\u62d2\u7edd\u6743\u9650\u540e Strip \u9690\u85cf, \u4e0d\u518d prompt (\u7528 @AppStorage('composer.photoPermissionAsked') \u6807\u8bb0)",
+        "\u663e\u793a\u6700\u8fd1 24h \u5185 4 \u5f20\u7f29\u7565\u56fe, \u6309\u65f6\u95f4\u5012\u5e8f",
+        "\u70b9\u51fb\u7f29\u7565\u56fe \u76f4\u63a5\u9644\u52a0\u5230 pendingAttachments, \u4e0d\u8df3 sheet",
+        "\u7f29\u7565\u56fe\u52a0\u8f7d\u7528 PHCachingImageManager \u907f\u514d\u5361\u987f, \u5206\u8fa8\u7387 <= 168x168",
+        "\u65e0\u6700\u8fd1\u7167\u7247\u65f6 Strip \u9690\u85cf (\u4e0d\u663e\u793a\u7a7a\u6001)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 16,
+      "passes": true,
+      "notes": ""
+    },
+    {
+      "id": "US-017",
+      "title": "Caret Spotlight + Ambient Dim: focus \u65f6\u80cc\u666f\u6697 20%, \u5361\u80cc RadialGradient",
+      "description": "As a \u7528\u6237, I want focus \u65f6\u80cc\u666f\u53d8\u6697 20% \u540c\u65f6\u5361\u7247\u80cc\u540e\u6cdb\u8d77\u6696\u767d\u5c04\u706f, so that \u5199\u4f5c\u4eea\u5f0f\u611f\u62c9\u6ee1.",
+      "acceptanceCriteria": [
+        "focus \u8fdb\u5165\u65f6 AmbientBackground \u6574\u4f53\u900f\u660e\u5ea6 0.8",
+        "Composer \u5361\u7247\u80cc\u540e RadialGradient (\u4e2d\u5fc3 caret \u4f4d\u7f6e, \u534a\u5f84 240pt, \u6696\u767d 0.12 opacity)",
+        "\u73b0\u6709 BreathingCaretView \u4fdd\u7559\u5e76\u63a5\u5165",
+        "focus \u9000\u51fa\u53cd\u5411\u52a8\u753b 0.4s",
+        "Reduced Motion \u5f00\u542f\u65f6\u7981\u7528 dim, \u4ec5\u9759\u6001\u5bf9\u6bd4",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 17,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-002 (AmbientBackground \u5df2\u7eaf\u5316)"
+    },
+    {
+      "id": "US-018",
+      "title": "Status Strip: \u5361\u7247\u9876 12pt mono \u884c DRAFTING \u00b7 N PHOTOS \u00b7 LOC \u00b7 age",
+      "description": "As a \u7528\u6237, I want \u5361\u7247\u9876\u90e8\u4e00\u884c 12pt mono \u663e\u793a\u72b6\u6001\u526f\u6807, so that \u6211\u80fd\u770b\u5230 Composer \u7684\u5b9e\u65f6\u72b6\u6001.",
+      "acceptanceCriteria": [
+        "\u5b57\u6bb5\u987a\u5e8f: <state> \u00b7 <attachment count> \u00b7 <location short> \u00b7 <draft age>",
+        "\u72b6\u6001\u679a\u4e3e: DRAFTING / SENDING / SENT / ERROR",
+        "\u53d1\u9001\u6210\u529f 1.2s \u5185\u663e\u793a SENT \u7136\u540e\u6574\u4e2a Composer \u6298\u53e0\u56de idle dock",
+        "\u5b57\u4f53 JetBrains Mono 12pt (\u5df2\u6ce8\u518c)",
+        "XXLarge+ Dynamic Type \u65f6\u7701\u7565 location \u5b57\u6bb5",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 18,
+      "passes": true,
+      "notes": "\u4f9d\u8d56 US-007 (state) + US-013 (location \u6765\u6e90)"
+    }
+  ]
+}

--- a/archive/2026-05-10-today-composer-liquid/prd.json
+++ b/archive/2026-05-10-today-composer-liquid/prd.json
@@ -1,0 +1,331 @@
+{
+  "project": "DayPage",
+  "branchName": "ralph/today-composer-liquid-refinement",
+  "description": "Today 主页极简优雅重塑 + Composer 3.0 Liquid Composition Surface — 整合 issue #252 + #250: 删 GlassTabBar, AmbientBackground 纯化, Day Orb 收敛, 空数据回退栈, i18n 修复 + L10n.swift, composerState 状态机, Liquid Morph, 5 形态 Adaptive Send, keyboard-attached toolbar, drag handle, 5 级 haptics, Context Spotlight Strip, Smart Templates, Lens Strip, Caret Spotlight, Status Strip",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "i18n 资源彻查：lproj target membership + L10n.swift 强类型枚举",
+      "description": "As a 用户, I want 主页文案显示中文/英文翻译而非原始 key, so that 截图不再出现 'empty.today.no_signals.title' 这类暴露字符串.",
+      "acceptanceCriteria": [
+        "Xcode DayPage target Build Phases Copy Bundle Resources 包含 zh-Hans.lproj 和 en.lproj",
+        "Xcode Project Localizations 启用 Chinese (Simplified) 与 English",
+        "Info.plist 含 CFBundleDevelopmentRegion=zh-Hans 与 CFBundleLocalizations=[zh-Hans, en]",
+        "新增 DayPage/Resources/L10n.swift 提供 L10n.Empty.todayNoSignalsTitle 强类型访问器",
+        "EmptyStateView.todayNoSignals() 改用 L10n.Empty.* 而非裸字面量",
+        "中英文系统语言切换后 hero 下方文案正确变化",
+        "grep -rn 'LocalizedStringKey(\"' DayPage/ 输出为 0 (除 L10n.swift)",
+        "xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build 通过",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "AmbientBackground 纯化：删 4 团暖色光斑，默认仅 cream 底",
+      "description": "As a 用户, I want 主页背景接近纯色奶油纸感, so that 视觉锚点回到字本身, 不再像 AI 演示稿.",
+      "acceptanceCriteria": [
+        "DayPage/DesignSystem/GlassSurface.swift AmbientBackground 默认仅渲染 DSColor.bgWarm (FAF7F2)",
+        "4 团 amber blob 用 @AppStorage('debug.ambientBlobs') 包起来, 默认 false",
+        "TodayView, DailyPageView, MemoDetailView 显式不传开关, 使用默认纯色行为",
+        "iPhone 17 Simulator 截图与改动前并排饱和度肉眼明显下降",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Day Orb 收敛：size 140pt + halo opacity 0.15 + orbFill ×0.5",
+      "description": "As a 用户, I want Day Orb 从中央巨大琥珀球变为纸上一枚轻晕, so that serif 日期 'Friday MAY 8' 成为视觉主角.",
+      "acceptanceCriteria": [
+        "DayPage/Features/Today/DayOrbView.swift halo 透明度从 0.4 改为 0.15",
+        "orbFill gradient stops 透明度全部 ×0.5",
+        "DayOrbView 暴露 size: CGFloat = 140 与 haloOpacity: CGFloat = 0.15 参数",
+        "TodayView 调用处显式传 size: 140",
+        "呼吸动画幅度 ×0.7",
+        "iPhone 17 Simulator 截图与改动前并排 orb 明显收敛",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": "依赖 US-002 (AmbientBackground 纯化先落地)"
+    },
+    {
+      "id": "US-004",
+      "title": "删除 GlassTabBar，账号头像迁入设置 sheet，右上仅留齿轮",
+      "description": "As a 用户, I want 顶部不再出现 [Today ▾] pill 和琥珀色头像, so that 整页只有 sidebar 一套导航语言, 视觉一致.",
+      "acceptanceCriteria": [
+        "删除 DayPage/Components/GlassTabBar.swift",
+        "从 RootView.swift / TodayView.swift / AppNavigationModel.swift 中移除所有 GlassTabBar / AppTab 引用",
+        "TodayView 顶部账号头像 (36pt 实心琥珀圆) 移除, 账号入口移到设置 sheet 顶部",
+        "TodayView 顶部右侧仅保留齿轮按钮 (28pt 玻璃圆)",
+        "Archive / Graph 切换通过 sidebar 完成, 回归 path 无歧义",
+        "grep -rn 'GlassTabBar' DayPage/ 输出为 0",
+        "xcodebuild build 通过",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "TodayViewModel 新增 TodayFallback 枚举与 fallbackContent 计算属性",
+      "description": "As a 开发者, I want TodayViewModel 暴露 fallback 内容选择, so that TodayView 在今日 0 memo 时能按优先级渲染存量内容卡.",
+      "acceptanceCriteria": [
+        "TodayViewModel 新增 enum TodayFallback { case yesterdayDailyPage(DailyPage), onThisDay([Memo]), weekRecap(WeekStats), pureEmpty }",
+        "TodayViewModel.fallbackContent: TodayFallback 计算属性按 yesterdayDailyPage > onThisDay > weekRecap > pureEmpty 优先级返回",
+        "优先级硬编码不可配置",
+        "新增 DayPageTests/TodayViewModelTests.swift 覆盖 4 种 fallback 状态",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": "依赖 US-001 (i18n 修复, 否则 fallback 文案也会暴露 key)"
+    },
+    {
+      "id": "US-006",
+      "title": "复活 OnThisDayCard 与 WeeklyRecapSection，TodayView 接入 fallback 渲染",
+      "description": "As a 用户, I want 即使今天没记, 主页也能展示昨日 Daily Page / On This Day / 本周回顾中的一张引子卡, so that Today 主页永不空白.",
+      "acceptanceCriteria": [
+        "TodayView 在 memos.isEmpty && !isLoading 时按 viewModel.fallbackContent 渲染对应卡",
+        "yesterdayDailyPage 复用 DailyPageEntryCard",
+        "onThisDay 复用 OnThisDayCard.swift (复活当前禁用引用)",
+        "weekRecap 复活 WeeklyRecapSection.swift 并接入",
+        "pureEmpty 仅显示 hero 下方一句小字 (不再独占整屏)",
+        "三种 fallback 卡点击行为: 昨日卡进入 DailyPageView, OnThisDay 进入 MemoDetailView, WeekRecap 进入 ArchiveView 周模式",
+        "原 EmptyStateView.todayNoSignals() 退化为单行小字",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": "依赖 US-005 (fallbackContent 计算属性)"
+    },
+    {
+      "id": "US-007",
+      "title": "InputBarV4 引入 ComposerState 状态机替换 userExpandedText",
+      "description": "As a 开发者, I want 用 composerState: .idle / .expanding / .open / .collapsing 替换 userExpandedText: Bool, so that 12 个签名时刻中过渡那一拍能被精确控制.",
+      "acceptanceCriteria": [
+        "InputBarV4.swift 新增 enum ComposerState: Equatable { case idle, expanding, open, collapsing }",
+        "删除 userExpandedText: Bool, 所有引用迁移到 state == .open || state == .expanding",
+        "状态转移函数 transition(to: ComposerState) 集中管理, 每次转移触发对应 haptic 与 animation",
+        "expanding / collapsing 持续时间 = .spring(response: 0.42, dampingFraction: 0.78)",
+        ".expanding / .collapsing 期间禁止接受新的状态切换 (防抖)",
+        "新增 DayPageTests/ComposerStateMachineTests.swift 覆盖所有合法/非法转移",
+        "xcodebuild build 通过",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-008",
+      "title": "Liquid Morph: idle 玻璃胶囊 matchedGeometryEffect 生长成 composition card",
+      "description": "As a 用户, I want 从 idle 三槽胶囊到 composing 卡片看到形态延续而非两个 view 切换, so that 切换有仪式感.",
+      "acceptanceCriteria": [
+        "用 matchedGeometryEffect(id: 'composer.surface', in: namespace) 把 idle 胶囊 morph 成 composing 圆角矩形",
+        "麦克风 orb 不消失: 64x64 缩到 28x28 并左移到卡片左下角作为切回语音入口",
+        "Aa 按钮淡出 = TextField caret 淡入 (同位置交叉淡入 200ms)",
+        "整段动画 .spring(response: 0.42, dampingFraction: 0.78)",
+        "动画起点触发 UIImpactFeedbackGenerator(.soft)",
+        "录屏验证任意一帧截图取出来形状都能解释从哪来",
+        "Reduced Motion 开启时降级为简单 fade (0.2s)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 8,
+      "passes": false,
+      "notes": "依赖 US-007 (ComposerState 状态机)"
+    },
+    {
+      "id": "US-009",
+      "title": "Adaptive Send Affordance：发送按钮 5 形态 (空/文本/文本+图/位置/多模态)",
+      "description": "As a 用户, I want 发送按钮根据 draft 形态变形, so that 我能从图形上读出现在发送会做什么.",
+      "acceptanceCriteria": [
+        "空态: 浅色 mic.fill 圆环 (柔光呼吸 1.6s/cycle), accessibilityLabel='按住说'",
+        "仅文本态: 实心琥珀 arrow.up, accessibilityLabel='发送'",
+        "文本+照片态: camera.fill + arrow.up 复合, accessibilityLabel='记下这一刻'",
+        "仅位置态: mappin.and.arrow.up, accessibilityLabel='标记此处'",
+        "多模态态: 琥珀 ring 带光晕脉动 (1.6s), accessibilityLabel='发送 N 项'",
+        "空态明确不再用 18% 透明琥珀圆",
+        "形态切换 .spring(response: 0.32, dampingFraction: 0.8)",
+        "VoiceOver 朗读对应 label",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 9,
+      "passes": false,
+      "notes": "依赖 US-007 (ComposerState 状态机)"
+    },
+    {
+      "id": "US-010",
+      "title": "Composer 工具栏迁移到 keyboard-attached (.toolbar placement: .keyboard)",
+      "description": "As a 用户, I want 工具栏跟键盘一起浮起, so that 不再形成键盘+工具栏双层堆叠.",
+      "acceptanceCriteria": [
+        "工具栏迁移到 .toolbar { ToolbarItemGroup(placement: .keyboard) { ... } }",
+        "卡片本体停在画面中段, 下方可见 timeline (带 vignette 渐隐遮罩)",
+        "键盘收起时工具栏跟随消失, 无残留高度占位",
+        "iPad 横屏键盘工具栏不溢出",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 10,
+      "passes": false,
+      "notes": "依赖 US-007"
+    },
+    {
+      "id": "US-011",
+      "title": "Drag-to-Collapse Handle: 卡片顶 36x4 capsule 上滑收起",
+      "description": "As a 用户, I want 卡片顶边一个 36x4 capsule handle 上滑可收起, so that 与 iOS sheet 语言一致.",
+      "acceptanceCriteria": [
+        "卡片顶部居中 36x4 灰色 capsule",
+        "上滑距离 > 32pt 触发 transition(to: .collapsing) 然后回 .idle",
+        "单击 handle 等价上滑 (accessibility)",
+        "折叠动画与 morph 反向播放",
+        "折叠触发 .medium impact",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 11,
+      "passes": false,
+      "notes": "依赖 US-007 + US-008"
+    },
+    {
+      "id": "US-012",
+      "title": "Haptics.swift 扩展 5 级触感阶梯并接入 Composer 流程",
+      "description": "As a 用户, I want 不同动作触发不同强度的触感, so that Composer 有材质感.",
+      "acceptanceCriteria": [
+        "DayPage/DesignSystem/Haptics.swift 暴露 5 级 API: .soft / .rigid(intensity:) / .medium / .light / .success / .warning",
+        "点 dock 任意键触发 .soft impact",
+        "Caret 首次出现 0.15s 延迟后触发 .rigid 0.3 强度",
+        "添加附件触发 .medium",
+        "删除附件触发 .light",
+        "发送成功触发 .success notification",
+        "录音太短/错误触发 .warning notification",
+        "至少 4 级在 Composer 流程中被实际触发",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 12,
+      "passes": false,
+      "notes": "可并行于 US-007 ~ US-011"
+    },
+    {
+      "id": "US-013",
+      "title": "ComposerContextProvider 服务：聚合 Weather/Location/lastMemo/Pasteboard",
+      "description": "As a 开发者, I want 一个 ComposerContextProvider 聚合所有上下文源, so that Spotlight Strip 能拿到统一的 chip 数据.",
+      "acceptanceCriteria": [
+        "新增 DayPage/Services/ComposerContextProvider.swift @MainActor final class",
+        "整合 WeatherService / LocationService / viewModel.memos.last / UIPasteboard.general",
+        "暴露 var chips: [ContextChip] 计算属性",
+        "ContextChip 类型: .weather(temp, condition) / .location(short) / .timeRitual(emoji, text) / .lastMemoTail(snippet) / .smartPaste(value)",
+        "lastMemoTail 计算缓存 60s 避免重复读 vault",
+        "新增 DayPageTests/ComposerContextProviderTests.swift",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 13,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-014",
+      "title": "Context Spotlight Strip: TextField 上方横向 chip 带",
+      "description": "As a 用户, I want TextField 上方一条横向 chip 带显示天气/位置/上一条尾巴/智能粘贴, so that 空 Composer 也有现在写什么的引子.",
+      "acceptanceCriteria": [
+        "Spotlight Strip 横向滚动, 每个 chip 28pt 高, 玻璃材质",
+        "数据源走 ComposerContextProvider.chips",
+        "点击 chip 对应内容塞入 draft (位置塞 Memo.Location, 时间塞 prompt, 上一条尾巴塞引用块, 剪贴板塞文本)",
+        "触摸软触感 .soft 0.4",
+        "空 Composer 至少 3 条 chip",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 14,
+      "passes": false,
+      "notes": "依赖 US-013"
+    },
+    {
+      "id": "US-015",
+      "title": "Smart Templates: 12 条时段模板 hardcode",
+      "description": "As a 用户, I want 空 Composer 显示 1 行时段模板, so that 我能一键得到今天怎么写的引子.",
+      "acceptanceCriteria": [
+        "12 条 hardcode 模板按时段映射: 06-11 晨/今天/醒来; 11-17 刚才/中午/想法; 17-22 最某刻/总结/明天; 22-06 回看/未完/梦",
+        "仅在 text.isEmpty && pendingAttachments.isEmpty 时显示",
+        "点击 模板文字塞入 TextField, placeholder 高亮 (.foregroundStyle(.secondary))",
+        "caret 定位到 placeholder 起点",
+        "用户开始打字后 placeholder 消失",
+        "不引入配置文件 / 设置项",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 15,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-016",
+      "title": "Inline Lens Strip: 最近 4 张照片缩略图 (懒加载相册权限)",
+      "description": "As a 用户, I want TextField 下方一条 56x56 圆角缩略图带, so that 我能一键附加最近 24h 内的照片, 无需跳 PhotosPicker.",
+      "acceptanceCriteria": [
+        "第一次展开 Composer 时 prompt PHPhotoLibrary.requestAuthorization(for: .readWrite)",
+        "拒绝权限后 Strip 隐藏, 不再 prompt (用 @AppStorage('composer.photoPermissionAsked') 标记)",
+        "显示最近 24h 内 4 张缩略图, 按时间倒序",
+        "点击缩略图 直接附加到 pendingAttachments, 不跳 sheet",
+        "缩略图加载用 PHCachingImageManager 避免卡顿, 分辨率 <= 168x168",
+        "无最近照片时 Strip 隐藏 (不显示空态)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 16,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-017",
+      "title": "Caret Spotlight + Ambient Dim: focus 时背景暗 20%, 卡背 RadialGradient",
+      "description": "As a 用户, I want focus 时背景变暗 20% 同时卡片背后泛起暖白射灯, so that 写作仪式感拉满.",
+      "acceptanceCriteria": [
+        "focus 进入时 AmbientBackground 整体透明度 0.8",
+        "Composer 卡片背后 RadialGradient (中心 caret 位置, 半径 240pt, 暖白 0.12 opacity)",
+        "现有 BreathingCaretView 保留并接入",
+        "focus 退出反向动画 0.4s",
+        "Reduced Motion 开启时禁用 dim, 仅静态对比",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 17,
+      "passes": false,
+      "notes": "依赖 US-002 (AmbientBackground 已纯化)"
+    },
+    {
+      "id": "US-018",
+      "title": "Status Strip: 卡片顶 12pt mono 行 DRAFTING · N PHOTOS · LOC · age",
+      "description": "As a 用户, I want 卡片顶部一行 12pt mono 显示状态副标, so that 我能看到 Composer 的实时状态.",
+      "acceptanceCriteria": [
+        "字段顺序: <state> · <attachment count> · <location short> · <draft age>",
+        "状态枚举: DRAFTING / SENDING / SENT / ERROR",
+        "发送成功 1.2s 内显示 SENT 然后整个 Composer 折叠回 idle dock",
+        "字体 JetBrains Mono 12pt (已注册)",
+        "XXLarge+ Dynamic Type 时省略 location 字段",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 18,
+      "passes": false,
+      "notes": "依赖 US-007 (state) + US-013 (location 来源)"
+    }
+  ]
+}

--- a/archive/2026-05-10-today-composer-liquid/progress.txt
+++ b/archive/2026-05-10-today-composer-liquid/progress.txt
@@ -1,0 +1,11 @@
+# DayPage v4 Liquid Glass - Ralph Progress Log
+
+Source PRD: tasks/prd-daypage-v4-liquid-glass.md
+Linked GitHub Issues: EPIC #245 / #243 #244 #246 #247 #248
+Branch: ralph/v4-liquid-glass
+Start: 2026-05-07
+
+Previous run (sentry-linear) archived at: archive/2026-05-07-sentry-linear/
+
+---
+

--- a/docs/web/PLAN.md
+++ b/docs/web/PLAN.md
@@ -1,0 +1,734 @@
+# DayPage Web (Codex) — 完整架构与实施方案
+
+> 状态：**已 approved，进入实施** · 作者：Claude · 日期：2026-05-10
+> 设计来源：Anthropic Claude Design 导出包 `daypage-system/` (Codex 原型)
+
+## 🔒 已锁定决策（2026-05-10）
+
+| 维度 | 决策 |
+|---|---|
+| 域名 | `app.daypage.io` 暂定（不实际购买/解析） |
+| 数据库 | Supabase（PostgreSQL 16 + pgvector） |
+| Supabase 部署 | **本地 Docker + supabase-cli**（开发） → 后续上 Supabase Cloud（生产） |
+| 文件存储 | **Supabase Storage**（替代 R2/S3） |
+| 认证 | **Auth.js v5 beta**（next-auth@5.0.0-beta.31）+ Apple Sign-In + Email magic link |
+| 租户 | 单租户（schema 仍带 `user_id` 字段，便于后续扩展） |
+| 离线 | Web 端做 PWA + Service Worker 离线缓存 |
+| iOS 改造 | 同意把 iOS AI 调用迁到后端代理 |
+| 首发模式 | 直接公开（不走 preview 期） |
+
+## 📦 锁定版本（2026-05-10 npm latest）
+
+| 包 | 版本 |
+|---|---|
+| next | **16.2.6** |
+| react / react-dom | **19.2.6** |
+| typescript | **5.9.x**（npm latest 6.0.3 是 nightly，用 5.9 LTS） |
+| tailwindcss | **4.3.0** |
+| @supabase/supabase-js | **2.105.4** |
+| @supabase/ssr | **0.10.3** |
+| next-auth | **5.0.0-beta.31** |
+| drizzle-orm | **0.45.2** |
+| @tanstack/react-query | **5.100.9** |
+| @trpc/server / client | **11.17.0** |
+| zod | **4.4.3** |
+| lucide-react | **1.14.0** |
+| react-markdown | **10.1.0** |
+| inngest | **3.x**（compile worker） |
+
+**注意 2026 新世代变更**：
+- Next 16 默认 Turbopack（dev + build），不需要再开 `--turbo`
+- React 19 全面 Server Components / Server Actions
+- Tailwind 4 新 CSS-first 配置（`@theme` 替代 `tailwind.config.ts`）
+- Auth.js v5 用 `auth()` helper 替代 `getServerSession()`
+
+---
+
+## 0. 一句话总览
+
+把 DayPage 的「**raw capture → AI compile → wiki/graph**」从 iOS 单机扩展为「**iOS + Web 双端，后端为唯一数据源**」的生产级知识系统。Web 端按 Codex 原型 1:1 复刻设计语言（warm-archival 美学），但**功能必须真实、无硬编码**——所有 API 真接 PostgreSQL，所有 AI 调用真走 DashScope。
+
+---
+
+## 1. 设计稿（Codex 原型）的功能盘点
+
+读完 `Codex.html` + 9 个 jsx + 1172 行 CSS 后的功能矩阵：
+
+| 视图 | 核心功能 | 数据依赖 |
+|---|---|---|
+| **Sidebar** | 5 个固定项（Home / Add / Chat / Wiki / Inbox）+ 动态 Domains 列表 + Inbox 数字徽标 + 用户信息区 | `domains[]` + `inbox unread count` + `user` |
+| **Home** | "What the system noticed"（AI 主动观察卡片，含动作按钮）、Recent activity、Domains at a glance（含 sparkline）、统计数（sources/pages/domains/backlinks） | `observations[]` + `recent_activity[]` + `domains[]` + 全局计数 |
+| **Add** | 统一输入（URL / 文本 / 文件 / 语音自动识别）、实时 compile queue（带进度条 + FULL/LIGHT 模式切换）、Recently compiled 列表 | `ingestion_queue[]` + `recent_compiled[]`，需要后台 worker 跑实际编译 |
+| **Chat** | 对话线程（用户问 + AI 答带数字引用 `{1}`）、右栏 References Cards（点引用高亮）、Suggested follow-ups、Save as synthesis page | `chat_threads / messages / citations`，AI 流式输出 |
+| **Wiki** | 左栏分组导航（Concepts / Sources / Entities / Synthesis）+ List/Graph 切换 + 搜索；中栏 page 内容（带 highlight annotations）+ 右栏 Sources / Backlinks / Provenance；Graph 模式渲染知识图谱 | `pages` + `entities` + `links` + `annotations` |
+| **Inbox** | 4 类待办：CONTRADICTION（矛盾，含 old/new 对比）/ SCHEMA（建议建新 cluster）/ ORPHAN（孤立内容建议归档）/ COMPILED（编译完成通知）；过滤 chips；每条带 1-4 个动作按钮 | `inbox_items[]`，由 AI 后台 worker 生产 |
+| **Onboarding** | 3 步：选 domain seeds → 投喂第一份内容 → 实时 compile 进度条 | `user.onboarded` + 第一次 compile |
+
+**设计语言关键点**：
+- 暖色档案美学：`#FAF8F6` 暖白底、`#5D3000` 琥珀棕主色、`#F5EDE3` accent-soft
+- 三套字体：Space Grotesk（display/headline）、Inter（body）、JetBrains Mono（meta/timestamps）
+- 12px 圆角卡片 + 1px 细边框 + 极淡阴影；强调"档案/手工"质感
+- 大量 ALL-CAPS 微排版作为 section label 与 metadata
+- 248px 固定侧边栏 + 主区流式布局
+- 视口锁定 1280px（设计稿 viewport meta）→ Web 端目标 ≥1280px 桌面优先，1024-1280 自适应，<1024 给降级单栏视图
+
+---
+
+## 2. 与现有 iOS 数据模型的对齐
+
+### 2.1 iOS 端现状（必须兼容）
+
+iOS 持久化在 `vault/raw/YYYY-MM-DD.md`，每文件多 memo 用 `\n\n---\n\n` 分隔。每个 memo 是 YAML front-matter + Markdown body（实际字段定义见 `DayPage/Models/Memo.swift:77-130`）：
+
+```yaml
+---
+id: <UUID>
+type: text|voice|photo|location|mixed
+created: 2026-05-10T09:42:00.000Z
+pinned_at: ...                    # optional
+location:
+  name: "..."
+  lat: 31.23
+  lng: 121.47
+weather: "..."
+device: "..."
+attachments:
+  - file: "assets/voice-...m4a"
+    kind: audio
+    duration: 42.5
+    transcript: "..."
+---
+<body markdown>
+```
+
+iOS 还有 `EntityPageService`、`OnThisDayIndex`、`SearchService`、`WeeklyRecapService` 等，所以本地已有部分 entity / page 概念，但都是文件系统上的衍生数据，没有 schema 化。
+
+### 2.2 Codex 模型 vs DayPage 模型 的映射
+
+| Codex 概念 | DayPage 对应 | 说明 |
+|---|---|---|
+| `source` (PDF / URL / voice / text) | `Memo` | Memo 即 source 的最小单元；Codex 的「source」是一组相关 memo 的逻辑聚合 |
+| `page` (Concept / Synthesis / Entity) | `EntityPage` (iOS 已有) + 新增 ConceptPage | iOS 已有 entity，Codex 新增 concept / synthesis 类型 |
+| `domain` | 顶层 cluster（新概念，iOS 暂无） | 用户/AI 定义的高层主题分类 |
+| `link` (backlinks) | iOS 已隐式存在（entity ref） | 显式建图，记录 `(from_page, to_page, source_memo)` |
+| `annotation` | iOS 没有 | 用户在 page 文本上的高亮 + 标签 |
+| `chat_thread / message / citation` | iOS 没有 | 全新 RAG 问答 |
+| `inbox_item` | iOS 没有 | AI 主动产出的待决策事项 |
+| `observation` | iOS 没有 | Home 页的「the system noticed」卡片 |
+
+### 2.3 数据迁移策略
+
+**核心原则**：vault 文件仍是 iOS 的 source of truth（不破坏离线性），后端把它当作 *上游数据流* 持续 sync 进 PostgreSQL。Web 端的所有写操作（chat、annotation、inbox 决策）只写后端；iOS 通过订阅 API 拿这些「派生」数据。
+
+```
+iOS 写 memo → vault/raw/*.md (本地 + iCloud)
+                    ↓ (上传 sync API)
+            后端 PostgreSQL (memos 表)
+                    ↓ (AI compile worker)
+            pages / entities / links / inbox_items
+                    ↑                      ↓
+                  Web 读写          iOS 订阅 API 显示
+```
+
+---
+
+## 3. 整体架构
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│                         Cloudflare CDN                           │
+└──────────────────┬─────────────────────────────┬─────────────────┘
+                   │ static                       │ /api/*
+                   ▼                              ▼
+        ┌─────────────────────┐       ┌──────────────────────┐
+        │  Next.js Web (Vercel)│       │  Next.js API Routes  │
+        │  React Server Comp   │       │  + tRPC / REST       │
+        │  Tailwind + tokens   │       │  next-auth (JWT)     │
+        └──────────┬───────────┘       └──────────┬───────────┘
+                   │                              │
+                   └──────────────┬───────────────┘
+                                  ▼
+                  ┌────────────────────────────────┐
+                  │   PostgreSQL (Neon / Supabase) │
+                  │   + Drizzle ORM                │
+                  │   + pgvector (embeddings)      │
+                  └────────┬───────────────────────┘
+                           │
+              ┌────────────┴──────────────┐
+              ▼                           ▼
+      ┌──────────────┐          ┌────────────────────┐
+      │  R2 / S3     │          │  Compile Worker    │
+      │  (assets)    │          │  (Inngest / BullMQ │
+      │  voice m4a   │          │   Vercel Cron)     │
+      │  photos      │          │  调 DashScope API  │
+      └──────────────┘          └────────────────────┘
+                                          │
+                                          ▼
+                              ┌──────────────────────┐
+                              │  阿里云 DashScope    │
+                              │  qwen-plus / qwen-vl │
+                              │  text-embedding-v3   │
+                              └──────────────────────┘
+
+        iOS App ──── 同样调 /api/* ─── (sync vault → backend)
+```
+
+### 3.1 技术栈定稿
+
+| 层 | 选型 | 理由 |
+|---|---|---|
+| 前端框架 | **Next.js 14 App Router** | SSR + RSC + API routes 一站式；Vercel 一键部；社区最大 |
+| 语言 | **TypeScript 5（strict）** | 全栈类型安全，配合 tRPC 端到端推断 |
+| 样式 | **Tailwind CSS + CSS variables** | tokens.css 直接搬入 globals.css 作为 CSS 变量；Tailwind 写 utility |
+| UI 库 | **自研 primitives（不用 shadcn 全套）** | 设计稿的视觉很特定，shadcn 默认风格会冲；只用 Radix UI 的 headless 部分（Dialog / Dropdown / Tabs） |
+| 字体 | **next/font 加载** Space Grotesk / Inter / JetBrains Mono | self-host，零 CLS |
+| 图标 | **lucide-react** | 设计稿用的就是 lucide |
+| 数据获取 | **TanStack Query (React Query)** + **tRPC v11** | 类型安全 + 乐观更新 + 缓存 |
+| 表单 | **React Hook Form + Zod** | 服务端共享 schema |
+| 富文本/Markdown 渲染 | **react-markdown + remark-gfm + rehype-highlight** | wiki page 渲染 |
+| 图谱 | **react-force-graph-2d** 或自研 SVG（设计稿是固定坐标 SVG，先静态版 → 后期升 force） | MVP 走静态 SVG 跟设计稿一致 |
+| 后端 ORM | **Drizzle ORM 0.45** | 比 Prisma 轻、SQL-first、edge-friendly |
+| 数据库 | **Supabase（PostgreSQL 16 + pgvector）** | 本地 supabase-cli + Cloud 生产；自带 Auth/Storage/Realtime |
+| 认证 | **Auth.js v5 beta** + Apple OAuth + Email magic link | Auth.js 表存 Supabase；session 走 JWT cookie |
+| 任务队列 | **Inngest** | compile worker、向量化、定时任务；本地 dev server + Cloud |
+| 文件存储 | **Supabase Storage** | 一站式，与 DB RLS 同源；voice m4a + photo + 文件 |
+| 实时推送 | **Server-Sent Events (SSE)** | chat 流式输出 + compile 进度推送（无需 WebSocket） |
+| 部署 | **Vercel** (web + api) + **Neon** (db) + **Inngest Cloud** (worker) | 全 serverless，按量付费 |
+| 监控 | **Sentry** + **Vercel Analytics** + **PostHog**（产品分析） | 你已经有 Sentry→Linear pipeline |
+| CI/CD | **GitHub Actions** → Vercel Preview → Production | PR-based |
+
+### 3.2 monorepo 还是 polyrepo？
+
+**推荐 monorepo**（pnpm workspaces）：
+
+```
+daypage/                                ← 现仓库
+  DayPage/                              ← iOS app（保持原样）
+  DayPage.xcodeproj/
+  web/                                  ← 新增 Next.js
+    app/                                  ← App Router
+    components/
+    lib/
+    server/                               ← API + db schema
+    public/
+    package.json
+  packages/
+    shared-types/                       ← Memo / Page / Entity / Inbox 类型 + Zod schema
+                                          （iOS 用 Swift 端独立定义，Web/后端共享 TS 版本）
+  pnpm-workspace.yaml
+  package.json
+  turbo.json                            ← Turborepo（可选，加速构建）
+```
+
+iOS 不动；shared-types 暂时只服务 Web/后端，避免引入 Swift-TS 代码生成的复杂度。等 schema 稳定后可以再用 OpenAPI 生成 Swift client。
+
+---
+
+## 4. 数据库 schema（核心表）
+
+```sql
+-- ========== USER ==========
+CREATE TABLE users (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email         TEXT UNIQUE NOT NULL,
+  apple_sub     TEXT UNIQUE,                       -- Apple Sign-In subject
+  name          TEXT,
+  avatar_url    TEXT,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  onboarded_at  TIMESTAMPTZ,
+  settings      JSONB DEFAULT '{}'::jsonb          -- domains 偏好、视图布局等
+);
+
+-- ========== MEMO (raw input, 1:1 与 iOS Memo) ==========
+CREATE TABLE memos (
+  id            UUID PRIMARY KEY,                  -- 与 iOS 的 UUID 直接一致
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  type          TEXT NOT NULL CHECK (type IN ('text','voice','photo','location','mixed','url','file')),
+  body          TEXT NOT NULL,
+  created_at    TIMESTAMPTZ NOT NULL,
+  pinned_at     TIMESTAMPTZ,
+  location      JSONB,                             -- {name, lat, lng}
+  weather       TEXT,
+  device        TEXT,
+  source_url    TEXT,                              -- web 端 URL 抓取后保留
+  ingest_mode   TEXT DEFAULT 'full' CHECK (ingest_mode IN ('full','light')),
+  compile_status TEXT DEFAULT 'pending' CHECK (compile_status IN ('pending','running','done','failed','skipped')),
+  compile_error TEXT,
+  word_count    INT,
+  origin        TEXT NOT NULL CHECK (origin IN ('ios','web','watch','api')),
+  vault_path    TEXT,                              -- iOS 来源时的 vault/raw/YYYY-MM-DD.md
+  updated_at    TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX memos_user_created ON memos(user_id, created_at DESC);
+CREATE INDEX memos_user_status  ON memos(user_id, compile_status);
+
+CREATE TABLE memo_attachments (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  memo_id       UUID NOT NULL REFERENCES memos ON DELETE CASCADE,
+  kind          TEXT NOT NULL CHECK (kind IN ('audio','photo','file','link_preview')),
+  storage_key   TEXT NOT NULL,                     -- R2 key
+  filename      TEXT,
+  mime_type     TEXT,
+  size_bytes    BIGINT,
+  duration_sec  REAL,
+  transcript    TEXT,
+  ocr_text      TEXT,
+  exif          JSONB,
+  created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ========== DOMAIN (top-level cluster) ==========
+CREATE TABLE domains (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  slug          TEXT NOT NULL,                     -- 'distsys'
+  label         TEXT NOT NULL,                     -- 'Distributed systems'
+  color         TEXT NOT NULL,                     -- '#5D3000'
+  position      INT DEFAULT 0,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, slug)
+);
+
+-- ========== PAGE (compiled artifact: concept / source / entity / synthesis) ==========
+CREATE TABLE pages (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  slug          TEXT NOT NULL,                     -- 'concept/raft.0a4'
+  type          TEXT NOT NULL CHECK (type IN ('concept','source','entity','synthesis','daily')),
+  domain_id     UUID REFERENCES domains,
+  title         TEXT NOT NULL,
+  status        TEXT DEFAULT 'live' CHECK (status IN ('live','draft','archived','cold')),
+  body_md       TEXT NOT NULL DEFAULT '',         -- Markdown
+  body_html     TEXT,                              -- 缓存渲染后 HTML（含 <mark> 标记）
+  metadata      JSONB DEFAULT '{}'::jsonb,         -- entity: {role, org}; concept: {summary}; etc.
+  embedding     VECTOR(1536),                      -- pgvector
+  source_count  INT DEFAULT 0,
+  backlink_count INT DEFAULT 0,
+  last_compiled_at TIMESTAMPTZ,
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (user_id, slug)
+);
+CREATE INDEX pages_user_type ON pages(user_id, type);
+CREATE INDEX pages_user_domain ON pages(user_id, domain_id);
+
+-- ========== LINK (page ↔ page, with provenance) ==========
+CREATE TABLE page_links (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  from_page_id  UUID NOT NULL REFERENCES pages ON DELETE CASCADE,
+  to_page_id    UUID NOT NULL REFERENCES pages ON DELETE CASCADE,
+  via_memo_id   UUID REFERENCES memos ON DELETE SET NULL,
+  weight        REAL DEFAULT 1.0,
+  rationale     TEXT,                              -- AI 生成的「为什么这条边」
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  UNIQUE (from_page_id, to_page_id, via_memo_id)
+);
+
+-- ========== PAGE_SOURCES (page ← memos, contribution 字段) ==========
+CREATE TABLE page_sources (
+  page_id       UUID NOT NULL REFERENCES pages ON DELETE CASCADE,
+  memo_id       UUID NOT NULL REFERENCES memos ON DELETE CASCADE,
+  contribution  TEXT,                              -- 'core protocol' / 'failure-mode framing'
+  weight        REAL DEFAULT 1.0,
+  PRIMARY KEY (page_id, memo_id)
+);
+
+-- ========== ANNOTATION (用户在 page 上的高亮) ==========
+CREATE TABLE annotations (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  page_id       UUID NOT NULL REFERENCES pages ON DELETE CASCADE,
+  anchor        JSONB NOT NULL,                    -- {section_idx, char_start, char_end, text}
+  tag           TEXT NOT NULL,                     -- 'important' / 'questionable' / 自定义
+  note          TEXT,
+  created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ========== CHAT (RAG over wiki) ==========
+CREATE TABLE chat_threads (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  title         TEXT NOT NULL,
+  status        TEXT DEFAULT 'active' CHECK (status IN ('active','archived','synthesized')),
+  synthesis_page_id UUID REFERENCES pages,         -- "Save as synthesis page" 后填
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  updated_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE TABLE chat_messages (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  thread_id     UUID NOT NULL REFERENCES chat_threads ON DELETE CASCADE,
+  role          TEXT NOT NULL CHECK (role IN ('user','assistant','system')),
+  content       TEXT NOT NULL,                     -- raw markdown w/ {n} citation tokens
+  citations     JSONB,                             -- [{n, page_id, memo_id, excerpt, type}]
+  suggested     JSONB,                             -- [string]
+  tokens_in     INT,
+  tokens_out    INT,
+  created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ========== INBOX (AI 产出的待决策项) ==========
+CREATE TABLE inbox_items (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  kind          TEXT NOT NULL CHECK (kind IN ('contradiction','schema','orphan','compiled','observation')),
+  title         TEXT NOT NULL,
+  body          TEXT NOT NULL,
+  payload       JSONB NOT NULL,                    -- {conflict: {old,new}} / {target_page_id} / {actions: [...]}
+  status        TEXT DEFAULT 'open' CHECK (status IN ('open','resolved','dismissed','snoozed')),
+  resolution    JSONB,                             -- {action, at, by}
+  created_at    TIMESTAMPTZ DEFAULT NOW(),
+  resolved_at   TIMESTAMPTZ
+);
+CREATE INDEX inbox_user_status ON inbox_items(user_id, status, created_at DESC);
+
+-- ========== ACTIVITY (Home 的 Recent activity feed) ==========
+CREATE TABLE activities (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  verb          TEXT NOT NULL,                     -- 'compiled' / 'linked' / 'drafted' / 'merged' / 'promoted' / 'archived'
+  subject       TEXT NOT NULL,                     -- 主体描述
+  target_type   TEXT,                              -- 'page' / 'memo' / 'inbox'
+  target_id     UUID,
+  created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+CREATE INDEX activities_user_created ON activities(user_id, created_at DESC);
+
+-- ========== DEVICE (iOS / Web 设备注册，用于 push) ==========
+CREATE TABLE devices (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       UUID NOT NULL REFERENCES users ON DELETE CASCADE,
+  platform      TEXT NOT NULL CHECK (platform IN ('ios','web','watch')),
+  push_token    TEXT,
+  last_seen_at  TIMESTAMPTZ,
+  metadata      JSONB,
+  created_at    TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ========== SYNC_STATE (vault 增量同步游标) ==========
+CREATE TABLE sync_state (
+  user_id       UUID NOT NULL,
+  device_id     UUID NOT NULL,
+  cursor        TIMESTAMPTZ NOT NULL,
+  PRIMARY KEY (user_id, device_id)
+);
+```
+
+**关键决策**：
+- `memos.id` 与 iOS UUID 直接复用 → 无 ID mapping
+- `pages.body_html` 缓存渲染结果（含 user annotation 的 `<mark>`）→ wiki 页秒开
+- `pgvector` embedding 用于 chat 的 RAG 检索（语义查相关 page）
+- 所有写操作都记 `activities` → Home 的 feed 现成
+
+---
+
+## 5. API 设计
+
+REST + tRPC 双模式：iOS 用 REST（更稳定、易调试），Web 用 tRPC（端到端类型）。两者底层共享同一组 Zod schema 与 service 层。
+
+### 5.1 资源端点
+
+```
+# Auth
+POST   /api/auth/apple              Apple Sign-In token 交换
+POST   /api/auth/email              magic link 发送
+GET    /api/auth/session            当前会话
+
+# Memos (iOS sync)
+GET    /api/memos?since=...&cursor=...
+POST   /api/memos                   单条创建（web 也用）
+POST   /api/memos/bulk              iOS 批量上传（vault diff）
+GET    /api/memos/:id
+PATCH  /api/memos/:id
+DELETE /api/memos/:id
+POST   /api/memos/:id/recompile     强制重新编译
+
+# Attachments (signed upload)
+POST   /api/attachments/sign        返回 R2 直传 URL
+POST   /api/attachments/finalize    上传完成回调
+
+# Domains
+GET    /api/domains
+POST   /api/domains
+PATCH  /api/domains/:id
+DELETE /api/domains/:id
+
+# Pages
+GET    /api/pages?type=&domain=&q=
+GET    /api/pages/:slug
+POST   /api/pages                   创建 synthesis page
+PATCH  /api/pages/:id               改 title / domain / status
+DELETE /api/pages/:id
+GET    /api/pages/:id/sources
+GET    /api/pages/:id/backlinks
+GET    /api/pages/:id/graph         单 page 局部图谱
+
+# Annotations
+POST   /api/annotations
+DELETE /api/annotations/:id
+
+# Chat (SSE 流式)
+POST   /api/chat/threads            新建 thread
+GET    /api/chat/threads
+GET    /api/chat/threads/:id        含 messages
+POST   /api/chat/threads/:id/messages   SSE stream
+POST   /api/chat/threads/:id/synthesize 转为 synthesis page
+
+# Inbox
+GET    /api/inbox?kind=&status=
+POST   /api/inbox/:id/resolve       {action: '...', payload?: {...}}
+POST   /api/inbox/:id/snooze
+POST   /api/inbox/:id/dismiss
+
+# Activity (Home feed)
+GET    /api/activities?cursor=...
+
+# Stats (Home hero)
+GET    /api/stats                   {sources, pages, domains, backlinks, deltas}
+
+# Search (跨 page + memo)
+GET    /api/search?q=
+
+# Compile (manual trigger / status)
+GET    /api/compile/queue           当前 user 的 queue
+POST   /api/compile/trigger         指定 memo_id
+
+# SSE
+GET    /api/stream/compile          实时 compile 进度
+GET    /api/stream/inbox            新 inbox 项推送
+```
+
+### 5.2 RAG 检索算法（chat）
+
+1. 用户提问 → embed query (DashScope `text-embedding-v3` 1536-d)
+2. `pages` 表按 `cosine similarity` 取 top-20，再用 metadata filter（domain）剪枝到 top-8
+3. 把 page bodies 拼成 context（每段截断到 800 tokens），加上引用编号 `[1] page_id=...`
+4. system prompt：「只能基于 context 回答；不知道就说不知道；引用必须用 `{n}` 格式对应 references」
+5. 调用 qwen-plus 流式生成 → 边生成边 SSE push 给前端
+6. 解析 `{n}` token → 写 `chat_messages.citations` JSONB
+7. 三条 suggested follow-ups：单独调一次 qwen 短 prompt 生成
+
+### 5.3 Compile worker 流水线
+
+```
+new memo (status=pending)
+  ↓
+worker pick up
+  ├─ 转录（如果是 voice）→ Whisper API
+  ├─ OCR（如果是 photo）→ qwen-vl
+  ├─ 抓取（如果是 URL）→ readability + cheerio
+  ├─ 切块 + embed → 写 memo embedding
+  ├─ AI compile：
+  │    LIGHT 模式 → 只生成摘要，挂到 source page
+  │    FULL 模式  → 召回 top-K 已有 page → 让 qwen 决定：
+  │                 • 更新哪些既有 page（diff patch）
+  │                 • 是否新建 concept page
+  │                 • 是否抽出新 entity
+  │                 • 是否产生 contradiction（→ inbox）
+  ├─ 应用 patch：写 pages / page_links / page_sources
+  ├─ 写 activity log
+  ├─ 触发 schema 检测（每 N 条跑一次）→ 是否提议新 cluster → inbox
+  └─ status = done，SSE push
+```
+
+---
+
+## 6. Web 端项目结构
+
+```
+web/
+  app/
+    layout.tsx                      ← root, 字体加载, providers
+    globals.css                     ← tokens.css 的内容直接搬入（CSS 变量）
+    page.tsx                        ← 重定向到 /home
+    (auth)/
+      login/page.tsx
+      onboarding/page.tsx           ← 3-step flow
+    (app)/
+      layout.tsx                    ← Sidebar + Topbar 包裹
+      home/page.tsx
+      add/page.tsx
+      chat/page.tsx                 ← thread list
+      chat/[id]/page.tsx            ← single thread
+      wiki/page.tsx                 ← list mode
+      wiki/[slug]/page.tsx          ← page detail
+      wiki/graph/page.tsx           ← graph mode
+      inbox/page.tsx
+      domain/[slug]/page.tsx        ← 单 domain 视图
+      settings/page.tsx
+    api/                            ← API routes
+      [...]
+  components/
+    ui/                             ← Btn / Chip / Card / Icon / Sparkline / SectionLabel（搬 primitives.jsx）
+    layout/
+      Sidebar.tsx
+      Topbar.tsx
+    home/
+      HeroBlock.tsx
+      ObservationCard.tsx
+      ActivityFeed.tsx
+      DomainGrid.tsx
+    add/
+      UnifiedInput.tsx
+      CompileQueue.tsx
+      RecentCompiled.tsx
+    chat/
+      ThreadView.tsx
+      MessageBubble.tsx
+      CitationCard.tsx
+      ChatComposer.tsx
+    wiki/
+      WikiNav.tsx
+      WikiPage.tsx
+      WikiGraph.tsx
+      AnnotationLayer.tsx
+      ProvenancePanel.tsx
+    inbox/
+      InboxFilters.tsx
+      InboxCard.tsx
+      ContradictionCompare.tsx
+  lib/
+    auth.ts
+    db.ts                           ← drizzle client
+    schema.ts                       ← drizzle schema = 上面 SQL 的 TS 版
+    ai/
+      dashscope.ts                  ← OpenAI-compatible client
+      compile.ts                    ← compile pipeline
+      rag.ts                        ← retrieval
+    sync/
+      vault-importer.ts             ← 解析 iOS 的 .md 文件
+    sse.ts                          ← Server-Sent Events helper
+    upload.ts                       ← R2 signed URL
+    fonts.ts                        ← next/font 配置
+  server/
+    routers/                        ← tRPC routers
+      memos.ts
+      pages.ts
+      chat.ts
+      inbox.ts
+      ...
+    trpc.ts
+  hooks/
+    useStream.ts                    ← SSE 订阅
+    useObservation.ts
+    ...
+  styles/
+    tokens.css                      ← 完整 token 定义
+  public/
+    fonts/                          ← 自托 woff2
+  middleware.ts                     ← auth 守卫
+  drizzle.config.ts
+  next.config.js
+  tailwind.config.ts                ← 把 tokens 暴露成 utility
+  package.json
+```
+
+---
+
+## 7. 同步策略（iOS ⇄ Web ⇄ Backend）
+
+### 7.1 写入路径
+
+- **iOS 写 memo**：先写 vault `.md`（保证离线）→ 后台 sync 任务 push 到 `/api/memos/bulk`
+  - 后端 upsert by `id`（UUID 是 iOS 生成的）
+  - 把 attachment 文件经 R2 直传上传
+- **Web 写 memo**：直接 POST `/api/memos`（无 vault 概念）
+  - iOS 拉到这条新 memo 后，**写回**本地 vault `.md` 文件（保持 iOS 端 vault 完整）
+
+### 7.2 拉取路径
+
+iOS 启动 / 切回前台时：
+```
+GET /api/memos?since={last_sync_cursor}
+GET /api/pages?since={last_sync_cursor}
+GET /api/inbox?since={last_sync_cursor}
+```
+返回新增/修改的资源 + 新游标。
+
+### 7.3 冲突处理
+
+- Memo 是 append-only（不允许编辑 body 后 sync），冲突场景极少
+- `pinned_at` / `compile_status` 这类可变字段：last-write-wins，以 `updated_at` 为准
+- 若 iOS 的 vault 与 backend 不一致（用户手动改了 .md），iOS 端保留本地，给用户一个「重新上传覆盖」的入口
+
+### 7.4 离线
+
+- iOS：vault 即离线缓存，所有读写本地优先
+- Web：用 React Query + IndexedDB（`@tanstack/react-query-persist-client`）做读缓存；写操作离线时排队，恢复后重发
+
+---
+
+## 8. AI 密钥与成本控制
+
+- **DashScope API key 只放 Vercel 环境变量**（`DASHSCOPE_API_KEY`），永远不下发到客户端
+- 浏览器调 `/api/chat/...` → 后端代理到 DashScope，response 流式转发
+- iOS 也走同一后端代理（不再像现在直接持有 key）→ key 旋转无需发 App Store 更新
+- 成本守门：
+  - 每用户每天 chat tokens 上限（默认 100k tokens / day，可配）
+  - Compile worker 启用 batch 模式，多条 memo 合一次 prompt
+  - Embeddings 缓存 7 天
+  - 重要：所有 LLM 调用都记 `tokens_in / tokens_out`，运营后台查询用量
+
+---
+
+## 9. 安全与合规
+
+- **认证**：Apple Sign-In（与 iOS 共用 Apple ID）+ Email magic link 兜底；JWT 短期 + refresh token
+- **授权**：所有 query 强制带 `where user_id = current_user.id`；用 Drizzle 的 RLS-like helper 包装
+- **XSS**：Markdown 渲染走 `react-markdown` 默认 sanitize；`dangerouslySetInnerHTML` 只在 server 端用 DOMPurify 后才允许
+- **CSRF**：next-auth 自带 CSRF token，所有 mutation 用 POST + token
+- **R2 直传**：用 presigned URL，每个 URL 限定 mime/size/有效期 5 min
+- **Rate limit**：`@upstash/ratelimit` 做 per-user 限流（chat: 60 req/min, mutation: 30 req/min）
+- **审计**：所有写操作落 `activities`，审计/回溯方便
+- **PII**：location 字段属敏感数据，DB 字段加密（pgcrypto）；用户可一键 export + delete account
+
+---
+
+## 10. 里程碑（粗估时间，单人投入）
+
+| Wave | 范围 | 产出 | 估时 |
+|---|---|---|---|
+| **W0 · 准备** | monorepo 改造、Vercel/Neon/R2/Inngest 接入、CI、Sentry | 空壳能跑 | 2 天 |
+| **W1 · 后端骨架** | Drizzle schema + 迁移、auth、`/api/memos` `/api/pages` `/api/inbox` `/api/stats`、R2 upload | iOS 能 sync 到云 | 4 天 |
+| **W2 · vault 导入** | iOS vault → backend 一次性导入脚本 + 增量 sync 客户端改造 | 现有数据全在云上 | 2 天 |
+| **W3 · Web 骨架 + Home** | Next.js shell、tokens、Sidebar、Topbar、Home view（真数据） | Home 页可看 | 3 天 |
+| **W4 · Add view + compile worker** | UnifiedInput、上传、queue、Inngest worker、LIGHT/FULL pipeline、SSE 进度 | 端到端编译 | 5 天 |
+| **W5 · Wiki view（List 模式）** | WikiNav、page renderer、annotation、provenance 侧栏 | 可读可标注 | 4 天 |
+| **W6 · Wiki Graph 模式** | force-graph 渲染、节点交互、局部展开 | 图谱可看 | 2 天 |
+| **W7 · Chat (RAG)** | embedding pipeline、检索、SSE 流式、引用解析、suggested follow-ups | 问答可用 | 4 天 |
+| **W8 · Inbox + Observations** | 4 类生成器（contradiction/schema/orphan/compiled）、observation worker、Home 卡片 | AI 主动卡片可见 | 4 天 |
+| **W9 · Onboarding + 设置** | 3 步 onboarding、settings 页、domain 编辑、export | 新用户可跑通 | 2 天 |
+| **W10 · 生产化** | E2E（Playwright）、a11y 审、性能（lighthouse ≥90）、文档、监控告警 | 可发布 | 3 天 |
+
+**合计 ~35 工作日**。这是真实的生产级估时——不是 hello world。
+
+---
+
+## 11. 风险与开放问题
+
+| 风险 | 应对 |
+|---|---|
+| Vault 数据迁移可能不一致 | W2 写一个 `vault-doctor` CLI，反向校验 backend ↔ vault hash |
+| qwen-plus context window 不够大 page 全文 | RAG 检索按段落级 chunk + rerank；page 长时只送 section heading |
+| Compile worker 失败导致 inbox 堆积 | 每个 worker step 幂等 + 死信队列 + 用户后台查看 |
+| Web 端 Graph 节点数 >500 渲染卡 | 默认只显示 1-hop，按需懒展开；超 1000 节点用 Canvas |
+| iOS 端密钥要从客户端拿掉 | 改造 iOS `CompilationService` 走后端代理，老版本兼容期保留两条路径 |
+
+**开放问题已全部锁定**（见顶部「已锁定决策」表）。后续若有新分歧，再单独提出。
+
+---
+
+## 12. 立即下一步
+
+如果你 review 通过这份方案，我会按这个顺序动手：
+
+1. 在 `web/` 起 Next.js 14 项目脚手架（pnpm + TS strict + Tailwind + tokens.css）
+2. 落地 `lib/schema.ts`（drizzle schema）+ 第一份迁移
+3. 写 `app/(app)/layout.tsx` + `Sidebar` + `Topbar`，把视觉骨架立起来
+4. 接 next-auth + 一个能登录的页面
+5. 实现 Home view 用真 API（先返回空数据也行，端到端跑通）
+
+**第 1-5 步 = W0 + W3 的一半，预计 2-3 天，做完发给你看 preview**。然后再继续 W1 / W4。
+
+> 我**不会**一次性写完 35 天的所有代码再交给你。每个 wave 跑完一轮，我把可见的成果发给你 review，你说继续就推进，你说回头改就回头改。

--- a/prd.json
+++ b/prd.json
@@ -1,331 +1,919 @@
 {
-  "project": "DayPage",
-  "branchName": "ralph/today-composer-liquid-refinement",
-  "description": "Today \u4e3b\u9875\u6781\u7b80\u4f18\u96c5\u91cd\u5851 + Composer 3.0 Liquid Composition Surface \u2014 \u6574\u5408 issue #252 + #250: \u5220 GlassTabBar, AmbientBackground \u7eaf\u5316, Day Orb \u6536\u655b, \u7a7a\u6570\u636e\u56de\u9000\u6808, i18n \u4fee\u590d + L10n.swift, composerState \u72b6\u6001\u673a, Liquid Morph, 5 \u5f62\u6001 Adaptive Send, keyboard-attached toolbar, drag handle, 5 \u7ea7 haptics, Context Spotlight Strip, Smart Templates, Lens Strip, Caret Spotlight, Status Strip",
+  "project": "DayPage V5 Codex",
+  "branchName": "ralph/v5-codex-web",
+  "description": "DayPage V5 终极形态第一阶段：Web (Codex) 骨架 + 后端 API + AI 编译引擎 + Agent 主动行动。覆盖 PRD V5 的 Wave 0-9（Web 端可用 + Agent 可受控行动）。源 PRD: tasks/prd-daypage-v5-codex.md。技术栈: Next.js 16 + TypeScript + Tailwind 4 + Supabase (本地 Docker) + Drizzle 0.45 + Auth.js v5 beta + Inngest + 后端代理 DashScope。",
   "userStories": [
     {
       "id": "US-001",
-      "title": "i18n \u8d44\u6e90\u5f7b\u67e5\uff1alproj target membership + L10n.swift \u5f3a\u7c7b\u578b\u679a\u4e3e",
-      "description": "As a \u7528\u6237, I want \u4e3b\u9875\u6587\u6848\u663e\u793a\u4e2d\u6587/\u82f1\u6587\u7ffb\u8bd1\u800c\u975e\u539f\u59cb key, so that \u622a\u56fe\u4e0d\u518d\u51fa\u73b0 'empty.today.no_signals.title' \u8fd9\u7c7b\u66b4\u9732\u5b57\u7b26\u4e32.",
+      "title": "Wave 0a: Monorepo 基础设施 (pnpm workspace + 根 package.json)",
+      "description": "As a developer, I need a monorepo skeleton so that web/ and existing iOS code can coexist.",
       "acceptanceCriteria": [
-        "Xcode DayPage target Build Phases Copy Bundle Resources \u5305\u542b zh-Hans.lproj \u548c en.lproj",
-        "Xcode Project Localizations \u542f\u7528 Chinese (Simplified) \u4e0e English",
-        "Info.plist \u542b CFBundleDevelopmentRegion=zh-Hans \u4e0e CFBundleLocalizations=[zh-Hans, en]",
-        "\u65b0\u589e DayPage/Resources/L10n.swift \u63d0\u4f9b L10n.Empty.todayNoSignalsTitle \u5f3a\u7c7b\u578b\u8bbf\u95ee\u5668",
-        "EmptyStateView.todayNoSignals() \u6539\u7528 L10n.Empty.* \u800c\u975e\u88f8\u5b57\u9762\u91cf",
-        "\u4e2d\u82f1\u6587\u7cfb\u7edf\u8bed\u8a00\u5207\u6362\u540e hero \u4e0b\u65b9\u6587\u6848\u6b63\u786e\u53d8\u5316",
-        "grep -rn 'LocalizedStringKey(\"' DayPage/ \u8f93\u51fa\u4e3a 0 (\u9664 L10n.swift)",
-        "xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build \u901a\u8fc7",
-        "Typecheck passes",
-        "Tests pass"
+        "Create pnpm-workspace.yaml at repo root listing 'web' and 'packages/*'",
+        "Create root package.json with workspace scripts: web:dev, web:build, web:lint, web:typecheck, db:start, db:reset",
+        "Set engines.node >=22, engines.pnpm >=10, packageManager pnpm@11.0.9",
+        "Run `pnpm install` succeeds",
+        ".gitignore already updated for web/Next/Supabase artifacts (verify, no change needed)",
+        "Typecheck passes (no TS files yet so nothing to check)"
       ],
       "priority": 1,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-002",
-      "title": "AmbientBackground \u7eaf\u5316\uff1a\u5220 4 \u56e2\u6696\u8272\u5149\u6591\uff0c\u9ed8\u8ba4\u4ec5 cream \u5e95",
-      "description": "As a \u7528\u6237, I want \u4e3b\u9875\u80cc\u666f\u63a5\u8fd1\u7eaf\u8272\u5976\u6cb9\u7eb8\u611f, so that \u89c6\u89c9\u951a\u70b9\u56de\u5230\u5b57\u672c\u8eab, \u4e0d\u518d\u50cf AI \u6f14\u793a\u7a3f.",
+      "title": "Wave 0b: Next.js 16 脚手架 (web/ 目录)",
+      "description": "As a developer, I need Next.js 16 with App Router scaffolded in web/ so we can build the Codex UI.",
       "acceptanceCriteria": [
-        "DayPage/DesignSystem/GlassSurface.swift AmbientBackground \u9ed8\u8ba4\u4ec5\u6e32\u67d3 DSColor.bgWarm (FAF7F2)",
-        "4 \u56e2 amber blob \u7528 @AppStorage('debug.ambientBlobs') \u5305\u8d77\u6765, \u9ed8\u8ba4 false",
-        "TodayView, DailyPageView, MemoDetailView \u663e\u5f0f\u4e0d\u4f20\u5f00\u5173, \u4f7f\u7528\u9ed8\u8ba4\u7eaf\u8272\u884c\u4e3a",
-        "iPhone 17 Simulator \u622a\u56fe\u4e0e\u6539\u52a8\u524d\u5e76\u6392\u9971\u548c\u5ea6\u8089\u773c\u660e\u663e\u4e0b\u964d",
-        "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Run `pnpm create next-app@latest web --typescript --tailwind --app --src-dir --use-pnpm --eslint --turbopack --import-alias '@/*' --skip-install --yes`",
+        "Rename web/package.json `name` to 'daypage-web'",
+        "Delete duplicated web/pnpm-workspace.yaml (let it inherit root)",
+        "Add `typecheck` script (tsc --noEmit) to web/package.json",
+        "Run `pnpm install` from repo root succeeds",
+        "Run `pnpm web:typecheck` passes",
+        "Verify in browser using dev-browser skill: `pnpm web:dev` serves http://localhost:3000 and renders default Next page"
       ],
       "priority": 2,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-003",
-      "title": "Day Orb \u6536\u655b\uff1asize 140pt + halo opacity 0.15 + orbFill \u00d70.5",
-      "description": "As a \u7528\u6237, I want Day Orb \u4ece\u4e2d\u592e\u5de8\u5927\u7425\u73c0\u7403\u53d8\u4e3a\u7eb8\u4e0a\u4e00\u679a\u8f7b\u6655, so that serif \u65e5\u671f 'Friday MAY 8' \u6210\u4e3a\u89c6\u89c9\u4e3b\u89d2.",
+      "title": "Wave 0c: 设计 token 系统 (globals.css + Tailwind 4 @theme)",
+      "description": "As a developer, I need Codex design tokens loaded as CSS variables so all components can use them.",
       "acceptanceCriteria": [
-        "DayPage/Features/Today/DayOrbView.swift halo \u900f\u660e\u5ea6\u4ece 0.4 \u6539\u4e3a 0.15",
-        "orbFill gradient stops \u900f\u660e\u5ea6\u5168\u90e8 \u00d70.5",
-        "DayOrbView \u66b4\u9732 size: CGFloat = 140 \u4e0e haloOpacity: CGFloat = 0.15 \u53c2\u6570",
-        "TodayView \u8c03\u7528\u5904\u663e\u5f0f\u4f20 size: 140",
-        "\u547c\u5438\u52a8\u753b\u5e45\u5ea6 \u00d70.7",
-        "iPhone 17 Simulator \u622a\u56fe\u4e0e\u6539\u52a8\u524d\u5e76\u6392 orb \u660e\u663e\u6536\u655b",
+        "Recreate Codex tokens.css content in web/src/app/globals.css per PRD V5 §10.3 (warm-archival color tokens, font families, spacing/radius)",
+        "Use Tailwind 4 @theme directive to expose tokens as utility classes (bg-warm, accent, fg-primary, etc.)",
+        "Add font imports for Space Grotesk, Inter, JetBrains Mono via next/font",
+        "Set body background to var(--bg-warm) and font-family to Inter",
+        "Define utility classes ds-display-lg, ds-h1, ds-h2, ds-section-label, ds-body-md, ds-mono-11 matching tokens.css",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: open / and confirm warm-white background + correct fonts loaded"
       ],
       "priority": 3,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-002 (AmbientBackground \u7eaf\u5316\u5148\u843d\u5730)"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-004",
-      "title": "\u5220\u9664 GlassTabBar\uff0c\u8d26\u53f7\u5934\u50cf\u8fc1\u5165\u8bbe\u7f6e sheet\uff0c\u53f3\u4e0a\u4ec5\u7559\u9f7f\u8f6e",
-      "description": "As a \u7528\u6237, I want \u9876\u90e8\u4e0d\u518d\u51fa\u73b0 [Today \u25be] pill \u548c\u7425\u73c0\u8272\u5934\u50cf, so that \u6574\u9875\u53ea\u6709 sidebar \u4e00\u5957\u5bfc\u822a\u8bed\u8a00, \u89c6\u89c9\u4e00\u81f4.",
+      "title": "Wave 0d: Supabase 本地 Docker 初始化",
+      "description": "As a developer, I need a local Supabase instance running so we can develop against real Postgres.",
       "acceptanceCriteria": [
-        "\u5220\u9664 DayPage/Components/GlassTabBar.swift",
-        "\u4ece RootView.swift / TodayView.swift / AppNavigationModel.swift \u4e2d\u79fb\u9664\u6240\u6709 GlassTabBar / AppTab \u5f15\u7528",
-        "TodayView \u9876\u90e8\u8d26\u53f7\u5934\u50cf (36pt \u5b9e\u5fc3\u7425\u73c0\u5706) \u79fb\u9664, \u8d26\u53f7\u5165\u53e3\u79fb\u5230\u8bbe\u7f6e sheet \u9876\u90e8",
-        "TodayView \u9876\u90e8\u53f3\u4fa7\u4ec5\u4fdd\u7559\u9f7f\u8f6e\u6309\u94ae (28pt \u73bb\u7483\u5706)",
-        "Archive / Graph \u5207\u6362\u901a\u8fc7 sidebar \u5b8c\u6210, \u56de\u5f52 path \u65e0\u6b67\u4e49",
-        "grep -rn 'GlassTabBar' DayPage/ \u8f93\u51fa\u4e3a 0",
-        "xcodebuild build \u901a\u8fc7",
-        "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Run `supabase init` creating supabase/config.toml at repo root",
+        "Edit supabase/config.toml: enable pgvector extension under [db.extensions]",
+        "Run `supabase start` succeeds (Docker via OrbStack)",
+        "Confirm `supabase status` outputs DB URL, anon key, service_role key, Studio URL",
+        "Add web/.env.local.example with NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY placeholders",
+        "Add web/.env.local with actual local values (already gitignored)",
+        "Typecheck passes"
       ],
       "priority": 4,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-005",
-      "title": "TodayViewModel \u65b0\u589e TodayFallback \u679a\u4e3e\u4e0e fallbackContent \u8ba1\u7b97\u5c5e\u6027",
-      "description": "As a \u5f00\u53d1\u8005, I want TodayViewModel \u66b4\u9732 fallback \u5185\u5bb9\u9009\u62e9, so that TodayView \u5728\u4eca\u65e5 0 memo \u65f6\u80fd\u6309\u4f18\u5148\u7ea7\u6e32\u67d3\u5b58\u91cf\u5185\u5bb9\u5361.",
+      "title": "Wave 1a: Drizzle ORM 接入 + 配置文件",
+      "description": "As a developer, I need Drizzle ORM configured so we can write type-safe DB schema.",
       "acceptanceCriteria": [
-        "TodayViewModel \u65b0\u589e enum TodayFallback { case yesterdayDailyPage(DailyPage), onThisDay([Memo]), weekRecap(WeekStats), pureEmpty }",
-        "TodayViewModel.fallbackContent: TodayFallback \u8ba1\u7b97\u5c5e\u6027\u6309 yesterdayDailyPage > onThisDay > weekRecap > pureEmpty \u4f18\u5148\u7ea7\u8fd4\u56de",
-        "\u4f18\u5148\u7ea7\u786c\u7f16\u7801\u4e0d\u53ef\u914d\u7f6e",
-        "\u65b0\u589e DayPageTests/TodayViewModelTests.swift \u8986\u76d6 4 \u79cd fallback \u72b6\u6001",
-        "Typecheck passes",
-        "Tests pass"
+        "Install drizzle-orm@0.45 + drizzle-kit + postgres + @types/pg in web/",
+        "Create web/drizzle.config.ts pointing to web/src/lib/db/schema.ts and out: web/drizzle/migrations",
+        "Create web/src/lib/db/client.ts exporting `db` (drizzle instance using postgres-js)",
+        "Add web/package.json scripts: db:generate, db:migrate, db:studio (drizzle-kit)",
+        "Typecheck passes"
       ],
       "priority": 5,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-001 (i18n \u4fee\u590d, \u5426\u5219 fallback \u6587\u6848\u4e5f\u4f1a\u66b4\u9732 key)"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-006",
-      "title": "\u590d\u6d3b OnThisDayCard \u4e0e WeeklyRecapSection\uff0cTodayView \u63a5\u5165 fallback \u6e32\u67d3",
-      "description": "As a \u7528\u6237, I want \u5373\u4f7f\u4eca\u5929\u6ca1\u8bb0, \u4e3b\u9875\u4e5f\u80fd\u5c55\u793a\u6628\u65e5 Daily Page / On This Day / \u672c\u5468\u56de\u987e\u4e2d\u7684\u4e00\u5f20\u5f15\u5b50\u5361, so that Today \u4e3b\u9875\u6c38\u4e0d\u7a7a\u767d.",
+      "title": "Wave 1b: Drizzle schema 第一批 (users + memos + memo_attachments)",
+      "description": "As a developer, I need the core memo tables defined so iOS can sync data.",
       "acceptanceCriteria": [
-        "TodayView \u5728 memos.isEmpty && !isLoading \u65f6\u6309 viewModel.fallbackContent \u6e32\u67d3\u5bf9\u5e94\u5361",
-        "yesterdayDailyPage \u590d\u7528 DailyPageEntryCard",
-        "onThisDay \u590d\u7528 OnThisDayCard.swift (\u590d\u6d3b\u5f53\u524d\u7981\u7528\u5f15\u7528)",
-        "weekRecap \u590d\u6d3b WeeklyRecapSection.swift \u5e76\u63a5\u5165",
-        "pureEmpty \u4ec5\u663e\u793a hero \u4e0b\u65b9\u4e00\u53e5\u5c0f\u5b57 (\u4e0d\u518d\u72ec\u5360\u6574\u5c4f)",
-        "\u4e09\u79cd fallback \u5361\u70b9\u51fb\u884c\u4e3a: \u6628\u65e5\u5361\u8fdb\u5165 DailyPageView, OnThisDay \u8fdb\u5165 MemoDetailView, WeekRecap \u8fdb\u5165 ArchiveView \u5468\u6a21\u5f0f",
-        "\u539f EmptyStateView.todayNoSignals() \u9000\u5316\u4e3a\u5355\u884c\u5c0f\u5b57",
-        "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "In web/src/lib/db/schema.ts define `users` table (uuid pk, email unique, apple_sub unique, name, avatar_url, created_at, onboarded_at, settings jsonb)",
+        "Define `memos` table per docs/web/PLAN.md §4 (uuid pk, user_id fk, type enum, body text, created_at, pinned_at, location jsonb, weather, device, source_url, ingest_mode, compile_status, origin, vault_path, updated_at)",
+        "Define `memo_attachments` table (uuid pk, memo_id fk, kind enum, storage_key, filename, mime_type, size_bytes, duration_sec, transcript, ocr_text, exif jsonb)",
+        "Add indexes: memos_user_created (user_id, created_at desc), memos_user_status (user_id, compile_status)",
+        "Run `pnpm --filter daypage-web db:generate` produces migration SQL file",
+        "Run `pnpm --filter daypage-web db:migrate` applies to local supabase",
+        "Verify tables exist in Supabase Studio",
+        "Typecheck passes"
       ],
       "priority": 6,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-005 (fallbackContent \u8ba1\u7b97\u5c5e\u6027)"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-007",
-      "title": "InputBarV4 \u5f15\u5165 ComposerState \u72b6\u6001\u673a\u66ff\u6362 userExpandedText",
-      "description": "As a \u5f00\u53d1\u8005, I want \u7528 composerState: .idle / .expanding / .open / .collapsing \u66ff\u6362 userExpandedText: Bool, so that 12 \u4e2a\u7b7e\u540d\u65f6\u523b\u4e2d\u8fc7\u6e21\u90a3\u4e00\u62cd\u80fd\u88ab\u7cbe\u786e\u63a7\u5236.",
+      "title": "Wave 1c: Drizzle schema 第二批 (domains + pages + page_links + page_sources)",
+      "description": "As a developer, I need page tables so AI compile can write structured wiki output.",
       "acceptanceCriteria": [
-        "InputBarV4.swift \u65b0\u589e enum ComposerState: Equatable { case idle, expanding, open, collapsing }",
-        "\u5220\u9664 userExpandedText: Bool, \u6240\u6709\u5f15\u7528\u8fc1\u79fb\u5230 state == .open || state == .expanding",
-        "\u72b6\u6001\u8f6c\u79fb\u51fd\u6570 transition(to: ComposerState) \u96c6\u4e2d\u7ba1\u7406, \u6bcf\u6b21\u8f6c\u79fb\u89e6\u53d1\u5bf9\u5e94 haptic \u4e0e animation",
-        "expanding / collapsing \u6301\u7eed\u65f6\u95f4 = .spring(response: 0.42, dampingFraction: 0.78)",
-        ".expanding / .collapsing \u671f\u95f4\u7981\u6b62\u63a5\u53d7\u65b0\u7684\u72b6\u6001\u5207\u6362 (\u9632\u6296)",
-        "\u65b0\u589e DayPageTests/ComposerStateMachineTests.swift \u8986\u76d6\u6240\u6709\u5408\u6cd5/\u975e\u6cd5\u8f6c\u79fb",
-        "xcodebuild build \u901a\u8fc7",
-        "Typecheck passes",
-        "Tests pass"
+        "Define `domains` (uuid pk, user_id fk, slug, label, color, position, created_at, unique(user_id, slug))",
+        "Define `pages` per PLAN.md §4 (uuid pk, user_id fk, slug, type enum, domain_id fk nullable, title, status enum, body_md, body_html, metadata jsonb, embedding vector(1536), source_count, backlink_count, last_compiled_at, timestamps, unique(user_id, slug))",
+        "Define `page_links` (uuid pk, user_id, from_page_id fk, to_page_id fk, via_memo_id fk nullable, weight, rationale, created_at)",
+        "Define `page_sources` composite pk (page_id, memo_id) with contribution + weight",
+        "Add indexes pages_user_type, pages_user_domain",
+        "Generate + run migration",
+        "Typecheck passes"
       ],
       "priority": 7,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-008",
-      "title": "Liquid Morph: idle \u73bb\u7483\u80f6\u56ca matchedGeometryEffect \u751f\u957f\u6210 composition card",
-      "description": "As a \u7528\u6237, I want \u4ece idle \u4e09\u69fd\u80f6\u56ca\u5230 composing \u5361\u7247\u770b\u5230\u5f62\u6001\u5ef6\u7eed\u800c\u975e\u4e24\u4e2a view \u5207\u6362, so that \u5207\u6362\u6709\u4eea\u5f0f\u611f.",
+      "title": "Wave 1d: Drizzle schema 第三批 (annotations + chat_threads + chat_messages + inbox_items + activities + devices + sync_state)",
+      "description": "As a developer, I need the remaining tables so chat / inbox / activity / sync features have storage.",
       "acceptanceCriteria": [
-        "\u7528 matchedGeometryEffect(id: 'composer.surface', in: namespace) \u628a idle \u80f6\u56ca morph \u6210 composing \u5706\u89d2\u77e9\u5f62",
-        "\u9ea6\u514b\u98ce orb \u4e0d\u6d88\u5931: 64x64 \u7f29\u5230 28x28 \u5e76\u5de6\u79fb\u5230\u5361\u7247\u5de6\u4e0b\u89d2\u4f5c\u4e3a\u5207\u56de\u8bed\u97f3\u5165\u53e3",
-        "Aa \u6309\u94ae\u6de1\u51fa = TextField caret \u6de1\u5165 (\u540c\u4f4d\u7f6e\u4ea4\u53c9\u6de1\u5165 200ms)",
-        "\u6574\u6bb5\u52a8\u753b .spring(response: 0.42, dampingFraction: 0.78)",
-        "\u52a8\u753b\u8d77\u70b9\u89e6\u53d1 UIImpactFeedbackGenerator(.soft)",
-        "\u5f55\u5c4f\u9a8c\u8bc1\u4efb\u610f\u4e00\u5e27\u622a\u56fe\u53d6\u51fa\u6765\u5f62\u72b6\u90fd\u80fd\u89e3\u91ca\u4ece\u54ea\u6765",
-        "Reduced Motion \u5f00\u542f\u65f6\u964d\u7ea7\u4e3a\u7b80\u5355 fade (0.2s)",
-        "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Define `annotations` (uuid pk, user_id, page_id fk, anchor jsonb, tag, note, created_at)",
+        "Define `chat_threads` (uuid pk, user_id, title, status enum, synthesis_page_id fk nullable, timestamps)",
+        "Define `chat_messages` (uuid pk, thread_id fk, role enum, content, citations jsonb, suggested jsonb, tokens_in, tokens_out, created_at)",
+        "Define `inbox_items` (uuid pk, user_id, kind enum, title, body, payload jsonb, status enum, resolution jsonb, created_at, resolved_at)",
+        "Define `activities` (uuid pk, user_id, verb, subject, target_type, target_id, created_at)",
+        "Define `devices` (uuid pk, user_id, platform enum, push_token, last_seen_at, metadata jsonb, created_at)",
+        "Define `sync_state` composite pk (user_id, device_id) with cursor timestamptz",
+        "Add indexes inbox_user_status, activities_user_created",
+        "Generate + run migration",
+        "Typecheck passes"
       ],
       "priority": 8,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-007 (ComposerState \u72b6\u6001\u673a)"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-009",
-      "title": "Adaptive Send Affordance\uff1a\u53d1\u9001\u6309\u94ae 5 \u5f62\u6001 (\u7a7a/\u6587\u672c/\u6587\u672c+\u56fe/\u4f4d\u7f6e/\u591a\u6a21\u6001)",
-      "description": "As a \u7528\u6237, I want \u53d1\u9001\u6309\u94ae\u6839\u636e draft \u5f62\u6001\u53d8\u5f62, so that \u6211\u80fd\u4ece\u56fe\u5f62\u4e0a\u8bfb\u51fa\u73b0\u5728\u53d1\u9001\u4f1a\u505a\u4ec0\u4e48.",
+      "title": "Wave 0e: Auth.js v5 beta 接入 + Apple OAuth provider",
+      "description": "As a user, I want to sign in with Apple ID on the web so I can access my own data.",
       "acceptanceCriteria": [
-        "\u7a7a\u6001: \u6d45\u8272 mic.fill \u5706\u73af (\u67d4\u5149\u547c\u5438 1.6s/cycle), accessibilityLabel='\u6309\u4f4f\u8bf4'",
-        "\u4ec5\u6587\u672c\u6001: \u5b9e\u5fc3\u7425\u73c0 arrow.up, accessibilityLabel='\u53d1\u9001'",
-        "\u6587\u672c+\u7167\u7247\u6001: camera.fill + arrow.up \u590d\u5408, accessibilityLabel='\u8bb0\u4e0b\u8fd9\u4e00\u523b'",
-        "\u4ec5\u4f4d\u7f6e\u6001: mappin.and.arrow.up, accessibilityLabel='\u6807\u8bb0\u6b64\u5904'",
-        "\u591a\u6a21\u6001\u6001: \u7425\u73c0 ring \u5e26\u5149\u6655\u8109\u52a8 (1.6s), accessibilityLabel='\u53d1\u9001 N \u9879'",
-        "\u7a7a\u6001\u660e\u786e\u4e0d\u518d\u7528 18% \u900f\u660e\u7425\u73c0\u5706",
-        "\u5f62\u6001\u5207\u6362 .spring(response: 0.32, dampingFraction: 0.8)",
-        "VoiceOver \u6717\u8bfb\u5bf9\u5e94 label",
+        "Install next-auth@5.0.0-beta.31 in web/",
+        "Create web/src/auth.ts exporting handlers, auth, signIn, signOut using NextAuth() with Apple provider + Email magic link provider",
+        "Create web/src/app/api/auth/[...nextauth]/route.ts re-exporting handlers",
+        "Configure Apple provider with env vars APPLE_CLIENT_ID, APPLE_CLIENT_SECRET, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY",
+        "Configure Email provider with SUPABASE_SMTP_* vars (use supabase local Inbucket for dev)",
+        "Create users row on first sign-in (Drizzle adapter or custom callback)",
+        "Add web/middleware.ts redirecting unauthenticated requests away from (app)/* to /login",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: visit /login, see 'Sign in with Apple' + email input"
       ],
       "priority": 9,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-007 (ComposerState \u72b6\u6001\u673a)"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-010",
-      "title": "Composer \u5de5\u5177\u680f\u8fc1\u79fb\u5230 keyboard-attached (.toolbar placement: .keyboard)",
-      "description": "As a \u7528\u6237, I want \u5de5\u5177\u680f\u8ddf\u952e\u76d8\u4e00\u8d77\u6d6e\u8d77, so that \u4e0d\u518d\u5f62\u6210\u952e\u76d8+\u5de5\u5177\u680f\u53cc\u5c42\u5806\u53e0.",
+      "title": "Wave 3a: App Layout 骨架 (Sidebar + Topbar + 路由分组)",
+      "description": "As a user, I want the Codex shell visible so I can navigate between Home/Add/Chat/Wiki/Inbox.",
       "acceptanceCriteria": [
-        "\u5de5\u5177\u680f\u8fc1\u79fb\u5230 .toolbar { ToolbarItemGroup(placement: .keyboard) { ... } }",
-        "\u5361\u7247\u672c\u4f53\u505c\u5728\u753b\u9762\u4e2d\u6bb5, \u4e0b\u65b9\u53ef\u89c1 timeline (\u5e26 vignette \u6e10\u9690\u906e\u7f69)",
-        "\u952e\u76d8\u6536\u8d77\u65f6\u5de5\u5177\u680f\u8ddf\u968f\u6d88\u5931, \u65e0\u6b8b\u7559\u9ad8\u5ea6\u5360\u4f4d",
-        "iPad \u6a2a\u5c4f\u952e\u76d8\u5de5\u5177\u680f\u4e0d\u6ea2\u51fa",
+        "Create web/src/app/(app)/layout.tsx with 248px sidebar + main column (matching Codex app.css .app grid)",
+        "Create empty page stubs at (app)/home, (app)/add, (app)/chat, (app)/wiki, (app)/inbox each rendering its name as h1",
+        "Sidebar renders: 5 fixed items (Home/Add/Chat/Wiki/Inbox) with lucide icons + active state highlight + Inbox badge slot (hardcoded 0 for now)",
+        "Topbar renders: breadcrumb 'Codex / <currentView>' + date string + Ask + Add buttons (no-op for now)",
+        "Active nav item background matches --accent-soft, text matches --accent",
+        "Sidebar footer shows user email from auth() session + Sign out link",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: navigate /home /add /chat /wiki /inbox and confirm sidebar highlight changes"
       ],
       "priority": 10,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-007"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-011",
-      "title": "Drag-to-Collapse Handle: \u5361\u7247\u9876 36x4 capsule \u4e0a\u6ed1\u6536\u8d77",
-      "description": "As a \u7528\u6237, I want \u5361\u7247\u9876\u8fb9\u4e00\u4e2a 36x4 capsule handle \u4e0a\u6ed1\u53ef\u6536\u8d77, so that \u4e0e iOS sheet \u8bed\u8a00\u4e00\u81f4.",
+      "title": "Wave 3b: UI primitives (Btn / Chip / Card / Icon / Sparkline / SectionLabel)",
+      "description": "As a developer, I need reusable components matching Codex visual language so views can be built quickly.",
       "acceptanceCriteria": [
-        "\u5361\u7247\u9876\u90e8\u5c45\u4e2d 36x4 \u7070\u8272 capsule",
-        "\u4e0a\u6ed1\u8ddd\u79bb > 32pt \u89e6\u53d1 transition(to: .collapsing) \u7136\u540e\u56de .idle",
-        "\u5355\u51fb handle \u7b49\u4ef7\u4e0a\u6ed1 (accessibility)",
-        "\u6298\u53e0\u52a8\u753b\u4e0e morph \u53cd\u5411\u64ad\u653e",
-        "\u6298\u53e0\u89e6\u53d1 .medium impact",
+        "Create web/src/components/ui/Btn.tsx supporting kind: primary|secondary|soft|ghost, size: sm|md, pill, icon, iconRight (port from PRD V5 §10.5 Codex primitives spec)",
+        "Create web/src/components/ui/Chip.tsx supporting tone: default|accent|success|warning|error|ghost, onClick",
+        "Create web/src/components/ui/Card.tsx supporting sunken variant",
+        "Create web/src/components/ui/Icon.tsx using lucide-react (install lucide-react@1.14)",
+        "Create web/src/components/ui/Sparkline.tsx (SVG, props: values, w, h, color, fill)",
+        "Create web/src/components/ui/SectionLabel.tsx (uppercase + tracking)",
+        "Add styles in globals.css for .btn, .btn--primary, .chip, .card, etc. matching Codex app.css conventions",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: temporarily add a Btn + Chip + Card to /home and confirm visual match Codex"
       ],
       "priority": 11,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-007 + US-008"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-012",
-      "title": "Haptics.swift \u6269\u5c55 5 \u7ea7\u89e6\u611f\u9636\u68af\u5e76\u63a5\u5165 Composer \u6d41\u7a0b",
-      "description": "As a \u7528\u6237, I want \u4e0d\u540c\u52a8\u4f5c\u89e6\u53d1\u4e0d\u540c\u5f3a\u5ea6\u7684\u89e6\u611f, so that Composer \u6709\u6750\u8d28\u611f.",
+      "title": "Wave 1e: API /api/memos 基础 CRUD",
+      "description": "As iOS / Web client, I need REST endpoints to create, list, get, patch, delete memos.",
       "acceptanceCriteria": [
-        "DayPage/DesignSystem/Haptics.swift \u66b4\u9732 5 \u7ea7 API: .soft / .rigid(intensity:) / .medium / .light / .success / .warning",
-        "\u70b9 dock \u4efb\u610f\u952e\u89e6\u53d1 .soft impact",
-        "Caret \u9996\u6b21\u51fa\u73b0 0.15s \u5ef6\u8fdf\u540e\u89e6\u53d1 .rigid 0.3 \u5f3a\u5ea6",
-        "\u6dfb\u52a0\u9644\u4ef6\u89e6\u53d1 .medium",
-        "\u5220\u9664\u9644\u4ef6\u89e6\u53d1 .light",
-        "\u53d1\u9001\u6210\u529f\u89e6\u53d1 .success notification",
-        "\u5f55\u97f3\u592a\u77ed/\u9519\u8bef\u89e6\u53d1 .warning notification",
-        "\u81f3\u5c11 4 \u7ea7\u5728 Composer \u6d41\u7a0b\u4e2d\u88ab\u5b9e\u9645\u89e6\u53d1",
+        "Create web/src/app/api/memos/route.ts: GET (list with cursor pagination + since filter) and POST (create with Zod validation)",
+        "Create web/src/app/api/memos/[id]/route.ts: GET, PATCH, DELETE (soft delete)",
+        "All handlers must call auth() and reject 401 if no session, scope queries to current user_id",
+        "Create operation accepts {type, body, created_at?, location?, weather?, device?, origin, ingest_mode?, attachments?[]}",
+        "Use Zod schemas in web/src/lib/schemas/memo.ts (shared with future tRPC layer)",
+        "Return Drizzle-typed memo objects",
+        "Add rate limit: 30 mutations/min per user using @upstash/ratelimit + in-memory fallback for dev",
         "Typecheck passes",
-        "Tests pass"
+        "Tests pass: write web/src/app/api/memos/__tests__/route.test.ts using Vitest covering create + list + 401 + scope isolation"
       ],
       "priority": 12,
-      "passes": true,
-      "notes": "\u53ef\u5e76\u884c\u4e8e US-007 ~ US-011"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-013",
-      "title": "ComposerContextProvider \u670d\u52a1\uff1a\u805a\u5408 Weather/Location/lastMemo/Pasteboard",
-      "description": "As a \u5f00\u53d1\u8005, I want \u4e00\u4e2a ComposerContextProvider \u805a\u5408\u6240\u6709\u4e0a\u4e0b\u6587\u6e90, so that Spotlight Strip \u80fd\u62ff\u5230\u7edf\u4e00\u7684 chip \u6570\u636e.",
+      "title": "Wave 1f: API /api/memos/bulk 批量上传 (iOS sync)",
+      "description": "As iOS app, I need to bulk push vault diff so V5 sync uplink works efficiently.",
       "acceptanceCriteria": [
-        "\u65b0\u589e DayPage/Services/ComposerContextProvider.swift @MainActor final class",
-        "\u6574\u5408 WeatherService / LocationService / viewModel.memos.last / UIPasteboard.general",
-        "\u66b4\u9732 var chips: [ContextChip] \u8ba1\u7b97\u5c5e\u6027",
-        "ContextChip \u7c7b\u578b: .weather(temp, condition) / .location(short) / .timeRitual(emoji, text) / .lastMemoTail(snippet) / .smartPaste(value)",
-        "lastMemoTail \u8ba1\u7b97\u7f13\u5b58 60s \u907f\u514d\u91cd\u590d\u8bfb vault",
-        "\u65b0\u589e DayPageTests/ComposerContextProviderTests.swift",
+        "Create web/src/app/api/memos/bulk/route.ts POST handler",
+        "Accept array of memos (max 100), upsert by id (id is UUID generated by iOS)",
+        "On conflict, last-write-wins by updated_at; do not overwrite location if backend already has one with later created_at",
+        "Return {accepted: [ids], skipped: [{id, reason}]}",
+        "Idempotent: same payload twice produces same DB state",
         "Typecheck passes",
-        "Tests pass"
+        "Tests pass: covering upsert, idempotency, scope, max-100 limit"
       ],
       "priority": 13,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-014",
-      "title": "Context Spotlight Strip: TextField \u4e0a\u65b9\u6a2a\u5411 chip \u5e26",
-      "description": "As a \u7528\u6237, I want TextField \u4e0a\u65b9\u4e00\u6761\u6a2a\u5411 chip \u5e26\u663e\u793a\u5929\u6c14/\u4f4d\u7f6e/\u4e0a\u4e00\u6761\u5c3e\u5df4/\u667a\u80fd\u7c98\u8d34, so that \u7a7a Composer \u4e5f\u6709\u73b0\u5728\u5199\u4ec0\u4e48\u7684\u5f15\u5b50.",
+      "title": "Wave 1g: API /api/attachments/sign + Supabase Storage 直传",
+      "description": "As a client, I need signed URLs to upload audio/photo/file directly to Supabase Storage.",
       "acceptanceCriteria": [
-        "Spotlight Strip \u6a2a\u5411\u6eda\u52a8, \u6bcf\u4e2a chip 28pt \u9ad8, \u73bb\u7483\u6750\u8d28",
-        "\u6570\u636e\u6e90\u8d70 ComposerContextProvider.chips",
-        "\u70b9\u51fb chip \u5bf9\u5e94\u5185\u5bb9\u585e\u5165 draft (\u4f4d\u7f6e\u585e Memo.Location, \u65f6\u95f4\u585e prompt, \u4e0a\u4e00\u6761\u5c3e\u5df4\u585e\u5f15\u7528\u5757, \u526a\u8d34\u677f\u585e\u6587\u672c)",
-        "\u89e6\u6478\u8f6f\u89e6\u611f .soft 0.4",
-        "\u7a7a Composer \u81f3\u5c11 3 \u6761 chip",
+        "Create Supabase Storage bucket 'memo-attachments' (private, no public access) via supabase migration SQL",
+        "Create web/src/app/api/attachments/sign/route.ts POST: input {memo_id, kind, mime_type, size_bytes}, return {upload_url, storage_key, expires_at}",
+        "Storage key format: `{user_id}/{memo_id}/{uuid}.{ext}`",
+        "Validate: mime_type in allowlist (audio/m4a, image/jpeg, image/png, image/heic, application/pdf), size <=50MB",
+        "Signed URL expiry 5 min",
+        "Create web/src/app/api/attachments/finalize/route.ts POST: input {memo_id, storage_key, kind, ...} writes memo_attachments row",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Tests pass: signing returns valid Supabase URL; finalize creates row"
       ],
       "priority": 14,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-013"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-015",
-      "title": "Smart Templates: 12 \u6761\u65f6\u6bb5\u6a21\u677f hardcode",
-      "description": "As a \u7528\u6237, I want \u7a7a Composer \u663e\u793a 1 \u884c\u65f6\u6bb5\u6a21\u677f, so that \u6211\u80fd\u4e00\u952e\u5f97\u5230\u4eca\u5929\u600e\u4e48\u5199\u7684\u5f15\u5b50.",
+      "title": "Wave 1h: API /api/domains + /api/inbox + /api/stats + /api/activities (基础)",
+      "description": "As a client, I need read endpoints for sidebar/home content so the UI has real data.",
       "acceptanceCriteria": [
-        "12 \u6761 hardcode \u6a21\u677f\u6309\u65f6\u6bb5\u6620\u5c04: 06-11 \u6668/\u4eca\u5929/\u9192\u6765; 11-17 \u521a\u624d/\u4e2d\u5348/\u60f3\u6cd5; 17-22 \u6700\u67d0\u523b/\u603b\u7ed3/\u660e\u5929; 22-06 \u56de\u770b/\u672a\u5b8c/\u68a6",
-        "\u4ec5\u5728 text.isEmpty && pendingAttachments.isEmpty \u65f6\u663e\u793a",
-        "\u70b9\u51fb \u6a21\u677f\u6587\u5b57\u585e\u5165 TextField, placeholder \u9ad8\u4eae (.foregroundStyle(.secondary))",
-        "caret \u5b9a\u4f4d\u5230 placeholder \u8d77\u70b9",
-        "\u7528\u6237\u5f00\u59cb\u6253\u5b57\u540e placeholder \u6d88\u5931",
-        "\u4e0d\u5f15\u5165\u914d\u7f6e\u6587\u4ef6 / \u8bbe\u7f6e\u9879",
+        "Create web/src/app/api/domains/route.ts: GET list, POST create",
+        "Create web/src/app/api/inbox/route.ts: GET list (filter by kind, status), default status='open'",
+        "Create web/src/app/api/stats/route.ts: GET returns {sources, pages, domains, backlinks, deltas:{sources_week, pages_week, backlinks_week}}",
+        "Create web/src/app/api/activities/route.ts: GET cursor-paginated list, default 20",
+        "All endpoints scoped to auth() user_id",
+        "Empty user returns sensible empty arrays / zero counts",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Tests pass: each endpoint returns 200 with empty data for fresh user, 401 without session"
       ],
       "priority": 15,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-016",
-      "title": "Inline Lens Strip: \u6700\u8fd1 4 \u5f20\u7167\u7247\u7f29\u7565\u56fe (\u61d2\u52a0\u8f7d\u76f8\u518c\u6743\u9650)",
-      "description": "As a \u7528\u6237, I want TextField \u4e0b\u65b9\u4e00\u6761 56x56 \u5706\u89d2\u7f29\u7565\u56fe\u5e26, so that \u6211\u80fd\u4e00\u952e\u9644\u52a0\u6700\u8fd1 24h \u5185\u7684\u7167\u7247, \u65e0\u9700\u8df3 PhotosPicker.",
+      "title": "Wave 3c: Home view 真数据 (Hero + Stats + Recent activity 占位)",
+      "description": "As a user, I want the Home page to show my real stats and recent activity so I see live data.",
       "acceptanceCriteria": [
-        "\u7b2c\u4e00\u6b21\u5c55\u5f00 Composer \u65f6 prompt PHPhotoLibrary.requestAuthorization(for: .readWrite)",
-        "\u62d2\u7edd\u6743\u9650\u540e Strip \u9690\u85cf, \u4e0d\u518d prompt (\u7528 @AppStorage('composer.photoPermissionAsked') \u6807\u8bb0)",
-        "\u663e\u793a\u6700\u8fd1 24h \u5185 4 \u5f20\u7f29\u7565\u56fe, \u6309\u65f6\u95f4\u5012\u5e8f",
-        "\u70b9\u51fb\u7f29\u7565\u56fe \u76f4\u63a5\u9644\u52a0\u5230 pendingAttachments, \u4e0d\u8df3 sheet",
-        "\u7f29\u7565\u56fe\u52a0\u8f7d\u7528 PHCachingImageManager \u907f\u514d\u5361\u987f, \u5206\u8fa8\u7387 <= 168x168",
-        "\u65e0\u6700\u8fd1\u7167\u7247\u65f6 Strip \u9690\u85cf (\u4e0d\u663e\u793a\u7a7a\u6001)",
+        "Update web/src/app/(app)/home/page.tsx to fetch /api/stats + /api/activities server-side (RSC)",
+        "Render Hero block with date string + headline (use placeholder text if empty) + 4 buttons (Add / Ask / Inbox)",
+        "Render Stats grid (4 cards: Sources / Wiki pages / Domains / Backlinks) using real numbers from /api/stats",
+        "Render Recent activity Card listing last 6 activities (when=relative time, what=verb+subject, target link)",
+        "Empty state: if stats all zero, show 'Nothing yet — add something to get started' with primary Add button",
+        "Match Codex visual exactly per PRD V5 §3 Home view sketch",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: log in, see Home page with zero stats + empty state CTA"
       ],
       "priority": 16,
-      "passes": true,
+      "passes": false,
       "notes": ""
     },
     {
       "id": "US-017",
-      "title": "Caret Spotlight + Ambient Dim: focus \u65f6\u80cc\u666f\u6697 20%, \u5361\u80cc RadialGradient",
-      "description": "As a \u7528\u6237, I want focus \u65f6\u80cc\u666f\u53d8\u6697 20% \u540c\u65f6\u5361\u7247\u80cc\u540e\u6cdb\u8d77\u6696\u767d\u5c04\u706f, so that \u5199\u4f5c\u4eea\u5f0f\u611f\u62c9\u6ee1.",
+      "title": "Wave 3d: Sidebar Domains 动态列表 + Inbox badge 真数据",
+      "description": "As a user, I want the sidebar to show my domains and unread inbox count from real data.",
       "acceptanceCriteria": [
-        "focus \u8fdb\u5165\u65f6 AmbientBackground \u6574\u4f53\u900f\u660e\u5ea6 0.8",
-        "Composer \u5361\u7247\u80cc\u540e RadialGradient (\u4e2d\u5fc3 caret \u4f4d\u7f6e, \u534a\u5f84 240pt, \u6696\u767d 0.12 opacity)",
-        "\u73b0\u6709 BreathingCaretView \u4fdd\u7559\u5e76\u63a5\u5165",
-        "focus \u9000\u51fa\u53cd\u5411\u52a8\u753b 0.4s",
-        "Reduced Motion \u5f00\u542f\u65f6\u7981\u7528 dim, \u4ec5\u9759\u6001\u5bf9\u6bd4",
+        "Update Sidebar to fetch /api/domains and /api/inbox?status=open server-side via RSC layout",
+        "Render dynamic Domains group below static items with colored dot + label + count per domain",
+        "Inbox item shows badge with count of unresolved inbox_items",
+        "If user has 0 domains, hide the Domains group label entirely",
+        "If badge count is 0, hide the badge",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: empty user sees no Domains group; insert a test domain via SQL and confirm it appears"
       ],
       "priority": 17,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-002 (AmbientBackground \u5df2\u7eaf\u5316)"
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-018",
-      "title": "Status Strip: \u5361\u7247\u9876 12pt mono \u884c DRAFTING \u00b7 N PHOTOS \u00b7 LOC \u00b7 age",
-      "description": "As a \u7528\u6237, I want \u5361\u7247\u9876\u90e8\u4e00\u884c 12pt mono \u663e\u793a\u72b6\u6001\u526f\u6807, so that \u6211\u80fd\u770b\u5230 Composer \u7684\u5b9e\u65f6\u72b6\u6001.",
+      "title": "Wave 4a: Add view 静态 UI (UnifiedInput + 空 Compile Queue)",
+      "description": "As a user, I want the Add page UI so I can type and submit content (compile worker comes later).",
       "acceptanceCriteria": [
-        "\u5b57\u6bb5\u987a\u5e8f: <state> \u00b7 <attachment count> \u00b7 <location short> \u00b7 <draft age>",
-        "\u72b6\u6001\u679a\u4e3e: DRAFTING / SENDING / SENT / ERROR",
-        "\u53d1\u9001\u6210\u529f 1.2s \u5185\u663e\u793a SENT \u7136\u540e\u6574\u4e2a Composer \u6298\u53e0\u56de idle dock",
-        "\u5b57\u4f53 JetBrains Mono 12pt (\u5df2\u6ce8\u518c)",
-        "XXLarge+ Dynamic Type \u65f6\u7701\u7565 location \u5b57\u6bb5",
+        "Update web/src/app/(app)/add/page.tsx",
+        "Render Hero block (section label + headline + sub)",
+        "Render UnifiedInput: textarea + hint chips (URL/File/Voice/Bookmarklet/auto-detect) + Save draft + Add buttons",
+        "Render empty Compile Queue Card with placeholder 'No items yet'",
+        "Render empty Recently Compiled Card",
+        "Submit button is disabled when textarea empty",
+        "Match Codex Add view visual per PRD V5 §3",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: navigate to /add, type text, confirm submit button enables"
       ],
       "priority": 18,
-      "passes": true,
-      "notes": "\u4f9d\u8d56 US-007 (state) + US-013 (location \u6765\u6e90)"
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-019",
+      "title": "Wave 4b: Add view 提交连接 /api/memos (基础 text 输入)",
+      "description": "As a user, I want submitting the Add form to actually create a memo via the API.",
+      "acceptanceCriteria": [
+        "On submit, POST to /api/memos with {type:'text', body, origin:'web'}; auto-detect type:'url' if body matches /^https?:\\/\\//",
+        "Use TanStack Query (install @tanstack/react-query@5.100) mutation with optimistic update",
+        "On success, clear textarea and prepend new memo to local Compile Queue list (status='pending')",
+        "On failure, show inline error + Retry button + keep textarea content",
+        "Compile Queue Card now lists the user's pending memos (fetched via /api/memos?compile_status=pending)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: submit a text memo, confirm it appears in queue and DB row exists"
+      ],
+      "priority": 19,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-020",
+      "title": "Wave 4c: AI provider 抽象层 + DashScope client",
+      "description": "As a developer, I need a unified LLM client so compile worker can call qwen models.",
+      "acceptanceCriteria": [
+        "Create web/src/lib/ai/provider.ts exporting interface LLMProvider with chat(), embed(), transcribe()",
+        "Create web/src/lib/ai/dashscope.ts implementing provider via OpenAI-compatible endpoint (https://dashscope.aliyuncs.com/compatible-mode/v1)",
+        "Use env var DASHSCOPE_API_KEY (server-only, never client)",
+        "Models: qwen-plus for chat, text-embedding-v3 for embed, paraformer for transcribe",
+        "Return typed responses; on error throw ProviderError with code (rate_limit/timeout/auth/server)",
+        "Add token logging side-effect: every call writes a row to prompt_log table (create new table for this)",
+        "Typecheck passes",
+        "Tests pass: mock fetch and verify request body / response parsing / error mapping"
+      ],
+      "priority": 20,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-021",
+      "title": "Wave 4d: Inngest 接入 + compile.memo function 骨架",
+      "description": "As a developer, I need a background worker so compile pipeline can run async.",
+      "acceptanceCriteria": [
+        "Install inngest@3.x in web/",
+        "Create web/src/lib/inngest/client.ts exporting `inngest` Inngest client with id 'daypage'",
+        "Create web/src/lib/inngest/functions/compile-memo.ts: function triggered by event 'memo/created' with steps: normalize, embed, recall, compile, apply, notify",
+        "For now each step just logs and updates memos.compile_status (pending → running → done); no real LLM calls yet",
+        "Create web/src/app/api/inngest/route.ts mounting Inngest serve handler",
+        "When /api/memos POST creates a memo, send event {name:'memo/created', data:{memo_id}}",
+        "Add npm script `dev:inngest` running `npx inngest-cli@latest dev`",
+        "Typecheck passes",
+        "Verify: submit a memo via Add page, observe inngest dev dashboard at http://localhost:8288 shows function ran, memo compile_status updated to 'done'"
+      ],
+      "priority": 21,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-022",
+      "title": "Wave 4e: Embed step 实接 DashScope + memo embedding 持久化",
+      "description": "As the compile pipeline, I need to actually embed memo text so RAG and recall work.",
+      "acceptanceCriteria": [
+        "Add embedding vector(1536) column to memos table (new migration)",
+        "In compile-memo function 'embed' step: chunk body into <=512-token segments, embed each, average to single vector, write to memos.embedding",
+        "If body empty (e.g. voice without transcript), skip embed",
+        "Cache: hash(body) → if same hash already embedded in last 7 days, reuse from a new embed_cache table",
+        "On API error, set memos.compile_status='failed' + memos.compile_error",
+        "Typecheck passes",
+        "Tests pass: mock dashscope, submit memo, verify embedding column populated"
+      ],
+      "priority": 22,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-023",
+      "title": "Wave 4f: Compile step LIGHT 模式 (生成摘要 + 关键词)",
+      "description": "As a user, I want LIGHT-mode memos to get a summary and tags so I can browse them later.",
+      "acceptanceCriteria": [
+        "In compile-memo function 'compile' step, if memo.ingest_mode='light', call qwen-plus with a structured prompt asking for {summary: string, keywords: string[], suggested_domain: string|null}",
+        "Use prompt template at web/src/lib/ai/prompts/compile-light.md (versioned)",
+        "Apply: write a new source-type page with title=truncated body OR summary, body_md=summary, metadata={keywords, source_memo_id}",
+        "Link page to memo via page_sources",
+        "Update memo.compile_status='done'",
+        "If LLM returns invalid JSON, retry once with stricter prompt; on second fail mark compile_status='failed'",
+        "Typecheck passes",
+        "Tests pass: mock qwen, submit text memo with ingest_mode='light', verify page row + page_sources row"
+      ],
+      "priority": 23,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-024",
+      "title": "Wave 4g: Compile step FULL 模式 (recall + patch existing pages or create new concept)",
+      "description": "As a user, I want FULL-mode memos to actually update my wiki, not just create source pages.",
+      "acceptanceCriteria": [
+        "In compile-memo 'recall' step: vector-search top-8 existing pages by cosine similarity to memo.embedding (only same user, status='live')",
+        "In 'compile' step (FULL mode): pass memo body + retrieved pages as context to qwen-plus with prompt at compile-full.md asking for tool-calling JSON: {operations: [{op: 'update_page'|'create_page'|'create_link'|'extract_entity', ...}]}",
+        "In 'apply' step: execute operations in DB transaction, write change_log table (create new table) for each",
+        "Each new page gets status='draft'; existing page updates increment a version counter",
+        "Validate: every cited page_id in operations must exist; reject invalid",
+        "Update memo.compile_status='done'",
+        "Typecheck passes",
+        "Tests pass: mock qwen returning create_page op, submit memo, verify page row created with status='draft' + change_log entry"
+      ],
+      "priority": 24,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-025",
+      "title": "Wave 4h: SSE 进度推送 /api/stream/compile",
+      "description": "As a user, I want to see live compile progress so I know the system is working.",
+      "acceptanceCriteria": [
+        "Create web/src/app/api/stream/compile/route.ts using Next.js streaming response (text/event-stream)",
+        "On connect, scope to current user (via auth())",
+        "Subscribe to Postgres LISTEN/NOTIFY channel 'compile_progress' OR poll memos every 2s for status changes",
+        "Send SSE events {type:'progress', memo_id, status, step?, progress?}",
+        "Compile worker emits NOTIFY after each pipeline step",
+        "Heartbeat ping every 15s to keep connection alive",
+        "Close connection cleanly on client disconnect",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: open /add, submit a memo, watch network tab for SSE events flowing"
+      ],
+      "priority": 25,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-026",
+      "title": "Wave 4i: Add view Compile Queue 实时进度 UI",
+      "description": "As a user, I want progress bars in the Compile Queue so I see compilation happen.",
+      "acceptanceCriteria": [
+        "Create web/src/hooks/useCompileStream.ts subscribing to /api/stream/compile via EventSource, updating local state per memo_id",
+        "Compile Queue Card uses this hook to render progress bar 0-100% per item",
+        "Step labels render (e.g. 'Embedding...', 'Compiling...')",
+        "On done, item shows green check + 'X pages updated' + auto-removes from queue after 3s",
+        "On failed, item shows red badge + error step name + Retry button (calls POST /api/memos/:id/recompile)",
+        "Add /api/memos/:id/recompile endpoint that re-sends inngest event",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: submit memo, watch progress bar fill, confirm completion state"
+      ],
+      "priority": 26,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-027",
+      "title": "Wave 4j: LIGHT/FULL chip 切换 + Recently Compiled 列表",
+      "description": "As a user, I want to switch a memo's compile tier and see what was recently compiled.",
+      "acceptanceCriteria": [
+        "Each Compile Queue item has a Chip showing current ingest_mode (LIGHT/FULL)",
+        "Click chip: PATCH /api/memos/:id with {ingest_mode: 'full'|'light'}, then trigger recompile",
+        "Toast confirms switch",
+        "Add 'Recently compiled' Card below queue: fetch /api/memos?compile_status=done&limit=8, ordered by updated_at desc",
+        "Each row shows: icon, title (truncated 90 chars), subtitle (type · word_count · created_at relative), mode chip, time",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: submit memo, after compile completes, see it in Recently compiled; click LIGHT chip to switch and observe re-compile"
+      ],
+      "priority": 27,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-028",
+      "title": "Wave 5a: Wiki view 路由 + 左侧 nav 静态结构",
+      "description": "As a user, I want the Wiki page layout so I can navigate between page groups.",
+      "acceptanceCriteria": [
+        "Update web/src/app/(app)/wiki/page.tsx with 3-column layout: 240px nav + flex-1 page + 280px aside",
+        "WikiNav component fetches /api/pages grouped by type (concept/source/entity/synthesis/daily)",
+        "Each group is collapsible (state persisted in localStorage)",
+        "Each row shows title + meta (source_count or 'draft' tag or conflict warning icon)",
+        "Active page highlighted",
+        "Top of nav: search input (no-op for now) + List/Graph mode toggle (Graph greyed out for later wave)",
+        "Empty state: if user has no pages, show 'Your wiki will grow here as AI compiles your memos'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: navigate to /wiki, see empty groups + search bar"
+      ],
+      "priority": 28,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-029",
+      "title": "Wave 5b: API /api/pages + /api/pages/:slug + /api/pages/:id/sources + /api/pages/:id/backlinks",
+      "description": "As a client, I need page CRUD and detail endpoints so Wiki view can show page content.",
+      "acceptanceCriteria": [
+        "GET /api/pages?type=&domain=&q= returns paginated list",
+        "GET /api/pages/:slug returns single page (404 if not user's)",
+        "POST /api/pages creates synthesis page (input: {title, body_md, type:'synthesis', source_thread_id?})",
+        "PATCH /api/pages/:id updates title / domain_id / status",
+        "DELETE /api/pages/:id soft-deletes (status='archived', or sets deleted_at)",
+        "GET /api/pages/:id/sources returns memos that contributed (joined via page_sources)",
+        "GET /api/pages/:id/backlinks returns pages that link TO this page (via page_links)",
+        "All scoped to user_id",
+        "Typecheck passes",
+        "Tests pass: cover happy path + 404 + scope isolation for each endpoint"
+      ],
+      "priority": 29,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-030",
+      "title": "Wave 5c: Wiki page detail UI (含 markdown 渲染 + 右侧 sources/backlinks/provenance)",
+      "description": "As a user, I want to read a wiki page with sources and backlinks visible.",
+      "acceptanceCriteria": [
+        "Create web/src/app/(app)/wiki/[slug]/page.tsx fetching /api/pages/:slug + sources + backlinks server-side",
+        "Render header: type chip + domain chip + 'updated X ago' chip + Annotate + Ask buttons + h1 title + byline (compiled from N sources · M backlinks · slug)",
+        "Render body using react-markdown@10 + remark-gfm + rehype-sanitize",
+        "Right aside: 3 blocks (Sources / Backlinks / Provenance) matching Codex visual",
+        "Each source row links to source memo detail (route stub OK for now)",
+        "Each backlink row links to /wiki/[slug]",
+        "Provenance block shows static text 'Last compiled X ago' for now",
+        "If page not found, render 'This page does not exist'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: insert a test page via SQL, navigate to /wiki/<slug>, confirm renders"
+      ],
+      "priority": 30,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-031",
+      "title": "Wave 5d: Annotation API + 高亮选中 toolbar",
+      "description": "As a user, I want to highlight text on a wiki page and tag it as important/questionable.",
+      "acceptanceCriteria": [
+        "POST /api/annotations creates annotation (input: {page_id, anchor:{section_idx,char_start,char_end,text}, tag, note?})",
+        "DELETE /api/annotations/:id removes annotation",
+        "GET /api/pages/:id/annotations returns all annotations for a page",
+        "Wiki page detail loads annotations + renders selected text wrapped in <mark class='user-mark' data-tag='...'> via remark plugin or DOM post-processing",
+        "On text selection, show floating toolbar with 3 buttons: Important / Questionable / Custom tag (modal)",
+        "Click button → POST annotation → re-fetch and re-render",
+        "Different tags get different colors (important=accent-soft, questionable=warning-soft)",
+        "Click existing highlight to delete",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: open a page with content, select text, click Important, confirm highlight persists after refresh"
+      ],
+      "priority": 31,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-032",
+      "title": "Wave 5e: Domain 视图 (/(app)/domain/[slug])",
+      "description": "As a user, I want to click a domain in sidebar and see its overview.",
+      "acceptanceCriteria": [
+        "Create web/src/app/(app)/domain/[slug]/page.tsx",
+        "Fetch domain by slug + pages where domain_id matches",
+        "Render: domain title (editable inline) + color picker chip + page count + activity stats (this week)",
+        "Render Pages list grouped by type",
+        "Sidebar Domain link routes to /domain/<slug>",
+        "PATCH /api/domains/:id supports renaming + color change",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: with seeded domain + pages, navigate to domain page and see content"
+      ],
+      "priority": 32,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-033",
+      "title": "Wave 5f: Daily Page worker + cron",
+      "description": "As a user, I want a daily diary page auto-generated each night summarizing the day's memos.",
+      "acceptanceCriteria": [
+        "Create inngest scheduled function 'daily-page' running at 00:30 UTC daily (will be per-user-timezone in later wave)",
+        "For each user with >=1 memo today, aggregate memos created in last 24h, call qwen-plus with prompt at daily-page.md to produce structured page (sections: Highlights / Locations / Themes / Mood)",
+        "Create or upsert page with type='daily', slug='daily/YYYY-MM-DD', title='YYYY-MM-DD Daily', status='live', body_md=result",
+        "Link via page_sources to all memos of that day",
+        "Idempotent: re-running same day overwrites the existing daily page",
+        "Typecheck passes",
+        "Tests pass: mock qwen, seed memos for a day, run function, verify daily page created with correct sources"
+      ],
+      "priority": 33,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-034",
+      "title": "Wave 6a: Wiki Graph view (静态布局, 与 Codex 一致)",
+      "description": "As a user, I want a graph visualization so I can see how my pages connect.",
+      "acceptanceCriteria": [
+        "Add /(app)/wiki Graph mode toggle: when active, render WikiGraph component",
+        "WikiGraph fetches /api/pages + /api/page_links (new endpoint that returns all links for current user)",
+        "Layout: simple force-directed using d3-force or react-force-graph-2d (install one, prefer d3-force for SVG control)",
+        "Node colors per type: concept=accent, draft=warning, entity=accent-hover, source=fg-muted, synthesis=success",
+        "Edges between linked pages (page_links table)",
+        "Click node → highlight node + 1-hop neighbors + show right-aside detail card with title + type + sources count + 'Open page' button",
+        "Pan + zoom with mouse",
+        "Empty state: if user has 0 pages, show 'Add and compile some content to start growing your graph'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: with seeded pages + links, navigate to /wiki and switch to Graph mode, see nodes"
+      ],
+      "priority": 34,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-035",
+      "title": "Wave 7a: Embedding pipeline 升级 + RAG retrieval helper",
+      "description": "As a developer, I need a robust retrieval function so chat can find relevant pages.",
+      "acceptanceCriteria": [
+        "Create web/src/lib/ai/rag.ts exporting retrievePages(userId, queryText, opts:{topK=8, domain?, excludePrivate=true})",
+        "Embed query via DashScope text-embedding-v3",
+        "Vector search pages.embedding using pgvector cosine similarity (HNSW index)",
+        "Add HNSW index on pages.embedding via migration",
+        "Return [{page_id, slug, title, type, body_md, score}], filtered by user_id and not deleted",
+        "If page.private=true, exclude unless opts.includePrivate",
+        "Typecheck passes",
+        "Tests pass: seed pages with known content, query, verify expected page returned with reasonable score"
+      ],
+      "priority": 35,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-036",
+      "title": "Wave 7b: Chat thread API (POST/GET /api/chat/threads)",
+      "description": "As a user, I want chat thread persistence so my conversations are saved.",
+      "acceptanceCriteria": [
+        "POST /api/chat/threads creates new thread {id, title:'New conversation', status:'active'}",
+        "GET /api/chat/threads lists user's threads ordered by updated_at desc, with optional status filter",
+        "GET /api/chat/threads/:id returns thread + messages array",
+        "PATCH /api/chat/threads/:id updates title or status",
+        "DELETE /api/chat/threads/:id soft-deletes",
+        "Auto-title: when first user message sent, schedule a small qwen call to summarize into <60 char title; update thread.title",
+        "Typecheck passes",
+        "Tests pass: create + list + scope isolation"
+      ],
+      "priority": 36,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-037",
+      "title": "Wave 7c: Chat send message API with SSE streaming",
+      "description": "As a user, I want chat answers to stream in real-time so I see progress.",
+      "acceptanceCriteria": [
+        "POST /api/chat/threads/:id/messages with {content} as SSE stream response (text/event-stream)",
+        "Step 1: write user message to chat_messages",
+        "Step 2: call retrievePages(userId, content, topK=8)",
+        "Step 3: build prompt with system instruction (cite with {n} format only, refuse if no context, never invent), user message, references",
+        "Step 4: call DashScope qwen-plus with stream=true; for each chunk emit SSE {type:'token', content:chunk}",
+        "Step 5: after stream end, parse {n} citation tokens, validate each n maps to a retrieved page; emit {type:'done', citations:[...], message_id}",
+        "Step 6: write assistant message to chat_messages with content + citations + tokens_in/out",
+        "Step 7: enforce per-user 100k tokens/day limit; reject 429 if exceeded",
+        "Typecheck passes",
+        "Tests pass: mock qwen stream, verify SSE events flow + citations parsed correctly"
+      ],
+      "priority": 37,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-038",
+      "title": "Wave 7d: Chat view UI (thread list + thread detail + composer)",
+      "description": "As a user, I want a complete chat interface matching Codex design.",
+      "acceptanceCriteria": [
+        "Update web/src/app/(app)/chat/page.tsx: shows thread list (left) + 'Select a conversation or start new' empty state",
+        "Create /(app)/chat/[id]/page.tsx with chat layout: main thread + 280px references sidebar matching Codex visual",
+        "Render messages: user (right-aligned) + assistant (left-aligned with role label)",
+        "Citation tokens {n} render as clickable .cite badges",
+        "Click .cite badge highlights matching reference card in right sidebar",
+        "Composer: textarea with Enter=send, Shift+Enter=newline + Send button",
+        "On send, POST to /api/chat/threads/:id/messages + consume SSE stream; tokens append to assistant bubble in real-time",
+        "Right sidebar: References list showing each cited page (number + type + title + excerpt); click → open page in new tab",
+        "Save as synthesis page button (no-op for now, wire in later wave)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: create thread, ask question against seeded pages, watch streaming answer + reference cards"
+      ],
+      "priority": 38,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-039",
+      "title": "Wave 7e: Suggested follow-ups + I-don't-know fallback",
+      "description": "As a user, I want suggested next questions and honest 'I don't know' answers.",
+      "acceptanceCriteria": [
+        "After assistant message complete, fire a 2nd lightweight qwen call with prompt at suggested-followups.md (input: thread context, output: 3 short questions)",
+        "Render 3 chips below assistant message; click → fills composer + sends",
+        "If retrievePages returns 0 results OR all scores < 0.4 threshold, skip LLM call and write canned assistant message: 'I don't know yet — try adding content about <topic> first.' + suggested 'Add' link",
+        "System prompt enforces: any sentence without {n} citation must be wrapped in italic + tagged [uncited]",
+        "Typecheck passes",
+        "Tests pass: verify low-score query returns I-don't-know without LLM call"
+      ],
+      "priority": 39,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-040",
+      "title": "Wave 8a: Conflict detection 集成到 compile-memo FULL 步骤",
+      "description": "As a user, I want the system to detect contradictions between new content and existing pages.",
+      "acceptanceCriteria": [
+        "In compile-memo FULL step, after recall, run a conflict-check sub-prompt: given new memo body + top-3 retrieved pages, ask qwen 'are there any factual contradictions? respond with JSON {conflicts: [{page_id, old_text, new_text, summary}]}'",
+        "For each detected conflict, write inbox_items row with kind='contradiction', payload={old_text, new_text, page_id, memo_id}",
+        "Add inbox row title='Two takes on <topic>' (qwen-generated)",
+        "Inbox badge in sidebar updates (already wired)",
+        "Typecheck passes",
+        "Tests pass: seed page with statement, submit memo with contradicting statement, verify inbox_item created"
+      ],
+      "priority": 40,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-041",
+      "title": "Wave 8b: Schema detection worker (cluster suggestion → inbox)",
+      "description": "As a user, I want the system to suggest new domains when it sees a clear cluster of related memos.",
+      "acceptanceCriteria": [
+        "Create inngest function 'schema-detect' triggered every 50 new memos per user (use a counter table or modulo on new_memo event)",
+        "Fetch user's last 200 memos with embeddings",
+        "Run HDBSCAN clustering (use 'density-clustering' npm pkg or simple kNN-based clustering since we don't need full HDBSCAN at first)",
+        "Identify clusters of >=8 memos NOT already mapped to existing domain",
+        "For each unmapped cluster, call qwen with cluster's memo titles to suggest a domain name",
+        "Write inbox_item kind='schema' with payload={cluster_memo_ids, suggested_name, suggested_color}",
+        "Idempotent: same cluster signature in last 7 days does not re-suggest",
+        "Typecheck passes",
+        "Tests pass: seed 10 memos all about 'distributed systems', run function, verify inbox_item with suggested name"
+      ],
+      "priority": 41,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-042",
+      "title": "Wave 8c: Cold storage detection cron",
+      "description": "As a user, I want suggestions to archive pages I haven't touched in 90+ days.",
+      "acceptanceCriteria": [
+        "Create inngest scheduled function 'orphan-detect' running daily at 04:00 UTC",
+        "For each user, find pages with last_compiled_at + 90 days < now AND backlink_count = 0 AND not recently viewed (need to add page_views table or use updated_at)",
+        "For each such page, write inbox_item kind='orphan' with payload={page_id, page_title, days_idle}",
+        "Cap: max 5 orphan suggestions per user per day to avoid spam",
+        "Idempotent: skip pages already in open inbox_item",
+        "Typecheck passes",
+        "Tests pass: seed page with old timestamps, run function, verify inbox_item created"
+      ],
+      "priority": 42,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-043",
+      "title": "Wave 8d: Observer agent daily worker + Home observations card",
+      "description": "As a user, I want the system to surface 'what it noticed' on Home so AI feels alive.",
+      "acceptanceCriteria": [
+        "Create inngest scheduled function 'observer-scan' running daily at 03:00 UTC per user",
+        "Aggregate signals: cluster growth (>=3x in past week), new entity emerged (>=3 mentions), dormant topic (no activity in 30d but has many backlinks), unresolved contradiction count",
+        "For each non-trivial signal, call qwen to write a 2-paragraph observation in user-facing prose, with 2-3 action button labels",
+        "Save to a new observations table (uuid, user_id, lead, body, actions jsonb, created_at, dismissed_at)",
+        "Cap: max 2 new observations per user per scan",
+        "Update GET /api/observations endpoint returning latest undismissed observations",
+        "Update Home view to render top 2 observations in 'What the system noticed' Card (already designed in Codex)",
+        "Each observation has Dismiss button (PATCH sets dismissed_at)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: insert a test observation row via SQL, see it on Home"
+      ],
+      "priority": 43,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-044",
+      "title": "Wave 8e: Inbox view UI + filter chips + contradiction old/new compare",
+      "description": "As a user, I want to triage AI suggestions in a dedicated inbox view.",
+      "acceptanceCriteria": [
+        "Update /(app)/inbox/page.tsx",
+        "Render section label 'Inbox · N items' + headline + sub",
+        "5 filter chips: All / Contradictions / Schema / Orphans / Compiled (count beside each)",
+        "Each card: kind chip + time + title + body + actions row",
+        "CONTRADICTION cards include side-by-side old/new compare panes matching Codex visual",
+        "SCHEMA cards include suggested domain name + color preview",
+        "ORPHAN cards include 'days idle' meta",
+        "COMPILED cards include 'view changes' link",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: seed each kind via SQL, navigate to /inbox, see cards correctly rendered"
+      ],
+      "priority": 44,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-045",
+      "title": "Wave 8f: Inbox 处理 actions + snooze/dismiss",
+      "description": "As a user, I want to act on inbox items so the suggestion gets resolved.",
+      "acceptanceCriteria": [
+        "POST /api/inbox/:id/resolve with {action: string, payload?: any} writes inbox_items.status='resolved' + resolution + executes the action (e.g. for SCHEMA accept: create domain row + assign cluster memos)",
+        "POST /api/inbox/:id/dismiss sets status='dismissed'",
+        "POST /api/inbox/:id/snooze with {until: timestamp} sets status='snoozed' + a snooze_until column",
+        "Snoozed items reappear when current time > snooze_until (handled by cron or query filter)",
+        "Inbox card actions: CONTRADICTION 4 buttons (Keep both / Use new / Keep mine / Open both pages); SCHEMA 3 buttons (Create page / Suggest different name / Not yet); ORPHAN 3 buttons (Cold-archive / Keep / Open page); COMPILED 2 buttons (View changes / Dismiss)",
+        "Each card has '...' menu with Snooze 1d / Snooze 1w / Dismiss / Resolve as...",
+        "After action, card disappears with fade animation + sidebar badge updates",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: seed contradiction, click 'Use new', confirm card disappears + badge decrements"
+      ],
+      "priority": 45,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-046",
+      "title": "Wave 9a: Agent permissions schema + Settings → Agent page",
+      "description": "As a user, I want to control which AI actions are allowed.",
+      "acceptanceCriteria": [
+        "Add agent_permissions jsonb column to users.settings or new agent_permissions table",
+        "8 action keys per PRD V5 §7.2: ACT-1 auto_tag_domain, ACT-2 auto_archive_cold, ACT-3 auto_merge_entities, ACT-4 auto_promote_drafts, ACT-5 auto_fetch_external, ACT-6 auto_weekly_recap, ACT-7 auto_cross_link, ACT-8 auto_send_digest",
+        "Defaults: ACT-1, ACT-6, ACT-8 = ON; rest = OFF",
+        "Create web/src/app/(app)/settings/agent/page.tsx with toggle list",
+        "Each toggle: label + risk badge (low/med) + 1-line description + switch",
+        "PATCH /api/settings/agent updates permissions",
+        "Add 'Pause all AI agents' kill-switch toggle at top",
+        "When kill-switch on, all Actor functions check this and skip work",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: open /settings/agent, toggle ACT-3, refresh, confirm persisted"
+      ],
+      "priority": 46,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-047",
+      "title": "Wave 9b: Agent audit log + change_log + Undo API",
+      "description": "As a user, I want to see what AI did and undo any action.",
+      "acceptanceCriteria": [
+        "Ensure change_log table exists (id, user_id, action_kind, target_type, target_id, before jsonb, after jsonb, reason, performed_by enum:'user'|'agent', agent_action_id text, created_at)",
+        "Every page/entity/link mutation writes a change_log row before applying",
+        "Create web/src/app/(app)/settings/activity/page.tsx fetching /api/activity-log paginated",
+        "Filter chips: All / by action_kind / by performed_by",
+        "Each row has Undo button (POST /api/activity-log/:id/undo) which applies before state",
+        "Undo only works if no later mutation depends on this state (else show 'Cannot undo: 2 newer changes depend on this')",
+        "Typecheck passes",
+        "Tests pass: seed change_log entries, undo a page update, verify before state restored"
+      ],
+      "priority": 47,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-048",
+      "title": "Wave 9c: Agent safety 6 重栅栏完整实施",
+      "description": "As a system, I need all 6 safety guards enforced so Actor agents never run wild.",
+      "acceptanceCriteria": [
+        "Guard 1: All Actor functions read user.agent_permissions before running; skip if not authorized",
+        "Guard 2: All Actor + Observer mutations write change_log + activity rows",
+        "Guard 3: Undo path verified working in US-047",
+        "Guard 4: Add notification_throttle table (user_id, kind, count, window_start); inbox creators check 'sent <=3 of this kind in last 24h' before creating",
+        "Guard 5: Add helper isUserSleepWindow(userId) checking user's timezone (default UTC) is between 22:00-08:00; push notification senders skip if true",
+        "Guard 6: Settings → Agent page kill-switch (already in US-046); when on, ALL Actor + observation functions early-return",
+        "Add web/src/lib/agent/guards.ts as central enforcement helper",
+        "Typecheck passes",
+        "Tests pass: each guard has a unit test verifying skip behavior"
+      ],
+      "priority": 48,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-049",
+      "title": "Wave 9d: ACT-1 Auto-tag domain 实现 + ACT-6 Weekly recap 实现",
+      "description": "As a user with default permissions, I want my new memos to get auto-tagged and a weekly digest.",
+      "acceptanceCriteria": [
+        "ACT-1: in compile-memo function 'apply' step, if user.agent_permissions.auto_tag_domain && memo has no domain, find best-matching domain (vector match on memo embedding vs domain centroid embeddings, threshold >0.6) and set memo.domain_id",
+        "ACT-6: create inngest scheduled function 'weekly-recap' running Sundays 18:00 user-local-time (use user.timezone or UTC)",
+        "Aggregate week's memos + new pages + locations + activity, call qwen with weekly-recap.md prompt",
+        "Save as page (type='synthesis', slug='recap/weekly/YYYY-WNN', status='draft')",
+        "Send web push notification (if device registered) and email digest if user.agent_permissions.auto_send_digest (ACT-8)",
+        "Both ACT-1 and ACT-6 write change_log + activity rows",
+        "Typecheck passes",
+        "Tests pass: ACT-1 assigns correct domain; ACT-6 creates draft recap page"
+      ],
+      "priority": 49,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-050",
+      "title": "Wave 9e: 收尾 — sidebar inbox badge live update via SSE + global SSE auth + smoke test",
+      "description": "As a user, I want sidebar badges and inbox to update in real-time across the app.",
+      "acceptanceCriteria": [
+        "Create /api/stream/global SSE endpoint: emits {type:'inbox_added'|'inbox_resolved'|'compile_done', payload}",
+        "Sidebar component subscribes; badge count increments/decrements live",
+        "Inbox view subscribes; new items appear at top with fade-in",
+        "Home observations subscribes; new card slides in",
+        "Verify SSE auth: invalid session returns 401 immediately; expired session closes connection cleanly",
+        "Run full smoke test: log in, submit a memo, watch (a) compile queue progress (b) new page appear in wiki nav (c) sidebar inbox badge if conflict detected (d) home observation if signal triggered",
+        "Document smoke test as docs/web/SMOKE-TEST.md with steps",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: run the documented smoke test end-to-end and confirm all 4 reactive updates work"
+      ],
+      "priority": 50,
+      "passes": false,
+      "notes": ""
     }
   ]
 }

--- a/scripts/ralph/archive/2026-05-10-today-composer-liquid/prd.json
+++ b/scripts/ralph/archive/2026-05-10-today-composer-liquid/prd.json
@@ -1,0 +1,331 @@
+{
+  "project": "DayPage",
+  "branchName": "ralph/today-composer-liquid-refinement",
+  "description": "Today 主页极简优雅重塑 + Composer 3.0 Liquid Composition Surface — 整合 issue #252 + #250: 删 GlassTabBar, AmbientBackground 纯化, Day Orb 收敛, 空数据回退栈, i18n 修复 + L10n.swift, composerState 状态机, Liquid Morph, 5 形态 Adaptive Send, keyboard-attached toolbar, drag handle, 5 级 haptics, Context Spotlight Strip, Smart Templates, Lens Strip, Caret Spotlight, Status Strip",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "i18n 资源彻查：lproj target membership + L10n.swift 强类型枚举",
+      "description": "As a 用户, I want 主页文案显示中文/英文翻译而非原始 key, so that 截图不再出现 'empty.today.no_signals.title' 这类暴露字符串.",
+      "acceptanceCriteria": [
+        "Xcode DayPage target Build Phases Copy Bundle Resources 包含 zh-Hans.lproj 和 en.lproj",
+        "Xcode Project Localizations 启用 Chinese (Simplified) 与 English",
+        "Info.plist 含 CFBundleDevelopmentRegion=zh-Hans 与 CFBundleLocalizations=[zh-Hans, en]",
+        "新增 DayPage/Resources/L10n.swift 提供 L10n.Empty.todayNoSignalsTitle 强类型访问器",
+        "EmptyStateView.todayNoSignals() 改用 L10n.Empty.* 而非裸字面量",
+        "中英文系统语言切换后 hero 下方文案正确变化",
+        "grep -rn 'LocalizedStringKey(\"' DayPage/ 输出为 0 (除 L10n.swift)",
+        "xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build 通过",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-002",
+      "title": "AmbientBackground 纯化：删 4 团暖色光斑，默认仅 cream 底",
+      "description": "As a 用户, I want 主页背景接近纯色奶油纸感, so that 视觉锚点回到字本身, 不再像 AI 演示稿.",
+      "acceptanceCriteria": [
+        "DayPage/DesignSystem/GlassSurface.swift AmbientBackground 默认仅渲染 DSColor.bgWarm (FAF7F2)",
+        "4 团 amber blob 用 @AppStorage('debug.ambientBlobs') 包起来, 默认 false",
+        "TodayView, DailyPageView, MemoDetailView 显式不传开关, 使用默认纯色行为",
+        "iPhone 17 Simulator 截图与改动前并排饱和度肉眼明显下降",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-003",
+      "title": "Day Orb 收敛：size 140pt + halo opacity 0.15 + orbFill ×0.5",
+      "description": "As a 用户, I want Day Orb 从中央巨大琥珀球变为纸上一枚轻晕, so that serif 日期 'Friday MAY 8' 成为视觉主角.",
+      "acceptanceCriteria": [
+        "DayPage/Features/Today/DayOrbView.swift halo 透明度从 0.4 改为 0.15",
+        "orbFill gradient stops 透明度全部 ×0.5",
+        "DayOrbView 暴露 size: CGFloat = 140 与 haloOpacity: CGFloat = 0.15 参数",
+        "TodayView 调用处显式传 size: 140",
+        "呼吸动画幅度 ×0.7",
+        "iPhone 17 Simulator 截图与改动前并排 orb 明显收敛",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": "依赖 US-002 (AmbientBackground 纯化先落地)"
+    },
+    {
+      "id": "US-004",
+      "title": "删除 GlassTabBar，账号头像迁入设置 sheet，右上仅留齿轮",
+      "description": "As a 用户, I want 顶部不再出现 [Today ▾] pill 和琥珀色头像, so that 整页只有 sidebar 一套导航语言, 视觉一致.",
+      "acceptanceCriteria": [
+        "删除 DayPage/Components/GlassTabBar.swift",
+        "从 RootView.swift / TodayView.swift / AppNavigationModel.swift 中移除所有 GlassTabBar / AppTab 引用",
+        "TodayView 顶部账号头像 (36pt 实心琥珀圆) 移除, 账号入口移到设置 sheet 顶部",
+        "TodayView 顶部右侧仅保留齿轮按钮 (28pt 玻璃圆)",
+        "Archive / Graph 切换通过 sidebar 完成, 回归 path 无歧义",
+        "grep -rn 'GlassTabBar' DayPage/ 输出为 0",
+        "xcodebuild build 通过",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 4,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-005",
+      "title": "TodayViewModel 新增 TodayFallback 枚举与 fallbackContent 计算属性",
+      "description": "As a 开发者, I want TodayViewModel 暴露 fallback 内容选择, so that TodayView 在今日 0 memo 时能按优先级渲染存量内容卡.",
+      "acceptanceCriteria": [
+        "TodayViewModel 新增 enum TodayFallback { case yesterdayDailyPage(DailyPage), onThisDay([Memo]), weekRecap(WeekStats), pureEmpty }",
+        "TodayViewModel.fallbackContent: TodayFallback 计算属性按 yesterdayDailyPage > onThisDay > weekRecap > pureEmpty 优先级返回",
+        "优先级硬编码不可配置",
+        "新增 DayPageTests/TodayViewModelTests.swift 覆盖 4 种 fallback 状态",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 5,
+      "passes": false,
+      "notes": "依赖 US-001 (i18n 修复, 否则 fallback 文案也会暴露 key)"
+    },
+    {
+      "id": "US-006",
+      "title": "复活 OnThisDayCard 与 WeeklyRecapSection，TodayView 接入 fallback 渲染",
+      "description": "As a 用户, I want 即使今天没记, 主页也能展示昨日 Daily Page / On This Day / 本周回顾中的一张引子卡, so that Today 主页永不空白.",
+      "acceptanceCriteria": [
+        "TodayView 在 memos.isEmpty && !isLoading 时按 viewModel.fallbackContent 渲染对应卡",
+        "yesterdayDailyPage 复用 DailyPageEntryCard",
+        "onThisDay 复用 OnThisDayCard.swift (复活当前禁用引用)",
+        "weekRecap 复活 WeeklyRecapSection.swift 并接入",
+        "pureEmpty 仅显示 hero 下方一句小字 (不再独占整屏)",
+        "三种 fallback 卡点击行为: 昨日卡进入 DailyPageView, OnThisDay 进入 MemoDetailView, WeekRecap 进入 ArchiveView 周模式",
+        "原 EmptyStateView.todayNoSignals() 退化为单行小字",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 6,
+      "passes": false,
+      "notes": "依赖 US-005 (fallbackContent 计算属性)"
+    },
+    {
+      "id": "US-007",
+      "title": "InputBarV4 引入 ComposerState 状态机替换 userExpandedText",
+      "description": "As a 开发者, I want 用 composerState: .idle / .expanding / .open / .collapsing 替换 userExpandedText: Bool, so that 12 个签名时刻中过渡那一拍能被精确控制.",
+      "acceptanceCriteria": [
+        "InputBarV4.swift 新增 enum ComposerState: Equatable { case idle, expanding, open, collapsing }",
+        "删除 userExpandedText: Bool, 所有引用迁移到 state == .open || state == .expanding",
+        "状态转移函数 transition(to: ComposerState) 集中管理, 每次转移触发对应 haptic 与 animation",
+        "expanding / collapsing 持续时间 = .spring(response: 0.42, dampingFraction: 0.78)",
+        ".expanding / .collapsing 期间禁止接受新的状态切换 (防抖)",
+        "新增 DayPageTests/ComposerStateMachineTests.swift 覆盖所有合法/非法转移",
+        "xcodebuild build 通过",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 7,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-008",
+      "title": "Liquid Morph: idle 玻璃胶囊 matchedGeometryEffect 生长成 composition card",
+      "description": "As a 用户, I want 从 idle 三槽胶囊到 composing 卡片看到形态延续而非两个 view 切换, so that 切换有仪式感.",
+      "acceptanceCriteria": [
+        "用 matchedGeometryEffect(id: 'composer.surface', in: namespace) 把 idle 胶囊 morph 成 composing 圆角矩形",
+        "麦克风 orb 不消失: 64x64 缩到 28x28 并左移到卡片左下角作为切回语音入口",
+        "Aa 按钮淡出 = TextField caret 淡入 (同位置交叉淡入 200ms)",
+        "整段动画 .spring(response: 0.42, dampingFraction: 0.78)",
+        "动画起点触发 UIImpactFeedbackGenerator(.soft)",
+        "录屏验证任意一帧截图取出来形状都能解释从哪来",
+        "Reduced Motion 开启时降级为简单 fade (0.2s)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 8,
+      "passes": false,
+      "notes": "依赖 US-007 (ComposerState 状态机)"
+    },
+    {
+      "id": "US-009",
+      "title": "Adaptive Send Affordance：发送按钮 5 形态 (空/文本/文本+图/位置/多模态)",
+      "description": "As a 用户, I want 发送按钮根据 draft 形态变形, so that 我能从图形上读出现在发送会做什么.",
+      "acceptanceCriteria": [
+        "空态: 浅色 mic.fill 圆环 (柔光呼吸 1.6s/cycle), accessibilityLabel='按住说'",
+        "仅文本态: 实心琥珀 arrow.up, accessibilityLabel='发送'",
+        "文本+照片态: camera.fill + arrow.up 复合, accessibilityLabel='记下这一刻'",
+        "仅位置态: mappin.and.arrow.up, accessibilityLabel='标记此处'",
+        "多模态态: 琥珀 ring 带光晕脉动 (1.6s), accessibilityLabel='发送 N 项'",
+        "空态明确不再用 18% 透明琥珀圆",
+        "形态切换 .spring(response: 0.32, dampingFraction: 0.8)",
+        "VoiceOver 朗读对应 label",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 9,
+      "passes": false,
+      "notes": "依赖 US-007 (ComposerState 状态机)"
+    },
+    {
+      "id": "US-010",
+      "title": "Composer 工具栏迁移到 keyboard-attached (.toolbar placement: .keyboard)",
+      "description": "As a 用户, I want 工具栏跟键盘一起浮起, so that 不再形成键盘+工具栏双层堆叠.",
+      "acceptanceCriteria": [
+        "工具栏迁移到 .toolbar { ToolbarItemGroup(placement: .keyboard) { ... } }",
+        "卡片本体停在画面中段, 下方可见 timeline (带 vignette 渐隐遮罩)",
+        "键盘收起时工具栏跟随消失, 无残留高度占位",
+        "iPad 横屏键盘工具栏不溢出",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 10,
+      "passes": false,
+      "notes": "依赖 US-007"
+    },
+    {
+      "id": "US-011",
+      "title": "Drag-to-Collapse Handle: 卡片顶 36x4 capsule 上滑收起",
+      "description": "As a 用户, I want 卡片顶边一个 36x4 capsule handle 上滑可收起, so that 与 iOS sheet 语言一致.",
+      "acceptanceCriteria": [
+        "卡片顶部居中 36x4 灰色 capsule",
+        "上滑距离 > 32pt 触发 transition(to: .collapsing) 然后回 .idle",
+        "单击 handle 等价上滑 (accessibility)",
+        "折叠动画与 morph 反向播放",
+        "折叠触发 .medium impact",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 11,
+      "passes": false,
+      "notes": "依赖 US-007 + US-008"
+    },
+    {
+      "id": "US-012",
+      "title": "Haptics.swift 扩展 5 级触感阶梯并接入 Composer 流程",
+      "description": "As a 用户, I want 不同动作触发不同强度的触感, so that Composer 有材质感.",
+      "acceptanceCriteria": [
+        "DayPage/DesignSystem/Haptics.swift 暴露 5 级 API: .soft / .rigid(intensity:) / .medium / .light / .success / .warning",
+        "点 dock 任意键触发 .soft impact",
+        "Caret 首次出现 0.15s 延迟后触发 .rigid 0.3 强度",
+        "添加附件触发 .medium",
+        "删除附件触发 .light",
+        "发送成功触发 .success notification",
+        "录音太短/错误触发 .warning notification",
+        "至少 4 级在 Composer 流程中被实际触发",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 12,
+      "passes": false,
+      "notes": "可并行于 US-007 ~ US-011"
+    },
+    {
+      "id": "US-013",
+      "title": "ComposerContextProvider 服务：聚合 Weather/Location/lastMemo/Pasteboard",
+      "description": "As a 开发者, I want 一个 ComposerContextProvider 聚合所有上下文源, so that Spotlight Strip 能拿到统一的 chip 数据.",
+      "acceptanceCriteria": [
+        "新增 DayPage/Services/ComposerContextProvider.swift @MainActor final class",
+        "整合 WeatherService / LocationService / viewModel.memos.last / UIPasteboard.general",
+        "暴露 var chips: [ContextChip] 计算属性",
+        "ContextChip 类型: .weather(temp, condition) / .location(short) / .timeRitual(emoji, text) / .lastMemoTail(snippet) / .smartPaste(value)",
+        "lastMemoTail 计算缓存 60s 避免重复读 vault",
+        "新增 DayPageTests/ComposerContextProviderTests.swift",
+        "Typecheck passes",
+        "Tests pass"
+      ],
+      "priority": 13,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-014",
+      "title": "Context Spotlight Strip: TextField 上方横向 chip 带",
+      "description": "As a 用户, I want TextField 上方一条横向 chip 带显示天气/位置/上一条尾巴/智能粘贴, so that 空 Composer 也有现在写什么的引子.",
+      "acceptanceCriteria": [
+        "Spotlight Strip 横向滚动, 每个 chip 28pt 高, 玻璃材质",
+        "数据源走 ComposerContextProvider.chips",
+        "点击 chip 对应内容塞入 draft (位置塞 Memo.Location, 时间塞 prompt, 上一条尾巴塞引用块, 剪贴板塞文本)",
+        "触摸软触感 .soft 0.4",
+        "空 Composer 至少 3 条 chip",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 14,
+      "passes": false,
+      "notes": "依赖 US-013"
+    },
+    {
+      "id": "US-015",
+      "title": "Smart Templates: 12 条时段模板 hardcode",
+      "description": "As a 用户, I want 空 Composer 显示 1 行时段模板, so that 我能一键得到今天怎么写的引子.",
+      "acceptanceCriteria": [
+        "12 条 hardcode 模板按时段映射: 06-11 晨/今天/醒来; 11-17 刚才/中午/想法; 17-22 最某刻/总结/明天; 22-06 回看/未完/梦",
+        "仅在 text.isEmpty && pendingAttachments.isEmpty 时显示",
+        "点击 模板文字塞入 TextField, placeholder 高亮 (.foregroundStyle(.secondary))",
+        "caret 定位到 placeholder 起点",
+        "用户开始打字后 placeholder 消失",
+        "不引入配置文件 / 设置项",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 15,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-016",
+      "title": "Inline Lens Strip: 最近 4 张照片缩略图 (懒加载相册权限)",
+      "description": "As a 用户, I want TextField 下方一条 56x56 圆角缩略图带, so that 我能一键附加最近 24h 内的照片, 无需跳 PhotosPicker.",
+      "acceptanceCriteria": [
+        "第一次展开 Composer 时 prompt PHPhotoLibrary.requestAuthorization(for: .readWrite)",
+        "拒绝权限后 Strip 隐藏, 不再 prompt (用 @AppStorage('composer.photoPermissionAsked') 标记)",
+        "显示最近 24h 内 4 张缩略图, 按时间倒序",
+        "点击缩略图 直接附加到 pendingAttachments, 不跳 sheet",
+        "缩略图加载用 PHCachingImageManager 避免卡顿, 分辨率 <= 168x168",
+        "无最近照片时 Strip 隐藏 (不显示空态)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 16,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-017",
+      "title": "Caret Spotlight + Ambient Dim: focus 时背景暗 20%, 卡背 RadialGradient",
+      "description": "As a 用户, I want focus 时背景变暗 20% 同时卡片背后泛起暖白射灯, so that 写作仪式感拉满.",
+      "acceptanceCriteria": [
+        "focus 进入时 AmbientBackground 整体透明度 0.8",
+        "Composer 卡片背后 RadialGradient (中心 caret 位置, 半径 240pt, 暖白 0.12 opacity)",
+        "现有 BreathingCaretView 保留并接入",
+        "focus 退出反向动画 0.4s",
+        "Reduced Motion 开启时禁用 dim, 仅静态对比",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 17,
+      "passes": false,
+      "notes": "依赖 US-002 (AmbientBackground 已纯化)"
+    },
+    {
+      "id": "US-018",
+      "title": "Status Strip: 卡片顶 12pt mono 行 DRAFTING · N PHOTOS · LOC · age",
+      "description": "As a 用户, I want 卡片顶部一行 12pt mono 显示状态副标, so that 我能看到 Composer 的实时状态.",
+      "acceptanceCriteria": [
+        "字段顺序: <state> · <attachment count> · <location short> · <draft age>",
+        "状态枚举: DRAFTING / SENDING / SENT / ERROR",
+        "发送成功 1.2s 内显示 SENT 然后整个 Composer 折叠回 idle dock",
+        "字体 JetBrains Mono 12pt (已注册)",
+        "XXLarge+ Dynamic Type 时省略 location 字段",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
+      ],
+      "priority": 18,
+      "passes": false,
+      "notes": "依赖 US-007 (state) + US-013 (location 来源)"
+    }
+  ]
+}

--- a/scripts/ralph/archive/2026-05-10-today-composer-liquid/progress.txt
+++ b/scripts/ralph/archive/2026-05-10-today-composer-liquid/progress.txt
@@ -1,0 +1,47 @@
+# Ralph Progress Log
+Started: Fri May  8 12:55:00 UTC 2026
+Branch: ralph/today-composer-liquid-refinement
+PRD: tasks/prd-today-composer-liquid-refinement.md
+Issues: getyak/daypage#252 (Today 主页极简) + #250 (Composer 3.0 Liquid Composition)
+---
+
+## Codebase Patterns
+
+### 沿用 v4 Liquid Glass 的既有模式
+- Motion tokens live in DayPage/DesignSystem/Motion.swift; always use Motion.fade/rise/slide/spring instead of raw animation values
+- Haptics tokens live in DayPage/DesignSystem/Haptics.swift; use Haptics.tapConfirm/commit/warn/success instead of UIImpactFeedbackGenerator directly
+- Glass surfaces in DayPage/DesignSystem/Surfaces.swift; use .liquidGlassCard/.liquidGlassPill/.liquidGlassPanel modifiers
+- DSFonts.serif(size:weight:italic:) returns cascading Latin→CJK font; never use DSFonts.newYork (deprecated)
+- CJKTextPolish.polish() is render-only; never apply before persisting to vault/raw/
+- NavigationStack with navigationDestination(for: Memo.ID.self) in TodayView drives all memo detail navigation
+- SwipeableMemoCard uses NavigationLink(value: memo.id) + .disabled(revealedSide != nil) to prevent push when swiped
+- GlassErrorBanner managed by ErrorBannerManager singleton; post via ErrorBannerManager.shared.post(...)
+- EmptyStateView has factory methods: .todayBlank(), .todayNoSignals(), .compileLocked(currentCount:), .archiveDayEmpty(), .micPermissionDenied()
+- DayOrbView lives in DayPage/Features/Today/DayOrbView.swift; takes signalCount: Int, size: CGFloat = 140, haloOpacity: CGFloat = 0.15
+- DailyPageMemoVM: lightweight MemoDetailViewModel for archive dates; follows same rewrite() pattern as TodayViewModel
+- MemoDetailView accepts `any MemoDetailViewModel` (protocol); both TodayViewModel and DailyPageMemoVM conform
+
+### 本轮新增的硬性规则
+- 删除文件前必须 `grep -rn '<SymbolName>' DayPage/` 确认无残留引用
+- 修改 i18n key 必须同时更新 zh-Hans.lproj 和 en.lproj 两份
+- 状态机转移函数禁止抛错；非法转移用 assert + log 兜底
+- 所有 Composer 动画必须支持 Reduced Motion 降级（fade-only 0.2s）
+- iPhone 17 Simulator 是默认验证机型；任何 UI 改动必须 `xcodebuild -destination 'platform=iOS Simulator,name=iPhone 17' build` 通过
+
+---
+[2026-05-08T06:43:53Z] Story #US-001: i18n 资源彻查：lproj target membership + L10n.swift 强类型枚举 — PASSED
+[2026-05-08T06:44:37Z] Story #US-002: AmbientBackground 纯化：删 4 团暖色光斑，默认仅 cream 底 — PASSED
+[2026-05-08T07:10:00Z] Story #US-003: Day Orb 收敛：size 140pt + halo opacity 0.15 + orbFill ×0.5 — PASSED
+[2026-05-08T06:45:47Z] Story #US-003: Day Orb 收敛：size 140pt + halo opacity 0.15 + orbFill ×0.5 — PASSED
+[2026-05-08T06:47:37Z] Story #US-004: 删除 GlassTabBar，账号头像迁入设置 sheet，右上仅留齿轮 — PASSED
+[2026-05-08T06:50:13Z] Story #US-005: TodayViewModel 新增 TodayFallback 枚举与 fallbackContent 计算属性 — PASSED
+[2026-05-08T06:53:35Z] Story #US-006: 复活 OnThisDayCard 与 WeeklyRecapSection，TodayView 接入 fallback 渲染 — PASSED
+[2026-05-08T06:55:59Z] Story #US-007: InputBarV4 引入 ComposerState 状态机替换 userExpandedText — PASSED
+[2026-05-08T06:59:54Z] Story #US-008: Liquid Morph: idle 玻璃胶囊 matchedGeometryEffect 生长成 composition card — PASSED
+[2026-05-08T07:04:02Z] Story #US-009: Adaptive Send Affordance：发送按钮 5 形态 (空/文本/文本+图/位置/多模态) — PASSED
+[2026-05-08T07:08:55Z] Story #US-010: Composer 工具栏迁移到 keyboard-attached (.toolbar placement: .keyboard) — PASSED
+[2026-05-08T07:11:56Z] Story #US-011: Drag-to-Collapse Handle: 卡片顶 36x4 capsule 上滑收起 — PASSED
+[2026-05-08T07:14:13Z] Story #US-012: Haptics.swift 扩展 5 级触感阶梯并接入 Composer 流程 — PASSED
+[2026-05-08T07:17:14Z] Story #US-013: ComposerContextProvider 服务：聚合 Weather/Location/lastMemo/Pasteboard — PASSED
+[2026-05-08T07:20:22Z] Story #US-014: Context Spotlight Strip: TextField 上方横向 chip 带 — PASSED
+[2026-05-08T07:23:05Z] Story #US-015: Smart Templates: 12 条时段模板 hardcode — PASSED

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -1,23 +1,19 @@
 {
-  "project": "DayPage",
-  "branchName": "ralph/today-composer-liquid-refinement",
-  "description": "Today 主页极简优雅重塑 + Composer 3.0 Liquid Composition Surface — 整合 issue #252 + #250: 删 GlassTabBar, AmbientBackground 纯化, Day Orb 收敛, 空数据回退栈, i18n 修复 + L10n.swift, composerState 状态机, Liquid Morph, 5 形态 Adaptive Send, keyboard-attached toolbar, drag handle, 5 级 haptics, Context Spotlight Strip, Smart Templates, Lens Strip, Caret Spotlight, Status Strip",
+  "project": "DayPage V5 Codex",
+  "branchName": "ralph/v5-codex-web",
+  "description": "DayPage V5 终极形态第一阶段：Web (Codex) 骨架 + 后端 API + AI 编译引擎 + Agent 主动行动。覆盖 PRD V5 的 Wave 0-9（Web 端可用 + Agent 可受控行动）。源 PRD: tasks/prd-daypage-v5-codex.md。技术栈: Next.js 16 + TypeScript + Tailwind 4 + Supabase (本地 Docker) + Drizzle 0.45 + Auth.js v5 beta + Inngest + 后端代理 DashScope。",
   "userStories": [
     {
       "id": "US-001",
-      "title": "i18n 资源彻查：lproj target membership + L10n.swift 强类型枚举",
-      "description": "As a 用户, I want 主页文案显示中文/英文翻译而非原始 key, so that 截图不再出现 'empty.today.no_signals.title' 这类暴露字符串.",
+      "title": "Wave 0a: Monorepo 基础设施 (pnpm workspace + 根 package.json)",
+      "description": "As a developer, I need a monorepo skeleton so that web/ and existing iOS code can coexist.",
       "acceptanceCriteria": [
-        "Xcode DayPage target Build Phases Copy Bundle Resources 包含 zh-Hans.lproj 和 en.lproj",
-        "Xcode Project Localizations 启用 Chinese (Simplified) 与 English",
-        "Info.plist 含 CFBundleDevelopmentRegion=zh-Hans 与 CFBundleLocalizations=[zh-Hans, en]",
-        "新增 DayPage/Resources/L10n.swift 提供 L10n.Empty.todayNoSignalsTitle 强类型访问器",
-        "EmptyStateView.todayNoSignals() 改用 L10n.Empty.* 而非裸字面量",
-        "中英文系统语言切换后 hero 下方文案正确变化",
-        "grep -rn 'LocalizedStringKey(\"' DayPage/ 输出为 0 (除 L10n.swift)",
-        "xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build 通过",
-        "Typecheck passes",
-        "Tests pass"
+        "Create pnpm-workspace.yaml at repo root listing 'web' and 'packages/*'",
+        "Create root package.json with workspace scripts: web:dev, web:build, web:lint, web:typecheck, db:start, db:reset",
+        "Set engines.node >=22, engines.pnpm >=10, packageManager pnpm@11.0.9",
+        "Run `pnpm install` succeeds",
+        ".gitignore already updated for web/Next/Supabase artifacts (verify, no change needed)",
+        "Typecheck passes (no TS files yet so nothing to check)"
       ],
       "priority": 1,
       "passes": false,
@@ -25,15 +21,16 @@
     },
     {
       "id": "US-002",
-      "title": "AmbientBackground 纯化：删 4 团暖色光斑，默认仅 cream 底",
-      "description": "As a 用户, I want 主页背景接近纯色奶油纸感, so that 视觉锚点回到字本身, 不再像 AI 演示稿.",
+      "title": "Wave 0b: Next.js 16 脚手架 (web/ 目录)",
+      "description": "As a developer, I need Next.js 16 with App Router scaffolded in web/ so we can build the Codex UI.",
       "acceptanceCriteria": [
-        "DayPage/DesignSystem/GlassSurface.swift AmbientBackground 默认仅渲染 DSColor.bgWarm (FAF7F2)",
-        "4 团 amber blob 用 @AppStorage('debug.ambientBlobs') 包起来, 默认 false",
-        "TodayView, DailyPageView, MemoDetailView 显式不传开关, 使用默认纯色行为",
-        "iPhone 17 Simulator 截图与改动前并排饱和度肉眼明显下降",
-        "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Run `pnpm create next-app@latest web --typescript --tailwind --app --src-dir --use-pnpm --eslint --turbopack --import-alias '@/*' --skip-install --yes`",
+        "Rename web/package.json `name` to 'daypage-web'",
+        "Delete duplicated web/pnpm-workspace.yaml (let it inherit root)",
+        "Add `typecheck` script (tsc --noEmit) to web/package.json",
+        "Run `pnpm install` from repo root succeeds",
+        "Run `pnpm web:typecheck` passes",
+        "Verify in browser using dev-browser skill: `pnpm web:dev` serves http://localhost:3000 and renders default Next page"
       ],
       "priority": 2,
       "passes": false,
@@ -41,36 +38,33 @@
     },
     {
       "id": "US-003",
-      "title": "Day Orb 收敛：size 140pt + halo opacity 0.15 + orbFill ×0.5",
-      "description": "As a 用户, I want Day Orb 从中央巨大琥珀球变为纸上一枚轻晕, so that serif 日期 'Friday MAY 8' 成为视觉主角.",
+      "title": "Wave 0c: 设计 token 系统 (globals.css + Tailwind 4 @theme)",
+      "description": "As a developer, I need Codex design tokens loaded as CSS variables so all components can use them.",
       "acceptanceCriteria": [
-        "DayPage/Features/Today/DayOrbView.swift halo 透明度从 0.4 改为 0.15",
-        "orbFill gradient stops 透明度全部 ×0.5",
-        "DayOrbView 暴露 size: CGFloat = 140 与 haloOpacity: CGFloat = 0.15 参数",
-        "TodayView 调用处显式传 size: 140",
-        "呼吸动画幅度 ×0.7",
-        "iPhone 17 Simulator 截图与改动前并排 orb 明显收敛",
+        "Recreate Codex tokens.css content in web/src/app/globals.css per PRD V5 §10.3 (warm-archival color tokens, font families, spacing/radius)",
+        "Use Tailwind 4 @theme directive to expose tokens as utility classes (bg-warm, accent, fg-primary, etc.)",
+        "Add font imports for Space Grotesk, Inter, JetBrains Mono via next/font",
+        "Set body background to var(--bg-warm) and font-family to Inter",
+        "Define utility classes ds-display-lg, ds-h1, ds-h2, ds-section-label, ds-body-md, ds-mono-11 matching tokens.css",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: open / and confirm warm-white background + correct fonts loaded"
       ],
       "priority": 3,
       "passes": false,
-      "notes": "依赖 US-002 (AmbientBackground 纯化先落地)"
+      "notes": ""
     },
     {
       "id": "US-004",
-      "title": "删除 GlassTabBar，账号头像迁入设置 sheet，右上仅留齿轮",
-      "description": "As a 用户, I want 顶部不再出现 [Today ▾] pill 和琥珀色头像, so that 整页只有 sidebar 一套导航语言, 视觉一致.",
+      "title": "Wave 0d: Supabase 本地 Docker 初始化",
+      "description": "As a developer, I need a local Supabase instance running so we can develop against real Postgres.",
       "acceptanceCriteria": [
-        "删除 DayPage/Components/GlassTabBar.swift",
-        "从 RootView.swift / TodayView.swift / AppNavigationModel.swift 中移除所有 GlassTabBar / AppTab 引用",
-        "TodayView 顶部账号头像 (36pt 实心琥珀圆) 移除, 账号入口移到设置 sheet 顶部",
-        "TodayView 顶部右侧仅保留齿轮按钮 (28pt 玻璃圆)",
-        "Archive / Graph 切换通过 sidebar 完成, 回归 path 无歧义",
-        "grep -rn 'GlassTabBar' DayPage/ 输出为 0",
-        "xcodebuild build 通过",
-        "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Run `supabase init` creating supabase/config.toml at repo root",
+        "Edit supabase/config.toml: enable pgvector extension under [db.extensions]",
+        "Run `supabase start` succeeds (Docker via OrbStack)",
+        "Confirm `supabase status` outputs DB URL, anon key, service_role key, Studio URL",
+        "Add web/.env.local.example with NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY placeholders",
+        "Add web/.env.local with actual local values (already gitignored)",
+        "Typecheck passes"
       ],
       "priority": 4,
       "passes": false,
@@ -78,53 +72,49 @@
     },
     {
       "id": "US-005",
-      "title": "TodayViewModel 新增 TodayFallback 枚举与 fallbackContent 计算属性",
-      "description": "As a 开发者, I want TodayViewModel 暴露 fallback 内容选择, so that TodayView 在今日 0 memo 时能按优先级渲染存量内容卡.",
+      "title": "Wave 1a: Drizzle ORM 接入 + 配置文件",
+      "description": "As a developer, I need Drizzle ORM configured so we can write type-safe DB schema.",
       "acceptanceCriteria": [
-        "TodayViewModel 新增 enum TodayFallback { case yesterdayDailyPage(DailyPage), onThisDay([Memo]), weekRecap(WeekStats), pureEmpty }",
-        "TodayViewModel.fallbackContent: TodayFallback 计算属性按 yesterdayDailyPage > onThisDay > weekRecap > pureEmpty 优先级返回",
-        "优先级硬编码不可配置",
-        "新增 DayPageTests/TodayViewModelTests.swift 覆盖 4 种 fallback 状态",
-        "Typecheck passes",
-        "Tests pass"
+        "Install drizzle-orm@0.45 + drizzle-kit + postgres + @types/pg in web/",
+        "Create web/drizzle.config.ts pointing to web/src/lib/db/schema.ts and out: web/drizzle/migrations",
+        "Create web/src/lib/db/client.ts exporting `db` (drizzle instance using postgres-js)",
+        "Add web/package.json scripts: db:generate, db:migrate, db:studio (drizzle-kit)",
+        "Typecheck passes"
       ],
       "priority": 5,
       "passes": false,
-      "notes": "依赖 US-001 (i18n 修复, 否则 fallback 文案也会暴露 key)"
+      "notes": ""
     },
     {
       "id": "US-006",
-      "title": "复活 OnThisDayCard 与 WeeklyRecapSection，TodayView 接入 fallback 渲染",
-      "description": "As a 用户, I want 即使今天没记, 主页也能展示昨日 Daily Page / On This Day / 本周回顾中的一张引子卡, so that Today 主页永不空白.",
+      "title": "Wave 1b: Drizzle schema 第一批 (users + memos + memo_attachments)",
+      "description": "As a developer, I need the core memo tables defined so iOS can sync data.",
       "acceptanceCriteria": [
-        "TodayView 在 memos.isEmpty && !isLoading 时按 viewModel.fallbackContent 渲染对应卡",
-        "yesterdayDailyPage 复用 DailyPageEntryCard",
-        "onThisDay 复用 OnThisDayCard.swift (复活当前禁用引用)",
-        "weekRecap 复活 WeeklyRecapSection.swift 并接入",
-        "pureEmpty 仅显示 hero 下方一句小字 (不再独占整屏)",
-        "三种 fallback 卡点击行为: 昨日卡进入 DailyPageView, OnThisDay 进入 MemoDetailView, WeekRecap 进入 ArchiveView 周模式",
-        "原 EmptyStateView.todayNoSignals() 退化为单行小字",
-        "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "In web/src/lib/db/schema.ts define `users` table (uuid pk, email unique, apple_sub unique, name, avatar_url, created_at, onboarded_at, settings jsonb)",
+        "Define `memos` table per docs/web/PLAN.md §4 (uuid pk, user_id fk, type enum, body text, created_at, pinned_at, location jsonb, weather, device, source_url, ingest_mode, compile_status, origin, vault_path, updated_at)",
+        "Define `memo_attachments` table (uuid pk, memo_id fk, kind enum, storage_key, filename, mime_type, size_bytes, duration_sec, transcript, ocr_text, exif jsonb)",
+        "Add indexes: memos_user_created (user_id, created_at desc), memos_user_status (user_id, compile_status)",
+        "Run `pnpm --filter daypage-web db:generate` produces migration SQL file",
+        "Run `pnpm --filter daypage-web db:migrate` applies to local supabase",
+        "Verify tables exist in Supabase Studio",
+        "Typecheck passes"
       ],
       "priority": 6,
       "passes": false,
-      "notes": "依赖 US-005 (fallbackContent 计算属性)"
+      "notes": ""
     },
     {
       "id": "US-007",
-      "title": "InputBarV4 引入 ComposerState 状态机替换 userExpandedText",
-      "description": "As a 开发者, I want 用 composerState: .idle / .expanding / .open / .collapsing 替换 userExpandedText: Bool, so that 12 个签名时刻中过渡那一拍能被精确控制.",
+      "title": "Wave 1c: Drizzle schema 第二批 (domains + pages + page_links + page_sources)",
+      "description": "As a developer, I need page tables so AI compile can write structured wiki output.",
       "acceptanceCriteria": [
-        "InputBarV4.swift 新增 enum ComposerState: Equatable { case idle, expanding, open, collapsing }",
-        "删除 userExpandedText: Bool, 所有引用迁移到 state == .open || state == .expanding",
-        "状态转移函数 transition(to: ComposerState) 集中管理, 每次转移触发对应 haptic 与 animation",
-        "expanding / collapsing 持续时间 = .spring(response: 0.42, dampingFraction: 0.78)",
-        ".expanding / .collapsing 期间禁止接受新的状态切换 (防抖)",
-        "新增 DayPageTests/ComposerStateMachineTests.swift 覆盖所有合法/非法转移",
-        "xcodebuild build 通过",
-        "Typecheck passes",
-        "Tests pass"
+        "Define `domains` (uuid pk, user_id fk, slug, label, color, position, created_at, unique(user_id, slug))",
+        "Define `pages` per PLAN.md §4 (uuid pk, user_id fk, slug, type enum, domain_id fk nullable, title, status enum, body_md, body_html, metadata jsonb, embedding vector(1536), source_count, backlink_count, last_compiled_at, timestamps, unique(user_id, slug))",
+        "Define `page_links` (uuid pk, user_id, from_page_id fk, to_page_id fk, via_memo_id fk nullable, weight, rationale, created_at)",
+        "Define `page_sources` composite pk (page_id, memo_id) with contribution + weight",
+        "Add indexes pages_user_type, pages_user_domain",
+        "Generate + run migration",
+        "Typecheck passes"
       ],
       "priority": 7,
       "passes": false,
@@ -132,109 +122,111 @@
     },
     {
       "id": "US-008",
-      "title": "Liquid Morph: idle 玻璃胶囊 matchedGeometryEffect 生长成 composition card",
-      "description": "As a 用户, I want 从 idle 三槽胶囊到 composing 卡片看到形态延续而非两个 view 切换, so that 切换有仪式感.",
+      "title": "Wave 1d: Drizzle schema 第三批 (annotations + chat_threads + chat_messages + inbox_items + activities + devices + sync_state)",
+      "description": "As a developer, I need the remaining tables so chat / inbox / activity / sync features have storage.",
       "acceptanceCriteria": [
-        "用 matchedGeometryEffect(id: 'composer.surface', in: namespace) 把 idle 胶囊 morph 成 composing 圆角矩形",
-        "麦克风 orb 不消失: 64x64 缩到 28x28 并左移到卡片左下角作为切回语音入口",
-        "Aa 按钮淡出 = TextField caret 淡入 (同位置交叉淡入 200ms)",
-        "整段动画 .spring(response: 0.42, dampingFraction: 0.78)",
-        "动画起点触发 UIImpactFeedbackGenerator(.soft)",
-        "录屏验证任意一帧截图取出来形状都能解释从哪来",
-        "Reduced Motion 开启时降级为简单 fade (0.2s)",
-        "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Define `annotations` (uuid pk, user_id, page_id fk, anchor jsonb, tag, note, created_at)",
+        "Define `chat_threads` (uuid pk, user_id, title, status enum, synthesis_page_id fk nullable, timestamps)",
+        "Define `chat_messages` (uuid pk, thread_id fk, role enum, content, citations jsonb, suggested jsonb, tokens_in, tokens_out, created_at)",
+        "Define `inbox_items` (uuid pk, user_id, kind enum, title, body, payload jsonb, status enum, resolution jsonb, created_at, resolved_at)",
+        "Define `activities` (uuid pk, user_id, verb, subject, target_type, target_id, created_at)",
+        "Define `devices` (uuid pk, user_id, platform enum, push_token, last_seen_at, metadata jsonb, created_at)",
+        "Define `sync_state` composite pk (user_id, device_id) with cursor timestamptz",
+        "Add indexes inbox_user_status, activities_user_created",
+        "Generate + run migration",
+        "Typecheck passes"
       ],
       "priority": 8,
       "passes": false,
-      "notes": "依赖 US-007 (ComposerState 状态机)"
+      "notes": ""
     },
     {
       "id": "US-009",
-      "title": "Adaptive Send Affordance：发送按钮 5 形态 (空/文本/文本+图/位置/多模态)",
-      "description": "As a 用户, I want 发送按钮根据 draft 形态变形, so that 我能从图形上读出现在发送会做什么.",
+      "title": "Wave 0e: Auth.js v5 beta 接入 + Apple OAuth provider",
+      "description": "As a user, I want to sign in with Apple ID on the web so I can access my own data.",
       "acceptanceCriteria": [
-        "空态: 浅色 mic.fill 圆环 (柔光呼吸 1.6s/cycle), accessibilityLabel='按住说'",
-        "仅文本态: 实心琥珀 arrow.up, accessibilityLabel='发送'",
-        "文本+照片态: camera.fill + arrow.up 复合, accessibilityLabel='记下这一刻'",
-        "仅位置态: mappin.and.arrow.up, accessibilityLabel='标记此处'",
-        "多模态态: 琥珀 ring 带光晕脉动 (1.6s), accessibilityLabel='发送 N 项'",
-        "空态明确不再用 18% 透明琥珀圆",
-        "形态切换 .spring(response: 0.32, dampingFraction: 0.8)",
-        "VoiceOver 朗读对应 label",
+        "Install next-auth@5.0.0-beta.31 in web/",
+        "Create web/src/auth.ts exporting handlers, auth, signIn, signOut using NextAuth() with Apple provider + Email magic link provider",
+        "Create web/src/app/api/auth/[...nextauth]/route.ts re-exporting handlers",
+        "Configure Apple provider with env vars APPLE_CLIENT_ID, APPLE_CLIENT_SECRET, APPLE_TEAM_ID, APPLE_KEY_ID, APPLE_PRIVATE_KEY",
+        "Configure Email provider with SUPABASE_SMTP_* vars (use supabase local Inbucket for dev)",
+        "Create users row on first sign-in (Drizzle adapter or custom callback)",
+        "Add web/middleware.ts redirecting unauthenticated requests away from (app)/* to /login",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: visit /login, see 'Sign in with Apple' + email input"
       ],
       "priority": 9,
       "passes": false,
-      "notes": "依赖 US-007 (ComposerState 状态机)"
+      "notes": ""
     },
     {
       "id": "US-010",
-      "title": "Composer 工具栏迁移到 keyboard-attached (.toolbar placement: .keyboard)",
-      "description": "As a 用户, I want 工具栏跟键盘一起浮起, so that 不再形成键盘+工具栏双层堆叠.",
+      "title": "Wave 3a: App Layout 骨架 (Sidebar + Topbar + 路由分组)",
+      "description": "As a user, I want the Codex shell visible so I can navigate between Home/Add/Chat/Wiki/Inbox.",
       "acceptanceCriteria": [
-        "工具栏迁移到 .toolbar { ToolbarItemGroup(placement: .keyboard) { ... } }",
-        "卡片本体停在画面中段, 下方可见 timeline (带 vignette 渐隐遮罩)",
-        "键盘收起时工具栏跟随消失, 无残留高度占位",
-        "iPad 横屏键盘工具栏不溢出",
+        "Create web/src/app/(app)/layout.tsx with 248px sidebar + main column (matching Codex app.css .app grid)",
+        "Create empty page stubs at (app)/home, (app)/add, (app)/chat, (app)/wiki, (app)/inbox each rendering its name as h1",
+        "Sidebar renders: 5 fixed items (Home/Add/Chat/Wiki/Inbox) with lucide icons + active state highlight + Inbox badge slot (hardcoded 0 for now)",
+        "Topbar renders: breadcrumb 'Codex / <currentView>' + date string + Ask + Add buttons (no-op for now)",
+        "Active nav item background matches --accent-soft, text matches --accent",
+        "Sidebar footer shows user email from auth() session + Sign out link",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: navigate /home /add /chat /wiki /inbox and confirm sidebar highlight changes"
       ],
       "priority": 10,
       "passes": false,
-      "notes": "依赖 US-007"
+      "notes": ""
     },
     {
       "id": "US-011",
-      "title": "Drag-to-Collapse Handle: 卡片顶 36x4 capsule 上滑收起",
-      "description": "As a 用户, I want 卡片顶边一个 36x4 capsule handle 上滑可收起, so that 与 iOS sheet 语言一致.",
+      "title": "Wave 3b: UI primitives (Btn / Chip / Card / Icon / Sparkline / SectionLabel)",
+      "description": "As a developer, I need reusable components matching Codex visual language so views can be built quickly.",
       "acceptanceCriteria": [
-        "卡片顶部居中 36x4 灰色 capsule",
-        "上滑距离 > 32pt 触发 transition(to: .collapsing) 然后回 .idle",
-        "单击 handle 等价上滑 (accessibility)",
-        "折叠动画与 morph 反向播放",
-        "折叠触发 .medium impact",
+        "Create web/src/components/ui/Btn.tsx supporting kind: primary|secondary|soft|ghost, size: sm|md, pill, icon, iconRight (port from PRD V5 §10.5 Codex primitives spec)",
+        "Create web/src/components/ui/Chip.tsx supporting tone: default|accent|success|warning|error|ghost, onClick",
+        "Create web/src/components/ui/Card.tsx supporting sunken variant",
+        "Create web/src/components/ui/Icon.tsx using lucide-react (install lucide-react@1.14)",
+        "Create web/src/components/ui/Sparkline.tsx (SVG, props: values, w, h, color, fill)",
+        "Create web/src/components/ui/SectionLabel.tsx (uppercase + tracking)",
+        "Add styles in globals.css for .btn, .btn--primary, .chip, .card, etc. matching Codex app.css conventions",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: temporarily add a Btn + Chip + Card to /home and confirm visual match Codex"
       ],
       "priority": 11,
       "passes": false,
-      "notes": "依赖 US-007 + US-008"
+      "notes": ""
     },
     {
       "id": "US-012",
-      "title": "Haptics.swift 扩展 5 级触感阶梯并接入 Composer 流程",
-      "description": "As a 用户, I want 不同动作触发不同强度的触感, so that Composer 有材质感.",
+      "title": "Wave 1e: API /api/memos 基础 CRUD",
+      "description": "As iOS / Web client, I need REST endpoints to create, list, get, patch, delete memos.",
       "acceptanceCriteria": [
-        "DayPage/DesignSystem/Haptics.swift 暴露 5 级 API: .soft / .rigid(intensity:) / .medium / .light / .success / .warning",
-        "点 dock 任意键触发 .soft impact",
-        "Caret 首次出现 0.15s 延迟后触发 .rigid 0.3 强度",
-        "添加附件触发 .medium",
-        "删除附件触发 .light",
-        "发送成功触发 .success notification",
-        "录音太短/错误触发 .warning notification",
-        "至少 4 级在 Composer 流程中被实际触发",
+        "Create web/src/app/api/memos/route.ts: GET (list with cursor pagination + since filter) and POST (create with Zod validation)",
+        "Create web/src/app/api/memos/[id]/route.ts: GET, PATCH, DELETE (soft delete)",
+        "All handlers must call auth() and reject 401 if no session, scope queries to current user_id",
+        "Create operation accepts {type, body, created_at?, location?, weather?, device?, origin, ingest_mode?, attachments?[]}",
+        "Use Zod schemas in web/src/lib/schemas/memo.ts (shared with future tRPC layer)",
+        "Return Drizzle-typed memo objects",
+        "Add rate limit: 30 mutations/min per user using @upstash/ratelimit + in-memory fallback for dev",
         "Typecheck passes",
-        "Tests pass"
+        "Tests pass: write web/src/app/api/memos/__tests__/route.test.ts using Vitest covering create + list + 401 + scope isolation"
       ],
       "priority": 12,
       "passes": false,
-      "notes": "可并行于 US-007 ~ US-011"
+      "notes": ""
     },
     {
       "id": "US-013",
-      "title": "ComposerContextProvider 服务：聚合 Weather/Location/lastMemo/Pasteboard",
-      "description": "As a 开发者, I want 一个 ComposerContextProvider 聚合所有上下文源, so that Spotlight Strip 能拿到统一的 chip 数据.",
+      "title": "Wave 1f: API /api/memos/bulk 批量上传 (iOS sync)",
+      "description": "As iOS app, I need to bulk push vault diff so V5 sync uplink works efficiently.",
       "acceptanceCriteria": [
-        "新增 DayPage/Services/ComposerContextProvider.swift @MainActor final class",
-        "整合 WeatherService / LocationService / viewModel.memos.last / UIPasteboard.general",
-        "暴露 var chips: [ContextChip] 计算属性",
-        "ContextChip 类型: .weather(temp, condition) / .location(short) / .timeRitual(emoji, text) / .lastMemoTail(snippet) / .smartPaste(value)",
-        "lastMemoTail 计算缓存 60s 避免重复读 vault",
-        "新增 DayPageTests/ComposerContextProviderTests.swift",
+        "Create web/src/app/api/memos/bulk/route.ts POST handler",
+        "Accept array of memos (max 100), upsert by id (id is UUID generated by iOS)",
+        "On conflict, last-write-wins by updated_at; do not overwrite location if backend already has one with later created_at",
+        "Return {accepted: [ids], skipped: [{id, reason}]}",
+        "Idempotent: same payload twice produces same DB state",
         "Typecheck passes",
-        "Tests pass"
+        "Tests pass: covering upsert, idempotency, scope, max-100 limit"
       ],
       "priority": 13,
       "passes": false,
@@ -242,34 +234,35 @@
     },
     {
       "id": "US-014",
-      "title": "Context Spotlight Strip: TextField 上方横向 chip 带",
-      "description": "As a 用户, I want TextField 上方一条横向 chip 带显示天气/位置/上一条尾巴/智能粘贴, so that 空 Composer 也有现在写什么的引子.",
+      "title": "Wave 1g: API /api/attachments/sign + Supabase Storage 直传",
+      "description": "As a client, I need signed URLs to upload audio/photo/file directly to Supabase Storage.",
       "acceptanceCriteria": [
-        "Spotlight Strip 横向滚动, 每个 chip 28pt 高, 玻璃材质",
-        "数据源走 ComposerContextProvider.chips",
-        "点击 chip 对应内容塞入 draft (位置塞 Memo.Location, 时间塞 prompt, 上一条尾巴塞引用块, 剪贴板塞文本)",
-        "触摸软触感 .soft 0.4",
-        "空 Composer 至少 3 条 chip",
+        "Create Supabase Storage bucket 'memo-attachments' (private, no public access) via supabase migration SQL",
+        "Create web/src/app/api/attachments/sign/route.ts POST: input {memo_id, kind, mime_type, size_bytes}, return {upload_url, storage_key, expires_at}",
+        "Storage key format: `{user_id}/{memo_id}/{uuid}.{ext}`",
+        "Validate: mime_type in allowlist (audio/m4a, image/jpeg, image/png, image/heic, application/pdf), size <=50MB",
+        "Signed URL expiry 5 min",
+        "Create web/src/app/api/attachments/finalize/route.ts POST: input {memo_id, storage_key, kind, ...} writes memo_attachments row",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Tests pass: signing returns valid Supabase URL; finalize creates row"
       ],
       "priority": 14,
       "passes": false,
-      "notes": "依赖 US-013"
+      "notes": ""
     },
     {
       "id": "US-015",
-      "title": "Smart Templates: 12 条时段模板 hardcode",
-      "description": "As a 用户, I want 空 Composer 显示 1 行时段模板, so that 我能一键得到今天怎么写的引子.",
+      "title": "Wave 1h: API /api/domains + /api/inbox + /api/stats + /api/activities (基础)",
+      "description": "As a client, I need read endpoints for sidebar/home content so the UI has real data.",
       "acceptanceCriteria": [
-        "12 条 hardcode 模板按时段映射: 06-11 晨/今天/醒来; 11-17 刚才/中午/想法; 17-22 最某刻/总结/明天; 22-06 回看/未完/梦",
-        "仅在 text.isEmpty && pendingAttachments.isEmpty 时显示",
-        "点击 模板文字塞入 TextField, placeholder 高亮 (.foregroundStyle(.secondary))",
-        "caret 定位到 placeholder 起点",
-        "用户开始打字后 placeholder 消失",
-        "不引入配置文件 / 设置项",
+        "Create web/src/app/api/domains/route.ts: GET list, POST create",
+        "Create web/src/app/api/inbox/route.ts: GET list (filter by kind, status), default status='open'",
+        "Create web/src/app/api/stats/route.ts: GET returns {sources, pages, domains, backlinks, deltas:{sources_week, pages_week, backlinks_week}}",
+        "Create web/src/app/api/activities/route.ts: GET cursor-paginated list, default 20",
+        "All endpoints scoped to auth() user_id",
+        "Empty user returns sensible empty arrays / zero counts",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Tests pass: each endpoint returns 200 with empty data for fresh user, 401 without session"
       ],
       "priority": 15,
       "passes": false,
@@ -277,17 +270,17 @@
     },
     {
       "id": "US-016",
-      "title": "Inline Lens Strip: 最近 4 张照片缩略图 (懒加载相册权限)",
-      "description": "As a 用户, I want TextField 下方一条 56x56 圆角缩略图带, so that 我能一键附加最近 24h 内的照片, 无需跳 PhotosPicker.",
+      "title": "Wave 3c: Home view 真数据 (Hero + Stats + Recent activity 占位)",
+      "description": "As a user, I want the Home page to show my real stats and recent activity so I see live data.",
       "acceptanceCriteria": [
-        "第一次展开 Composer 时 prompt PHPhotoLibrary.requestAuthorization(for: .readWrite)",
-        "拒绝权限后 Strip 隐藏, 不再 prompt (用 @AppStorage('composer.photoPermissionAsked') 标记)",
-        "显示最近 24h 内 4 张缩略图, 按时间倒序",
-        "点击缩略图 直接附加到 pendingAttachments, 不跳 sheet",
-        "缩略图加载用 PHCachingImageManager 避免卡顿, 分辨率 <= 168x168",
-        "无最近照片时 Strip 隐藏 (不显示空态)",
+        "Update web/src/app/(app)/home/page.tsx to fetch /api/stats + /api/activities server-side (RSC)",
+        "Render Hero block with date string + headline (use placeholder text if empty) + 4 buttons (Add / Ask / Inbox)",
+        "Render Stats grid (4 cards: Sources / Wiki pages / Domains / Backlinks) using real numbers from /api/stats",
+        "Render Recent activity Card listing last 6 activities (when=relative time, what=verb+subject, target link)",
+        "Empty state: if stats all zero, show 'Nothing yet — add something to get started' with primary Add button",
+        "Match Codex visual exactly per PRD V5 §3 Home view sketch",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: log in, see Home page with zero stats + empty state CTA"
       ],
       "priority": 16,
       "passes": false,
@@ -295,37 +288,632 @@
     },
     {
       "id": "US-017",
-      "title": "Caret Spotlight + Ambient Dim: focus 时背景暗 20%, 卡背 RadialGradient",
-      "description": "As a 用户, I want focus 时背景变暗 20% 同时卡片背后泛起暖白射灯, so that 写作仪式感拉满.",
+      "title": "Wave 3d: Sidebar Domains 动态列表 + Inbox badge 真数据",
+      "description": "As a user, I want the sidebar to show my domains and unread inbox count from real data.",
       "acceptanceCriteria": [
-        "focus 进入时 AmbientBackground 整体透明度 0.8",
-        "Composer 卡片背后 RadialGradient (中心 caret 位置, 半径 240pt, 暖白 0.12 opacity)",
-        "现有 BreathingCaretView 保留并接入",
-        "focus 退出反向动画 0.4s",
-        "Reduced Motion 开启时禁用 dim, 仅静态对比",
+        "Update Sidebar to fetch /api/domains and /api/inbox?status=open server-side via RSC layout",
+        "Render dynamic Domains group below static items with colored dot + label + count per domain",
+        "Inbox item shows badge with count of unresolved inbox_items",
+        "If user has 0 domains, hide the Domains group label entirely",
+        "If badge count is 0, hide the badge",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: empty user sees no Domains group; insert a test domain via SQL and confirm it appears"
       ],
       "priority": 17,
       "passes": false,
-      "notes": "依赖 US-002 (AmbientBackground 已纯化)"
+      "notes": ""
     },
     {
       "id": "US-018",
-      "title": "Status Strip: 卡片顶 12pt mono 行 DRAFTING · N PHOTOS · LOC · age",
-      "description": "As a 用户, I want 卡片顶部一行 12pt mono 显示状态副标, so that 我能看到 Composer 的实时状态.",
+      "title": "Wave 4a: Add view 静态 UI (UnifiedInput + 空 Compile Queue)",
+      "description": "As a user, I want the Add page UI so I can type and submit content (compile worker comes later).",
       "acceptanceCriteria": [
-        "字段顺序: <state> · <attachment count> · <location short> · <draft age>",
-        "状态枚举: DRAFTING / SENDING / SENT / ERROR",
-        "发送成功 1.2s 内显示 SENT 然后整个 Composer 折叠回 idle dock",
-        "字体 JetBrains Mono 12pt (已注册)",
-        "XXLarge+ Dynamic Type 时省略 location 字段",
+        "Update web/src/app/(app)/add/page.tsx",
+        "Render Hero block (section label + headline + sub)",
+        "Render UnifiedInput: textarea + hint chips (URL/File/Voice/Bookmarklet/auto-detect) + Save draft + Add buttons",
+        "Render empty Compile Queue Card with placeholder 'No items yet'",
+        "Render empty Recently Compiled Card",
+        "Submit button is disabled when textarea empty",
+        "Match Codex Add view visual per PRD V5 §3",
         "Typecheck passes",
-        "Verify in browser using dev-browser skill"
+        "Verify in browser using dev-browser skill: navigate to /add, type text, confirm submit button enables"
       ],
       "priority": 18,
       "passes": false,
-      "notes": "依赖 US-007 (state) + US-013 (location 来源)"
+      "notes": ""
+    },
+    {
+      "id": "US-019",
+      "title": "Wave 4b: Add view 提交连接 /api/memos (基础 text 输入)",
+      "description": "As a user, I want submitting the Add form to actually create a memo via the API.",
+      "acceptanceCriteria": [
+        "On submit, POST to /api/memos with {type:'text', body, origin:'web'}; auto-detect type:'url' if body matches /^https?:\\/\\//",
+        "Use TanStack Query (install @tanstack/react-query@5.100) mutation with optimistic update",
+        "On success, clear textarea and prepend new memo to local Compile Queue list (status='pending')",
+        "On failure, show inline error + Retry button + keep textarea content",
+        "Compile Queue Card now lists the user's pending memos (fetched via /api/memos?compile_status=pending)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: submit a text memo, confirm it appears in queue and DB row exists"
+      ],
+      "priority": 19,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-020",
+      "title": "Wave 4c: AI provider 抽象层 + DashScope client",
+      "description": "As a developer, I need a unified LLM client so compile worker can call qwen models.",
+      "acceptanceCriteria": [
+        "Create web/src/lib/ai/provider.ts exporting interface LLMProvider with chat(), embed(), transcribe()",
+        "Create web/src/lib/ai/dashscope.ts implementing provider via OpenAI-compatible endpoint (https://dashscope.aliyuncs.com/compatible-mode/v1)",
+        "Use env var DASHSCOPE_API_KEY (server-only, never client)",
+        "Models: qwen-plus for chat, text-embedding-v3 for embed, paraformer for transcribe",
+        "Return typed responses; on error throw ProviderError with code (rate_limit/timeout/auth/server)",
+        "Add token logging side-effect: every call writes a row to prompt_log table (create new table for this)",
+        "Typecheck passes",
+        "Tests pass: mock fetch and verify request body / response parsing / error mapping"
+      ],
+      "priority": 20,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-021",
+      "title": "Wave 4d: Inngest 接入 + compile.memo function 骨架",
+      "description": "As a developer, I need a background worker so compile pipeline can run async.",
+      "acceptanceCriteria": [
+        "Install inngest@3.x in web/",
+        "Create web/src/lib/inngest/client.ts exporting `inngest` Inngest client with id 'daypage'",
+        "Create web/src/lib/inngest/functions/compile-memo.ts: function triggered by event 'memo/created' with steps: normalize, embed, recall, compile, apply, notify",
+        "For now each step just logs and updates memos.compile_status (pending → running → done); no real LLM calls yet",
+        "Create web/src/app/api/inngest/route.ts mounting Inngest serve handler",
+        "When /api/memos POST creates a memo, send event {name:'memo/created', data:{memo_id}}",
+        "Add npm script `dev:inngest` running `npx inngest-cli@latest dev`",
+        "Typecheck passes",
+        "Verify: submit a memo via Add page, observe inngest dev dashboard at http://localhost:8288 shows function ran, memo compile_status updated to 'done'"
+      ],
+      "priority": 21,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-022",
+      "title": "Wave 4e: Embed step 实接 DashScope + memo embedding 持久化",
+      "description": "As the compile pipeline, I need to actually embed memo text so RAG and recall work.",
+      "acceptanceCriteria": [
+        "Add embedding vector(1536) column to memos table (new migration)",
+        "In compile-memo function 'embed' step: chunk body into <=512-token segments, embed each, average to single vector, write to memos.embedding",
+        "If body empty (e.g. voice without transcript), skip embed",
+        "Cache: hash(body) → if same hash already embedded in last 7 days, reuse from a new embed_cache table",
+        "On API error, set memos.compile_status='failed' + memos.compile_error",
+        "Typecheck passes",
+        "Tests pass: mock dashscope, submit memo, verify embedding column populated"
+      ],
+      "priority": 22,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-023",
+      "title": "Wave 4f: Compile step LIGHT 模式 (生成摘要 + 关键词)",
+      "description": "As a user, I want LIGHT-mode memos to get a summary and tags so I can browse them later.",
+      "acceptanceCriteria": [
+        "In compile-memo function 'compile' step, if memo.ingest_mode='light', call qwen-plus with a structured prompt asking for {summary: string, keywords: string[], suggested_domain: string|null}",
+        "Use prompt template at web/src/lib/ai/prompts/compile-light.md (versioned)",
+        "Apply: write a new source-type page with title=truncated body OR summary, body_md=summary, metadata={keywords, source_memo_id}",
+        "Link page to memo via page_sources",
+        "Update memo.compile_status='done'",
+        "If LLM returns invalid JSON, retry once with stricter prompt; on second fail mark compile_status='failed'",
+        "Typecheck passes",
+        "Tests pass: mock qwen, submit text memo with ingest_mode='light', verify page row + page_sources row"
+      ],
+      "priority": 23,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-024",
+      "title": "Wave 4g: Compile step FULL 模式 (recall + patch existing pages or create new concept)",
+      "description": "As a user, I want FULL-mode memos to actually update my wiki, not just create source pages.",
+      "acceptanceCriteria": [
+        "In compile-memo 'recall' step: vector-search top-8 existing pages by cosine similarity to memo.embedding (only same user, status='live')",
+        "In 'compile' step (FULL mode): pass memo body + retrieved pages as context to qwen-plus with prompt at compile-full.md asking for tool-calling JSON: {operations: [{op: 'update_page'|'create_page'|'create_link'|'extract_entity', ...}]}",
+        "In 'apply' step: execute operations in DB transaction, write change_log table (create new table) for each",
+        "Each new page gets status='draft'; existing page updates increment a version counter",
+        "Validate: every cited page_id in operations must exist; reject invalid",
+        "Update memo.compile_status='done'",
+        "Typecheck passes",
+        "Tests pass: mock qwen returning create_page op, submit memo, verify page row created with status='draft' + change_log entry"
+      ],
+      "priority": 24,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-025",
+      "title": "Wave 4h: SSE 进度推送 /api/stream/compile",
+      "description": "As a user, I want to see live compile progress so I know the system is working.",
+      "acceptanceCriteria": [
+        "Create web/src/app/api/stream/compile/route.ts using Next.js streaming response (text/event-stream)",
+        "On connect, scope to current user (via auth())",
+        "Subscribe to Postgres LISTEN/NOTIFY channel 'compile_progress' OR poll memos every 2s for status changes",
+        "Send SSE events {type:'progress', memo_id, status, step?, progress?}",
+        "Compile worker emits NOTIFY after each pipeline step",
+        "Heartbeat ping every 15s to keep connection alive",
+        "Close connection cleanly on client disconnect",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: open /add, submit a memo, watch network tab for SSE events flowing"
+      ],
+      "priority": 25,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-026",
+      "title": "Wave 4i: Add view Compile Queue 实时进度 UI",
+      "description": "As a user, I want progress bars in the Compile Queue so I see compilation happen.",
+      "acceptanceCriteria": [
+        "Create web/src/hooks/useCompileStream.ts subscribing to /api/stream/compile via EventSource, updating local state per memo_id",
+        "Compile Queue Card uses this hook to render progress bar 0-100% per item",
+        "Step labels render (e.g. 'Embedding...', 'Compiling...')",
+        "On done, item shows green check + 'X pages updated' + auto-removes from queue after 3s",
+        "On failed, item shows red badge + error step name + Retry button (calls POST /api/memos/:id/recompile)",
+        "Add /api/memos/:id/recompile endpoint that re-sends inngest event",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: submit memo, watch progress bar fill, confirm completion state"
+      ],
+      "priority": 26,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-027",
+      "title": "Wave 4j: LIGHT/FULL chip 切换 + Recently Compiled 列表",
+      "description": "As a user, I want to switch a memo's compile tier and see what was recently compiled.",
+      "acceptanceCriteria": [
+        "Each Compile Queue item has a Chip showing current ingest_mode (LIGHT/FULL)",
+        "Click chip: PATCH /api/memos/:id with {ingest_mode: 'full'|'light'}, then trigger recompile",
+        "Toast confirms switch",
+        "Add 'Recently compiled' Card below queue: fetch /api/memos?compile_status=done&limit=8, ordered by updated_at desc",
+        "Each row shows: icon, title (truncated 90 chars), subtitle (type · word_count · created_at relative), mode chip, time",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: submit memo, after compile completes, see it in Recently compiled; click LIGHT chip to switch and observe re-compile"
+      ],
+      "priority": 27,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-028",
+      "title": "Wave 5a: Wiki view 路由 + 左侧 nav 静态结构",
+      "description": "As a user, I want the Wiki page layout so I can navigate between page groups.",
+      "acceptanceCriteria": [
+        "Update web/src/app/(app)/wiki/page.tsx with 3-column layout: 240px nav + flex-1 page + 280px aside",
+        "WikiNav component fetches /api/pages grouped by type (concept/source/entity/synthesis/daily)",
+        "Each group is collapsible (state persisted in localStorage)",
+        "Each row shows title + meta (source_count or 'draft' tag or conflict warning icon)",
+        "Active page highlighted",
+        "Top of nav: search input (no-op for now) + List/Graph mode toggle (Graph greyed out for later wave)",
+        "Empty state: if user has no pages, show 'Your wiki will grow here as AI compiles your memos'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: navigate to /wiki, see empty groups + search bar"
+      ],
+      "priority": 28,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-029",
+      "title": "Wave 5b: API /api/pages + /api/pages/:slug + /api/pages/:id/sources + /api/pages/:id/backlinks",
+      "description": "As a client, I need page CRUD and detail endpoints so Wiki view can show page content.",
+      "acceptanceCriteria": [
+        "GET /api/pages?type=&domain=&q= returns paginated list",
+        "GET /api/pages/:slug returns single page (404 if not user's)",
+        "POST /api/pages creates synthesis page (input: {title, body_md, type:'synthesis', source_thread_id?})",
+        "PATCH /api/pages/:id updates title / domain_id / status",
+        "DELETE /api/pages/:id soft-deletes (status='archived', or sets deleted_at)",
+        "GET /api/pages/:id/sources returns memos that contributed (joined via page_sources)",
+        "GET /api/pages/:id/backlinks returns pages that link TO this page (via page_links)",
+        "All scoped to user_id",
+        "Typecheck passes",
+        "Tests pass: cover happy path + 404 + scope isolation for each endpoint"
+      ],
+      "priority": 29,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-030",
+      "title": "Wave 5c: Wiki page detail UI (含 markdown 渲染 + 右侧 sources/backlinks/provenance)",
+      "description": "As a user, I want to read a wiki page with sources and backlinks visible.",
+      "acceptanceCriteria": [
+        "Create web/src/app/(app)/wiki/[slug]/page.tsx fetching /api/pages/:slug + sources + backlinks server-side",
+        "Render header: type chip + domain chip + 'updated X ago' chip + Annotate + Ask buttons + h1 title + byline (compiled from N sources · M backlinks · slug)",
+        "Render body using react-markdown@10 + remark-gfm + rehype-sanitize",
+        "Right aside: 3 blocks (Sources / Backlinks / Provenance) matching Codex visual",
+        "Each source row links to source memo detail (route stub OK for now)",
+        "Each backlink row links to /wiki/[slug]",
+        "Provenance block shows static text 'Last compiled X ago' for now",
+        "If page not found, render 'This page does not exist'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: insert a test page via SQL, navigate to /wiki/<slug>, confirm renders"
+      ],
+      "priority": 30,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-031",
+      "title": "Wave 5d: Annotation API + 高亮选中 toolbar",
+      "description": "As a user, I want to highlight text on a wiki page and tag it as important/questionable.",
+      "acceptanceCriteria": [
+        "POST /api/annotations creates annotation (input: {page_id, anchor:{section_idx,char_start,char_end,text}, tag, note?})",
+        "DELETE /api/annotations/:id removes annotation",
+        "GET /api/pages/:id/annotations returns all annotations for a page",
+        "Wiki page detail loads annotations + renders selected text wrapped in <mark class='user-mark' data-tag='...'> via remark plugin or DOM post-processing",
+        "On text selection, show floating toolbar with 3 buttons: Important / Questionable / Custom tag (modal)",
+        "Click button → POST annotation → re-fetch and re-render",
+        "Different tags get different colors (important=accent-soft, questionable=warning-soft)",
+        "Click existing highlight to delete",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: open a page with content, select text, click Important, confirm highlight persists after refresh"
+      ],
+      "priority": 31,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-032",
+      "title": "Wave 5e: Domain 视图 (/(app)/domain/[slug])",
+      "description": "As a user, I want to click a domain in sidebar and see its overview.",
+      "acceptanceCriteria": [
+        "Create web/src/app/(app)/domain/[slug]/page.tsx",
+        "Fetch domain by slug + pages where domain_id matches",
+        "Render: domain title (editable inline) + color picker chip + page count + activity stats (this week)",
+        "Render Pages list grouped by type",
+        "Sidebar Domain link routes to /domain/<slug>",
+        "PATCH /api/domains/:id supports renaming + color change",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: with seeded domain + pages, navigate to domain page and see content"
+      ],
+      "priority": 32,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-033",
+      "title": "Wave 5f: Daily Page worker + cron",
+      "description": "As a user, I want a daily diary page auto-generated each night summarizing the day's memos.",
+      "acceptanceCriteria": [
+        "Create inngest scheduled function 'daily-page' running at 00:30 UTC daily (will be per-user-timezone in later wave)",
+        "For each user with >=1 memo today, aggregate memos created in last 24h, call qwen-plus with prompt at daily-page.md to produce structured page (sections: Highlights / Locations / Themes / Mood)",
+        "Create or upsert page with type='daily', slug='daily/YYYY-MM-DD', title='YYYY-MM-DD Daily', status='live', body_md=result",
+        "Link via page_sources to all memos of that day",
+        "Idempotent: re-running same day overwrites the existing daily page",
+        "Typecheck passes",
+        "Tests pass: mock qwen, seed memos for a day, run function, verify daily page created with correct sources"
+      ],
+      "priority": 33,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-034",
+      "title": "Wave 6a: Wiki Graph view (静态布局, 与 Codex 一致)",
+      "description": "As a user, I want a graph visualization so I can see how my pages connect.",
+      "acceptanceCriteria": [
+        "Add /(app)/wiki Graph mode toggle: when active, render WikiGraph component",
+        "WikiGraph fetches /api/pages + /api/page_links (new endpoint that returns all links for current user)",
+        "Layout: simple force-directed using d3-force or react-force-graph-2d (install one, prefer d3-force for SVG control)",
+        "Node colors per type: concept=accent, draft=warning, entity=accent-hover, source=fg-muted, synthesis=success",
+        "Edges between linked pages (page_links table)",
+        "Click node → highlight node + 1-hop neighbors + show right-aside detail card with title + type + sources count + 'Open page' button",
+        "Pan + zoom with mouse",
+        "Empty state: if user has 0 pages, show 'Add and compile some content to start growing your graph'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: with seeded pages + links, navigate to /wiki and switch to Graph mode, see nodes"
+      ],
+      "priority": 34,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-035",
+      "title": "Wave 7a: Embedding pipeline 升级 + RAG retrieval helper",
+      "description": "As a developer, I need a robust retrieval function so chat can find relevant pages.",
+      "acceptanceCriteria": [
+        "Create web/src/lib/ai/rag.ts exporting retrievePages(userId, queryText, opts:{topK=8, domain?, excludePrivate=true})",
+        "Embed query via DashScope text-embedding-v3",
+        "Vector search pages.embedding using pgvector cosine similarity (HNSW index)",
+        "Add HNSW index on pages.embedding via migration",
+        "Return [{page_id, slug, title, type, body_md, score}], filtered by user_id and not deleted",
+        "If page.private=true, exclude unless opts.includePrivate",
+        "Typecheck passes",
+        "Tests pass: seed pages with known content, query, verify expected page returned with reasonable score"
+      ],
+      "priority": 35,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-036",
+      "title": "Wave 7b: Chat thread API (POST/GET /api/chat/threads)",
+      "description": "As a user, I want chat thread persistence so my conversations are saved.",
+      "acceptanceCriteria": [
+        "POST /api/chat/threads creates new thread {id, title:'New conversation', status:'active'}",
+        "GET /api/chat/threads lists user's threads ordered by updated_at desc, with optional status filter",
+        "GET /api/chat/threads/:id returns thread + messages array",
+        "PATCH /api/chat/threads/:id updates title or status",
+        "DELETE /api/chat/threads/:id soft-deletes",
+        "Auto-title: when first user message sent, schedule a small qwen call to summarize into <60 char title; update thread.title",
+        "Typecheck passes",
+        "Tests pass: create + list + scope isolation"
+      ],
+      "priority": 36,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-037",
+      "title": "Wave 7c: Chat send message API with SSE streaming",
+      "description": "As a user, I want chat answers to stream in real-time so I see progress.",
+      "acceptanceCriteria": [
+        "POST /api/chat/threads/:id/messages with {content} as SSE stream response (text/event-stream)",
+        "Step 1: write user message to chat_messages",
+        "Step 2: call retrievePages(userId, content, topK=8)",
+        "Step 3: build prompt with system instruction (cite with {n} format only, refuse if no context, never invent), user message, references",
+        "Step 4: call DashScope qwen-plus with stream=true; for each chunk emit SSE {type:'token', content:chunk}",
+        "Step 5: after stream end, parse {n} citation tokens, validate each n maps to a retrieved page; emit {type:'done', citations:[...], message_id}",
+        "Step 6: write assistant message to chat_messages with content + citations + tokens_in/out",
+        "Step 7: enforce per-user 100k tokens/day limit; reject 429 if exceeded",
+        "Typecheck passes",
+        "Tests pass: mock qwen stream, verify SSE events flow + citations parsed correctly"
+      ],
+      "priority": 37,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-038",
+      "title": "Wave 7d: Chat view UI (thread list + thread detail + composer)",
+      "description": "As a user, I want a complete chat interface matching Codex design.",
+      "acceptanceCriteria": [
+        "Update web/src/app/(app)/chat/page.tsx: shows thread list (left) + 'Select a conversation or start new' empty state",
+        "Create /(app)/chat/[id]/page.tsx with chat layout: main thread + 280px references sidebar matching Codex visual",
+        "Render messages: user (right-aligned) + assistant (left-aligned with role label)",
+        "Citation tokens {n} render as clickable .cite badges",
+        "Click .cite badge highlights matching reference card in right sidebar",
+        "Composer: textarea with Enter=send, Shift+Enter=newline + Send button",
+        "On send, POST to /api/chat/threads/:id/messages + consume SSE stream; tokens append to assistant bubble in real-time",
+        "Right sidebar: References list showing each cited page (number + type + title + excerpt); click → open page in new tab",
+        "Save as synthesis page button (no-op for now, wire in later wave)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: create thread, ask question against seeded pages, watch streaming answer + reference cards"
+      ],
+      "priority": 38,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-039",
+      "title": "Wave 7e: Suggested follow-ups + I-don't-know fallback",
+      "description": "As a user, I want suggested next questions and honest 'I don't know' answers.",
+      "acceptanceCriteria": [
+        "After assistant message complete, fire a 2nd lightweight qwen call with prompt at suggested-followups.md (input: thread context, output: 3 short questions)",
+        "Render 3 chips below assistant message; click → fills composer + sends",
+        "If retrievePages returns 0 results OR all scores < 0.4 threshold, skip LLM call and write canned assistant message: 'I don't know yet — try adding content about <topic> first.' + suggested 'Add' link",
+        "System prompt enforces: any sentence without {n} citation must be wrapped in italic + tagged [uncited]",
+        "Typecheck passes",
+        "Tests pass: verify low-score query returns I-don't-know without LLM call"
+      ],
+      "priority": 39,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-040",
+      "title": "Wave 8a: Conflict detection 集成到 compile-memo FULL 步骤",
+      "description": "As a user, I want the system to detect contradictions between new content and existing pages.",
+      "acceptanceCriteria": [
+        "In compile-memo FULL step, after recall, run a conflict-check sub-prompt: given new memo body + top-3 retrieved pages, ask qwen 'are there any factual contradictions? respond with JSON {conflicts: [{page_id, old_text, new_text, summary}]}'",
+        "For each detected conflict, write inbox_items row with kind='contradiction', payload={old_text, new_text, page_id, memo_id}",
+        "Add inbox row title='Two takes on <topic>' (qwen-generated)",
+        "Inbox badge in sidebar updates (already wired)",
+        "Typecheck passes",
+        "Tests pass: seed page with statement, submit memo with contradicting statement, verify inbox_item created"
+      ],
+      "priority": 40,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-041",
+      "title": "Wave 8b: Schema detection worker (cluster suggestion → inbox)",
+      "description": "As a user, I want the system to suggest new domains when it sees a clear cluster of related memos.",
+      "acceptanceCriteria": [
+        "Create inngest function 'schema-detect' triggered every 50 new memos per user (use a counter table or modulo on new_memo event)",
+        "Fetch user's last 200 memos with embeddings",
+        "Run HDBSCAN clustering (use 'density-clustering' npm pkg or simple kNN-based clustering since we don't need full HDBSCAN at first)",
+        "Identify clusters of >=8 memos NOT already mapped to existing domain",
+        "For each unmapped cluster, call qwen with cluster's memo titles to suggest a domain name",
+        "Write inbox_item kind='schema' with payload={cluster_memo_ids, suggested_name, suggested_color}",
+        "Idempotent: same cluster signature in last 7 days does not re-suggest",
+        "Typecheck passes",
+        "Tests pass: seed 10 memos all about 'distributed systems', run function, verify inbox_item with suggested name"
+      ],
+      "priority": 41,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-042",
+      "title": "Wave 8c: Cold storage detection cron",
+      "description": "As a user, I want suggestions to archive pages I haven't touched in 90+ days.",
+      "acceptanceCriteria": [
+        "Create inngest scheduled function 'orphan-detect' running daily at 04:00 UTC",
+        "For each user, find pages with last_compiled_at + 90 days < now AND backlink_count = 0 AND not recently viewed (need to add page_views table or use updated_at)",
+        "For each such page, write inbox_item kind='orphan' with payload={page_id, page_title, days_idle}",
+        "Cap: max 5 orphan suggestions per user per day to avoid spam",
+        "Idempotent: skip pages already in open inbox_item",
+        "Typecheck passes",
+        "Tests pass: seed page with old timestamps, run function, verify inbox_item created"
+      ],
+      "priority": 42,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-043",
+      "title": "Wave 8d: Observer agent daily worker + Home observations card",
+      "description": "As a user, I want the system to surface 'what it noticed' on Home so AI feels alive.",
+      "acceptanceCriteria": [
+        "Create inngest scheduled function 'observer-scan' running daily at 03:00 UTC per user",
+        "Aggregate signals: cluster growth (>=3x in past week), new entity emerged (>=3 mentions), dormant topic (no activity in 30d but has many backlinks), unresolved contradiction count",
+        "For each non-trivial signal, call qwen to write a 2-paragraph observation in user-facing prose, with 2-3 action button labels",
+        "Save to a new observations table (uuid, user_id, lead, body, actions jsonb, created_at, dismissed_at)",
+        "Cap: max 2 new observations per user per scan",
+        "Update GET /api/observations endpoint returning latest undismissed observations",
+        "Update Home view to render top 2 observations in 'What the system noticed' Card (already designed in Codex)",
+        "Each observation has Dismiss button (PATCH sets dismissed_at)",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: insert a test observation row via SQL, see it on Home"
+      ],
+      "priority": 43,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-044",
+      "title": "Wave 8e: Inbox view UI + filter chips + contradiction old/new compare",
+      "description": "As a user, I want to triage AI suggestions in a dedicated inbox view.",
+      "acceptanceCriteria": [
+        "Update /(app)/inbox/page.tsx",
+        "Render section label 'Inbox · N items' + headline + sub",
+        "5 filter chips: All / Contradictions / Schema / Orphans / Compiled (count beside each)",
+        "Each card: kind chip + time + title + body + actions row",
+        "CONTRADICTION cards include side-by-side old/new compare panes matching Codex visual",
+        "SCHEMA cards include suggested domain name + color preview",
+        "ORPHAN cards include 'days idle' meta",
+        "COMPILED cards include 'view changes' link",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: seed each kind via SQL, navigate to /inbox, see cards correctly rendered"
+      ],
+      "priority": 44,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-045",
+      "title": "Wave 8f: Inbox 处理 actions + snooze/dismiss",
+      "description": "As a user, I want to act on inbox items so the suggestion gets resolved.",
+      "acceptanceCriteria": [
+        "POST /api/inbox/:id/resolve with {action: string, payload?: any} writes inbox_items.status='resolved' + resolution + executes the action (e.g. for SCHEMA accept: create domain row + assign cluster memos)",
+        "POST /api/inbox/:id/dismiss sets status='dismissed'",
+        "POST /api/inbox/:id/snooze with {until: timestamp} sets status='snoozed' + a snooze_until column",
+        "Snoozed items reappear when current time > snooze_until (handled by cron or query filter)",
+        "Inbox card actions: CONTRADICTION 4 buttons (Keep both / Use new / Keep mine / Open both pages); SCHEMA 3 buttons (Create page / Suggest different name / Not yet); ORPHAN 3 buttons (Cold-archive / Keep / Open page); COMPILED 2 buttons (View changes / Dismiss)",
+        "Each card has '...' menu with Snooze 1d / Snooze 1w / Dismiss / Resolve as...",
+        "After action, card disappears with fade animation + sidebar badge updates",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: seed contradiction, click 'Use new', confirm card disappears + badge decrements"
+      ],
+      "priority": 45,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-046",
+      "title": "Wave 9a: Agent permissions schema + Settings → Agent page",
+      "description": "As a user, I want to control which AI actions are allowed.",
+      "acceptanceCriteria": [
+        "Add agent_permissions jsonb column to users.settings or new agent_permissions table",
+        "8 action keys per PRD V5 §7.2: ACT-1 auto_tag_domain, ACT-2 auto_archive_cold, ACT-3 auto_merge_entities, ACT-4 auto_promote_drafts, ACT-5 auto_fetch_external, ACT-6 auto_weekly_recap, ACT-7 auto_cross_link, ACT-8 auto_send_digest",
+        "Defaults: ACT-1, ACT-6, ACT-8 = ON; rest = OFF",
+        "Create web/src/app/(app)/settings/agent/page.tsx with toggle list",
+        "Each toggle: label + risk badge (low/med) + 1-line description + switch",
+        "PATCH /api/settings/agent updates permissions",
+        "Add 'Pause all AI agents' kill-switch toggle at top",
+        "When kill-switch on, all Actor functions check this and skip work",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: open /settings/agent, toggle ACT-3, refresh, confirm persisted"
+      ],
+      "priority": 46,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-047",
+      "title": "Wave 9b: Agent audit log + change_log + Undo API",
+      "description": "As a user, I want to see what AI did and undo any action.",
+      "acceptanceCriteria": [
+        "Ensure change_log table exists (id, user_id, action_kind, target_type, target_id, before jsonb, after jsonb, reason, performed_by enum:'user'|'agent', agent_action_id text, created_at)",
+        "Every page/entity/link mutation writes a change_log row before applying",
+        "Create web/src/app/(app)/settings/activity/page.tsx fetching /api/activity-log paginated",
+        "Filter chips: All / by action_kind / by performed_by",
+        "Each row has Undo button (POST /api/activity-log/:id/undo) which applies before state",
+        "Undo only works if no later mutation depends on this state (else show 'Cannot undo: 2 newer changes depend on this')",
+        "Typecheck passes",
+        "Tests pass: seed change_log entries, undo a page update, verify before state restored"
+      ],
+      "priority": 47,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-048",
+      "title": "Wave 9c: Agent safety 6 重栅栏完整实施",
+      "description": "As a system, I need all 6 safety guards enforced so Actor agents never run wild.",
+      "acceptanceCriteria": [
+        "Guard 1: All Actor functions read user.agent_permissions before running; skip if not authorized",
+        "Guard 2: All Actor + Observer mutations write change_log + activity rows",
+        "Guard 3: Undo path verified working in US-047",
+        "Guard 4: Add notification_throttle table (user_id, kind, count, window_start); inbox creators check 'sent <=3 of this kind in last 24h' before creating",
+        "Guard 5: Add helper isUserSleepWindow(userId) checking user's timezone (default UTC) is between 22:00-08:00; push notification senders skip if true",
+        "Guard 6: Settings → Agent page kill-switch (already in US-046); when on, ALL Actor + observation functions early-return",
+        "Add web/src/lib/agent/guards.ts as central enforcement helper",
+        "Typecheck passes",
+        "Tests pass: each guard has a unit test verifying skip behavior"
+      ],
+      "priority": 48,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-049",
+      "title": "Wave 9d: ACT-1 Auto-tag domain 实现 + ACT-6 Weekly recap 实现",
+      "description": "As a user with default permissions, I want my new memos to get auto-tagged and a weekly digest.",
+      "acceptanceCriteria": [
+        "ACT-1: in compile-memo function 'apply' step, if user.agent_permissions.auto_tag_domain && memo has no domain, find best-matching domain (vector match on memo embedding vs domain centroid embeddings, threshold >0.6) and set memo.domain_id",
+        "ACT-6: create inngest scheduled function 'weekly-recap' running Sundays 18:00 user-local-time (use user.timezone or UTC)",
+        "Aggregate week's memos + new pages + locations + activity, call qwen with weekly-recap.md prompt",
+        "Save as page (type='synthesis', slug='recap/weekly/YYYY-WNN', status='draft')",
+        "Send web push notification (if device registered) and email digest if user.agent_permissions.auto_send_digest (ACT-8)",
+        "Both ACT-1 and ACT-6 write change_log + activity rows",
+        "Typecheck passes",
+        "Tests pass: ACT-1 assigns correct domain; ACT-6 creates draft recap page"
+      ],
+      "priority": 49,
+      "passes": false,
+      "notes": ""
+    },
+    {
+      "id": "US-050",
+      "title": "Wave 9e: 收尾 — sidebar inbox badge live update via SSE + global SSE auth + smoke test",
+      "description": "As a user, I want sidebar badges and inbox to update in real-time across the app.",
+      "acceptanceCriteria": [
+        "Create /api/stream/global SSE endpoint: emits {type:'inbox_added'|'inbox_resolved'|'compile_done', payload}",
+        "Sidebar component subscribes; badge count increments/decrements live",
+        "Inbox view subscribes; new items appear at top with fade-in",
+        "Home observations subscribes; new card slides in",
+        "Verify SSE auth: invalid session returns 401 immediately; expired session closes connection cleanly",
+        "Run full smoke test: log in, submit a memo, watch (a) compile queue progress (b) new page appear in wiki nav (c) sidebar inbox badge if conflict detected (d) home observation if signal triggered",
+        "Document smoke test as docs/web/SMOKE-TEST.md with steps",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill: run the documented smoke test end-to-end and confirm all 4 reactive updates work"
+      ],
+      "priority": 50,
+      "passes": false,
+      "notes": ""
     }
   ]
 }

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,47 +1,65 @@
-# Ralph Progress Log
-Started: Fri May  8 12:55:00 UTC 2026
-Branch: ralph/today-composer-liquid-refinement
-PRD: tasks/prd-today-composer-liquid-refinement.md
-Issues: getyak/daypage#252 (Today 主页极简) + #250 (Composer 3.0 Liquid Composition)
+# Ralph Progress Log — DayPage V5 Codex
+Started: 2026-05-10
+Branch: ralph/v5-codex-web
+Source PRD: tasks/prd-daypage-v5-codex.md
+Technical plan: docs/web/PLAN.md
+Design source: Anthropic Claude Design export `daypage-system/` (Codex prototype, 6 views + 1172 lines CSS)
+
+Previous run (today-composer-liquid-refinement) archived at:
+  - archive/2026-05-10-today-composer-liquid/ (root, redundant)
+  - scripts/ralph/archive/2026-05-10-today-composer-liquid/ (canonical per ralph convention)
+
 ---
 
 ## Codebase Patterns
 
-### 沿用 v4 Liquid Glass 的既有模式
-- Motion tokens live in DayPage/DesignSystem/Motion.swift; always use Motion.fade/rise/slide/spring instead of raw animation values
-- Haptics tokens live in DayPage/DesignSystem/Haptics.swift; use Haptics.tapConfirm/commit/warn/success instead of UIImpactFeedbackGenerator directly
-- Glass surfaces in DayPage/DesignSystem/Surfaces.swift; use .liquidGlassCard/.liquidGlassPill/.liquidGlassPanel modifiers
-- DSFonts.serif(size:weight:italic:) returns cascading Latin→CJK font; never use DSFonts.newYork (deprecated)
-- CJKTextPolish.polish() is render-only; never apply before persisting to vault/raw/
-- NavigationStack with navigationDestination(for: Memo.ID.self) in TodayView drives all memo detail navigation
-- SwipeableMemoCard uses NavigationLink(value: memo.id) + .disabled(revealedSide != nil) to prevent push when swiped
-- GlassErrorBanner managed by ErrorBannerManager singleton; post via ErrorBannerManager.shared.post(...)
-- EmptyStateView has factory methods: .todayBlank(), .todayNoSignals(), .compileLocked(currentCount:), .archiveDayEmpty(), .micPermissionDenied()
-- DayOrbView lives in DayPage/Features/Today/DayOrbView.swift; takes signalCount: Int, size: CGFloat = 140, haloOpacity: CGFloat = 0.15
-- DailyPageMemoVM: lightweight MemoDetailViewModel for archive dates; follows same rewrite() pattern as TodayViewModel
-- MemoDetailView accepts `any MemoDetailViewModel` (protocol); both TodayViewModel and DailyPageMemoVM conform
+### V5 跨端架构（PRD V5 §3 / §8）
+- iOS vault `vault/raw/YYYY-MM-DD.md` 仍是 iOS 端 source of truth（V1-V4 兼容），V5 不破坏
+- 后端 PostgreSQL 是云端 single source of truth，iOS 通过 sync API 上传/拉取增量
+- 所有 memo UUID 由 iOS 端生成，后端 upsert by id（避免 mapping 表）
+- 所有 page/entity/annotation UUID 由后端生成，客户端拉取后写入本地缓存
+- 时间字段统一 ISO8601 with Z (UTC)，client 显示时转用户本地时区
+- 删除一律 soft-delete (`deleted_at`)，30 天后 worker 物理删除
 
-### 本轮新增的硬性规则
-- 删除文件前必须 `grep -rn '<SymbolName>' DayPage/` 确认无残留引用
-- 修改 i18n key 必须同时更新 zh-Hans.lproj 和 en.lproj 两份
-- 状态机转移函数禁止抛错；非法转移用 assert + log 兜底
-- 所有 Composer 动画必须支持 Reduced Motion 降级（fade-only 0.2s）
-- iPhone 17 Simulator 是默认验证机型；任何 UI 改动必须 `xcodebuild -destination 'platform=iOS Simulator,name=iPhone 17' build` 通过
+### Web 端工程约束（PRD V5 §10 / docs/web/PLAN.md §3.1）
+- Next.js 16 App Router (Turbopack 默认，不需要 --turbo flag)
+- React 19 Server Components 优先，Client Components 仅用于交互
+- Tailwind 4 用 CSS-first @theme 配置（不再有 tailwind.config.ts）
+- TypeScript strict 模式
+- 字体走 next/font self-host（Space Grotesk / Inter / JetBrains Mono），零 CLS
+- 所有 API route 必须 `await auth()` 验证 + scope by user_id
+- 所有 mutation 必须事务性 + 写 change_log + 写 activity
+- 所有 LLM 调用必须落 prompt_log 表 (含 tokens_in/out)
+- 所有写操作有 rate limit (mutation 30/min, chat 60/min)
+- DashScope/Claude API key 仅在 server，永远不下发客户端
+
+### Codex 设计语言（PRD V5 §10）
+- warm-archival 美学：#FAF8F6 暖白底 + #5D3000 琥珀棕主色
+- 3 套字体：Space Grotesk (display) / Inter (body) / JetBrains Mono (meta)
+- 12px 圆角卡片 + 1px 细边框 + 极淡阴影
+- ALL-CAPS 微排版做 section label 与 metadata
+- 248px 固定侧边栏 + 主区流式
+- Motion: 140ms ease-out 转场；严禁 bouncy spring（与档案美学冲突）
+- 桌面优先 ≥1280px，1024-1280 自适应，<1024 简化版
+
+### Agent 安全 6 重栅栏（PRD V5 §7.4 / Wave 9c）
+- Guard 1: Actor 默认全关，逐项授权 (Settings → Agent)
+- Guard 2: 所有 action 写 change_log + activity
+- Guard 3: 所有 action 可逐条 undo
+- Guard 4: 同 user 同类通知 ≤3/24h
+- Guard 5: user 本地时区 22:00-08:00 不发推
+- Guard 6: 全局 kill-switch 一键停所有 Actor + Observer
+
+### 测试约定
+- Vitest 跑单元测试与 API route 测试
+- E2E 用 Playwright（Wave 21 集中铺开，前期手动验证）
+- 浏览器验证（dev-browser skill）是 frontend story 完成的必备 acceptance criterion
+- 类型检查 `pnpm web:typecheck` 是所有 story 完成的必备 criterion
+
+### iOS 兼容性
+- iOS V1-V4 所有功能保留不变
+- 不修改 vault `.md` 格式（YAML front-matter + Markdown body）
+- iOS 端云同步是 opt-in（第一次启动后引导，但可拒绝）
+- iOS AI key 改走后端代理（V5 必做）
 
 ---
-[2026-05-08T06:43:53Z] Story #US-001: i18n 资源彻查：lproj target membership + L10n.swift 强类型枚举 — PASSED
-[2026-05-08T06:44:37Z] Story #US-002: AmbientBackground 纯化：删 4 团暖色光斑，默认仅 cream 底 — PASSED
-[2026-05-08T07:10:00Z] Story #US-003: Day Orb 收敛：size 140pt + halo opacity 0.15 + orbFill ×0.5 — PASSED
-[2026-05-08T06:45:47Z] Story #US-003: Day Orb 收敛：size 140pt + halo opacity 0.15 + orbFill ×0.5 — PASSED
-[2026-05-08T06:47:37Z] Story #US-004: 删除 GlassTabBar，账号头像迁入设置 sheet，右上仅留齿轮 — PASSED
-[2026-05-08T06:50:13Z] Story #US-005: TodayViewModel 新增 TodayFallback 枚举与 fallbackContent 计算属性 — PASSED
-[2026-05-08T06:53:35Z] Story #US-006: 复活 OnThisDayCard 与 WeeklyRecapSection，TodayView 接入 fallback 渲染 — PASSED
-[2026-05-08T06:55:59Z] Story #US-007: InputBarV4 引入 ComposerState 状态机替换 userExpandedText — PASSED
-[2026-05-08T06:59:54Z] Story #US-008: Liquid Morph: idle 玻璃胶囊 matchedGeometryEffect 生长成 composition card — PASSED
-[2026-05-08T07:04:02Z] Story #US-009: Adaptive Send Affordance：发送按钮 5 形态 (空/文本/文本+图/位置/多模态) — PASSED
-[2026-05-08T07:08:55Z] Story #US-010: Composer 工具栏迁移到 keyboard-attached (.toolbar placement: .keyboard) — PASSED
-[2026-05-08T07:11:56Z] Story #US-011: Drag-to-Collapse Handle: 卡片顶 36x4 capsule 上滑收起 — PASSED
-[2026-05-08T07:14:13Z] Story #US-012: Haptics.swift 扩展 5 级触感阶梯并接入 Composer 流程 — PASSED
-[2026-05-08T07:17:14Z] Story #US-013: ComposerContextProvider 服务：聚合 Weather/Location/lastMemo/Pasteboard — PASSED
-[2026-05-08T07:20:22Z] Story #US-014: Context Spotlight Strip: TextField 上方横向 chip 带 — PASSED
-[2026-05-08T07:23:05Z] Story #US-015: Smart Templates: 12 条时段模板 hardcode — PASSED

--- a/tasks/prd-daypage-v5-codex.md
+++ b/tasks/prd-daypage-v5-codex.md
@@ -1,0 +1,1844 @@
+# PRD: DayPage V5 · Codex —— 终极形态产品蓝图
+
+> **生成日期**：2026-05-10
+> **作者**：Claude（与主理人 Xinwei 共同澄清）
+> **来源**：Anthropic Claude Design 导出包 `daypage-system/`（Codex 原型 6 视图 + 1172 行 CSS）+ iOS V1-V4 PRD 演化历史 + 主理人对终极形态的口述
+> **目标版本**：V5.0(跨端知识系统时代)
+> **状态**：**主理人 review 中** —— 重大方向决策已锁定（见 §0），细节实现待 Wave 拆分
+> **本文档与既有 PRD 关系**：
+> - V1 = MVP 原型 / V2 = 功能补完 / V3 = 体验升级 / V4 = liquid-glass 视觉
+> - **V5 = 平台跃迁**：从「iOS 单机日志工具」→「跨端 AI 知识系统 Codex」
+> - V1-V4 的所有功能继续承袭，V5 新增 Web 端、AI 主动行动、多设备同步、终极形态愿景
+> **本 PRD 不是工程实施排期**，是产品蓝图。具体技术方案见姊妹文档 `docs/web/PLAN.md`。
+
+---
+
+## 目录
+
+- [§0 锁定决策](#0-锁定决策)
+- [§1 产品愿景与价值主张](#1-产品愿景与价值主张)
+- [§2 用户画像](#2-用户画像)
+- [§3 终极形态全景图](#3-终极形态全景图)
+- [§4 功能模块详述（24 个模块）](#4-功能模块详述)
+- [§5 用户故事（72 条 US）](#5-用户故事)
+- [§6 功能性需求（FR · 编号锁定）](#6-功能性需求-fr)
+- [§7 AI Agent 主动行动模型](#7-ai-agent-主动行动模型)
+- [§8 数据模型与跨端同步](#8-数据模型与跨端同步)
+- [§9 多平台战略](#9-多平台战略)
+- [§10 设计语言与品牌系统](#10-设计语言与品牌系统)
+- [§11 Non-Goals（明确不做）](#11-non-goals)
+- [§12 终极形态商业模型（描述，不实施）](#12-终极形态商业模型)
+- [§13 隐私、安全、合规](#13-隐私安全合规)
+- [§14 北极星与成功指标](#14-北极星与成功指标)
+- [§15 Wave 拆分与里程碑](#15-wave-拆分与里程碑)
+- [§16 风险登记册](#16-风险登记册)
+- [§17 Open Questions](#17-open-questions)
+
+---
+
+## §0 锁定决策
+
+主理人在 PRD 启动澄清环节明确确认：
+
+| 决策维度 | 锁定方向 |
+|---|---|
+| **核心价值主张** | **三合一**：「思考的档案库」+「数字生命」+「习惯追踪/年度总结」—— 同一产品在不同**时间维度**与不同**用户成熟度**下的不同感知。三者共享底层 raw memo 数据 + AI 编译引擎，差异在编译产物的呈现层。 |
+| **变现** | **本 PRD 不实施订阅/支付** —— 只在 §12 描述形态。所有 V5 wave 都按"无支付门槛"开发；功能边界按"全用户都能用全部功能"画。 |
+| **范围** | **完整版** —— 终极形态全景图，含 iOS / Watch / macOS / Web / 企业版 / 公开 API。3 年路线图。 |
+| **激进度** | **中等激进** —— 含 AI Agent 主动行动、多模态输入、跨设备无缝。**不含**：跨用户公共知识云 marketplace、用户间语义网络分享、第三方插件市场。 |
+| **设计来源** | **Codex 原型为 Web 端的 1:1 视觉参考**（warm-archival 美学），但功能必须真实可生产 |
+| **技术栈** | 见 `docs/web/PLAN.md`：Next.js 16 + Supabase + Auth.js v5 + Drizzle + Inngest + 后端代理 AI |
+| **iOS** | 继续承袭 V1-V4 全部能力；新增云同步 + 卸载本地 AI key |
+
+---
+
+## §1 产品愿景与价值主张
+
+### 1.1 一句话产品定义
+
+> **DayPage 是一个把「你今天乱糟糟的输入」编译成「你将来能反向检索的自己」的跨端 AI 知识系统。**
+
+### 1.2 三层价值主张（同一产品的不同感知层）
+
+DayPage 终极形态在用户视角是**同一个产品**，但在不同使用阶段、不同人格、不同年龄段，会被感知为不同的东西：
+
+#### 层 A · 「思考的档案库」（Thinking Archive）
+
+**面向**：知识工作者、研究者、创作者、深度学习者
+**心智**：我有大量碎片输入（论文 PDF、播客笔记、灵光一现、对话），我不想再用 Notion/Obsidian 手动整理。
+**形态感知**：DayPage 像 Notion + Obsidian + Roam Research 的 **AI 自治版**——你只管丢，系统主动建 wiki、连 backlink、画 graph、抽 entity。
+**核心使用动作**：Add（投喂）→ Wiki 浏览 → Chat（RAG 问答）→ Inbox（处理 AI 主动建议）
+**对应 Codex 视图**：Add / Wiki / Chat / Inbox 是这层用户的主战场
+
+#### 层 B · 「数字生命」（Digital Life Twin）
+
+**面向**：所有重度长期用户（用了 1 年以上的人）
+**心智**：DayPage 知道我去年这个时候在哪、说过什么、读过什么、心情如何——它**变成了我可以对话的过去**。
+**形态感知**：On This Day、Year in Review、"问 2024 年的你怎么看这件事"、AI Persona（基于你历史输入训练的对话风格）。
+**核心使用动作**：Home 页的「the system noticed」卡片、与"过去的自己"对话、年度/月度回顾、"那次去东京我说了什么？"地图检索
+**对应 Codex 视图**：Home / Chat 是这层的主入口；这层在 V5 中通过 §7 AI Agent 显式触达
+
+#### 层 C · 「习惯追踪 + 生活记录」（Lifelog）
+
+**面向**：轻度用户、生活记录爱好者、Day One 老用户、心境日记用户
+**心智**：我就想记一下今天去了哪、做了什么、心情如何，最好能定期看到"我这个月做得怎么样"。
+**形态感知**：每天打开 Today 输入两句话 → 月底/年底自动出图文回顾报告 → 偶尔翻 archive。
+**核心使用动作**：Today 输入 → Archive 月历视图 → Weekly Recap → On This Day
+**对应**：iOS 端 V1-V4 已有完整支持；V5 增强是**自动报告分发**（每周日早上推送一份"上周的你"卡片）
+
+### 1.3 三层之间的演化路径
+
+```
+新用户 → 层 C（轻量记录，1-2 周）
+       → 层 A（开始投喂深度内容，AI 编译产生第一批 wiki page）
+       → 层 B（积累 6 个月以上数据后，"过去的自己"具象化）
+```
+
+**关键洞察**：用户**不会自己跨越层级**。产品必须在合适时机**主动暴露下一层**：
+- 第 14 天首次 Wiki 自动生成 → 推送「你已经有第一份知识网络了」 → 引导进入层 A
+- 第 180 天首次 Year in Review 候选 → 推送「过去半年的你长这样」 → 引导进入层 B
+
+### 1.4 与竞品的差异化（一句话定位）
+
+| 竞品 | 它的强项 | DayPage 的差异点 |
+|---|---|---|
+| Day One | 漂亮的日记体验 | DayPage 比它**多 AI 编译**，碎片→结构化 |
+| Notion | 全能数据库 | DayPage 比它**少手动**，AI 自治建 wiki |
+| Obsidian | 双向链接 + 本地优先 | DayPage 比它**多移动端 + AI**，且 backlink 自动建 |
+| Roam Research | 思维网络 | DayPage 比它**多多模态输入 + 跨端** |
+| Notebook LM | RAG 问答 | DayPage 比它**多日常 capture + 长期演化** |
+| Reflect / Mem | AI + 笔记 | DayPage 比它**多 nomad/位置/语音原生支持 + 跨端深度同步** |
+
+**一句话**：**没有任何竞品同时具备 ① iOS-first 的低摩擦 capture + ② 真正的 AI 自治编译 + ③ 跨端无缝 + ④ 长期演化的"数字生命"叙事**。这四点的组合就是 DayPage 的护城河。
+
+---
+
+## §2 用户画像
+
+### 2.1 P1 主画像 · "数字游民学者" Aria
+
+- **基本信息**：32 岁，独立研究者 / 技术写作者，常驻清迈+东京+里斯本三地
+- **设备**：iPhone 16 Pro + Apple Watch + MacBook Air M3 + iPad Pro
+- **当前痛点**：
+  - 每天读 5+ 篇论文 / 听 3 个播客 / 拍照若干，灵感丢一半
+  - Notion 维护成本太高，Obsidian 在手机上烂
+  - 在飞机上没法用 cloud 工具
+- **使用场景**：
+  - 早上散步：iPhone 语音记 30s 想法
+  - 咖啡馆工作：Mac 上 paste 论文 URL → 一会儿出现在 wiki
+  - 飞机上：iPhone 离线翻 wiki 找上次写过的某个概念
+  - 月底：Mac 上跑 Year in Review，导出 PDF 给自己
+
+### 2.2 P2 副画像 · "终身学习者" Felix
+
+- **基本信息**：40 岁，产品经理，业余学量子计算
+- **设备**：iPhone + Mac
+- **使用频次**：每天 5-10 条 memo
+- **核心需求**：把碎片学习变成"半年后还记得的知识"，而不是"读过就忘"
+
+### 2.3 P3 副画像 · "生活记录人" Sky
+
+- **基本信息**：28 岁，设计师，喜欢拍照、写日记、看心情曲线
+- **设备**：iPhone + Watch
+- **核心需求**：日记 + 照片 + 月度回顾，**几乎不关心 wiki/chat**，但喜欢 On This Day 给的惊喜
+
+### 2.4 P4 终极画像 · "5 年用户" Aria-2031
+
+- 已经积累 **3 万+** memo、**500+** wiki page、**80+** entity
+- 每周要问"过去的自己"3-5 次
+- 把 DayPage 当作"外部记忆"，遗忘内部记忆
+- **新风险**：数据迁移恐惧、平台 lock-in 焦虑 → V5 必须解决（§13）
+
+---
+
+## §3 终极形态全景图
+
+### 3.1 产品矩阵（5 端 + 1 平台）
+
+```
+                       ┌─────────────────────────────────┐
+                       │   DayPage Cloud (Backend)       │
+                       │   PostgreSQL + Inngest + R2 +   │
+                       │   AI Engine (DashScope/Claude)  │
+                       └────────────┬────────────────────┘
+                                    │ /api/v1/*
+        ┌──────────┬───────────────┼─────────────┬──────────────┐
+        ▼          ▼               ▼             ▼              ▼
+   ┌────────┐ ┌────────┐  ┌─────────────┐ ┌──────────┐  ┌──────────┐
+   │  iOS   │ │ Watch  │  │  macOS App  │ │   Web    │  │ Public   │
+   │ (主)   │ │ (语音) │  │ (深度工作)  │ │ (Codex)  │  │   API    │
+   └────────┘ └────────┘  └─────────────┘ └──────────┘  └──────────┘
+       ▲          ▲              ▲             ▲              ▲
+       │          │              │             │              │
+   capture     capture       work-mode      browse +       第三方
+   on the go   wrist         long-form      share        integrations
+```
+
+### 3.2 五端功能矩阵
+
+| 功能 | iOS | Watch | macOS | Web | API |
+|---|:---:|:---:|:---:|:---:|:---:|
+| Today Quick Capture（文字/语音/照片/位置） | ● | ◐ (语音) | ● | ● | ● |
+| Archive 月历回看 | ● | ○ | ● | ● | ● |
+| Wiki 浏览 | ● | ○ | ● | ●● (主) | ● |
+| Wiki 编辑（annotation） | ● | ○ | ● | ●● (主) | ● |
+| Graph 图谱视图 | ◐ | ○ | ●● (主) | ●● (主) | ● |
+| Chat / RAG 问答 | ● | ◐ (Siri) | ●● | ●● | ● |
+| Inbox 处理 AI 建议 | ● | ◐ (推送) | ● | ●● (主) | ● |
+| AI Agent 主动行动 | ● | ● | ● | ● | – |
+| 全局搜索 | ● | ○ | ●● (Spotlight) | ● | ● |
+| Year in Review 报告 | ● | ○ | ●● (PDF 导出) | ●● (网页分享) | ● |
+| Onboarding | ● | – | ● | ● | – |
+| 实体页（Entity） | ● | ○ | ● | ● | ● |
+| Settings / Account | ● | ◐ | ● | ●● (主) | – |
+| 数据导出 / 删除账号 | ● | – | ● | ● | ● |
+| Webhook / 第三方接入 | – | – | – | ● | ●● (主) |
+
+图例：● 完整 / ●● 主战场 / ◐ 简化版 / ○ 不做 / – 不适用
+
+### 3.3 终极形态的"完整一天"剧本
+
+> **2027 年 11 月 15 日，Aria 在里斯本一家咖啡馆，距离 V5 上线 18 个月**
+
+**07:32** 散步路上，iPhone 锁屏滑出 capture 卡片，按住 Watch 表冠说：「今天读 Henrik 的 Spanner 论文有个新理解——TrueTime 不是技术细节，是 Google 在赌"误差可量化"作为产品哲学」 → Watch 上传到 Cloud
+
+**07:45** 早餐时打开 iPhone，**Home 页 AI Agent 卡片**：「我注意到这是你 14 天内第 3 次提到 TrueTime。已经把它从 'mention' 升级为独立 Concept Page，并把你 9 月那条 Spanner 笔记和 5 月的 Lamport 引用全连进来了。要不要看看？」
+
+**09:15** 在 Mac 上打开 DayPage Web，**Wiki Graph** 视图，TrueTime 节点周围已经有 7 条边。点开看到完整 page，AI 已经给"误差可量化"那段做了 `important` 标记（基于 Aria 过去对类似句子的高亮模式）
+
+**11:20** 在 Web 端 Add 框 paste 一个 PDF URL（Hennessy 的新书章节）→ 立即出现在 Compile Queue → 25 秒后变 done → Inbox 弹一条「这本书 Ch.4 与你已有的 'Replicated state machines' 页 5 处冲突——它说 leaderless 在 multi-region 才占优，你之前的笔记说 single-leader 永远更快。要不要把这条挂为 tracked contradiction？」
+
+**14:00** 飞往清迈的航班起飞前，iPhone 自动拉取最新 wiki snapshot → 飞机上离线翻看 → Annotate 几句
+
+**18:40** 落地后 Apple Watch 推送：「检测到你换了时区。已自动用清迈天气更新今天 location memo。要不要播放一段 'on this day in 2026' 的语音回顾？你去年同一天也在清迈。」
+
+**22:30** 睡前 iPhone 推「**周报候选**」卡片 → 一键生成 → 分享给伴侣
+
+**关键观察**：这一天里，Aria 主动操作 ≈ 6 次；AI 主动触达 ≈ 5 次。**主动:被动比例 = 1.2:1**。这是终极形态的核心设计准则：**AI 不再是工具，而是"住在数据里的同事"**。
+
+---
+
+## §4 功能模块详述
+
+V5 终极形态共包含 **24 个功能模块**，分为 6 大类：
+
+### 4.A · Capture 类（输入端，4 个）
+
+#### M1 · Universal Quick Capture（万能速记）
+- 入口：iOS Today 页 / Watch 表冠 / Mac 全局快捷键 ⌥Space / Web 顶栏 / Siri / Share Sheet / Email-to-DayPage
+- 输入类型自动识别：文字 / 语音（自动转写）/ 照片（自动 OCR + EXIF）/ 视频（首帧+音频转写）/ URL（抓取+清洗）/ 文件（PDF/EPUB/Markdown 解析）/ 位置（自动捕获 + 反向地理编码）
+- **每条 memo 强制嵌入元数据**：时间、位置、天气、设备、网络状态、电量（用于行为模式分析）
+- 离线写入本地 → 联网自动同步
+- **3 秒规则**：从想到记到的时间不超过 3 秒（含锁屏唤醒）
+
+#### M2 · Voice-First Capture（语音优先）
+- 长按发送键开始录 → 松手停止 → 自动转写显示在卡片
+- 转写引擎：Whisper (短) / DashScope ASR (中) / 本地 Apple Speech (离线)
+- 同时保留 m4a 原音频 → 后期可重听 / 重转写
+- Watch 端支持 1 分钟以内语音，自动转 iPhone 同步队列
+- AI 后处理：去口头禅、加标点、识别关键实体
+
+#### M3 · Multimodal Capture（多模态输入，激进）
+- **AR 标注**：iOS Camera 拍黑板 → AR 模式直接在画面上画箭头标注 → 保存为带标注的图像 memo
+- **手势/手势库**：用户自定义 3D Touch 手势 → 一键调用某个 capture 模板（如"读书笔记"）
+- **音频环境识别**：录音时检测背景音（咖啡馆/飞机/室外）→ 自动加 tag
+- **眼动追踪笔记**（Vision Pro 适配，Post-V5）
+
+#### M4 · Inbox-from-Anywhere（外部入口）
+- **Email-to-DayPage**：用户拿到一个 `<userid>@in.daypage.io` 邮箱地址 → 转发任何邮件即入 Inbox
+- **Webhook ingest**：第三方服务 POST `/api/v1/ingest` → 进 raw 队列
+- **浏览器扩展**：Chrome/Safari 扩展，一键剪藏当前页（含选中文本/截图/URL）
+- **iOS Share Sheet**：分享任何 App 内容到 DayPage
+- **macOS Finder Quick Action**：右键文件 → "Send to DayPage"
+
+### 4.B · Compile 类（AI 编译引擎，4 个）
+
+#### M5 · Two-Tier Compile（双档编译）
+- **LIGHT 模式**（默认 reading-only 内容）：
+  - 仅生成摘要、关键词、可能 entity → 挂到 source page
+  - 不创建 concept page、不更新 wiki
+  - 用户在 Add 视图可一键 upgrade 为 FULL
+- **FULL 模式**（默认 user-authored 内容）：
+  - 召回相关 page top-K → 让 LLM 决定 patch 操作
+  - 可能产生：更新现有 page / 新建 concept page / 抽取 entity / 创建 backlink / 触发 inbox（schema 建议、矛盾检测）
+- **触发策略**：
+  - 用户输入：默认 FULL
+  - 抓取的 web 内容：默认 LIGHT，AI 评估"信号密度"决定是否升级
+  - 用户可在 Settings 永久切换默认档
+
+#### M6 · Compile Pipeline（编译流水线）
+
+每个 memo 经历的 step（每步幂等、可单独重跑）：
+
+```
+1. NORMALIZE   清洗格式、提取纯文本
+2. TRANSCRIBE  voice → text（如适用）
+3. OCR         photo → text（如适用）
+4. FETCH       URL → article body（如适用，readability 算法）
+5. CHUNK       切段（按段落或固定 token 数）
+6. EMBED       text-embedding-v3 → 1536-d vector
+7. RECALL      向量召回 top-K 相关 page
+8. COMPILE     LLM 生成 patch（JSON tool calling）
+9. APPLY       事务性写入 page / link / source / annotation
+10. INDEX      更新搜索索引、backlink count
+11. NOTIFY     SSE 推前端 / push 通知
+12. ACT        触发 §7 Agent 评估是否需主动行动
+```
+
+#### M7 · Schema Detection（自动建 cluster）
+- 后台 worker 定期（每 50 条新 memo 跑一次）
+- 用 HDBSCAN 在最近 N 条 memo 的 embedding 上做聚类
+- 发现"明显但未命名"的 cluster → 推 inbox：「这 14 条都聊 X，要不要建一个新 domain 'X'？」
+- 用户接受 → 自动创建 domain + 把这些 memo 关联
+
+#### M8 · Conflict Detection（矛盾检测）
+- 每次新 memo 编译时，LLM 检查与现有 page 的语义冲突
+- 检测到冲突 → 写 inbox 的 CONTRADICTION 项，包含：
+  - 旧表述 + 新表述对比
+  - 4 个动作：Keep both as tracked / Use new / Keep mine / Open both pages
+- 用户解决后，patch 应用到 page，并记录 `change_log` 表
+
+### 4.C · Knowledge Surface（知识呈现，6 个）
+
+#### M9 · Wiki Page System
+- **页类型**：Concept / Source / Entity / Synthesis / Daily / Domain
+- 每个 page 含：title、type、domain、status (live/draft/archived/cold)、body_md、metadata、source_count、backlink_count
+- **Daily Page** 自动生成：每晚 00:30 把当日所有 memo + 编译产物聚合成一份 daily diary
+- **Synthesis Page**：用户在 Chat 里"Save as synthesis page"产出
+- **Cold Storage**：90 天无访问、无 backlink 的 page → 推 inbox 询问归档
+
+#### M10 · Wiki Navigation
+- 左侧分组导航（Concepts / Sources / Entities / Synthesis / Daily / Domains）
+- 顶部搜索（`/` 快捷键全局聚焦）
+- 列表 / Graph 双模式切换
+- 每条带 meta（source 数 / 是否 draft / 是否含冲突）
+
+#### M11 · Knowledge Graph（图谱）
+- **三层视图**：
+  - **Domain 视图**：node = page, edge = link（Codex 静态版）
+  - **Entity 视图**：node = entity（人/组织/项目/地点），edge = co-mention
+  - **Time 视图**：横轴时间，纵轴 domain，散点是 memo
+- **交互**：拖拽、缩放、点击展开、按 type 过滤、按 domain 染色
+- **物理引擎**：force-directed（节点 >100 时降级到分层 layout）
+- macOS / Web 主战场；iOS 简化版（只看不编辑）
+
+#### M12 · Annotation Layer（用户标注层）
+- 用户在 page 上选中文本 → 弹 toolbar：标记为 important / questionable / 自定义 tag / 添加 note
+- 标注存独立表，不修改 page body
+- AI 重新编译时**读取**用户标注作为信号 → "用户标了 important 的句子，下次扩展这个 concept 时要保留"
+- Annotation 在前端通过 `<mark>` 渲染，不同 tag 不同颜色
+
+#### M13 · Provenance Trail（来源追溯）
+- 每个 page 段落可点击 → 显示「这段来自 memo X、memo Y」
+- 每条 memo 可反查 → "我贡献了哪些 page 的哪些段落"
+- 时间机器：选某个时间点 → 看 page 在那时候长什么样
+- Compile log：每次 LLM patch 都有完整 prompt + response + 决策 rationale 记录
+
+#### M14 · Search & Discovery
+- **混合搜索**：BM25（keyword）+ 向量（语义）+ metadata filter
+- 搜索范围：page / memo / entity / annotation 四类切换
+- 联想：边输入边显示「相似的过去 memo」「相关 page」
+- **"模糊回忆"模式**：用户输入"我去年那个关于啥来着..." → AI 反向问 3 个澄清问题 → 定位
+
+### 4.D · Conversation & Agent（对话与代理，4 个）
+
+#### M15 · Wiki Chat（基于个人 wiki 的 RAG）
+- 对话基础：仅基于用户自己的 wiki + memo（不引外部知识）
+- 数字引用 `{n}` 强制格式 → 解析为 reference cards
+- Suggested follow-ups（每答必给 3 条）
+- "Save as synthesis page" → 把这个对话凝练成 page
+- 多 thread 管理（左侧 thread 列表）
+- 长对话自动 compaction
+
+#### M16 · Past-Self Dialogue（与过去的自己对话）
+- 选定时间段（"2024 年 9 月"）→ 系统用那段时间的 memo 作 context 训练 mini persona
+- 用户问：「2024 年 9 月的我怎么看待远程工作？」
+- AI 用第一人称回答，引用具体当时的 memo
+- 极强情绪冲击力 → "层 B：数字生命"的核心体验
+
+#### M17 · AI Agent · Observer（观察者代理）
+- 长驻后台，定时（每天/每小时）扫描数据
+- 输出 4 类 Inbox 项 + Home 页 observations 卡片
+- 详见 §7
+
+#### M18 · AI Agent · Actor（行动者代理）
+- 用户授权后可执行的"动作"：
+  - 自动归档冷 page
+  - 自动 merge 重复 entity
+  - 自动给新 memo 打 domain tag
+  - 自动生成 weekly recap 草稿
+  - 调用外部 API（如查 arXiv 补 reference）
+- 所有 Actor 行动有 audit log，可逐条撤销
+- 详见 §7
+
+### 4.E · Reflection & Memory（反思与记忆，3 个）
+
+#### M19 · On This Day（今日回顾）
+- iOS V3 已实现简版；V5 升级：
+  - 跨年回顾（"2024/2025/2026 同一天"）
+  - 不仅看 memo，还看那天的 page diff（"那天你新建了 X concept"）
+  - AI 写 1 段 "你那天" 的总结
+  - 可设定时推送（早 7:00 / 午 12:00 / 晚 22:00）
+
+#### M20 · Periodic Recap（周报/月报/年报）
+- **Weekly Recap**：每周日 18:00 自动生成草稿 → 推送 → 用户编辑确认 → 保存为 page
+- **Monthly Recap**：每月 1 日 → 含数据图（最常去的地点、最活跃的 domain、出现最多的 entity）
+- **Year in Review**：每年 12/20 → 含整年所有维度的可视化 + AI 写的"年度叙事"+ 可分享网页 URL
+- 用户可一键导出 PDF
+- macOS 端有专门的 "Recap Builder" 编辑器
+
+#### M21 · Memory Lane（记忆漫步）
+- "随机漫步"按钮 → 系统随机选 5 条尘封 memo + 1 个被遗忘 page
+- "情绪回放"：选定情绪标签 → 看历史上同类情绪的所有 memo
+- "地图回放"：地图视图 → 点某个城市 → 看所有发生在那的 memo
+
+### 4.F · System & Trust（系统与信任，3 个）
+
+#### M22 · Cross-Device Sync（跨端同步）
+- 后端 PostgreSQL = single source of truth
+- iOS 用 vault `.md` 作离线缓存（仍是 V1-V4 的格式）
+- Web/macOS 用 IndexedDB / SQLite 作离线缓存
+- 同步协议：拉模型（device 主动 GET `/api/sync?since=cursor`）+ SSE 推（后端有更新立即推 push notification）
+- 冲突策略：last-write-wins，但 user-edited annotation 永远优先于 AI patch
+
+#### M23 · Privacy Vault（隐私保险箱）
+- 任何 memo / page 可标记为 "private"
+- Private 内容：不进 RAG context、不参与 cross-page link、不出现在 graph、AI 不能引用
+- 用户主密码（独立于账号密码）解锁
+- 详见 §13
+
+#### M24 · Data Sovereignty（数据主权）
+- 一键全量导出（ZIP 内含所有 raw markdown + 所有 page markdown + JSON 元数据 + 所有 attachment）
+- 一键删除账号（GDPR 兼容，30 天内彻底清除，含 backup）
+- 自托管选项（PRD V5 不实施，但架构预留）
+- iOS vault 即"本地副本"，云端永远只是"加速器"，用户随时拔网线还能用
+
+---
+
+## §5 用户故事
+
+> 共 **72 条 US**，按模块分组。每条 US 在 §15 Wave 拆分中归属到具体 Wave。
+> Acceptance Criteria（AC）用 checklist 表达。
+> 标记说明：
+> - 🆕 = V5 全新功能
+> - 🔄 = V1-V4 已有，V5 升级
+> - 📱 = iOS / ⌚️ = Watch / 💻 = macOS / 🌐 = Web / 🔌 = API
+
+### 5.A Capture 类（US-001 ~ US-014）
+
+#### US-001 🆕 🌐 Web 端万能速记入口
+**描述**：作为 Web 用户，我希望在任何页面都能快速调出 Add 输入框，让我能立即记录想法。
+**AC**：
+- [ ] 全局快捷键 `⌘K` 唤出 quick-capture 浮层
+- [ ] 浮层支持 文字 / URL（自动检测） / 文件拖拽 / 录音（需麦克风权限）
+- [ ] 提交后立即出现在 Compile Queue
+- [ ] Esc 关闭，状态保留 5 分钟（防误关）
+- [ ] 离线时入本地 IndexedDB 队列，恢复网络自动 push
+- [ ] Verify in browser using dev-browser skill
+
+#### US-002 🔄 📱 iOS 锁屏快速记录
+**描述**：作为 iPhone 用户，我希望从锁屏控制中心一键打开 capture，长按发送键录音。
+**AC**：
+- [ ] iOS Control Center 添加 DayPage 快捷小组件
+- [ ] 点开直达 Today，输入框自动聚焦
+- [ ] 发送键长按 ≥0.3s 进入录音模式
+- [ ] 录音过程中显示实时波形与时长
+- [ ] 松手停止 + 自动转写 + 自动保存
+- [ ] 录音中误触屏幕其他区域不停止
+- [ ] 跑通 V3 PRD 已定的"语音转写完整率 100%"
+
+#### US-003 🆕 ⌚️ Watch 表冠快速语音
+**描述**：作为 Watch 用户，我希望按一下表冠侧键就能说话记一条。
+**AC**：
+- [ ] Watch App 主屏只有一个大按钮 + 当日 memo 数
+- [ ] 长按表冠侧键启动 capture（可在 iPhone 端配置）
+- [ ] 录音上限 60s（超时自动停止保存）
+- [ ] 离线录制存本地 → 配对 iPhone 上线后自动同步
+- [ ] Watch 显示「已同步 ✓」动画
+
+#### US-004 🆕 🌐💻 全局快捷键速记
+**描述**：作为桌面用户，我希望在任何应用里按快捷键唤出 DayPage 输入框。
+**AC**：
+- [ ] macOS 注册 `⌥Space`（可改）全局热键
+- [ ] Web 端在 PWA 安装后注册 keyboard shortcut（Chromium API）
+- [ ] 唤出的浮窗 max 480x320pt，固定屏幕中央
+- [ ] 按 ⌘Enter 提交并关闭
+- [ ] 提交后右上角显示 toast「Captured」3s
+
+#### US-005 🆕 📱🌐 URL 智能抓取
+**描述**：作为用户，我希望粘贴 URL 后系统自动抓取页面内容并整理。
+**AC**：
+- [ ] 输入框检测以 http/https 开头 → 显示 link 图标
+- [ ] 提交后后端用 readability 算法抽正文（不抓导航/广告/侧栏）
+- [ ] YouTube 链接 → 抽 transcript（如有字幕）
+- [ ] 抓取失败 → 保存原 URL + 让用户手动粘贴正文
+- [ ] 抓取成功后显示 word count、estimated read time
+- [ ] AI 自动判断 LIGHT/FULL 档（reddit/twitter 默认 LIGHT，arxiv/wsj 默认 FULL）
+
+#### US-006 🆕 🌐 文件拖拽上传
+**描述**：作为 Web 用户，我希望直接把 PDF / 图片 / Markdown 拖到页面任何位置就能上传。
+**AC**：
+- [ ] 全页面支持 drop zone（拖入时显示半透明虚线框）
+- [ ] 支持类型：PDF / DOCX / TXT / MD / JPG / PNG / HEIC / MP3 / M4A / WAV
+- [ ] 单文件上限 50MB
+- [ ] 多文件并行上传
+- [ ] 上传中显示进度
+- [ ] 上传完成后 PDF 自动 OCR + 切章节，每章节一条 memo
+- [ ] Verify in browser using dev-browser skill
+
+#### US-007 🆕 📱 iOS Share Sheet 接收
+**描述**：作为用户，我希望从 Safari/Twitter/Apple Notes 一键分享内容到 DayPage。
+**AC**：
+- [ ] iOS Share Extension 显示 DayPage 图标
+- [ ] 选择后展示精简 capture 表单（预填分享内容）
+- [ ] 可选 LIGHT/FULL 档
+- [ ] 不离开当前 App 即可保存
+- [ ] 离线时入队列
+
+#### US-008 🆕 🌐 浏览器扩展剪藏
+**描述**：作为深度用户，我希望用浏览器扩展一键剪藏当前网页/选中文本。
+**AC**：
+- [ ] 提供 Chrome / Safari / Firefox 扩展
+- [ ] 工具栏图标点击 → 弹小窗，预填页面 URL + 截图缩略图 + 选中文本
+- [ ] 可加备注 + 选 tag
+- [ ] 提交后扩展显示「Sent to DayPage ✓」
+
+#### US-009 🆕 🔌 Email-to-DayPage
+**描述**：作为用户，我希望转发任何邮件到我的专属 DayPage 邮箱即可保存。
+**AC**：
+- [ ] Settings 页显示用户专属地址 `<random>@in.daypage.io`
+- [ ] 邮件标题作为 memo title
+- [ ] 邮件正文清洗后作为 body
+- [ ] 附件自动入 Storage，并关联到该 memo
+- [ ] 防滥用：每个用户每天上限 100 封，超出告警
+
+#### US-010 🆕 🔌 Webhook ingest
+**描述**：作为开发者用户，我希望用 webhook 把第三方服务的内容打入 DayPage。
+**AC**：
+- [ ] Settings 生成 personal API token
+- [ ] POST `/api/v1/ingest` 接受 `{type, body, metadata, attachments[]}` JSON
+- [ ] 限流 60 req/min
+- [ ] 返回 memo id + status
+- [ ] 文档页有 curl 示例
+
+#### US-011 🔄 📱 位置元数据自动嵌入
+**描述**：作为 nomad，我希望每条 memo 自动带上当时的位置（已在 fix/location-embed-and-voice-scroll 分支修复，纳入 V5）。
+**AC**：
+- [ ] 任何 memo 创建时立即获取一次 GPS（5s 超时）
+- [ ] 位置失败不阻塞保存
+- [ ] 反向地理编码异步进行，结果回写 memo
+- [ ] 用户在 Settings 可关闭位置采集
+
+#### US-012 🔄 📱 天气元数据
+**描述**：作为用户，我希望 memo 自动带上当时的天气，将来回看更有氛围。
+**AC**：
+- [ ] 每条 memo 带 weather 字段（如 `多云 22°C`）
+- [ ] 同一小时内不重复请求 API（10 分钟缓存）
+- [ ] 失败时字段为 null
+
+#### US-013 🆕 📱 音频环境识别（中等激进）
+**描述**：作为用户，我希望系统识别我录音时的环境（咖啡馆/室外/走路），自动加 tag。
+**AC**：
+- [ ] 录音过程中分析麦克风背景噪声（YAMNet 或类似 on-device 模型）
+- [ ] 识别 5 类：silence / cafe / outdoor / vehicle / crowd
+- [ ] 写入 memo 的 `environment` 字段
+- [ ] 用户可在 Settings 关闭
+
+#### US-014 🆕 📱 离线 capture 队列
+**描述**：作为飞机/隧道用户，我希望离线时录的 memo 不会丢，联网自动同步。
+**AC**：
+- [ ] 离线创建的 memo 立即写入本地 vault
+- [ ] 在 Today 顶部显示「3 条等待同步」灰色 badge
+- [ ] 联网后自动 push，成功后 badge 消失
+- [ ] 同步失败有重试 + 错误提示
+
+### 5.B Compile 类（US-015 ~ US-024）
+
+#### US-015 🆕 🌐 Compile Queue 实时进度
+**描述**：作为用户，我希望在 Add 视图实时看到每条 memo 的编译进度。
+**AC**：
+- [ ] 每条 queue item 显示进度条 0-100%
+- [ ] 通过 SSE 接收后端进度推送
+- [ ] 完成后绿色 ✓ + 显示「3 pages updated」
+- [ ] 失败显示红色 + 错误信息 + Retry 按钮
+- [ ] Verify in browser using dev-browser skill
+
+#### US-016 🆕 🌐 LIGHT / FULL 模式切换
+**描述**：作为用户，我希望能在 queue 中点击 chip 切换某条的编译档位。
+**AC**：
+- [ ] 每条 queue item 有 LIGHT/FULL chip
+- [ ] 点击 chip 立即切换 + 触发重编译
+- [ ] FULL→LIGHT 不删除已生成的 page，只是不再深度更新
+- [ ] LIGHT→FULL 触发完整流水线
+
+#### US-017 🆕 🌐💻 Recompile 单条 memo
+**描述**：作为用户，我希望对某条已编译的 memo 触发重编译（比如 LLM 升级了）。
+**AC**：
+- [ ] memo 详情页有 "Recompile" 按钮
+- [ ] 重编译会撤销旧 patch（基于 change_log）再应用新 patch
+- [ ] 期间 page 显示「being recompiled」
+- [ ] 失败可回滚
+
+#### US-018 🆕 🌐 Compile 历史时间机器
+**描述**：作为用户，我希望看到一个 page 在过去某个时间点的样子。
+**AC**：
+- [ ] page 详情页右上角有时间轴 slider
+- [ ] 拖动可显示该时刻的 page snapshot
+- [ ] 用 change_log 表回放
+- [ ] "Restore to this version" 按钮（创建新版本，不破坏历史）
+
+#### US-019 🆕 🌐 Schema 检测建议
+**描述**：作为用户，我希望系统发现新的 cluster 时主动建议建 domain。
+**AC**：
+- [ ] 后端 worker 每 50 条新 memo 跑一次聚类
+- [ ] 检测到新 cluster 写入 inbox（kind=schema）
+- [ ] inbox 卡片显示：cluster 中的代表 memo + 建议名称
+- [ ] 用户可改名字 / 接受 / 拒绝
+
+#### US-020 🆕 🌐 Conflict 处理流程
+**描述**：作为用户，我希望系统检测到我的笔记与新 ingest 内容矛盾时显示对比，让我决策。
+**AC**：
+- [ ] inbox 显示矛盾卡片，左旧右新对比
+- [ ] 4 个动作按钮：Keep both as tracked / Use new / Keep mine / Open both pages
+- [ ] 决策后写 change_log，更新 page
+- [ ] "tracked contradiction" 在 page 上以特殊样式渲染
+
+#### US-021 🆕 🌐 编译失败可视化
+**描述**：作为用户，我希望编译失败时知道具体哪一步挂了，能重试或人工介入。
+**AC**：
+- [ ] 失败 memo 在 queue 显示红色 + 失败步骤名
+- [ ] 点击展开可见错误详情（DLQ 内容）
+- [ ] 可选 "Retry only this step" / "Retry full pipeline" / "Skip and mark as raw-only"
+
+#### US-022 🆕 🌐 Compile rationale 透明
+**描述**：作为深度用户，我希望看到每个 page patch 背后 LLM 的"为什么这样改"。
+**AC**：
+- [ ] page 详情页 "Provenance" 侧栏可展开 compile rationale
+- [ ] 显示触发该 patch 的 memo + LLM prompt 摘要 + 决策理由
+- [ ] 每条 rationale 可点 thumbs up/down 反馈，用于后期 RLHF
+
+#### US-023 🆕 🌐 LIGHT/FULL 默认档设置
+**描述**：作为用户，我希望按内容类型设置默认档位。
+**AC**：
+- [ ] Settings → Compile defaults
+- [ ] 5 类内容（user-typed / voice / web / file / email）每类可选默认 LIGHT/FULL
+- [ ] 默认值合理（user-typed=FULL, web=LIGHT 由 AI 评估）
+
+#### US-024 🆕 🌐 Cold storage 询问归档
+**描述**：作为用户，我希望系统提示我归档 90 天没碰过的 page。
+**AC**：
+- [ ] 后端 cron 每天扫一次冷 page
+- [ ] 推 inbox（kind=orphan）
+- [ ] 用户可一次性 batch 接受/全部拒绝
+- [ ] 归档后 page 移到 cold storage，不出现在 wiki nav，但仍可搜索
+
+### 5.C Knowledge Surface（US-025 ~ US-039）
+
+#### US-025 🆕 🌐 Wiki List 视图
+**描述**：作为用户，我希望左侧分组导航能让我快速找到任何 page。
+**AC**：
+- [ ] 5 大分组（Concepts / Sources / Entities / Synthesis / Daily）可折叠
+- [ ] 每组按更新时间排序
+- [ ] 每条显示 title、sub-meta（source 数 / draft tag / conflict 警示）
+- [ ] 当前选中 page 高亮
+- [ ] 顶部 `/` 快捷键聚焦搜索框
+- [ ] Verify in browser using dev-browser skill
+
+#### US-026 🆕 🌐 Wiki Page Detail
+**描述**：作为用户，我希望 page 详情页清晰呈现内容、来源、反链。
+**AC**：
+- [ ] 顶部 chip 显示 type / domain / 更新时间
+- [ ] 大字号 title
+- [ ] 正文支持 Markdown 全特性 + KaTeX 数学公式 + Mermaid 图
+- [ ] 右侧栏 3 块：Sources / Backlinks / Provenance
+- [ ] 每个 source 可点击 → 打开原 memo
+- [ ] Verify in browser using dev-browser skill
+
+#### US-027 🆕 🌐 Annotation 高亮
+**描述**：作为用户，我希望选中 page 任何文本后能加高亮和 tag。
+**AC**：
+- [ ] 选中文本后弹 toolbar：important / questionable / 自定义 tag / 加 note
+- [ ] 高亮持久化到 annotations 表
+- [ ] 不同 tag 不同色（important=琥珀，questionable=红，自定义=用户选）
+- [ ] 高亮可点击编辑/删除
+- [ ] 重新编译时 LLM 把 annotation 作为重要信号
+
+#### US-028 🆕 🌐💻 Knowledge Graph
+**描述**：作为用户，我希望看到所有 page 与 entity 之间的网络。
+**AC**：
+- [ ] 默认渲染当前 domain 的所有 node
+- [ ] 节点颜色按 type 区分（concept/draft/entity/source/synthesis）
+- [ ] 边粗细按 link weight
+- [ ] 节点点击 → 高亮该节点 + 1-hop 邻居 + 显示侧栏 detail
+- [ ] 拖拽 / 滚轮缩放 / 双击居中
+- [ ] 顶部过滤：按 type / domain / 时间范围
+- [ ] >100 节点切换到 Canvas 渲染
+
+#### US-029 🆕 💻 Graph 时间动画
+**描述**：作为用户，我希望看到我的知识网络是怎么"长出来"的（时间动画）。
+**AC**：
+- [ ] Graph 视图右下角 "Play timeline" 按钮
+- [ ] 从最早一条 memo 开始按月推进，新 node/edge 渐入
+- [ ] 速度可调（1 月/秒 ~ 1 年/秒）
+- [ ] 可暂停/拖动 timeline
+
+#### US-030 🆕 🌐 Entity 实体页
+**描述**：作为用户，我希望每个被 AI 识别的实体（人/组织/项目/地点）有独立页面。
+**AC**：
+- [ ] entity page 有：名称、类型、别名、相关 page、相关 memo、出现次数 timeline
+- [ ] 用户可手动 merge 重复 entity
+- [ ] 用户可改名 / 改类型
+- [ ] 实体可以有 metadata（如 person 的 role / org）
+
+#### US-031 🆕 🌐 Domain 视图
+**描述**：作为用户，我希望点击侧栏 domain 直接看该 domain 的所有 page + 概览。
+**AC**：
+- [ ] domain 详情页显示：page 列表、本周/本月活动统计、graph 缩略图
+- [ ] 顶部可改 domain 名/颜色
+- [ ] 可拖拽改 domain 顺序
+
+#### US-032 🆕 🌐 全局搜索
+**描述**：作为用户，我希望一个搜索框能搜遍所有 page / memo / entity / annotation。
+**AC**：
+- [ ] `/` 全局快捷键
+- [ ] 类型切换 chips（All / Pages / Memos / Entities / Annotations）
+- [ ] 每条结果显示 type + 高亮匹配片段 + meta
+- [ ] BM25 + 向量混合排序
+- [ ] 结果点击直达对应详情页
+- [ ] 历史搜索保存（可清除）
+
+#### US-033 🆕 🌐 模糊回忆模式
+**描述**：作为用户，我记不清某事的细节，希望 AI 反向问我问题帮我定位。
+**AC**：
+- [ ] Search 顶部有 "I half-remember..." 入口
+- [ ] 用户输入模糊描述
+- [ ] AI 问 3 轮澄清问题（地点/时间/相关人/相关 concept）
+- [ ] 收敛到候选 3-5 条 memo
+
+#### US-034 🆕 🌐 Synthesis Page 创建
+**描述**：作为用户，我希望从 Chat 对话生成 synthesis page。
+**AC**：
+- [ ] Chat 顶部有 "Save as synthesis page" 按钮
+- [ ] 点击后 LLM 把对话凝练为结构化 page
+- [ ] 用户可在 page 编辑器修改 + 设 domain + 发布
+- [ ] synthesis page 自动反链原 chat thread
+
+#### US-035 🆕 🌐 Daily Page 自动生成
+**描述**：作为用户，我希望每天自动生成一份 daily diary page。
+**AC**：
+- [ ] 每晚 00:30 把当日所有 memo 聚合
+- [ ] 按主题分组、加 AI 总结、嵌入位置/天气/行程
+- [ ] 生成的 page 可编辑
+- [ ] 在 Wiki nav "Daily" 分组下按日期倒序
+
+#### US-036 🆕 🌐 Page 草稿与发布
+**描述**：作为用户，我希望 AI 新建的 page 先放草稿，我审完再发布。
+**AC**：
+- [ ] AI 新建的 concept page 默认 status=draft
+- [ ] draft page 在 nav 显示 pulse 标记
+- [ ] 顶部有 "Promote to live" 按钮
+- [ ] 用户编辑过后自动 promote
+
+#### US-037 🆕 🌐 Page 历史版本
+**描述**：作为用户，我希望看到 page 的所有历史版本，能 diff 与回滚。
+**AC**：
+- [ ] page 顶部 "..." 菜单 → "Version history"
+- [ ] 列表显示所有版本时间 + 触发原因（哪条 memo / 哪次 manual edit）
+- [ ] diff view 高亮变更（增加=绿底，删除=红删除线）
+- [ ] "Restore" 按钮创建新版本
+
+#### US-038 🆕 🌐 Page 导出 / 分享
+**描述**：作为用户，我希望把单个 page 导出为 PDF 或分享 URL。
+**AC**：
+- [ ] page 顶部 Share 按钮
+- [ ] 选项：Export PDF / Export Markdown / Public link（仅管理员可生成）
+- [ ] Public link 是 read-only 网页，含 page 内容 + DayPage 品牌 + "Powered by DayPage"
+- [ ] 用户可随时撤销 public link
+
+#### US-039 🆕 🌐 Provenance trail 段落级
+**描述**：作为用户，我希望知道 page 中某段话来自哪条 memo。
+**AC**：
+- [ ] 鼠标悬停某段落，左侧出现 source 小标
+- [ ] 点击展开显示来源 memo 列表
+- [ ] 多 source 时显示贡献度百分比
+
+### 5.D Conversation & Agent（US-040 ~ US-053）
+
+#### US-040 🆕 🌐 Wiki Chat 基础对话
+**描述**：作为用户，我希望像问 ChatGPT 一样问我自己的 wiki。
+**AC**：
+- [ ] Chat 视图含 thread list + thread detail + composer
+- [ ] composer 支持 Enter 发送，Shift+Enter 换行
+- [ ] AI 流式输出（SSE）
+- [ ] 答案中的 `{n}` 渲染为可点击数字徽标，点击高亮右栏对应 reference card
+- [ ] reference card 点击打开 source page
+
+#### US-041 🆕 🌐 Suggested follow-ups
+**描述**：作为用户，每个 AI 回答后希望系统建议 3 条相关后续问题。
+**AC**：
+- [ ] 每个 AI message 下显示 3 个 chip
+- [ ] 点击 chip 直接发送
+- [ ] chip 的内容根据 thread context 生成
+
+#### US-042 🆕 🌐 Multi-thread chat
+**描述**：作为用户，我希望开多个对话，按主题归档。
+**AC**：
+- [ ] Chat 左侧栏列出所有 thread
+- [ ] 可按 active / archived / synthesized 过滤
+- [ ] 可重命名 / 删除 / 归档
+- [ ] thread 自动按内容生成标题
+
+#### US-043 🆕 🌐 Chat 引用透明
+**描述**：作为用户，我希望知道 AI 答案中每个事实从哪个 page 来的。
+**AC**：
+- [ ] 答案中所有事实必须有 `{n}` 引用
+- [ ] 没有引用支撑的句子用斜体灰字显示并加 "[uncited]" 标记
+- [ ] 系统 prompt 强制：「不能引用就说不知道」
+
+#### US-044 🆕 🌐 "我不知道" 优先
+**描述**：作为用户，我希望 AI 不会乱编。
+**AC**：
+- [ ] 当检索到的 page 不足以回答时，AI 直接回 "I don't know yet"
+- [ ] 给出 "你可以先 add X 让我学习" 的建议
+- [ ] 用户可在 Settings 调严格度（strict / balanced / creative）
+
+#### US-045 🆕 🌐 Past-Self Dialogue
+**描述**：作为用户，我希望选定时间段后能与"那时候的我"对话。
+**AC**：
+- [ ] Chat 顶部有 "Talk to past me" 按钮
+- [ ] 弹出时间段选择器（默认 30 天前 / 1 年前 / 自定义）
+- [ ] 系统创建特殊 thread，title 自动 "Past me · 2024-09"
+- [ ] AI 答案使用第一人称，引用那段时间的 memo
+- [ ] 答案有 emoji 与语气模拟，模仿用户当时风格（基于历史 memo 训练 prompt）
+
+#### US-046 🆕 🌐 Persona 定制
+**描述**：作为用户，我希望调整 AI 与我对话的语气。
+**AC**：
+- [ ] Settings → AI Persona
+- [ ] 4 档：Neutral / Mentor / Friend / Skeptic
+- [ ] 自定义 persona prompt（高级）
+
+#### US-047 🆕 ⌚️📱 Siri 集成
+**描述**：作为用户，我希望对 Siri 说「问 DayPage 我上周读了什么」就能得到答案。
+**AC**：
+- [ ] iOS App Intents 注册 "Ask DayPage" intent
+- [ ] Siri 触发 → 调用 RAG → 用 AVSpeech 语音回复
+- [ ] 同时弹通知，点开看完整答案 + reference
+
+#### US-048 🆕 🌐 AI Agent 主动观察
+**描述**：作为用户，我希望系统发现"有趣的模式"时主动通知我。
+**AC**：
+- [ ] Home 页 "What the system noticed" 卡片显示最新 observation
+- [ ] observation 来自后端 worker（每天凌晨跑一次）
+- [ ] 类型：cluster growing fast / new entity emerged / topic dormant / contradiction unresolved
+- [ ] 每条 observation 有 2-3 个动作按钮
+- [ ] Verify in browser using dev-browser skill
+
+#### US-049 🆕 🌐 Agent Action 授权
+**描述**：作为用户，我希望明确授权 AI 能做的"动作"，未授权动作不会自动执行。
+**AC**：
+- [ ] Settings → Agent Permissions 显示所有可授权 action（共 8 类，详见 §7）
+- [ ] 默认只授权"低风险只读"（如 schema 检测）
+- [ ] 高风险（如自动 merge entity）默认关闭
+- [ ] 已授权的 action 可在 Activity log 查看
+
+#### US-050 🆕 🌐 Agent Action 审计日志
+**描述**：作为用户，我希望看到 AI 替我做了什么，能撤销。
+**AC**：
+- [ ] Settings → Activity log
+- [ ] 显示所有 agent action，按时间倒序
+- [ ] 每条 action 有 "Undo" 按钮（基于 change_log）
+- [ ] 可按 action 类型 / 时间范围过滤
+
+#### US-051 🆕 🌐 Inbox 处理流
+**描述**：作为用户，我希望 inbox 显示所有待我决策的 AI 建议，按类型过滤。
+**AC**：
+- [ ] inbox 顶部 5 个 chip：All / Contradictions / Schema / Orphans / Compiled
+- [ ] 每条卡片显示 kind / time / title / body / 1-4 个动作按钮
+- [ ] CONTRADICTION 卡片含 old/new 对比 pane
+- [ ] 处理后卡片消失（移到 resolved），sidebar inbox badge 数字更新
+
+#### US-052 🆕 🌐 Snooze inbox 项
+**描述**：作为用户，我希望某些 inbox 项稍后再处理。
+**AC**：
+- [ ] 每条 inbox 卡片右上角 "..."
+- [ ] 选项：Snooze 1d / Snooze 1w / Dismiss / Resolve as...
+- [ ] Snooze 后到期重新出现
+
+#### US-053 🆕 🌐 Inbox 推送通知
+**描述**：作为用户，我希望新的 inbox 项能在重要时弹通知。
+**AC**：
+- [ ] Settings → Notifications 可开关 4 类 inbox 推送
+- [ ] CONTRADICTION 默认开启（重要决策）
+- [ ] iOS / Web Push API
+- [ ] 通知点击直达对应 inbox 项
+
+### 5.E Reflection & Memory（US-054 ~ US-061）
+
+#### US-054 🔄 📱 On This Day
+**描述**：作为用户，我希望每天看到「去年/前年/N 年前的今天」我做了什么。
+**AC**：
+- [ ] iOS V3 已实现，V5 升级：跨年合并显示
+- [ ] iOS Today 顶部 banner 出现
+- [ ] 点击展开看完整时间线
+- [ ] 每条可点击跳到 daily page
+
+#### US-055 🆕 🌐 On This Day Web
+**描述**：作为 Web 用户，我希望 Home 页有"今日回顾"模块。
+**AC**：
+- [ ] Home 页底部有 "On this day" section
+- [ ] 横向 scrollable cards（每年一张）
+- [ ] 点击跳到对应 daily page
+
+#### US-056 🆕 📱🌐 Weekly Recap 自动生成
+**描述**：作为用户，每周日希望系统给我推一份"这周的你"。
+**AC**：
+- [ ] 每周日 18:00 worker 跑生成
+- [ ] 内容含：本周 memo 数 / 最活跃 domain / 新建 page / 去过的地方 / AI 写的 1 段叙事
+- [ ] 推送到 iOS / Web 通知
+- [ ] 用户可编辑后保存为 page
+
+#### US-057 🆕 💻🌐 Monthly Recap
+**描述**：作为用户，每月初希望看到上个月的可视化报告。
+**AC**：
+- [ ] 每月 1 日 00:30 生成
+- [ ] 含 5 类图：地图（去过的地方）/ domain 活动柱图 / entity 出现频次 / 心情曲线（如有）/ 时间投入饼图
+- [ ] 可导出 PDF
+- [ ] macOS 端有交互式编辑器，调整图表样式
+
+#### US-058 🆕 💻🌐 Year in Review
+**描述**：作为用户，每年 12 月底希望系统给我一份"年度叙事"。
+**AC**：
+- [ ] 12/20 自动生成草稿
+- [ ] 含整年所有维度可视化 + AI 写 3-5 段叙事
+- [ ] 可生成可分享网页（带 OG 图）
+- [ ] 可导出 PDF
+- [ ] 高互动 onboarding 小动画
+
+#### US-059 🆕 📱🌐 Memory Lane · Random Walk
+**描述**：作为用户，我希望系统偶尔随机推一些尘封 memo 让我回忆。
+**AC**：
+- [ ] iOS Today 顶部偶尔出现 "A memory" 卡
+- [ ] Web Home 有 "Random walk" 入口
+- [ ] 推送频次每周 1-2 次（用户可调）
+- [ ] 算法偏向 6 月以前 + 90 天没看过的 memo
+
+#### US-060 🆕 🌐 Memory Lane · 地图回放
+**描述**：作为用户，我希望地图视图上点某个城市能看所有那里的 memo。
+**AC**：
+- [ ] Wiki / Memory tab 下有 Map view
+- [ ] 全球地图，每个 memo 是一个点
+- [ ] 点击某点 → 弹卡片
+- [ ] 可按时间范围筛选
+- [ ] 城市级 cluster 自动合并
+
+#### US-061 🆕 🌐 Memory Lane · 情绪回放
+**描述**：作为用户，我希望按情绪标签翻历史 memo。
+**AC**：
+- [ ] 系统从 memo 文本自动抽情绪标签（5 类：joy / sad / anxious / proud / reflective）
+- [ ] Memory tab 有情绪 timeline
+- [ ] 点某个情绪 → 列出所有相关 memo
+
+### 5.F System & Trust（US-062 ~ US-072）
+
+#### US-062 🆕 ⚙️ Apple Sign-In 登录
+**描述**：作为用户，我希望用 Apple ID 在 iOS / Web 用同一账号登录。
+**AC**：
+- [ ] iOS 集成 Sign in with Apple
+- [ ] Web 用 Auth.js v5 + Apple OAuth provider
+- [ ] 同一 Apple sub 自动关联同一用户
+- [ ] 首次登录走 onboarding；之后直达 home
+
+#### US-063 🆕 ⚙️ Email magic link 兜底
+**描述**：作为非 Apple 用户，我希望用邮箱登录。
+**AC**：
+- [ ] Web 登录页有 "Continue with email" 按钮
+- [ ] 输入邮箱 → 收到 magic link → 点击登录
+- [ ] 链接 15 min 过期
+- [ ] 同邮箱可绑定 Apple ID 后两种登录方式都能用
+
+#### US-064 🆕 ⚙️ 跨端同步
+**描述**：作为用户，我希望 iOS 写的内容立即在 Web 看到，反之亦然。
+**AC**：
+- [ ] iOS sync 间隔：前台 30s / 后台 15min / push wake-up 立即
+- [ ] Web 后端有更新时通过 SSE 推到所有在线 device
+- [ ] 同步状态指示器（左下角小点：绿=已同步 / 黄=同步中 / 红=失败）
+- [ ] 冲突 last-write-wins，用户标注永远优先
+
+#### US-065 🆕 ⚙️ 离线优先
+**描述**：作为用户，我希望任何端离线都能继续使用基础功能。
+**AC**：
+- [ ] iOS：vault 即离线缓存（V1-V4 已有）
+- [ ] Web：PWA + Service Worker，缓存 wiki + recent memo
+- [ ] macOS：本地 SQLite 镜像
+- [ ] 离线时所有写入入本地队列，上线自动 push
+
+#### US-066 🆕 ⚙️ Privacy Vault
+**描述**：作为用户，我希望某些 memo / page 标记为 private，AI 不读不引。
+**AC**：
+- [ ] memo / page 详情页右上角有 "Make private" 切换
+- [ ] private 内容：不进 RAG context、不出现在 graph、不被 link
+- [ ] 解锁需要主密码（独立于账号密码）
+- [ ] 解锁状态超时 15 min 自动锁回
+
+#### US-067 🆕 ⚙️ 全量数据导出
+**描述**：作为用户，我希望一键导出所有数据为 ZIP。
+**AC**：
+- [ ] Settings → Data → Export all
+- [ ] 后台生成 ZIP（含 raw .md / page .md / JSON metadata / Storage attachments）
+- [ ] 完成后 email 链接（24h 有效）
+- [ ] 用户可选择只导出某段时间
+
+#### US-068 🆕 ⚙️ 删除账号
+**描述**：作为用户，我希望能彻底删除账号与所有数据（GDPR）。
+**AC**：
+- [ ] Settings → Account → Delete account
+- [ ] 二次确认（输入邮箱）
+- [ ] 30 天内可恢复（保留 soft-delete）
+- [ ] 30 天后所有数据 + backup 物理删除
+- [ ] 删除后发确认邮件
+
+#### US-069 🆕 ⚙️ 多设备管理
+**描述**：作为用户，我希望看到所有登录的设备能远程登出。
+**AC**：
+- [ ] Settings → Devices 列出所有设备（platform / 最后活跃 / IP 地理位置）
+- [ ] 每条 "Sign out" 按钮
+- [ ] "Sign out all other devices" 一键操作
+
+#### US-070 🆕 🔌 Public API
+**描述**：作为开发者用户，我希望用 API 读写自己的 DayPage 数据。
+**AC**：
+- [ ] Settings → API tokens 生成 token（scope 控制）
+- [ ] 文档站 docs.daypage.io 含完整 OpenAPI spec
+- [ ] 端点：所有 CRUD + chat + search
+- [ ] 限流 60 req/min per token
+- [ ] 提供 TS / Python SDK
+
+#### US-071 🆕 ⚙️ Settings 中心
+**描述**：作为用户，我希望一个清晰的 Settings 页面控制所有偏好。
+**AC**：
+- [ ] 分组：Account / Notifications / Compile / Agent / Privacy / Data / Devices / API / Appearance / About
+- [ ] 改动立即保存（无需点 Save）
+- [ ] 有搜索框
+
+#### US-072 🆕 ⚙️ Onboarding
+**描述**：作为新用户，我希望前 3 步能让我立即看到产品的价值。
+**AC**：
+- [ ] Step 1：选 2-5 个 domain seed（"你想想清楚什么？"）
+- [ ] Step 2：投喂 1 个种子内容（URL / 文本 / 跳过）
+- [ ] Step 3：实时 compile 进度条 → 完成 → 进入 home，已有第 1 个 page
+- [ ] 整体 ≤ 90s 完成
+- [ ] 中途可跳过，进 home 后随时可重启
+
+---
+
+## §6 功能性需求 FR
+
+> 以"系统必须……"形式声明，无歧义、可测试。
+> FR 与 §5 US 的关系：US 是用户视角的故事，FR 是系统层面的硬约束。同一功能在两边各表述一次，FR 更适合工程实现 checklist。
+
+### 6.A Capture & Storage
+
+- **FR-1**：系统**必须**接受 7 种 memo 类型：text / voice / photo / video / location / url / file
+- **FR-2**：系统**必须**为每条 memo 自动嵌入：created (ISO8601 ms) / location (GPS+geocode) / weather / device / origin
+- **FR-3**：系统**必须**在用户离线时把 memo 写入本地队列，联网后自动重试 3 次
+- **FR-4**：系统**必须**支持单文件 ≤50MB 的附件上传（Supabase Storage）
+- **FR-5**：iOS 端**必须**继续使用 `vault/raw/YYYY-MM-DD.md` 作为本地真实存储（V1-V4 兼容）
+- **FR-6**：后端**必须**用 PostgreSQL 作为云端 single source of truth，schema 见 `docs/web/PLAN.md` §4
+- **FR-7**：每条 memo 在云端的 ID **必须**与 iOS 端 UUID 完全一致（避免 mapping）
+
+### 6.B Compile Pipeline
+
+- **FR-8**：系统**必须**实现 12-step compile pipeline（NORMALIZE / TRANSCRIBE / OCR / FETCH / CHUNK / EMBED / RECALL / COMPILE / APPLY / INDEX / NOTIFY / ACT）
+- **FR-9**：每个 pipeline step **必须**幂等，可单独重跑
+- **FR-10**：失败的 step **必须**进入 dead letter queue 并通知用户
+- **FR-11**：所有 page mutation **必须**事务性 + 写 change_log 表
+- **FR-12**：每条 LLM 调用**必须**记录 tokens_in / tokens_out / model / cost / latency
+- **FR-13**：embeddings **必须**缓存 7 天（同 memo 内容不重复 embed）
+- **FR-14**：编译失败**不得**删除原 memo
+
+### 6.C Wiki & Page
+
+- **FR-15**：page **必须**支持 6 种 type：concept / source / entity / synthesis / daily / domain
+- **FR-16**：page **必须**支持 4 种 status：live / draft / archived / cold
+- **FR-17**：所有 page mutation **必须**保留历史版本（可回滚 N 个版本，N 默认 50）
+- **FR-18**：Daily page **必须**每晚 00:30 自动生成
+- **FR-19**：page 渲染**必须**用 react-markdown + remark-gfm + rehype-sanitize（防 XSS）
+- **FR-20**：annotation **必须**独立存储，不修改 page body
+- **FR-21**：cold page（90 天无访问 + 无 backlink）**必须**触发 inbox orphan 项
+
+### 6.D Chat & RAG
+
+- **FR-22**：Chat 答案**必须**仅基于用户自己的 wiki 与 memo，不引外部知识
+- **FR-23**：Chat 答案中所有事实**必须**有 `{n}` 引用；无引用支撑的句子用斜体灰字
+- **FR-24**：检索不到足够 context 时**必须**回 "I don't know yet" + 引导用户 add
+- **FR-25**：Chat 流式输出**必须**用 SSE（不用 WebSocket）
+- **FR-26**：每个 chat thread **必须**支持 "Save as synthesis page"
+
+### 6.E Agent
+
+- **FR-27**：Observer agent **必须**每天 03:00 跑一次全量扫描
+- **FR-28**：Actor agent 的所有动作**必须**先经过用户授权（Settings → Agent Permissions）
+- **FR-29**：每个 agent action **必须**写 audit log，可逐条 undo
+- **FR-30**：Schema 检测**必须**每 50 条新 memo 跑一次聚类
+- **FR-31**：Conflict 检测**必须**在每次 FULL 编译时执行
+- **FR-32**：Agent 不得在用户 sleep timezone（22:00-08:00）发推送
+
+### 6.F Sync & Offline
+
+- **FR-33**：所有端**必须**支持离线读 + 离线写
+- **FR-34**：sync 协议**必须**用 cursor-based pagination（避免大 payload）
+- **FR-35**：服务端有更新**必须**通过 SSE 立即推送已在线 device
+- **FR-36**：Web 端**必须**实现 PWA + Service Worker
+- **FR-37**：冲突解决策略：last-write-wins，但 user-edited annotation 永远优先于 AI patch
+
+### 6.G Security & Privacy
+
+- **FR-38**：所有 query **必须**强制带 `where user_id = current_user.id`
+- **FR-39**：DashScope/Claude API key **不得**下发到任何客户端
+- **FR-40**：Markdown 渲染**必须**经 sanitization（防 XSS）
+- **FR-41**：所有 Storage 直传 URL **必须**带 mime/size/expiry 限制
+- **FR-42**：所有 mutation **必须**带 CSRF token
+- **FR-43**：每用户每天 chat tokens **必须**有上限（默认 100k tokens / day）
+- **FR-44**：Rate limit：mutation 30 req/min / chat 60 req/min / ingest webhook 60 req/min
+- **FR-45**：所有 attachment URL **必须**走 signed URL（不公开桶）
+- **FR-46**：Private 内容**不得**进入 RAG context、不得在 graph 显示、不得被 link
+- **FR-47**：删除账号**必须**在 30 天内彻底清除所有数据 + backup（GDPR）
+
+### 6.H Observability
+
+- **FR-48**：所有 API 调用**必须**记录 trace_id（OpenTelemetry）
+- **FR-49**：所有 LLM 调用**必须**写 prompt_log 表（含完整 prompt 与 response）
+- **FR-50**：所有 user action **必须**写 activity 表
+- **FR-51**：错误**必须**上报 Sentry，关键错误自动开 Linear issue（沿用现有 pipeline）
+
+---
+
+## §7 AI Agent 主动行动模型
+
+V5 的 AI 不仅是 RAG 后端，而是**长驻后台的"住户"**。这一节定义 Agent 的行为边界、触发条件、授权模型、审计机制。
+
+### 7.1 Agent 分层
+
+**两类 Agent**：
+
+#### Observer（观察者）—— 默认全开
+- **职责**：扫描数据、识别模式、产出 inbox 建议与 home observations
+- **不修改任何用户数据**
+- **风险**：低
+- **示例**：发现新 cluster、检测矛盾、识别冷 page、追踪话题热度
+
+#### Actor（行动者）—— 默认全关，需逐项授权
+- **职责**：替用户执行具体动作（创建/合并/归档/调用外部 API）
+- **修改用户数据**
+- **风险**：中-高
+- **示例**：自动 merge 重复 entity、自动归档冷 page、调 arXiv API 补 reference
+
+### 7.2 Action Catalog（共 8 类）
+
+| ID | 名称 | 风险 | 默认 | 描述 |
+|---|---|:---:|:---:|---|
+| ACT-1 | Auto-tag domain | 低 | ON | 给新 memo 自动打 domain tag |
+| ACT-2 | Auto-archive cold pages | 中 | OFF | 90 天无访问 page 自动 archive |
+| ACT-3 | Auto-merge duplicate entities | 中 | OFF | 高相似度 entity 自动合并 |
+| ACT-4 | Auto-promote draft pages | 低 | OFF | 用户读了 draft page 5 次后自动 promote 为 live |
+| ACT-5 | Auto-fetch external refs | 中 | OFF | 检测到论文标题 → 调 arXiv 自动补 BibTeX |
+| ACT-6 | Auto-generate weekly recap | 低 | ON | 每周日生成草稿（用户审后再发布） |
+| ACT-7 | Auto-cross-link similar pages | 中 | OFF | 检测到 2 个 page 高度相关时自动建 link |
+| ACT-8 | Auto-send digest email | 低 | ON | 每周一 09:00 发 weekly digest 邮件 |
+
+### 7.3 触发模型
+
+```
+                    ┌──────────────────┐
+                    │  Trigger Source  │
+                    └────────┬─────────┘
+                             │
+        ┌────────────────────┼────────────────────┐
+        ▼                    ▼                    ▼
+   ┌──────────┐         ┌────────┐          ┌──────────┐
+   │ on-event │         │  cron  │          │ user-ask │
+   │ (memo    │         │(daily  │          │  (chat)  │
+   │ created) │         │ 03:00) │          │          │
+   └─────┬────┘         └───┬────┘          └────┬─────┘
+         │                  │                    │
+         └──────────────────┼────────────────────┘
+                            ▼
+                  ┌──────────────────┐
+                  │  Agent Engine    │
+                  │  (Observer/Actor)│
+                  └────────┬─────────┘
+                           ▼
+                  ┌──────────────────┐
+                  │  Output Channel  │
+                  └────────┬─────────┘
+            ┌──────────────┼──────────────┐
+            ▼              ▼              ▼
+       ┌────────┐    ┌──────────┐   ┌────────┐
+       │ Inbox  │    │   Home   │   │  Push  │
+       │  Item  │    │  Banner  │   │  Notif │
+       └────────┘    └──────────┘   └────────┘
+```
+
+### 7.4 安全栅栏
+
+- **栅栏 1：默认安全** —— Actor 默认全关，用户主动开
+- **栅栏 2：审计可见** —— 所有 action 写 audit log，Settings 可查
+- **栅栏 3：可撤销** —— 所有 action 都基于 change_log，可逐条 undo
+- **栅栏 4：通知节流** —— 同一 user 同一类型通知 1 天最多 3 条
+- **栅栏 5：sleep 安静** —— 用户本地时区 22:00-08:00 不发推
+- **栅栏 6：紧急停机** —— Settings 顶部 "Pause all AI agents" 一键开关
+
+### 7.5 Agent Prompt 模板规范
+
+所有 Agent prompt **必须**遵循结构：
+
+```
+[ROLE] You are a DayPage <observer|actor> agent.
+[TASK] <one-sentence task>
+[CONTEXT] <relevant data, max 8K tokens>
+[CONSTRAINTS]
+  - Do not invent facts
+  - Cite memo/page IDs in every claim
+  - If uncertain, say "uncertain" with reason
+[OUTPUT FORMAT] Strict JSON matching schema X
+```
+
+所有 prompt 入版本控制（`web/lib/ai/prompts/*.md`），所有 response 落 prompt_log 表，便于回溯与 RLHF。
+
+---
+
+## §8 数据模型与跨端同步
+
+详见 `docs/web/PLAN.md` §4（13 张核心表 + pgvector embedding）。
+
+本节只补充与 PRD 强相关的几个**业务约束**：
+
+### 8.1 ID 一致性
+
+- 所有 memo 的 UUID 由 **iOS 端生成**，后端 upsert by ID
+- 所有 page / entity / annotation 的 UUID 由**后端生成**，iOS 拉取后写入本地缓存
+- 所有 ID 用 v4 UUID（不依赖时间，避免泄露）
+
+### 8.2 时间戳约定
+
+- 所有时间字段用 `TIMESTAMPTZ`（含时区）
+- 所有客户端发送时间**必须**带 `Z`（UTC）
+- 显示时由 client 转用户本地时区（i18n）
+
+### 8.3 软删除策略
+
+- memo / page / entity / inbox_item 删除走 soft-delete（加 `deleted_at`）
+- soft-delete 30 天后由后台 worker 物理删除
+- 删除账号触发立即软删 + 30 天后物理删
+
+### 8.4 Sync 协议
+
+```
+GET /api/sync/cursor                                返回当前 device 的 sync cursor
+GET /api/sync/pull?since={cursor}&types=memo,page   返回增量 + 新 cursor
+POST /api/sync/push                                  上传本地 dirty 数据
+SSE /api/stream/sync                                 服务端推送实时更新
+```
+
+### 8.5 跨端冲突解决
+
+| 字段 | 冲突策略 |
+|---|---|
+| memo.body | 不允许编辑（append-only），无冲突 |
+| memo.pinned_at | last-write-wins by `updated_at` |
+| memo.location | 后端 wins（防止 iOS 重新地理编码覆盖云端正确数据） |
+| page.body_md | last-write-wins，但若一边是 user-edit 一边是 AI-patch，user-edit 永远 wins |
+| annotation | 不允许跨端编辑同一 annotation，按 ID 隔离 |
+
+---
+
+## §9 多平台战略
+
+### 9.1 iOS（主端）
+
+- 当前 V1-V4 已交付，V5 增量：
+  - 接入云同步（vault → backend）
+  - 卸载本地 AI key（改走后端代理）
+  - 新增 Wiki / Chat / Inbox 简化版（main entry 仍是 Today / Archive）
+  - 新增 AI Agent 推送通知
+  - Watch 进一步增强（一键语音）
+- 维持离线优先 + vault 文件为本地真实存储
+
+### 9.2 Apple Watch
+
+- 极简：1 个大按钮（语音 capture）+ 当日 memo 数 + 同步状态
+- 配合 iPhone 解锁：表冠侧键长按直接录音
+- 不展示 wiki / chat / graph
+
+### 9.3 macOS（深度工作端）
+
+- 用 SwiftUI（与 iOS 共享代码）或 Catalyst
+- 主战场：long-form 编辑、Graph 大屏、Recap Builder、Spotlight 集成
+- 全局快捷键 ⌥Space
+- 菜单栏小图标（点击展开 mini quick capture）
+
+### 9.4 Web（Codex）
+
+- 主战场：Wiki 浏览、Inbox 处理、Chat 深度对话、Graph、Settings
+- 桌面优先（≥1280px），1024-1280 自适应，<1024 简化版
+- PWA + Service Worker + 离线缓存
+- 浏览器扩展（Chrome/Safari/Firefox）
+
+### 9.5 Public API
+
+- REST + 完整 OpenAPI 文档
+- TS / Python SDK
+- 限流 + audit log
+- 不开放写入到他人数据（仅自己 token 范围）
+
+### 9.6 平台优先级（给开发资源排期）
+
+V5 整体生命周期内的开发顺序：
+1. **Web (Codex)** —— V5 第一交付，因为最缺、最能展示价值
+2. **后端 API + iOS 同步改造** —— Web 完成后 iOS 必须能同步
+3. **Public API 文档化** —— Web 端 API 即 Public API 的子集
+4. **macOS** —— Web 成熟后 wrap 一层
+5. **浏览器扩展** —— 工程量小，作为 V5 末期惊喜
+6. **Watch 增强** —— 在已有基础上小迭代
+
+---
+
+## §10 设计语言与品牌系统
+
+### 10.1 设计来源
+
+- **Web 端**：Codex 原型（warm-archival 美学），见 §1 与 `daypage-system/project/src/tokens.css`
+- **iOS 端**：继续 V4 的 liquid-glass + 暖色基调
+- **共享品牌色**：`#5D3000` 琥珀棕（accent）、`#FAF8F6` 暖白底
+
+### 10.2 设计原则（5 条）
+
+1. **Archive Aesthetic** · 档案质感：暖色底、衬线/无衬线对比、ALL-CAPS 微排版
+2. **Editorial Hierarchy** · 编辑式层级：大标题、长 leading、引文 italic
+3. **Calm Typography** · 安静的排版：3 字体（Display/Body/Mono），不滥用粗体
+4. **Generous Whitespace** · 留白慷慨：12px 圆角、24px 卡片间距、不挤
+5. **Functional Glow** · 功能性光泽：仅在 active state / agent pulse 用 amber glow
+
+### 10.3 颜色 Token
+
+```
+背景层：
+  --bg-warm:        #FAF8F6   page background
+  --surface-white:  #FFFFFF   cards
+  --surface-sunken: #F3F0EB   inputs / wells
+
+前景层：
+  --fg-primary:     #2B2822
+  --fg-muted:       #6B6560
+  --fg-subtle:      #A39F99
+
+主色：
+  --accent:         #5D3000
+  --accent-hover:   #7A3F00
+  --accent-soft:    #F5EDE3
+  --accent-border: #E8DCCA
+
+语义色：
+  --success: #4C7A3F  --success-soft: #EBF3E5
+  --warning: #A66A00  --warning-soft: #F8ECD6
+  --error:   #A23A2E  --error-soft:   #F5E1DC
+
+热力图：
+  --heatmap-empty/low/mid/high
+```
+
+### 10.4 字体系统
+
+| 用途 | Family | Weight |
+|---|---|---|
+| Display / Headline | Space Grotesk | 500/600/700 |
+| Body | Inter | 400/500/600/700 |
+| Mono / Meta | JetBrains Mono | 400/500/700 |
+
+### 10.5 组件原语（与 Codex 一致）
+
+- Btn (primary/secondary/soft/ghost) × (sm/md) × (pill?)
+- Chip (default/accent/success/warning/error/ghost)
+- Card (default/sunken)
+- Icon (lucide)
+- Sparkline (mini SVG)
+- SectionLabel (ALL-CAPS)
+- Pulse (active dot)
+- Heatmap (archive)
+
+### 10.6 Motion
+
+- 页面转场 140ms ease-out
+- Hover 过渡 100ms
+- Pulse 动画 1.6s ease-in-out infinite
+- 严禁 bouncy spring（与 archive 美学冲突）
+
+---
+
+## §11 Non-Goals
+
+明确**不做**的事，避免 scope creep：
+
+### 11.1 V5 周期内不做
+
+- ❌ **跨用户公共知识云**：不做"分享你的 wiki 给他人订阅"、不做 marketplace
+- ❌ **多人协作 wiki**：不做 Notion/Confluence 式多人编辑
+- ❌ **第三方插件市场**：不做 Obsidian-style plugin ecosystem
+- ❌ **训练自定义 LLM**：不做用户数据训练个性化模型
+- ❌ **支付/订阅系统**：本 PRD 只描述形态，不实施支付
+- ❌ **企业 SSO / SAML**：等 Team 版（Post-V5）
+- ❌ **iCloud Family Sharing**
+- ❌ **Android App**：HTML5 PWA 兜底
+- ❌ **Vision Pro 原生 App**：用 iPad 兼容版兜底
+
+### 11.2 永远不做
+
+- ❌ **广告**：DayPage 是付费产品，永不引入广告
+- ❌ **数据销售**：用户数据永不出售给第三方
+- ❌ **内容审查**：用户私人 vault 内容不做内容审查
+- ❌ **强制云同步**：iOS vault 永远是用户的（可拒绝同步）
+
+---
+
+## §12 终极形态商业模型（描述，不实施）
+
+> ⚠️ **本 PRD 不实施任何支付/订阅功能**。本节只描述终极形态愿景，供产品决策参考。
+> 实际 V5 开发：所有功能对所有用户开放，不区分免费 / 付费。
+
+### 12.1 三层定价（终极形态）
+
+#### Free Tier（永久免费）
+- 无限 raw memo（仅本地 + iCloud）
+- 100 条/月 AI compile
+- 不限 wiki page，但只 LIGHT 模式
+- 不能用 Chat
+- 不能用 Agent Actor
+- iOS / Web 均可用
+- **价值定位**：Day One 替代品
+
+#### Pro $12 / 月 or $108 / 年
+- 全部 capture 类型
+- 不限 AI compile（fair-use cap，~3000 条/月）
+- FULL compile 模式
+- Chat + RAG（100k tokens / 天）
+- 全部 Agent Action 可授权
+- macOS 桌面 App
+- 浏览器扩展
+- Year in Review 高级模板
+- 全量数据导出
+- **价值定位**：知识工作者的「思考的档案库」
+
+#### Team $25 / 人 / 月（Post-V5）
+- Pro 全部
+- 跨人共享 wiki
+- 团队 Graph 视图
+- Admin 控制台
+- SSO / SAML
+- 优先 support
+
+### 12.2 转化漏斗假设（用于 PRD 设计取舍）
+
+```
+Anonymous landing visitor
+     │ ↓ 8% 注册
+Free user (D1)
+     │ ↓ 35% 留存到 D7
+Active free user
+     │ ↓ 50% 用过 1 次 compile
+Engaged free user
+     │ ↓ 12% 撞到限额或被 Pro 功能吸引
+Pro converter (LTV $144 if year)
+     │ ↓ 5% 引荐到 Team
+Team customer (LTV ~$3K/y)
+```
+
+### 12.3 付费触发点设计
+
+虽然 V5 不实施，但功能设计上**保留付费触发点**位置：
+
+| 触发点 | 现 V5 表现 | 终极形态付费墙 |
+|---|---|---|
+| Chat 用 100k tokens / 天 | 全开 | Free 无 chat / Pro 100k / Team 不限 |
+| FULL compile | 全开 | Free LIGHT only / Pro FULL |
+| Year in Review 高级模板 | 全开 | Free 基础模板 / Pro 全部 |
+| Agent Actor 8 类 action | 全开 | Free 只 Observer / Pro 全部 |
+| macOS App | 不发布（V5 周期内） | Pro only |
+| 浏览器扩展 | 全开 | Pro only |
+
+### 12.4 反向验证：哪些功能用户**不应**愿意付费
+
+- Today / Archive 基础 capture：Day One 是 $35/年 一次性 + iCloud 同步，DayPage 必须**比 Day One 免费部分更好**
+- 简单文字日记：用户已有 Apple Notes / Bear，付费门槛高
+- 单纯地图回放：Apple Photos 已经免费
+
+→ 所以**不能把核心 capture 功能锁在付费墙后**。付费的价值只能在「AI compile + 知识网络 + 跨端深度同步 + 数字生命叙事」上。
+
+### 12.5 与 V5 实施的边界
+
+V5 PRD 的**所有 US 都不带付费墙逻辑**。但 §6 FR-43（chat tokens 上限）等限制保留为"系统总闸"，未来加付费墙时只是改阈值，不需要重构。
+
+---
+
+## §13 隐私、安全、合规
+
+### 13.1 隐私三原则
+
+1. **数据归用户所有**：用户随时可一键导出全量数据 / 删除账号
+2. **AI 不偷看 private**：标记 private 的内容不进 RAG、不进 graph、不被 link
+3. **零数据销售**：永不出售用户数据给第三方
+
+### 13.2 加密
+
+- **传输层**：所有 API HTTPS（TLS 1.3）
+- **静态层**：PostgreSQL 数据库由 Supabase 加密（AES-256）
+- **敏感字段**：location 用 pgcrypto 字段级加密
+- **Private vault**：用户主密码派生 key，server 无法解密 private 内容
+
+### 13.3 合规
+
+- **GDPR**：欧盟用户数据可一键导出/删除
+- **CCPA**：加州用户同上
+- **COPPA**：限制 13 岁以下用户注册
+- **PIPL**：中国境内用户数据存中国区（Supabase 暂无中国 region → V5 不支持中国大陆，明示）
+
+### 13.4 第三方数据共享
+
+- **DashScope（阿里云）**：发送 memo / page text 用于 LLM 推理（不留存）
+- **Apple**：iOS Sign-In sub
+- **Sentry**：错误堆栈（自动 PII 脱敏）
+- **PostHog**：匿名行为分析（用户可关）
+- 所有第三方在 Privacy Policy 明示
+
+### 13.5 滥用防护
+
+- 注册验证邮件
+- IP 频率限制（每 IP 注册 ≤3 账号 / 24h）
+- 已知 disposable email 域名拒绝
+- Webhook ingest 每用户每天上限 1000 条
+
+### 13.6 数据保留
+
+- Active 账号：永久
+- Soft-deleted 账号：30 天
+- Backup 滚动 90 天后过期
+- 日志 / audit：12 个月
+
+---
+
+## §14 北极星与成功指标
+
+### 14.1 北极星指标
+
+> **Weekly AI-Compiled Memos per Active User (WCAU)**
+
+定义：一周内 status=done 的 FULL compile memo 数（per active user）。
+
+为什么这个指标：
+- 反映用户**真实在投喂**（不是只来 capture）
+- 反映 AI 编译**真实在产出价值**（不是 LIGHT 摆设）
+- 与付费意愿强相关（重度用户 = 高 WCAU = 更可能 Pro）
+
+目标：V5 上线 6 个月内 P50 用户 WCAU ≥ 15。
+
+### 14.2 关键指标矩阵
+
+| 类别 | 指标 | V5 上线 6 个月目标 |
+|---|---|---|
+| **Acquisition** | Web 注册转化率（landing → register） | ≥ 8% |
+| **Activation** | D1 完成 onboarding | ≥ 70% |
+| **Activation** | D7 创建 ≥3 条 memo | ≥ 50% |
+| **Engagement** | WCAU (P50) | ≥ 15 |
+| **Engagement** | Chat 使用率（D30 至少用 1 次） | ≥ 35% |
+| **Engagement** | Inbox 处理率（D7 内处理） | ≥ 60% |
+| **Retention** | D30 retention | ≥ 30% |
+| **Retention** | D90 retention | ≥ 18% |
+| **Quality** | AI compile 成功率 | ≥ 98% |
+| **Quality** | RAG "I don't know" 率（应该高） | 5-15% 之间 |
+| **Quality** | Inbox 用户接受率（resolved/total） | ≥ 50% |
+| **Trust** | 数据导出请求率 | < 2% / month |
+| **Trust** | 删除账号率 | < 1% / month |
+
+### 14.3 体验质量指标
+
+- **首屏 LCP**：≤ 1.5s（4G）
+- **Wiki page 切换**：≤ 200ms（已缓存）
+- **Compile 完成时间 P50**：≤ 30s
+- **Sync 延迟 P95**：≤ 5s
+- **WCAG 2.1 AA**：100% 合规
+
+---
+
+## §15 Wave 拆分与里程碑
+
+> **本节不是承诺时间表，是工程节奏建议**。每个 Wave 跑完一轮 review，不强求全部跑完。
+
+### Wave 0 · 准备（W0，~3 天）
+- monorepo 改造（pnpm workspace + web/）
+- Vercel + Supabase Cloud + Inngest Cloud 接入
+- CI / CD pipeline
+- Sentry + PostHog
+- Auth.js v5 + Supabase Auth 接入
+- **可见产出**：空壳 web 能跑 + 能登录
+
+### Wave 1 · 后端骨架（W1，~5 天）
+- Drizzle schema + 迁移（13 张表）
+- /api/memos /api/pages /api/inbox /api/stats 基础 CRUD
+- Supabase Storage 接入
+- iOS sync API
+- **覆盖 US**：US-014 部分、US-062~064、FR-1~7
+- **可见产出**：iOS 能上传 vault 到云
+
+### Wave 2 · vault 导入（W2，~3 天）
+- 一次性 vault 导入脚本
+- iOS 客户端 sync 改造
+- vault-doctor 校验工具
+- **覆盖 US**：US-064、US-067 部分
+- **可见产出**：现有数据全在云上
+
+### Wave 3 · Web 骨架 + Home（W3，~4 天）
+- Next.js 16 shell + tokens.css 全套
+- Sidebar / Topbar
+- Home view 真数据
+- 字体加载 + PWA manifest
+- **覆盖 US**：US-001、US-025、US-048、US-054、US-055
+- **可见产出**：Web home 能看到自己的 memo 数据
+
+### Wave 4 · Add view + Compile worker（W4，~6 天）
+- UnifiedInput
+- Inngest worker 接入
+- 12-step pipeline 落地（先简化版：只做 normalize / embed / compile / apply）
+- SSE 进度推送
+- LIGHT/FULL 切换
+- **覆盖 US**：US-001、US-005~006、US-014~017、US-021、US-023、FR-8~14
+- **可见产出**：端到端编译跑通
+
+### Wave 5 · Wiki List 视图（W5，~5 天）
+- WikiNav + Page detail + Sources/Backlinks/Provenance 侧栏
+- Markdown 渲染
+- Annotation 层（基础）
+- **覆盖 US**：US-025~027、US-031、US-035~036、US-039
+- **可见产出**：能浏览 + 标注 wiki
+
+### Wave 6 · Wiki Graph 视图（W6，~3 天）
+- react-force-graph-2d 集成
+- 节点交互
+- 时间轴 slider
+- **覆盖 US**：US-028~029
+- **可见产出**：可视化知识网络
+
+### Wave 7 · Chat (RAG)（W7，~5 天）
+- pgvector embedding pipeline
+- 检索算法
+- SSE 流式回答
+- 引用解析 + reference cards
+- Suggested follow-ups
+- "I don't know" 兜底
+- **覆盖 US**：US-040~044、FR-22~26
+- **可见产出**：可问答自己的 wiki
+
+### Wave 8 · Inbox + Observer Agent（W8，~5 天）
+- 4 类 inbox item 生成器
+- Observer agent worker
+- Home 页 observation 卡片
+- inbox 处理流（含 contradiction 对比）
+- **覆盖 US**：US-019~020、US-024、US-048、US-051~053
+- **可见产出**：AI 主动建议生效
+
+### Wave 9 · Agent Actor + 安全栅栏（W9，~3 天）
+- Settings → Agent Permissions
+- 8 类 action 实现
+- Audit log + Undo
+- 全局停机开关
+- **覆盖 US**：US-049~050、FR-27~32
+- **可见产出**：Actor agent 可受控行动
+
+### Wave 10 · Search + Memory（W10，~4 天）
+- 全局搜索（混合 BM25 + vector）
+- 模糊回忆模式
+- Memory Lane（地图 / 情绪 / 随机漫步）
+- On This Day Web
+- **覆盖 US**：US-032~033、US-055、US-059~061
+- **可见产出**：检索与回顾闭环
+
+### Wave 11 · Recap System（W11，~4 天）
+- Weekly Recap worker
+- Monthly Recap
+- Year in Review draft
+- 可分享网页 + PDF 导出
+- **覆盖 US**：US-056~058
+- **可见产出**：自动报告系统
+
+### Wave 12 · Past-Self Dialogue + Persona（W12，~3 天）
+- Past-self prompt 模板
+- Persona 自定义
+- Time-window context 召回
+- **覆盖 US**：US-045~046
+- **可见产出**："数字生命"叙事激活
+
+### Wave 13 · iOS 端融合（W13，~5 天）
+- iOS Wiki / Chat / Inbox 简化版
+- 卸载本地 AI key（改走后端代理）
+- iOS Agent 推送
+- iOS On This Day V5 升级
+- **覆盖 US**：US-002、US-007、US-011~014、US-047、US-053、US-054
+- **可见产出**：iOS 进入 V5 时代
+
+### Wave 14 · Watch 增强（W14，~2 天）
+- Watch 一键语音
+- 表冠快捷
+- 同步指示
+- **覆盖 US**：US-003
+- **可见产出**：Watch 端到端可用
+
+### Wave 15 · macOS App（W15，~6 天）
+- SwiftUI 版（与 iOS 共享）或 Catalyst
+- 全局快捷键
+- 菜单栏 mini capture
+- Recap Builder
+- Spotlight 集成
+- **覆盖 US**：US-004、US-029、US-057~058
+- **可见产出**：macOS 桌面端
+
+### Wave 16 · 浏览器扩展（W16，~3 天）
+- Chrome / Safari / Firefox
+- 一键剪藏
+- **覆盖 US**：US-008
+- **可见产出**：扩展上架
+
+### Wave 17 · 外部入口（W17，~3 天）
+- Email-to-DayPage
+- Webhook ingest
+- Public API + OpenAPI 文档
+- TS / Python SDK
+- **覆盖 US**：US-009~010、US-070
+- **可见产出**：API 生态启动
+
+### Wave 18 · Privacy Vault（W18，~3 天）
+- 主密码 + private flag
+- Private 内容隔离
+- **覆盖 US**：US-066、FR-46
+- **可见产出**：隐私保险箱可用
+
+### Wave 19 · Settings + Account（W19，~4 天）
+- Settings 中心（10 个分组）
+- Devices 管理
+- 数据导出 / 删除账号
+- API tokens
+- **覆盖 US**：US-067~069、US-071
+- **可见产出**：账号体系完整
+
+### Wave 20 · 多模态升级（W20，~5 天）
+- 音频环境识别
+- AR 标注（iOS Camera）
+- 高级 OCR / PDF 章节切分
+- **覆盖 US**：US-013、US-006 升级
+- **可见产出**："中等激进"多模态体验
+
+### Wave 21 · 生产化（W21，~5 天）
+- E2E（Playwright）覆盖 P0 流程
+- a11y 全面审
+- 性能（lighthouse ≥ 95）
+- 文档（用户文档 + 开发者文档）
+- 监控告警全套
+- **覆盖**：全部 FR 验收
+- **可见产出**：可公开发布
+
+**总计**：~21 wave / ~85 工作日（单人投入）
+
+---
+
+## §16 风险登记册
+
+| ID | 风险 | 影响 | 概率 | 缓解 |
+|---|---|---|---|---|
+| R1 | DashScope 长期限流或断供 | 高 | 中 | 抽象 LLM provider 层，可切 Claude / OpenAI / 自托管 |
+| R2 | qwen 编译质量不达预期 | 高 | 中 | 关键 prompt 入版本控制，定期 eval；提供切到更强模型选项 |
+| R3 | Vault 数据迁移导致 iOS 端数据丢失 | 高 | 低 | vault-doctor 工具反向校验 hash；强制 backup 提示 |
+| R4 | Web 端 Graph 大节点性能崩 | 中 | 中 | >100 切 Canvas，>1000 切 web worker |
+| R5 | Inngest 定价超预算 | 中 | 中 | 关键 worker 可降级到 Vercel Cron + Postgres queue |
+| R6 | Supabase 中国不可访问 | 中 | 高 | 已在 §13.3 明示不支持中国大陆 |
+| R7 | AI Agent 误操作引发用户数据混乱 | 高 | 中 | §7.4 六重栅栏；所有 action 可 undo |
+| R8 | 用户主密码遗忘致 private 永久锁定 | 高 | 低 | 主密码不丢失也不能解；Settings 顶部明确警告 |
+| R9 | iOS 老用户拒绝云同步 | 中 | 中 | iOS 同步可选；vault-only 模式继续支持 V1-V4 体验 |
+| R10 | Auth.js v5 beta API 变更 | 低 | 中 | 锁版本，关注 milestone；最坏 fallback v4 |
+| R11 | Next.js 16 Turbopack 出 bug | 低 | 低 | 可临时 fallback webpack |
+| R12 | Apple Sign-In 审核被卡 | 中 | 低 | 同时支持 email magic link 兜底 |
+| R13 | 多端冲突频繁 | 中 | 中 | 冲突时弹用户选择 UI；audit log 可回滚 |
+| R14 | LLM 幻觉引用错误 page | 高 | 中 | system prompt 强制带 ID；后端做引用 ID 存在性校验，无效引用红框警示 |
+| R15 | 单 user 数据增长致单租户性能崩 | 中 | 低 | 每用户有数据量监控；超阈值告警；准备 sharding 方案 |
+
+---
+
+## §17 Open Questions
+
+> 写完 PRD 后剩余的、影响**实施细节**但不影响**整体方向**的问题。可分批回答。
+
+### 17.A 模型与提示词
+1. Compile 用 qwen-plus / qwen-max / qwen-vl-max？混合策略？
+2. Embedding 用 DashScope text-embedding-v3 还是 OpenAI text-embedding-3-large？维度？
+3. Chat 是否提供"切到 Claude" 选项给重度用户（自付 token）？
+4. Past-Self Dialogue 用什么 persona prompt 模板？是否要让用户上传"语气样本"？
+
+### 17.B AI Agent 边界
+5. ACT-3（auto-merge entity）何时算"高相似度"？余弦 ≥0.92？
+6. Observer 通知频率上限是不是 3/天/用户？太多会成骚扰
+7. Agent 是否允许调用 web search（如查 arXiv）？还是仅用本地 wiki？
+
+### 17.C 数据与同步
+8. iOS vault `.md` 与后端的 reconciliation 跑频率？
+9. 多设备同时编辑同一 page 时是否启用 OT/CRDT，还是 simple LWW？
+10. 离线超过 30 天的设备重新上线时是 full re-sync 还是 incremental？
+
+### 17.D 商业（即使本 PRD 不实施，但要预留）
+11. 如果未来加付费墙，触发点用 hard limit 还是 soft nudge？
+12. Pro 用户是否绑定 Apple ID Family Sharing？
+13. Public API 是否限免费用户使用？
+
+### 17.E 多平台
+14. macOS 端用纯 SwiftUI / Catalyst / Tauri (Web wrap)？
+15. 浏览器扩展是否做 Edge / Brave 单独发布？
+16. Watch 是否支持 standalone（不依赖 iPhone）？
+
+### 17.F 隐私
+17. Private vault 主密码遗忘是否提供"销毁 private 数据后重置"的选项？
+18. 是否提供 "Local-only mode"（完全不传云）的高级选项？
+
+### 17.G 设计与品牌
+19. DayPage 与 Codex 是否做品牌合并（统一叫 DayPage）还是双品牌（Web 叫 Codex by DayPage）？
+20. 是否需要重新做 logo / 视觉识别 V5？
+
+---
+
+## 附录 A · 与既有 PRD 的关系
+
+| PRD | 关系 |
+|---|---|
+| `prd-daypage-mvp.md` (V1) | V1 全部能力被 V5 承袭，不变 |
+| `prd-daypage-v2-roadmap.md` (V2) | V2 的功能向 issue 在 V5 中按需融合 |
+| `prd-daypage-v3-experience.md` (V3) | V3 的体验升级（On This Day / 视觉 / 编译反馈）继续生效，V5 增量 |
+| `prd-daypage-v4-liquid-glass.md` (V4) | V4 的 iOS 视觉系统继续生效 |
+| `prd-today-composer-liquid-refinement.md` | iOS 输入条精修，继续生效 |
+| `prd-auth-login.md` | 登录方案被 V5 §6.G 覆盖，可归档 |
+| `prd-sentry-linear-integration.md` | 已落地，V5 继续使用 |
+
+V5 不替代任何既有 PRD，是**叠加**的更上层文档。
+
+## 附录 B · 与技术方案的关系
+
+- 本 PRD 描述**做什么、为什么、给谁**
+- 姊妹文档 `docs/web/PLAN.md` 描述**怎么做**（架构、技术栈、API、表结构、Wave 工程细节）
+- `docs/web/PLAN.md` §0 锁定决策 与 本 PRD §0 锁定决策 互相一致
+
+---
+
+## 附录 C · 文档维护
+
+- 本 PRD 是 **living document**，随 Wave 推进可更新但 §0 锁定决策不轻易动
+- 任何 §6 FR 的修改需在 commit message 注明 "FR-N changed: <reason>"
+- 任何 §11 Non-Goals 的开放需经过主理人显式确认
+- 每个 Wave 完成时在 §15 对应位置打 ✅
+
+---
+
+**END · DayPage V5 · Codex PRD · 2026-05-10**


### PR DESCRIPTION
## Summary

把 DayPage 从「iOS 单机日志工具」扩展为「iOS + Watch + macOS + Web (Codex) + 公开 API」的跨端 AI 知识系统。Web 端按 Anthropic Claude Design 导出的 Codex 原型 1:1 复刻视觉，所有功能真接 PostgreSQL + DashScope，无 mock。

**本 PR 只入文档与任务清单，不写一行实施代码**。后续 Wave 拆 issue 实施。

## 包含内容

- **`tasks/prd-daypage-v5-codex.md`** (84KB) — 17 章产品蓝图：3 层价值主张（档案库 / 数字生命 / 习惯追踪）+ 24 模块 + 72 user stories + 51 FR + AI Agent 主动行动模型 + 21 Wave 路线图 + 北极星 WCAU 指标
- **`docs/web/PLAN.md`** (34KB) — 技术方案：13 表 PostgreSQL schema + 50 个 API endpoint + RAG/compile pipeline/sync 协议 + Next.js 16 + Supabase + Drizzle + Auth.js v5 + Inngest 选型理由
- **`prd.json` + `scripts/ralph/prd.json`** — Ralph 自动执行任务清单：50 条 user stories 覆盖 Wave 0-9（Web 骨架 → 后端 API → AI 编译引擎 → Agent 可受控行动），branchName `ralph/v5-codex-web`
- **`scripts/ralph/progress.txt`** — Ralph 进度日志重置 + 写入 V5 Codebase Patterns
- **`archive/` + `scripts/ralph/archive/`** — 旧 V4 today-composer-liquid 状态归档
- **`.gitignore`** 增补 Next.js / Turbopack / Vercel / Supabase 本地 / Drizzle meta 等构建产物规则

## 锁定决策（与主理人对齐）

| 维度 | 锁定方向 |
|---|---|
| 价值主张 | 三合一（档案库 + 数字生命 + 习惯追踪），同一产品不同感知层 |
| 范围 | 完整版 — 终极形态全景图，含全平台 + 公开 API + 3 年路线图 |
| 变现 | 本 PRD 不实施支付，仅在 §12 描述形态（Free / Pro $12 / Team $25） |
| 租户 | 单租户起步，schema 仍带 `user_id` 便于扩展 |
| 离线 | Web 端做 PWA + Service Worker |
| iOS | 维持 V1-V4 全部能力，新增云同步 + AI key 迁后端代理 |
| 首发 | 直接公开（不走 preview 期） |
| 激进度 | 中等 — 含 AI Agent 主动行动 + 多模态，不含跨用户 marketplace |
| 技术栈 | Next.js 16 + Supabase 本地 Docker + Drizzle 0.45 + Auth.js v5 beta + Inngest + DashScope qwen-plus |

## 与既有 PRD 的关系

V1-V4 的所有功能继续承袭。V5 是**叠加**在它们之上的更上层产品蓝图，不替代任何一份现有 PRD。详见 PRD §附录 A。

## Test plan

本 PR 不含任何代码改动，无需运行测试。文档审阅项：

- [ ] PRD §0 锁定决策与你的理解一致
- [ ] PRD §1.4 竞品差异化（vs Day One/Notion/Obsidian/Roam/NotebookLM/Reflect）有说服力
- [ ] PRD §3.3「2027 年完整一天剧本」描述的产品形态符合预期
- [ ] PRD §7 AI Agent 6 重栅栏的"中等激进"边界画得合理
- [ ] PRD §12 商业模型（即使本 PRD 不实施）的付费触发点设计合理
- [ ] PRD §15 21 个 Wave 的依赖排序与里程碑合理
- [ ] `docs/web/PLAN.md` 的技术选型与你的判断一致
- [ ] Ralph prd.json 50 条 story 颗粒度合适（一个 iteration 能完成）
- [ ] §17 20 个 Open Questions 中的关键问题（17.A 模型选型 / 17.B Agent 边界 / 17.G 品牌合并）值得后续讨论

## 后续动作

PR merge 后：
1. 切到新分支 `ralph/v5-codex-web`（Ralph 会自动 checkout）
2. `cd scripts/ralph && ./ralph.sh` 启动自动循环
3. 它会按 priority 顺序依次完成 US-001 → US-050
4. 每完成一条 commit + 在 progress.txt 追加学习笔记 + 把对应 `passes` 改为 true
5. Wave 9 完成（约 50 story，~28 工作日单人投入）后再考虑是否继续 Wave 10+