### PR TITLE
fix: restore Today view scrolling — replace .mask() with .overlay()

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -266,16 +266,17 @@ struct TodayView: View {
                     // US-010: Vignette gradient at the bottom edge fades timeline
                     // content behind the composer dock, so cards appear to recede
                     // rather than abruptly stopping at the input bar boundary.
-                    .mask(
-                        VStack(spacing: 0) {
-                            Rectangle()
-                            LinearGradient(
-                                colors: [Color.black, Color.clear],
-                                startPoint: .top,
-                                endPoint: .bottom
-                            )
-                            .frame(height: 40)
-                        }
+                    // Note: overlay+allowsHitTesting(false) preserves scroll gestures;
+                    // .mask() on a ScrollView blocks hit-testing and breaks scrolling.
+                    .overlay(
+                        LinearGradient(
+                            colors: [Color.clear, DSColor.bgWarm],
+                            startPoint: .top,
+                            endPoint: .bottom
+                        )
+                        .frame(height: 40)
+                        .allowsHitTesting(false),
+                        alignment: .bottom
                     )
                     .coordinateSpace(name: "todayScroll")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)


### PR DESCRIPTION
## Problem
The Today view's timeline could not scroll. With 5 memos but screen showing only 2-3, the remaining items were inaccessible.

## Root Cause
`.mask()` applied to the `ScrollView` participates in SwiftUI's hit-testing pass, consuming all touch events and preventing the scroll gesture from reaching the `ScrollView`.

## Fix
Replaced `.mask(VStack { Rectangle(); LinearGradient... })` with `.overlay(LinearGradient(...).allowsHitTesting(false), alignment: .bottom)`.

- Vignette fade effect at the bottom edge is preserved visually (40pt gradient from transparent to background)
- `.allowsHitTesting(false)` ensures the overlay is invisible to gestures
- Scroll gestures now reach the `ScrollView` unobstructed

## Changes
- `DayPage/Features/Today/TodayView.swift`: 1 file, +11/-10