### PR TITLE
fix(web): sidebar 桌面端重复 + home/chat 响应式修复 (#273)

### DIFF
--- a/web/src/app/(app)/chat/page.tsx
+++ b/web/src/app/(app)/chat/page.tsx
@@ -38,9 +38,10 @@ export default async function ChatPage() {
   }
 
   return (
-    <div style={{ display: "flex", height: "calc(100vh - 52px)" }}>
+    <div className="chat-index" style={{ display: "flex", height: "calc(100vh - 52px)" }}>
       {/* Thread list sidebar */}
       <aside
+        className="chat-index__aside"
         style={{
           width: "280px",
           flexShrink: 0,

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from "react";
 import { auth, signOut } from "@/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { Plus } from "lucide-react";
 import { headers } from "next/headers";
 import { db } from "@/lib/db/client";
 import { users, domains, inbox_items } from "@/lib/db/schema";

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -2,7 +2,6 @@ import { ReactNode } from "react";
 import { auth, signOut } from "@/auth";
 import { redirect } from "next/navigation";
 import Link from "next/link";
-import { Plus } from "lucide-react";
 import { headers } from "next/headers";
 import { db } from "@/lib/db/client";
 import { users, domains, inbox_items } from "@/lib/db/schema";
@@ -12,7 +11,7 @@ import { NavItem, NavItemLink, type NavIconName } from "./_components/NavItem";
 import { SystemRow } from "./_components/SystemRow";
 import { TopbarDate } from "./_components/TopbarDate";
 import { NewDomainButton } from "./_components/NewDomainButton";
-import { MobileSidebarDrawer } from "./_components/MobileSidebarDrawer";
+import { MobileSidebarDrawer, HamburgerButton } from "./_components/MobileSidebarDrawer";
 
 type NavSpec = { href: string; label: string; iconName: NavIconName; meta?: string };
 
@@ -165,56 +164,51 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
   );
 
   return (
-    <div className="flex min-h-screen">
-      {/* Sidebar — hidden on mobile, visible on lg+ */}
-      <aside className="sb hidden lg:flex w-[248px] shrink-0">
-        {sidebarContent}
-      </aside>
-
-      {/* Mobile drawer — rendered only on < lg via CSS */}
-      <MobileSidebarDrawer>
-        <aside className="sb" style={{ width: "100%", height: "100%" }}>
+    <MobileSidebarDrawer sidebar={sidebarContent}>
+      <div className="flex min-h-screen">
+        {/* Sidebar — hidden on mobile, visible on lg+ */}
+        <aside className="sb hidden lg:flex w-[248px] shrink-0">
           {sidebarContent}
         </aside>
-      </MobileSidebarDrawer>
 
-      {/* Main column — full width on mobile, calc on lg+ */}
-      <div className="flex flex-col min-h-screen w-full lg:w-[calc(100%-248px)]">
-        {/* Topbar */}
-        <header
-          style={{
-            height: "52px",
-            borderBottom: "1px solid var(--accent-border)",
-            background: "var(--surface-white)",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            padding: "0 1rem 0 1rem",
-            flexShrink: 0,
-          }}
-        >
-          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-            {/* Hamburger — visible on mobile only, rendered inside MobileSidebarDrawer */}
-            <span className="mobile-menu-btn-placeholder" />
-            <span className="ds-section-label">Codex</span>
-            <span style={{ color: "var(--fg-subtle)", fontSize: "0.75rem" }}>/</span>
-            <span style={{ fontSize: "0.875rem", fontWeight: 500, color: "var(--fg-primary)" }}>
-              {viewLabel}
-            </span>
-          </div>
-          <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
-            <TopbarDate />
-            <Link href="/chat" className="btn btn--soft btn--sm" aria-label="Ask — open chat">Ask</Link>
-            <Link href="/add" className="btn btn--primary btn--sm">Add</Link>
-          </div>
-        </header>
+        {/* Main column — full width on mobile, calc on lg+ */}
+        <div className="flex flex-col min-h-screen w-full lg:w-[calc(100%-248px)]">
+          {/* Topbar */}
+          <header
+            style={{
+              height: "52px",
+              borderBottom: "1px solid var(--accent-border)",
+              background: "var(--surface-white)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "0 1rem 0 1rem",
+              flexShrink: 0,
+            }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              {/* Hamburger — visible on mobile only, opens the drawer via context */}
+              <HamburgerButton />
+              <span className="ds-section-label">Codex</span>
+              <span style={{ color: "var(--fg-subtle)", fontSize: "0.75rem" }}>/</span>
+              <span style={{ fontSize: "0.875rem", fontWeight: 500, color: "var(--fg-primary)" }}>
+                {viewLabel}
+              </span>
+            </div>
+            <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
+              <TopbarDate />
+              <Link href="/chat" className="btn btn--soft btn--sm" aria-label="Ask — open chat">Ask</Link>
+              <Link href="/add" className="btn btn--primary btn--sm">Add</Link>
+            </div>
+          </header>
 
-        {/* Page content */}
-        <main style={{ flex: 1, overflowY: "auto" }}>
-          {children}
-        </main>
+          {/* Page content */}
+          <main style={{ flex: 1, overflowY: "auto" }}>
+            {children}
+          </main>
+        </div>
       </div>
-    </div>
+    </MobileSidebarDrawer>
   );
 }
 

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -843,4 +843,21 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
 
   /* Inbox conflict: single-column on narrow screens */
   .inbox-conflict { grid-template-columns: 1fr; }
+
+  /* Home page: stack hero, drop domain grid to 2-up, reflow activity rows */
+  .hero { grid-template-columns: 1fr; gap: 16px; }
+  .hero-headline { font-size: 32px; }
+  .grid-4 { grid-template-columns: repeat(2, 1fr); }
+  .activity-row { grid-template-columns: 72px 1fr; row-gap: 6px; }
+  .activity-row .what + * { grid-column: 1 / -1; }
+  .observation { flex-direction: column; gap: 8px; }
+  .observation__lead { width: auto; padding-top: 0; }
+}
+
+/* Home page: tighter breakpoints for narrow phones */
+@media (max-width: 640px) {
+  .page { padding: 20px 16px 64px; }
+  .stats { grid-template-columns: 1fr; }
+  .grid-4 { grid-template-columns: 1fr; }
+  .hero-headline { font-size: 28px; letter-spacing: -0.2px; }
 }


### PR DESCRIPTION
Closes #273

## Summary

- 修复 `(app)/layout.tsx` 错把 `<aside>` 当 `children` 传给 `MobileSidebarDrawer` 导致桌面端 sidebar 渲染两份的根本问题
- 用真正的 `<HamburgerButton />` 替换 topbar 里的 `mobile-menu-btn-placeholder` 占位
- 顺手修 home 页响应式断裂：`.hero / .stats / .grid-4 / .activity-row / .observation` 加 1023px 和 640px 断点
- 修 `/chat` 索引页 aside 在移动端不收缩的问题（class 名和 CSS 媒体查询规则对不上）

## Root cause

`MobileDrawerProvider({ sidebar, children })` 的契约：`sidebar` → fixed 抽屉，`children` → 文档流。Layout 把 `<aside>` 作为 children 传入，结果 children 直接渲染在桌面 `<aside class="sb hidden lg:flex">` 旁边，两份并排。

## Files changed

| File | Change |
|---|---|
| `web/src/app/(app)/layout.tsx` | Wrap layout in drawer, pass `sidebar` prop, swap placeholder for `<HamburgerButton />`, drop unused import |
| `web/src/app/globals.css` | Add `.hero / .stats / .grid-4 / .activity-row` responsive rules in existing `@media (max-width:1023px)` block + new 640px block |
| `web/src/app/(app)/chat/page.tsx` | Attach `chat-index` / `chat-index__aside` classes so existing mobile override matches |

## Verification

- `pnpm build`: ✓ Compiled successfully
- `pnpm typecheck`: 仅触发 pre-existing 错误（`schema-detect.ts`, `attachment.ts`, `memo.ts`, `tests/visual.spec.ts`, `@playwright/test` 缺失）— 与本改动无关
- Render-tree 手动追踪：
  - **Desktop (≥lg)**：`<aside class="sb hidden lg:flex">` 唯一可见 sidebar；hamburger `lg:hidden` 隐藏；drawer panel `translateX(-100%)` 离屏
  - **Mobile (<lg)**：桌面 aside `display:none`；hamburger 可见；点击 → context `open()` → drawer 滑入
- **未跑端到端 Playwright 验证**：项目缺 `@playwright/test` 依赖，且 `dev-bypass` 端点已被测试代码引用但实际未实现。建议下个 PR 把这两个补上后回归。

## Audit punch list (后续 issue 建议)

来自全站体检（Evaluator agent 输出，源码层面）：

### 应该单独开 issue 跟进
- **P1 home page 全是 mock data**：`openInboxCount`, hero 日期、observations、recent activity、domains 全是静态字面量 (`home/page.tsx:7,46-67,87`)。Round 1 skeleton 应改为真实数据查询。
- **P1 多处 "coming soon" disabled 按钮**：home 三个 hero CTA（Draft the page / Show what it would link / Not yet）、All domains、Keep tracked、wiki 的 "Ask about this page"、add 的 voice 按钮、chat 的 attach 按钮、sidebar 的 Settings。看起来像未完成 feature 泄漏到生产 UI。
- **P2 a11y**：domain dot 用纯颜色无 `aria-label`；topbar 缺 `role="banner"` 和 `<h1>`；`sb__domain-dot` 同样问题。
- **P2 i18n/copy**：curly quote vs straight quote vs `&apos;` 混用；建议统一。
- **P2 NavItem.active 用 `pathname.startsWith(href)`**：`/home` 会匹配 `/homepage`，今天没事但是定时炸弹。
- **P2 MobileSidebarDrawer 在 lg+ 仍 mount 不可见 dialog**：可以包 `lg:hidden` 进一步省事件监听。

### 不该在本 PR 改的更大问题
- `pnpm typecheck` 上一堆 pre-existing 错（drizzle overload、`@playwright/test` 没装、NextAuth v5 session type）— 单独开 chore issue 一次性清。
- `dev-bypass` 端点被测试引用但没实现 — 阻断了所有 authed e2e。

## Test plan

- [ ] 桌面 1440 访问 `/home`：左侧只见一份 sidebar
- [ ] 平板 768 访问 `/home`：hero 单列堆叠、domain 卡片 2 列
- [ ] 手机 375 访问 `/home`：hero 单列、stats 1 列、domain 1 列、hamburger 可见
- [ ] 手机 375 访问 `/chat`：thread aside 收缩到全宽
- [ ] 点击 hamburger 抽屉滑入、点 backdrop / Esc 关闭