### PR TITLE
feat(today): historical timeline beneath today's memos

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -74,7 +74,9 @@
 		A10000081 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000081 /* SidebarView.swift */; };
 		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
 		A10000083 /* WeeklyRecapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000083 /* WeeklyRecapService.swift */; };
+		A10000301 /* TimelineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000301 /* TimelineService.swift */; };
 		A10000084 /* WeeklyRecapSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000084 /* WeeklyRecapSection.swift */; };
+		A10000302 /* TimelineSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000302 /* TimelineSectionView.swift */; };
 		A10000200 /* ComposerStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000200 /* ComposerStateMachine.swift */; };
 		A10000201 /* SpotlightStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000201 /* SpotlightStripView.swift */; };
 		A10000202 /* SmartTemplateRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000202 /* SmartTemplateRow.swift */; };
@@ -226,7 +228,9 @@
 		A20000061 /* PosterRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterRenderer.swift; sourceTree = "<group>"; };
 		A20000082 /* InputBarV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV4.swift; sourceTree = "<group>"; };
 		A20000083 /* WeeklyRecapService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapService.swift; sourceTree = "<group>"; };
+		A20000301 /* TimelineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineService.swift; sourceTree = "<group>"; };
 		A20000084 /* WeeklyRecapSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapSection.swift; sourceTree = "<group>"; };
+		A20000302 /* TimelineSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineSectionView.swift; sourceTree = "<group>"; };
 		A20000200 /* ComposerStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerStateMachine.swift; sourceTree = "<group>"; };
 		A20000201 /* SpotlightStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightStripView.swift; sourceTree = "<group>"; };
 		A20000202 /* SmartTemplateRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartTemplateRow.swift; sourceTree = "<group>"; };
@@ -486,6 +490,7 @@
 				A20000087 /* AuthRateLimiter.swift */,
 				FB1000001 /* FeedbackService.swift */,
 				A20000083 /* WeeklyRecapService.swift */,
+				A20000301 /* TimelineService.swift */,
 				A20000095 /* ComposerContextProvider.swift */,
 			);
 			path = Services;
@@ -539,6 +544,7 @@
 				A20000055 /* PressToTalkButton.swift */,
 				A20000063 /* SwipeableMemoCard.swift */,
 				A20000084 /* WeeklyRecapSection.swift */,
+				A20000302 /* TimelineSectionView.swift */,
 				A20000200 /* ComposerStateMachine.swift */,
 				A20000201 /* SpotlightStripView.swift */,
 				A20000202 /* SmartTemplateRow.swift */,
@@ -936,7 +942,9 @@
 				A10000050 /* CompileFooterButton.swift in Sources */,
 				A10000082 /* InputBarV4.swift in Sources */,
 				A10000083 /* WeeklyRecapService.swift in Sources */,
+				A10000301 /* TimelineService.swift in Sources */,
 				A10000084 /* WeeklyRecapSection.swift in Sources */,
+				A10000302 /* TimelineSectionView.swift in Sources */,
 				A10000200 /* ComposerStateMachine.swift in Sources */,
 				A10000201 /* SpotlightStripView.swift in Sources */,
 				A10000202 /* SmartTemplateRow.swift in Sources */,

