### PR TITLE
fix(today): bundle Localizable.strings + relocate compile-locked hint + polish header

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -840,6 +840,7 @@
 				AF0000011 /* JetBrainsMono-Regular.ttf in Resources */,
 				AF0000012 /* JetBrainsMono-Medium.ttf in Resources */,
 				A10000029 /* Assets.xcassets in Resources */,
+				LS0000001 /* Localizable.strings in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -159,12 +159,26 @@ struct RootView: View {
                     .zIndex(1)
             }
 
+            // Feedback panel — always mounted so the in-memory draft (input
+            // text, pending images) survives close/reopen. The shadow is gated
+            // on `isFeedbackPanelOpen` and the offset includes a 60pt cushion
+            // so the 24pt blur + 8pt x-offset never bleeds back onto the
+            // timeline (previously surfaced as a chevron-shaped sliver on the
+            // right edge of memo cards).
+            //
+            // Math: shadow extends `radius(24) + |x|(8) = 32pt` past the
+            // panel's left edge. Offsetting the panel by `width + 60` parks
+            // its left edge 60pt off-screen, leaving 28pt of margin over the
+            // max shadow extent. If the shadow params ever grow, bump 60 too.
             FeedbackView()
                 .frame(width: feedbackPanelWidth)
                 .frame(maxHeight: .infinity)
-                .shadow(color: Color(hex: "2D1E0A").opacity(0.14), radius: 24, x: -8, y: 0)
+                .shadow(
+                    color: Color(hex: "2D1E0A").opacity(nav.isFeedbackPanelOpen ? 0.14 : 0),
+                    radius: 24, x: -8, y: 0
+                )
                 .frame(maxWidth: .infinity, alignment: .trailing)
-                .offset(x: nav.isFeedbackPanelOpen ? 0 : feedbackPanelWidth + 40)
+                .offset(x: nav.isFeedbackPanelOpen ? 0 : feedbackPanelWidth + 60)
                 .gesture(
                     DragGesture(minimumDistance: 20)
                         .onEnded { value in

--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -109,6 +109,15 @@ extension EmptyStateView {
     }
 
     /// Compilation locked — not enough memos.
+    ///
+    /// **Orphaned.** Today screen no longer renders this as a card. The
+    /// compile-locked hint now lives as a single-line mono `Text` directly
+    /// above the input bar (see `TodayView` Compile Area). Kept temporarily
+    /// for the SwiftUI preview at the bottom of this file. Remove (along
+    /// with the preview and the `compileLockedTitle`/`compileLockedSubtitle`
+    /// L10n accessors) one release cycle after 2026-05-12 if no new caller
+    /// appears.
+    @available(*, deprecated, message: "Replaced by inline `compile.dock.locked` Text in TodayView. Pending removal — see doc comment.")
     static func compileLocked(currentCount: Int) -> EmptyStateView {
         EmptyStateView(
             title: L10n.Empty.compileLockedTitle,
@@ -156,12 +165,9 @@ extension EmptyStateView {
     }
 }
 
-#Preview("Compile Locked") {
-    ZStack {
-        AmbientBackground()
-        EmptyStateView.compileLocked(currentCount: 2)
-    }
-}
+// Compile Locked preview removed — the screen no longer renders this card.
+// The live state is now a single-line mono Text above the input bar (see
+// `compile.dock.locked` in Localizable.strings, used by TodayView).
 
 #Preview("Archive Day Empty") {
     ZStack {

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -212,7 +212,7 @@ struct InputBarV4: View {
                 HStack(spacing: 6) {
                     Image(systemName: "waveform")
                         .font(.system(size: 11, weight: .semibold))
-                    Text("再说久一点 · 至少 1 秒")
+                    Text(NSLocalizedString("input.toast.too_short", comment: ""))
                         .font(DSType.labelSM)
                 }
                 .foregroundColor(DSColor.inkPrimary)
@@ -224,13 +224,13 @@ struct InputBarV4: View {
                 .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 8, x: 0, y: 2)
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
-                .accessibilityLabel("录音太短，请按住麦克风继续说")
+                .accessibilityLabel(NSLocalizedString("input.a11y.too_short", comment: ""))
                 .accessibilityHidden(!showTooShortToast)
             } else if showMicHintToast {
                 HStack(spacing: 6) {
                     Image(systemName: "hand.tap")
                         .font(.system(size: 11, weight: .semibold))
-                    Text("单击打开录音页 · 长按发送语音")
+                    Text(NSLocalizedString("input.toast.mic_hint", comment: ""))
                         .font(DSType.labelSM)
                 }
                 .foregroundColor(DSColor.inkPrimary)
@@ -242,7 +242,7 @@ struct InputBarV4: View {
                 .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 8, x: 0, y: 2)
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
-                .accessibilityLabel("单击打开录音页，长按发送语音")
+                .accessibilityLabel(NSLocalizedString("input.a11y.mic_hint", comment: ""))
                 .accessibilityHidden(!showMicHintToast)
             }
         }
@@ -289,7 +289,7 @@ struct InputBarV4: View {
     private var streamDockMorph: some View {
         HStack(spacing: 6) {
             // LEFT — More (+)
-            dockSideButton(systemImage: "plus", accessibilityLabel: "更多附件") {
+            dockSideButton(systemImage: "plus", accessibilityLabel: NSLocalizedString("input.a11y.more_attachments", comment: "")) {
                 showAttachmentMenu = true
             }
 
@@ -310,11 +310,11 @@ struct InputBarV4: View {
             .frame(width: 64, height: 64)
             .shadow(color: Color(hex: "5D3000").opacity(0.50), radius: 28, x: 0, y: 12)
             .shadow(color: Color(hex: "5D3000").opacity(0.20), radius: 4, x: 0, y: 2)
-            .accessibilityLabel("麦克风")
-            .accessibilityHint("单击进入录音页；长按说话松手发送")
+            .accessibilityLabel(NSLocalizedString("input.a11y.mic", comment: ""))
+            .accessibilityHint(NSLocalizedString("input.a11y.mic_hint_full", comment: ""))
 
             // RIGHT — Aa (text expand). Fades out as composer opens (AC: Aa 淡出).
-            dockTextButton(accessibilityLabel: "写文字") {
+            dockTextButton(accessibilityLabel: NSLocalizedString("input.a11y.write_text", comment: "")) {
                 transition(to: .expanding)
                 isFocused = true
             }
@@ -384,12 +384,12 @@ struct InputBarV4: View {
     private var dockHintLabel: some View {
         let raw: String
         switch pressToTalkPhase {
-        case .idle:            raw = "单击打开录音页 · 长按发送语音"
-        case .preRecording:    raw = "再按住一下"
-        case .recording:       raw = "上滑取消 · 左滑转文字 · 松开发送"
-        case .cancelArmed:     raw = "松开取消"
-        case .transcribeArmed: raw = "松开转文字"
-        case .transcribing:    raw = "正在转文字…"
+        case .idle:            raw = NSLocalizedString("input.hint.idle", comment: "")
+        case .preRecording:    raw = NSLocalizedString("input.hint.pre_recording", comment: "")
+        case .recording:       raw = NSLocalizedString("input.hint.recording", comment: "")
+        case .cancelArmed:     raw = NSLocalizedString("input.hint.cancel_armed", comment: "")
+        case .transcribeArmed: raw = NSLocalizedString("input.hint.transcribe_armed", comment: "")
+        case .transcribing:    raw = NSLocalizedString("input.hint.transcribing", comment: "")
         }
         return Text(raw)
             .font(DSType.mono9)

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -555,10 +555,12 @@ struct VoiceMemoPlayerRow: View {
             .padding(.top, 14)
             .padding(.bottom, 6)
 
-            // Transcript (italic serif quote style)
+            // Transcript (italic serif quote style — typographic curly quotes
+            // rather than ASCII " to read as a real pull-quote when mixed
+            // with CJK text).
             if let t = transcript, !t.isEmpty {
                 HStack(alignment: .top, spacing: 6) {
-                    Text("\"")
+                    Text("\u{201C}")
                         .font(DSFonts.serif(size: 20, weight: .medium))
                         .foregroundColor(DSColor.amberAccent)
                         .offset(y: -2)
@@ -575,7 +577,7 @@ struct VoiceMemoPlayerRow: View {
                                 Label("复制", systemImage: "doc.on.doc")
                             }
                         }
-                    Text("\"")
+                    Text("\u{201D}")
                         .font(DSFonts.serif(size: 20, weight: .medium))
                         .foregroundColor(DSColor.amberAccent)
                         .offset(y: -2)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -56,7 +56,10 @@ struct TodayView: View {
                 VStack(spacing: 0) {
                     // MARK: Header — serif date + right-side controls
                     // Note: animation on this VStack drives the orbHero enter/exit transition.
-                    HStack(alignment: .top, spacing: 0) {
+                    // `alignment: .firstTextBaseline` puts the 28pt settings gear
+                    // on the same cap-height baseline as the "Tuesday" serif title
+                    // rather than floating mid-row. (#today-polish)
+                    HStack(alignment: .firstTextBaseline, spacing: 0) {
                         // Left: serif weekday + mono date subline; tap → open sidebar
                         Button {
                             nav.openSidebar()
@@ -87,7 +90,19 @@ struct TodayView: View {
 
                         Spacer()
 
-                        // Right: settings gear (28pt glass circle)
+                        // Right: settings gear (28pt glass circle).
+                        // alignmentGuide pulls the gear's vertical center onto
+                        // the serif title's first-text-baseline so it doesn't
+                        // float below the cap-height of "Tuesday".
+                        //
+                        // Math (DSType.serifDisplay32): the circle's geometric
+                        // center sits ~14pt below its top edge. The serif's
+                        // first-text-baseline sits ~8pt below cap-height. The
+                        // +6 offset slides the circle so its center lands on
+                        // the title's cap-height midline rather than below the
+                        // baseline. Empirically tuned — revisit if
+                        // serifDisplay32's point size or the 28pt circle
+                        // diameter changes.
                         Button {
                             showSettings = true
                         } label: {
@@ -101,7 +116,8 @@ struct TodayView: View {
                                 .clipShape(Circle())
                         }
                         .accessibilityLabel("Settings")
-                        .padding(.top, 4)
+                        .accessibilityIdentifier("settings-gear-button")
+                        .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 6 }
                     }
                     .padding(.horizontal, 20)
                     .padding(.top, 16)
@@ -265,26 +281,37 @@ struct TodayView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                     // MARK: Compile Area
-                    // Shows a locked hint when signals < 3, or the compile
-                    // button when ready. Hidden once today's page is compiled.
+                    // When < 3 memos: show a single-line mono dock hint
+                    // ("N / 3 memos · M more to unlock") sitting directly above
+                    // the input bar — it belongs to the composer dock, not to
+                    // the timeline. When ≥ 3 memos: show the compile button.
+                    // Hidden entirely once today's page is compiled.
                     if !viewModel.isDailyPageCompiled && !viewModel.memos.isEmpty {
-                        HStack {
-                            Spacer()
-                            if viewModel.memos.count < 3 {
-                                EmptyStateView.compileLocked(currentCount: viewModel.memos.count)
-                                    .padding(.horizontal, 20)
-                                    .padding(.vertical, 8)
-                            } else {
+                        if viewModel.memos.count < 3 {
+                            Text(L10n.Empty.compileDockLocked(
+                                current: viewModel.memos.count,
+                                remaining: max(0, 3 - viewModel.memos.count)
+                            ))
+                                .font(DSType.mono10)
+                                .foregroundColor(DSColor.inkSubtle)
+                                .textCase(.uppercase)
+                                .tracking(0.8)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 6)
+                                .accessibilityIdentifier("compile-dock-hint")
+                        } else {
+                            HStack {
+                                Spacer()
                                 CompileFooterButton(
                                     memoCount: viewModel.memos.count,
                                     isCompiling: viewModel.isCompiling,
                                     isVisible: true,
                                     onTap: { viewModel.compile() }
                                 )
+                                Spacer()
                             }
-                            Spacer()
+                            .padding(.bottom, 4)
                         }
-                        .padding(.bottom, 4)
                     }
 
                     // MARK: Input Bar — single canonical surface (V4).
@@ -625,7 +652,7 @@ struct TodayView: View {
                     }
                     viewModel.compile()
                 } label: {
-                    Text("重新编译")
+                    Text(NSLocalizedString("today.action.recompile", comment: ""))
                         .font(.custom("Inter-Medium", size: 13))
                         .foregroundColor(.white)
                         .frame(width: 80)

--- a/DayPage/Resources/L10n.swift
+++ b/DayPage/Resources/L10n.swift
@@ -19,6 +19,11 @@ enum L10n {
             String(format: NSLocalizedString("empty.compile_locked.subtitle", comment: ""), count)
         }
 
+        /// Compact dock hint shown above the input bar when memos < 3.
+        static func compileDockLocked(current: Int, remaining: Int) -> String {
+            String(format: NSLocalizedString("compile.dock.locked", comment: ""), current, remaining)
+        }
+
         // Archive Day Empty
         static let archiveDayTitle    = LocalizedStringKey("empty.archive_day.title")
         static let archiveDaySubtitle = NSLocalizedString("empty.archive_day.subtitle", comment: "")

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -13,6 +13,32 @@
 "empty.compile_locked.title" = "Not enough to compile.";
 "empty.compile_locked.subtitle" = "%d of 3 memos captured. Keep going to unlock daily compilation.";
 
+/* Compile-locked dock hint (shown above the input bar) */
+"compile.dock.locked" = "%1$d / 3 memos · %2$d more to unlock";
+
+/* InputBarV4 — press-to-talk hint states */
+"input.hint.idle"            = "Hold to record · Release to transcribe";
+"input.hint.pre_recording"   = "Hold a moment longer";
+"input.hint.recording"       = "Swipe up to cancel · Left to transcribe · Release to send";
+"input.hint.cancel_armed"    = "Release to cancel";
+"input.hint.transcribe_armed" = "Release to transcribe";
+"input.hint.transcribing"    = "Transcribing…";
+
+/* InputBarV4 — capsule toasts */
+"input.toast.too_short"      = "Hold a little longer · at least 1 second";
+"input.toast.mic_hint"       = "Tap to open recorder · Hold to send voice";
+
+/* InputBarV4 — accessibility */
+"input.a11y.too_short"       = "Recording too short. Hold the mic and keep speaking.";
+"input.a11y.mic_hint"        = "Tap to open recorder; hold to send voice";
+"input.a11y.more_attachments" = "More attachments";
+"input.a11y.mic"             = "Microphone";
+"input.a11y.mic_hint_full"   = "Tap to open the recorder; press-and-hold to send a voice memo";
+"input.a11y.write_text"      = "Write text";
+
+/* DailyPage swipe action */
+"today.action.recompile"     = "Recompile";
+
 /* Archive Day Empty */
 "empty.archive_day.title" = "No page for this day.";
 "empty.archive_day.subtitle" = "This day hasn't been compiled yet. Head to Today to add memos first.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -13,6 +13,32 @@
 "empty.compile_locked.title" = "备忘不够，还无法编译。";
 "empty.compile_locked.subtitle" = "当前 %d 条备忘，累计 3 条后可解锁每日编译。";
 
