### PR TITLE
fix(sidebar): restore Today/Archive/Graph nav + Recent activity list

### DIFF
--- a/DayPage/App/AppNavigationModel.swift
+++ b/DayPage/App/AppNavigationModel.swift
@@ -18,6 +18,12 @@ final class AppNavigationModel: ObservableObject {
     @Published var isSidebarOpen: Bool = false
     @Published var isFeedbackPanelOpen: Bool = false
 
+    /// Deep-link target for ArchiveView. When set, ArchiveView opens its
+    /// DayDetailView for this date the next time it observes the change.
+    /// Cleared by ArchiveView once consumed so re-tapping the same row in the
+    /// sidebar still triggers the navigation.
+    @Published var pendingArchiveDate: String? = nil
+
     init() {}
 
     func openSidebar() {
@@ -34,6 +40,14 @@ final class AppNavigationModel: ObservableObject {
 
     func navigate(to tab: AppTab) {
         selectedTab = tab
+        closeSidebar()
+    }
+
+    /// Switch to Archive and ask ArchiveView to open the DayDetailView for the
+    /// given `YYYY-MM-DD` once it appears.
+    func openArchive(at dateString: String) {
+        pendingArchiveDate = dateString
+        selectedTab = .archive
         closeSidebar()
     }
 

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -23,9 +23,24 @@ struct SidebarView: View {
                     .frame(height: 0.5)
                     .padding(.bottom, 8)
 
-                navSection
+                ScrollView(showsIndicators: false) {
+                    VStack(alignment: .leading, spacing: 0) {
+                        navSection
+                            .padding(.top, 4)
 
-                Spacer()
+                        if !sidebarVM.recentDays.isEmpty {
+                            recentSection
+                                .padding(.top, 18)
+                        }
+
+                        // Always show feedback row at the bottom of the
+                        // scrollable area so it stays reachable even when the
+                        // Recent list grows.
+                        feedbackSection
+                            .padding(.top, 18)
+                    }
+                    .padding(.bottom, 24)
+                }
 
                 Rectangle()
                     .fill(DSColor.inkFaint)
@@ -37,6 +52,11 @@ struct SidebarView: View {
         }
         .task {
             sidebarVM.bind(authService: authService)
+        }
+        .onChange(of: nav.isSidebarOpen) { isOpen in
+            // Refresh the recent-day list every time the drawer opens so the
+            // user sees the latest activity without having to relaunch.
+            if isOpen { sidebarVM.refreshRecentDays() }
         }
         .sheet(isPresented: $showSettings) {
             SettingsView()
@@ -66,9 +86,20 @@ struct SidebarView: View {
 
     // MARK: - Nav Items
 
-    // Primary nav (Today/Archive/Graph) moved to GlassTabBar pill — sidebar keeps Feedback only.
+    /// Primary nav: Today / Archive / Graph. Graph is gated behind a Post-MVP
+    /// chip until the knowledge-graph feature ships (PRD NG-3).
     private var navSection: some View {
         VStack(alignment: .leading, spacing: 2) {
+            navItem(tab: .today, icon: "square.and.pencil", label: "Today")
+            navItem(tab: .archive, icon: "archivebox", label: "Archive")
+            navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted", label: "Graph", disabled: true)
+        }
+        .padding(.horizontal, 12)
+    }
+
+    private var feedbackSection: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            sectionLabel("Support")
             navItem(tab: .feedback, icon: "bubble.left.and.exclamationmark.bubble.right", label: "Feedback")
         }
         .padding(.horizontal, 12)
@@ -76,7 +107,7 @@ struct SidebarView: View {
 
     @ViewBuilder
     private func navItem(tab: AppTab, icon: String, label: String, disabled: Bool = false) -> some View {
-        let isActive = nav.selectedTab == tab
+        let isActive = nav.selectedTab == tab && tab != .feedback
 
         Button {
             guard !disabled else { return }
@@ -128,6 +159,72 @@ struct SidebarView: View {
         }
         .disabled(disabled)
         .buttonStyle(.plain)
+    }
+
+    // MARK: - Recent Section
+
+    /// "Commit history" style list: the most recent days that actually have
+    /// memos, tapping a row jumps straight to that day's detail view in
+    /// Archive. Refreshed on every sidebar open via `refreshRecentDays()`.
+    private var recentSection: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            sectionLabel("Recent")
+
+            ForEach(sidebarVM.recentDays) { day in
+                recentRow(day: day)
+            }
+        }
+        .padding(.horizontal, 12)
+    }
+
+    private func recentRow(day: RecentDay) -> some View {
+        Button {
+            nav.openArchive(at: day.dateString)
+        } label: {
+            HStack(spacing: 12) {
+                Color.clear.frame(width: 2, height: 20)
+
+                Image(systemName: "circle.fill")
+                    .font(.system(size: 6))
+                    .frame(width: 20)
+                    .foregroundColor(DSColor.amberAccent.opacity(0.75))
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(Self.formatRowTitle(day.dateString))
+                        .font(DSType.bodySM)
+                        .foregroundColor(DSColor.inkPrimary)
+                    Text(day.dateString)
+                        .font(DSType.mono9)
+                        .foregroundColor(DSColor.inkSubtle)
+                        .tracking(0.5)
+                        .textCase(.uppercase)
+                }
+
+                Spacer()
+
+                Text("\(day.memoCount)")
+                    .font(DSType.mono10)
+                    .foregroundColor(DSColor.inkMuted)
+                    .padding(.horizontal, 6)
+                    .padding(.vertical, 2)
+                    .background(DSColor.amberSoft, in: Capsule())
+            }
+            .padding(.trailing, 16)
+            .padding(.vertical, 7)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text)
+            .font(DSType.mono9)
+            .foregroundColor(DSColor.inkSubtle)
+            .tracking(1.2)
+            .textCase(.uppercase)
+            .padding(.leading, 34)  // align with row text column (2 + 12 + 20)
+            .padding(.bottom, 4)
     }
 
     // MARK: - Bottom Section
@@ -197,4 +294,40 @@ struct SidebarView: View {
         }
         .buttonStyle(.plain)
     }
+
+    // MARK: - Date Formatting
+
+    /// Renders the row title as "Today" / "Yesterday" / weekday name to keep
+    /// the list scannable; falls back to month-day for older entries.
+    private static func formatRowTitle(_ dateString: String) -> String {
+        guard let date = isoFormatter.date(from: dateString) else { return dateString }
+        let cal = Calendar.current
+        if cal.isDateInToday(date) { return "Today" }
+        if cal.isDateInYesterday(date) { return "Yesterday" }
+        let daysAgo = cal.dateComponents([.day], from: cal.startOfDay(for: date), to: cal.startOfDay(for: Date())).day ?? 0
+        if daysAgo < 7 { return weekdayFormatter.string(from: date) }
+        return monthDayFormatter.string(from: date)
+    }
+
+    private static let isoFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone.current
+        return f
+    }()
+
+    private static let weekdayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "EEEE"
+        return f
+    }()
+
+    private static let monthDayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "MMM d"
+        return f
+    }()
 }