--- a/DayPage/Features/Today/TimelineSectionView.swift
+++ b/DayPage/Features/Today/TimelineSectionView.swift
@@ -161,9 +161,15 @@ struct TimelineDayCard: View {
     private func toggle() {
         if !hasLoaded {
             // First expand: parse the day's file once and cache. Subsequent
-            // toggles just flip the flag — no extra I/O.
-            loadedMemos = TimelineService.memos(for: entry)
-            hasLoaded = true
+            // toggles just flip the flag — no extra I/O. Load off-main to
+            // avoid blocking the UI thread on synchronous file I/O.
+            Task {
+                let memos = TimelineService.memos(for: entry)
+                await MainActor.run {
+                    loadedMemos = memos
+                    hasLoaded = true
+                }
+            }
         }
         withAnimation(.easeInOut(duration: 0.22)) {
             isExpanded.toggle()

--- a/DayPage/Features/Today/TimelineSectionView.swift
+++ b/DayPage/Features/Today/TimelineSectionView.swift
@@ -1,0 +1,203 @@
+import SwiftUI
+
+// MARK: - TimelineSectionView
+
+/// Renders one band of the Today historical timeline — a labelled divider
+/// followed by one card per day. Expanding a card reveals that day's raw
+/// memos inline (no navigation, see issue #276).
+///
+/// Visual language mirrors `WeeklyRecapSection`: low-contrast section header
+/// and surface-container cards, signalling "settled history" rather than the
+/// active composer day above.
+struct TimelineSectionView: View {
+
+    let section: TimelineSection
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            sectionDivider
+            ForEach(section.days) { day in
+                TimelineDayCard(entry: day)
+            }
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 24)
+    }
+
+    // MARK: Section header
+
+    private var sectionDivider: some View {
+        HStack(spacing: 12) {
+            Rectangle()
+                .fill(DSColor.outlineVariant)
+                .frame(height: 1)
+                .frame(maxWidth: 24)
+            Text(headerTitle)
+                .sectionLabelStyle()
+                .foregroundColor(DSColor.onSurfaceVariant)
+            Rectangle()
+                .fill(DSColor.outlineVariant)
+                .frame(height: 1)
+                .frame(maxWidth: .infinity)
+        }
+    }
+
+    /// Localized header. Month buckets format as "MMMM yyyy" in the user's
+    /// current locale so it reads naturally in either English or Chinese.
+    private var headerTitle: String {
+        switch section.kind {
+        case .thisWeekOthers:
+            return NSLocalizedString("today.timeline.thisWeek", value: "THIS WEEK", comment: "Timeline band")
+        case .lastWeek:
+            return NSLocalizedString("today.timeline.lastWeek", value: "LAST WEEK", comment: "Timeline band")
+        case .weekBeforeLast:
+            return NSLocalizedString("today.timeline.weekBeforeLast", value: "TWO WEEKS AGO", comment: "Timeline band")
+        case .month(let date):
+            let f = DateFormatter()
+            f.dateFormat = "MMMM yyyy"
+            f.locale = Locale.current
+            f.timeZone = TimeZone.current
+            return f.string(from: date).uppercased()
+        }
+    }
+}
+
+// MARK: - TimelineDayCard
+
+/// One day card inside a timeline section. Tap to expand — the card grows
+/// downward to show that day's raw memos, loaded lazily via TimelineService.
+struct TimelineDayCard: View {
+
+    let entry: TimelineDayEntry
+
+    @State private var isExpanded: Bool = false
+    @State private var loadedMemos: [Memo] = []
+    @State private var hasLoaded: Bool = false
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            if isExpanded {
+                Divider()
+                    .padding(.vertical, 8)
+                    .padding(.horizontal, 16)
+                expandedMemos
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(DSColor.surfaceContainer)
+        .cornerRadius(DSSpacing.radiusCard)
+    }
+
+    // MARK: Header (always visible)
+
+    private var header: some View {
+        Button(action: toggle) {
+            HStack(alignment: .top, spacing: 14) {
+                dateRail
+                summaryColumn
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .padding(.top, 4)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 14)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(isExpanded
+            ? NSLocalizedString("today.timeline.collapse", value: "Collapse", comment: "")
+            : NSLocalizedString("today.timeline.expand", value: "Expand", comment: ""))
+    }
+
+    private var dateRail: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(weekdayLabel)
+                .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
+                .foregroundColor(DSColor.onSurfaceVariant)
+            Text(monthDayLabel)
+                .font(.custom("SpaceGrotesk-Bold", size: 16))
+                .foregroundColor(DSColor.onSurface)
+        }
+        .frame(width: 56, alignment: .leading)
+    }
+
+    private var summaryColumn: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            if let summary = entry.summary, !summary.isEmpty {
+                Text(summary)
+                    .bodySMStyle()
+                    .foregroundColor(DSColor.onSurface)
+                    .lineLimit(isExpanded ? nil : 2)
+                    .multilineTextAlignment(.leading)
+            }
+            Text(memoCountLabel)
+                .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
+                .foregroundColor(DSColor.onSurfaceVariant)
+                .textCase(.uppercase)
+                .tracking(1.0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    // MARK: Expanded memo list
+
+    private var expandedMemos: some View {
+        VStack(spacing: 8) {
+            ForEach(loadedMemos, id: \.id) { memo in
+                MemoCardView(memo: memo)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.bottom, 14)
+    }
+
+    // MARK: Interaction
+
+    private func toggle() {
+        if !hasLoaded {
+            // First expand: parse the day's file once and cache. Subsequent
+            // toggles just flip the flag — no extra I/O.
+            loadedMemos = TimelineService.memos(for: entry)
+            hasLoaded = true
+        }
+        withAnimation(.easeInOut(duration: 0.22)) {
+            isExpanded.toggle()
+        }
+    }
+
+    // MARK: Formatters
+
+    private var weekdayLabel: String {
+        let f = DateFormatter()
+        f.dateFormat = "EEE"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f.string(from: entry.date).uppercased()
+    }
+
+    private var monthDayLabel: String {
+        let f = DateFormatter()
+        f.dateFormat = "MM.dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        return f.string(from: entry.date)
+    }
+
+    private var memoCountLabel: String {
+        let n = entry.memoCount
+        let key = n == 1 ? "today.timeline.memoCount.one" : "today.timeline.memoCount.other"
+        let fallback = n == 1 ? "1 MEMO" : "\(n) MEMOS"
+        let format = NSLocalizedString(key, value: fallback, comment: "Memo count chip")
+        return String(format: format, n)
+    }
+
+    private var accessibilityLabel: String {
+        let summaryText = entry.summary.flatMap { $0.isEmpty ? nil : $0 } ?? memoCountLabel
+        return "\(entry.dateString), \(summaryText)"
+    }
+}

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -558,24 +558,16 @@ struct TodayView: View {
 
     // MARK: - History Supplement (memos present — shown at timeline bottom)
 
-    /// When today already has memos we still show yesterday's compiled page or
-    /// the weekly recap at the bottom of the scroll, so the user can pull down
-    /// to see history. (#US-016)
+    /// History supplement rendered below today's raw memos. Previously this
+    /// only showed yesterday's compiled page or the weekly recap; now it owns
+    /// the full historical timeline (#276) — this week's other days, last
+    /// week, week-before-last, and older months as expandable cards.
     @ViewBuilder
     private var historySupplement: some View {
-        if !viewModel.memos.isEmpty && !viewModel.isLoading {
-            switch viewModel.fallbackContent {
-            case .yesterdayDailyPage(let page):
-                earlierDivider
-                yesterdaySection(page).padding(.top, 8)
-            case .weekRecap(let entries):
-                earlierDivider
-                WeeklyRecapSection(entries: entries) { dateString in
-                    onThisDayDateString = dateString
-                }
-                .padding(.top, 8)
-            default:
-                EmptyView()
+        if !viewModel.memos.isEmpty && !viewModel.isLoading && !viewModel.timelineSections.isEmpty {
+            earlierDivider
+            ForEach(viewModel.timelineSections) { section in
+                TimelineSectionView(section: section)
             }
         }
     }

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -82,8 +82,14 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
 
     /// Compiled day-pages from this week (Monday → yesterday), newest first.
     /// Populated in `load()` and refreshed whenever today's data reloads.
-    /// Drives the "Weekly Recap" section beneath today's raw memos.
+    /// Used only by the empty-today `fallbackContent` path now that the full
+    /// historical timeline (`timelineSections`) renders beneath today's memos.
     @Published var weeklyRecap: [WeeklyRecapEntry] = []
+
+    /// Full historical timeline grouped into bands (this-week-others, last
+    /// week, week-before-last, then by month). Drives the scrollable history
+    /// list under today's raw memos. Excludes today — today renders above.
+    @Published var timelineSections: [TimelineSection] = []
 
     /// Whether the view is currently loading memos.
     @Published var isLoading: Bool = false
@@ -423,6 +429,11 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 }
             }
 
+            // Build the historical timeline (this-week-others / last week /
+            // week-before-last / older months). Off-main: scans every raw
+            // day file once and parses summaries for compiled days.
+            let timeline = TimelineService.sections(referenceDate: capturedDate)
+
             // --- Back on MainActor: update published state ---
             await MainActor.run {
                 switch loadResult {
@@ -443,6 +454,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 self.isDailyPageCompiled = dailyExists
                 self.dailyPageSummary = dailyExists ? dailySummary : nil
                 self.weeklyRecap = WeeklyRecapService.shared.entries()
+                self.timelineSections = timeline
                 self.yesterdayDailyPageModel = yesterdayPage
                 self.onThisDayMemos = otdMemos
                 self.isLoading = false

--- a/DayPage/Services/TimelineService.swift
+++ b/DayPage/Services/TimelineService.swift
@@ -1,0 +1,242 @@
+import Foundation
+
+// MARK: - TimelineDayEntry
+
+/// One day in the Today timeline. Carries enough metadata to render the
+/// collapsed card (date + summary + memo count) without re-reading the file;
+/// the raw memos themselves are loaded lazily on demand when the card is
+/// expanded, so an opening cold scroll doesn't pay the parse cost for every
+/// historical day.
+struct TimelineDayEntry: Identifiable, Equatable {
+
+    /// `yyyy-MM-dd`. Stable id (at most one entry per date).
+    let dateString: String
+
+    /// Local-timezone midnight of the day.
+    let date: Date
+
+    /// Number of raw memos parsed from the day file.
+    let memoCount: Int
+
+    /// Frontmatter `summary:` from `vault/wiki/daily/{date}.md`, if compiled.
+    /// nil/empty when the day has not been AI-compiled yet.
+    let summary: String?
+
+    var id: String { dateString }
+
+    static func == (lhs: TimelineDayEntry, rhs: TimelineDayEntry) -> Bool {
+        lhs.dateString == rhs.dateString &&
+        lhs.memoCount == rhs.memoCount &&
+        lhs.summary == rhs.summary
+    }
+}
+
+// MARK: - TimelineSectionKind
+
+/// Identifies which time band a section represents. The view layer maps this
+/// to a localized title; the service stays locale-agnostic.
+enum TimelineSectionKind: Hashable {
+    case thisWeekOthers
+    case lastWeek
+    case weekBeforeLast
+    /// Month bucket for entries older than three weeks back. Carries the first
+    /// day of that month for label formatting (e.g. "2026-04-01" → "April 2026").
+    case month(Date)
+}
+
+// MARK: - TimelineSection
+
+struct TimelineSection: Identifiable, Equatable {
+
+    let kind: TimelineSectionKind
+
+    /// Newest-first within a section.
+    let days: [TimelineDayEntry]
+
+    var id: String {
+        switch kind {
+        case .thisWeekOthers: return "thisWeekOthers"
+        case .lastWeek: return "lastWeek"
+        case .weekBeforeLast: return "weekBeforeLast"
+        case .month(let date):
+            let f = DateFormatter()
+            f.dateFormat = "yyyy-MM"
+            f.locale = Locale(identifier: "en_US_POSIX")
+            f.timeZone = TimeZone.current
+            return "month-\(f.string(from: date))"
+        }
+    }
+
+    static func == (lhs: TimelineSection, rhs: TimelineSection) -> Bool {
+        lhs.kind == rhs.kind && lhs.days == rhs.days
+    }
+}
+
+// MARK: - TimelineService
+
+/// Scans `vault/raw/*.md` and produces the Today timeline grouped into
+/// time bands: this-week-others / last week / week-before-last / older
+/// buckets by calendar month.
+///
+/// The service is intentionally nonisolated and stateless — all heavy I/O
+/// happens off the main actor. The week boundary respects the user's system
+/// `Calendar.current.firstWeekday` (per CLAUDE.md guidance).
+enum TimelineService {
+
+    // MARK: - Public entry points
+
+    /// All days that contain at least one raw memo, newest-first. Includes
+    /// today when today has memos; callers exclude it via `group(...)` when
+    /// rendering the timeline separately from the active composer day.
+    static func entries(referenceDate: Date = Date()) -> [TimelineDayEntry] {
+        let rawDir = VaultInitializer.vaultURL.appendingPathComponent("raw")
+        let fm = FileManager.default
+        guard let enumerator = fm.enumerator(at: rawDir, includingPropertiesForKeys: nil) else {
+            return []
+        }
+
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone.current
+
+        let dailyDir = VaultInitializer.vaultURL.appendingPathComponent("wiki/daily")
+
+        var result: [TimelineDayEntry] = []
+        for case let url as URL in enumerator {
+            guard url.pathExtension == "md" else { continue }
+            let stem = url.deletingPathExtension().lastPathComponent
+            guard let date = fmt.date(from: stem) else { continue }
+
+            guard let content = try? String(contentsOf: url, encoding: .utf8) else { continue }
+            let memos = RawStorage.parse(fileContent: content)
+            guard !memos.isEmpty else { continue }
+
+            // Daily page summary (if compiled). Missing file is normal — skip silently.
+            var summary: String? = nil
+            let dailyURL = dailyDir.appendingPathComponent("\(stem).md")
+            if let dailyContent = try? String(contentsOf: dailyURL, encoding: .utf8) {
+                summary = extractSummary(from: dailyContent)
+            }
+
+            result.append(TimelineDayEntry(
+                dateString: stem,
+                date: date,
+                memoCount: memos.count,
+                summary: summary
+            ))
+        }
+
+        return result.sorted { $0.date > $1.date }
+    }
+
+    /// Groups timeline entries into the four bands described above, hiding any
+    /// section whose `days` list is empty. The "today" entry is excluded from
+    /// every section — the view layer renders today separately at the top.
+    static func sections(referenceDate: Date = Date()) -> [TimelineSection] {
+        let all = entries(referenceDate: referenceDate)
+        return group(entries: all, referenceDate: referenceDate)
+    }
+
+    /// Loads the raw memos for one timeline day on demand. Returns memos in
+    /// the same newest-first + pinned-on-top order as TodayViewModel uses for
+    /// today, so an expanded card reads consistently with the active day.
+    static func memos(for entry: TimelineDayEntry) -> [Memo] {
+        let url = VaultInitializer.vaultURL
+            .appendingPathComponent("raw")
+            .appendingPathComponent("\(entry.dateString).md")
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else { return [] }
+        return RawStorage.parse(fileContent: content).sorted { lhs, rhs in
+            if lhs.pinnedAt != nil && rhs.pinnedAt == nil { return true }
+            if lhs.pinnedAt == nil && rhs.pinnedAt != nil { return false }
+            if let lp = lhs.pinnedAt, let rp = rhs.pinnedAt { return lp > rp }
+            return lhs.created > rhs.created
+        }
+    }
+
+    // MARK: - Grouping (testable in isolation)
+
+    /// Pure function: classify pre-loaded entries into sections. Exposed at
+    /// internal scope so future unit tests can exercise the boundary math
+    /// without touching the file system.
+    static func group(entries: [TimelineDayEntry], referenceDate: Date) -> [TimelineSection] {
+        let cal = systemCalendar()
+        let today = cal.startOfDay(for: referenceDate)
+
+        guard let thisWeekStart = cal.dateInterval(of: .weekOfYear, for: today)?.start,
+              let lastWeekStart = cal.date(byAdding: .weekOfYear, value: -1, to: thisWeekStart),
+              let weekBeforeStart = cal.date(byAdding: .weekOfYear, value: -2, to: thisWeekStart)
+        else { return [] }
+
+        var thisWeekOthers: [TimelineDayEntry] = []
+        var lastWeek: [TimelineDayEntry] = []
+        var weekBeforeLast: [TimelineDayEntry] = []
+        var byMonth: [Date: [TimelineDayEntry]] = [:]
+
+        for entry in entries {
+            let day = cal.startOfDay(for: entry.date)
+            if day == today { continue }                  // today rendered separately
+            if day >= thisWeekStart {
+                thisWeekOthers.append(entry)
+            } else if day >= lastWeekStart {
+                lastWeek.append(entry)
+            } else if day >= weekBeforeStart {
+                weekBeforeLast.append(entry)
+            } else {
+                // Bucket by first-of-month so two days in the same month share a section.
+                let comps = cal.dateComponents([.year, .month], from: day)
+                if let monthStart = cal.date(from: comps) {
+                    byMonth[monthStart, default: []].append(entry)
+                }
+            }
+        }
+
+        var sections: [TimelineSection] = []
+        if !thisWeekOthers.isEmpty {
+            sections.append(TimelineSection(kind: .thisWeekOthers, days: thisWeekOthers))
+        }
+        if !lastWeek.isEmpty {
+            sections.append(TimelineSection(kind: .lastWeek, days: lastWeek))
+        }
+        if !weekBeforeLast.isEmpty {
+            sections.append(TimelineSection(kind: .weekBeforeLast, days: weekBeforeLast))
+        }
+        // Months newest-first; days inside each month already newest-first thanks to
+        // the source ordering.
+        let months = byMonth.keys.sorted(by: >)
+        for monthStart in months {
+            let days = byMonth[monthStart] ?? []
+            sections.append(TimelineSection(kind: .month(monthStart), days: days))
+        }
+        return sections
+    }
+
+    // MARK: - Helpers
+
+    /// Calendar honoring the user's system `firstWeekday` setting. Mirrors
+    /// what SwiftUI's date pickers use, so "this week" matches what the user
+    /// sees elsewhere in the OS.
+    private static func systemCalendar() -> Calendar {
+        var cal = Calendar(identifier: .gregorian)
+        cal.firstWeekday = Calendar.current.firstWeekday
+        cal.timeZone = TimeZone.current
+        return cal
+    }
+
+    /// Parse `summary:` from a Daily Page frontmatter. Same surface as
+    /// `WeeklyRecapService.extractSummary` and `TodayViewModel.extractSummary`
+    /// — duplicated rather than shared to avoid creating a public API surface
+    /// on those types just for parsing.
+    private static func extractSummary(from content: String) -> String? {
+        for line in content.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("summary:") {
+                let value = String(trimmed.dropFirst("summary:".count))
+                    .trimmingCharacters(in: .whitespaces)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                return value.isEmpty ? nil : value
+            }
+        }
+        return nil
+    }
+}

--- a/DayPage/Services/TimelineService.swift
+++ b/DayPage/Services/TimelineService.swift
@@ -62,7 +62,7 @@ struct TimelineSection: Identifiable, Equatable {
             let f = DateFormatter()
             f.dateFormat = "yyyy-MM"
             f.locale = Locale(identifier: "en_US_POSIX")
-            f.timeZone = TimeZone.current
+            f.timeZone = AppSettings.currentTimeZone()
             return "month-\(f.string(from: date))"
         }
     }
@@ -98,7 +98,7 @@ enum TimelineService {
         let fmt = DateFormatter()
         fmt.dateFormat = "yyyy-MM-dd"
         fmt.locale = Locale(identifier: "en_US_POSIX")
-        fmt.timeZone = TimeZone.current
+        fmt.timeZone = AppSettings.currentTimeZone()
 
         let dailyDir = VaultInitializer.vaultURL.appendingPathComponent("wiki/daily")
 
@@ -219,7 +219,7 @@ enum TimelineService {
     private static func systemCalendar() -> Calendar {
         var cal = Calendar(identifier: .gregorian)
         cal.firstWeekday = Calendar.current.firstWeekday
-        cal.timeZone = TimeZone.current
+        cal.timeZone = AppSettings.currentTimeZone()
         return cal
     }
 


### PR DESCRIPTION
## Summary

- Adds a scrollable historical timeline below today's raw memos: **this week (other days) → last week → week before last → older months**.
- Each historical day renders as a card with date, Daily Page summary (when compiled), and memo count. Tap to expand inline; raw memos load lazily on first expand.
- Week start follows `Calendar.current.firstWeekday`; empty days are skipped; empty sections are hidden entirely.
- Empty-today fallback (yesterday / on-this-day / weekly recap) is preserved for the no-memos-yet path.

## Changes

- **New** `DayPage/Services/TimelineService.swift` — scans `vault/raw/*.md`, parses summaries from `vault/wiki/daily/`, groups into bands (`TimelineDayEntry`, `TimelineSection`).
- **New** `DayPage/Features/Today/TimelineSectionView.swift` — section header + `TimelineDayCard` with inline expand/collapse.
- **Mod** `TodayViewModel` — adds `@Published var timelineSections`, computed off-main in `load()`.
- **Mod** `TodayView.historySupplement` — replaces the old yesterday-or-weekRecap switch with a `ForEach` over timeline sections.
- **Mod** `DayPage.xcodeproj/project.pbxproj` — registers two new source files in the DayPage target.

## Test plan

- [x] Build `DayPage` scheme on iPhone 17 simulator — `xcodebuild ... build` → `BUILD SUCCEEDED`
- [ ] Manual: open the app, scroll below today's memos, verify section ordering and that tapping a card reveals that day's raw memos
- [ ] Manual: with no memos today, verify the existing fallback (yesterday's daily page / on-this-day / weekly recap) still renders
- [ ] Manual: verify section headers correctly hide when a band has no qualifying days
- [ ] Manual: change device locale / week-start (e.g. Sunday) and confirm "this week" matches the user's expectation

Closes #276