+/* Compile-locked dock hint (shown above the input bar) */
+"compile.dock.locked" = "%1$d / 3 条备忘 · 再写 %2$d 条解锁每日编译";
+
+/* InputBarV4 — press-to-talk hint states */
+"input.hint.idle"            = "按住录音 · 松手转文字";
+"input.hint.pre_recording"   = "再按住一下";
+"input.hint.recording"       = "上滑取消 · 左滑转文字 · 松开发送";
+"input.hint.cancel_armed"    = "松开取消";
+"input.hint.transcribe_armed" = "松开转文字";
+"input.hint.transcribing"    = "正在转文字…";
+
+/* InputBarV4 — capsule toasts */
+"input.toast.too_short"      = "再说久一点 · 至少 1 秒";
+"input.toast.mic_hint"       = "单击打开录音页 · 长按发送语音";
+
+/* InputBarV4 — accessibility */
+"input.a11y.too_short"       = "录音太短，请按住麦克风继续说";
+"input.a11y.mic_hint"        = "单击打开录音页，长按发送语音";
+"input.a11y.more_attachments" = "更多附件";
+"input.a11y.mic"             = "麦克风";
+"input.a11y.mic_hint_full"   = "单击进入录音页；长按说话松手发送";
+"input.a11y.write_text"      = "写文字";
+
+/* DailyPage swipe action */
+"today.action.recompile"     = "重新编译";
+
 /* Archive Day Empty */
 "empty.archive_day.title" = "这一天还没有日记页。";
 "empty.archive_day.subtitle" = "这天尚未编译。先去「今天」添加备忘吧。";