--- a/DayPage/App/SidebarViewModel.swift
+++ b/DayPage/App/SidebarViewModel.swift
@@ -1,15 +1,31 @@
 import SwiftUI
 
+// MARK: - RecentDay
+
+/// One row in the sidebar "Recent" section: a date string (`YYYY-MM-DD`) and
+/// the count of memos recorded that day. Memo count drives the trailing badge
+/// so the user can spot heavy-input days at a glance.
+struct RecentDay: Identifiable, Equatable {
+    let dateString: String  // YYYY-MM-DD
+    let memoCount: Int
+
+    var id: String { dateString }
+}
+
 // MARK: - SidebarViewModel
 
-/// Derives display-ready account info from the current auth session.
-/// Keeps SidebarView free of direct string manipulation on session data.
+/// Derives display-ready account info from the current auth session and
+/// surfaces the last few days that contain memos, so the sidebar can act as a
+/// fast jump list ("commit history") into Archive.
 @MainActor
 final class SidebarViewModel: ObservableObject {
 
     @Published var isLoggedIn: Bool = false
     @Published var accountEmail: String = ""
     @Published var accountInitial: String = "?"
+
+    /// Most recent days (descending) with at least one memo, capped to 7.
+    @Published var recentDays: [RecentDay] = []
 
     private var authStateTask: Task<Void, Never>?
 
@@ -34,6 +50,15 @@ final class SidebarViewModel: ObservableObject {
         }
     }
 
+    /// Re-scan `vault/raw/*.md` and publish the most recent 7 days off the
+    /// main actor. Safe to call repeatedly (e.g. whenever the sidebar opens).
+    func refreshRecentDays() {
+        Task { [weak self] in
+            let days = await Self.scanRecentDays(limit: 7)
+            await MainActor.run { self?.recentDays = days }
+        }
+    }
+
     private func updateFrom(authService: AuthService) {
         let email = authService.session?.user.email ?? ""
         isLoggedIn = authService.session != nil
@@ -43,5 +68,56 @@ final class SidebarViewModel: ObservableObject {
 
     deinit {
         authStateTask?.cancel()
+    }
+
+    // MARK: - Vault Scan
+
+    /// Reads `vault/raw/YYYY-MM-DD.md`, counts memos per day (memos are
+    /// separated by `\n\n---\n\n`), and returns the most recent `limit` days
+    /// in descending order. Missing/unreadable files are skipped silently.
+    nonisolated private static func scanRecentDays(limit: Int) async -> [RecentDay] {
+        await Task.detached(priority: .utility) {
+            let fm = FileManager.default
+            let rawDir = VaultInitializer.vaultURL.appendingPathComponent("raw")
+            guard let entries = try? fm.contentsOfDirectory(atPath: rawDir.path) else {
+                return []
+            }
+
+            // Keep only YYYY-MM-DD.md filenames; sort descending.
+            let dateStrings: [String] = entries.compactMap { name in
+                guard name.hasSuffix(".md") else { return nil }
+                let base = String(name.dropLast(3))
+                guard base.count == 10,
+                      base[base.index(base.startIndex, offsetBy: 4)] == "-",
+                      base[base.index(base.startIndex, offsetBy: 7)] == "-" else { return nil }
+                let digits = base.replacingOccurrences(of: "-", with: "")
+                guard digits.count == 8, digits.allSatisfy({ $0.isNumber }) else { return nil }
+                return base
+            }
+            .sorted(by: >)
+
+            var out: [RecentDay] = []
+            for dateStr in dateStrings.prefix(limit) {
+                let url = rawDir.appendingPathComponent("\(dateStr).md")
+                let count = countMemos(at: url, fileManager: fm)
+                if count > 0 {
+                    out.append(RecentDay(dateString: dateStr, memoCount: count))
+                }
+            }
+            return out
+        }.value
+    }
+
+    /// Count memos in a single raw daily file. Memos are separated by the
+    /// canonical `\n\n---\n\n` delimiter (see Models/Memo.swift). Empty file
+    /// or read failure → 0.
+    nonisolated private static func countMemos(at url: URL, fileManager: FileManager) -> Int {
+        guard let data = try? Data(contentsOf: url),
+              let text = String(data: data, encoding: .utf8) else { return 0 }
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return 0 }
+        // Each `\n\n---\n\n` boundary adds one memo on top of the first.
+        let separator = "\n\n---\n\n"
+        return trimmed.components(separatedBy: separator).count
     }
 }

--- a/DayPage/App/SidebarViewModel.swift
+++ b/DayPage/App/SidebarViewModel.swift
@@ -109,15 +109,16 @@ final class SidebarViewModel: ObservableObject {
     }
 
     /// Count memos in a single raw daily file. Memos are separated by the