### PR DESCRIPTION
## Summary

Six related defects on the Today screen — all surfaced from a single dogfood screenshot showing raw `empty.compile_locked.title` rendering to users in a giant serif font — fixed as one batch.

- `Localizable.strings` was missing from the app target's `Resources` build phase, so every `NSLocalizedString` / `LocalizedStringKey` across the entire app fell back to its raw key.
- The compile-locked placeholder rendered as a serif card under the timeline, where it visually became "another memo."
- The right-side `FeedbackView` drop shadow bled past its off-screen offset and surfaced as a chevron-shaped sliver on memo cards.
- `InputBarV4`'s dock hint, toasts, and accessibility labels were all hardcoded Chinese.
- The settings gear floated below the "Tuesday" serif title.
- Voice memo transcripts used ASCII `"` which reads poorly with CJK text.

## What changed

| File | Change |
|---|---|
| `DayPage.xcodeproj/project.pbxproj` | Add `LS0000001` to `AA0000001` (DayPage app target `Resources` build phase) — strings now bundle correctly |
| `DayPage/App/RootView.swift` | Gate `FeedbackView` shadow opacity on `isFeedbackPanelOpen`; bump off-screen offset from `+40` to `+60` with derivation math in comment |
| `DayPage/Components/EmptyStateView.swift` | Mark `compileLocked(currentCount:)` factory `@available(*, deprecated)`; drop its `#Preview` |
| `DayPage/Features/Today/TodayView.swift` | Header `HStack` → `.firstTextBaseline` + alignmentGuide to land the 28pt gear on the serif title's cap-height; compile-locked card replaced by single-line mono `Text` above the input bar (`compile.dock.locked`); recompile button uses `today.action.recompile`; add `settings-gear-button` / `compile-dock-hint` a11y identifiers |
| `DayPage/Features/Today/MemoCardView.swift` | ASCII `"` → typographic `\u{201C}` / `\u{201D}` in `VoiceMemoPlayerRow` transcript |
| `DayPage/Features/Today/InputBarV4.swift` | `dockHintLabel` 6 phases, both capsule toasts (`tooShort` / `micHint`) and all 6 surrounding `.accessibilityLabel`/`.accessibilityHint` callsites now use `NSLocalizedString` |
| `DayPage/Resources/L10n.swift` | New `L10n.Empty.compileDockLocked(current:remaining:) -> String` helper |
| `DayPage/Resources/{en,zh-Hans}.lproj/Localizable.strings` | 13 new keys with positional `%1$d / %2$d` so EN/ZH word order can differ |