-    /// canonical `\n\n---\n\n` delimiter (see Models/Memo.swift). Empty file
-    /// or read failure → 0.
+    /// canonical `<!-- daypage-memo-separator -->` delimiter (see
+    /// RawStorage.swift). Empty file or read failure → 0.
     nonisolated private static func countMemos(at url: URL, fileManager: FileManager) -> Int {
         guard let data = try? Data(contentsOf: url),
               let text = String(data: data, encoding: .utf8) else { return 0 }
         let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return 0 }
-        // Each `\n\n---\n\n` boundary adds one memo on top of the first.
-        let separator = "\n\n---\n\n"
-        return trimmed.components(separatedBy: separator).count
+        // Try the canonical separator first, fall back to the legacy `---` form.
+        let modern = trimmed.components(separatedBy: RawStorage.memoSeparator)
+        if modern.count > 1 { return modern.count }
+        return trimmed.components(separatedBy: RawStorage.legacyMemoSeparator).count
     }
 }

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -490,6 +490,10 @@ struct ArchiveView: View {
             .onAppear {
                 viewModel.loadMonth()
                 Task { await preScanVault() }
+                consumePendingArchiveDate()
+            }
+            .onChange(of: nav.pendingArchiveDate) { _ in
+                consumePendingArchiveDate()
             }
             .fullScreenCover(isPresented: $showDayDetail) {
                 if let dateStr = selectedDateString {
@@ -515,6 +519,21 @@ struct ArchiveView: View {
     private func handleDateTap(dateStr: String) {
         selectedDateString = dateStr
         showDayDetail = true
+    }
+
+    /// Consume any pending deep-link from the sidebar's Recent row. Cleared
+    /// after consumption so re-tapping the same row in the drawer still
+    /// triggers a new presentation.
+    private func consumePendingArchiveDate() {
+        guard let dateStr = nav.pendingArchiveDate else { return }
+        nav.pendingArchiveDate = nil
+        selectedDateString = dateStr
+        // Defer the cover so SwiftUI commits the tab switch first; presenting
+        // a fullScreenCover during the same runloop as the tab change can
+        // race and skip the animation on some iOS 16 builds.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+            showDayDetail = true
+        }
     }
 
     // MARK: - Vault Pre-Scan (US-006)


### PR DESCRIPTION
Closes #271

## Summary

- Restore Today / Archive / Graph rows in the sidebar drawer (Graph kept as Post-MVP chip)
- Add a "Recent" section that lists the most recent 7 days with memos as a commit-history-style jump list; tap → opens that day's DayDetailView in Archive
- New `AppNavigationModel.openArchive(at:)` deep-link path consumed by ArchiveView

## Why

After the recent sidebar refactor (`SidebarView.swift:69` comment "moved to GlassTabBar pill"), the drawer only showed Feedback — but `GlassTabBar` was never mounted anywhere. Users tapping the top-left header had no way to reach Archive; `nav.selectedTab` was stuck on `.today`. This restores the missing entry points and adds a recent-activity jump list per the requested "formal / elegant" sidebar shape.

## Files

- `DayPage/App/SidebarView.swift` — rebuilt drawer (brand header / nav / Recent / Support / bottom)
- `DayPage/App/SidebarViewModel.swift` — `RecentDay` model + `refreshRecentDays()` scanning `vault/raw/*.md`
- `DayPage/App/AppNavigationModel.swift` — `pendingArchiveDate` + `openArchive(at:)`
- `DayPage/Features/Archive/ArchiveView.swift` — consume `pendingArchiveDate`, present `DayDetailView`

## Test plan

- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → green
- [ ] Manual: tap top-left header on Today → drawer shows Today / Archive / Graph (Post-MVP), Recent days (if any), Support / Feedback, Settings, Account
- [ ] Manual: tap "Archive" → switches to ArchiveView, amber highlight on Archive when sidebar reopened
- [ ] Manual: tap a Recent day → opens that day's detail view in Archive
- [ ] Manual: re-tap the same Recent day → still opens (pendingArchiveDate is cleared after consumption)