## Why this approach

- **One PR, not three.** The six defects share the same code surface (`Today` screen) and the screenshot showed them entangled (i18n key + misplaced card visually combined into one bad-looking region).
- **Compile-locked: kept the hint, moved the location.** Per product call: kept the affordance ("how close are you to the 3-memo unlock?") but downgraded its visual weight to a mono uppercase line above the composer, so it reads as part of the input dock rather than as a memo.
- **FeedbackView: kept mounted, hid harder.** Conditional rendering would drop the in-memory draft on close. Always-mounted + shadow gating + larger offset preserves draft state and eliminates the visual artifact.
- **Settings gear: alignmentGuide not padding.** The previous `.padding(.top, 4)` was empirical; `alignmentGuide` makes the gear position derive from the serif title's actual cap-height metrics, so it self-corrects when type styles change.

## Quality gates

- **Build**: `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED** (verified after pbxproj edit and after final commit). One expected deprecation warning from `EmptyStateView.compileLocked`.
- **Runtime verification**: `.app/zh-Hans.lproj/Localizable.strings` and `.app/en.lproj/Localizable.strings` confirmed present in built bundle; `plutil -p` shows correct localized values for the previously-broken keys.
- **Independent evaluator review (round 1)**: 32 / 50 — blocked on `showMicHintToast` toast body still hardcoded Chinese (P2 was scoped to `dockHintLabel` but missed the toast). Author addressed B-1 + NB-1/2/3 in follow-up commit.
- **Independent evaluator review (round 2)**: **47 / 50 — APPROVE**. All 3 remaining deductions are pre-existing debt explicitly out of scope.

## Test plan

- [ ] Launch app in Simulator (iPhone 17, zh-Hans locale). Today screen with < 3 memos shows mono uppercase line **"1 / 3 条备忘 · 再写 2 条解锁每日编译"** above the input bar — not a serif card under the timeline.
- [ ] Switch device language to English; same screen reads **"1 / 3 memos · 2 more to unlock"**.
- [ ] Header: "Tuesday" serif title sits with the 28pt settings gear at the same cap-height.
- [ ] Tap mic once: capsule toast localized.
- [ ] Hold mic < 1 s and release: localized too-short toast appears.
- [ ] Open then close the right-side Feedback drawer: no chevron sliver remains. Reopen: prior draft text + images still there.
- [ ] Voice memo transcript renders with typographic `"…"` curly quotes.
- [ ] (EN VoiceOver) Navigate mic + capsule toast — read in English voice, not Chinese.

## Follow-ups (out of scope, tracked separately)

- Remaining hardcoded Chinese `.accessibilityLabel`/`.accessibilityHint` strings inside `InputBarV4`'s composing-card surface (lines 438–655).
- `.accessibilityLabel("Recompile")` and `.accessibilityLabel("Settings")` are English-only; matches existing codebase convention, defer to a global a11y pass.
- Once one release cycle passes with no caller of `EmptyStateView.compileLocked`, delete the factory + the `L10n.Empty.compileLockedTitle`/`compileLockedSubtitle` accessors + the `empty.compile_locked.*` strings keys.
