### PR TITLE
feat(web): unify LLM via OpenAI + collapsible desktop sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,8 @@ DayPage/
   Config/           GeneratedSecrets (gitignored)
 ```
 
+**CODEX frontend**: lives in this repo's `web/` directory (Next.js) — the same app served at `localhost:3000`. Its env vars (e.g. `DASHSCOPE_API_KEY`) must be configured in `web/.env.local`, not in the iOS-side `Config/GeneratedSecrets.swift`.
+
 **Pipeline**: Today (raw input) → AI compilation → Daily Page (structured diary) → Entity Pages → Graph (Post-MVP knowledge network).
 
 ## Coding Conventions

--- a/web/src/app/(app)/_components/DesktopSidebarShell.tsx
+++ b/web/src/app/(app)/_components/DesktopSidebarShell.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { ChevronsLeft, ChevronsRight } from "lucide-react";
+
+const STORAGE_KEY = "daypage.sidebarCollapsed";
+const EXPANDED_W = 248;
+const COLLAPSED_W = 60;
+
+/**
+ * Desktop sidebar shell with icon-only collapse. The collapsed state is
+ * persisted to localStorage and broadcast to CSS via `data-collapsed` on the
+ * outer <aside> (rules in globals.css hide labels/meta/etc. when collapsed)
+ * and to the layout grid via the `--sb-w` CSS variable on <html>.
+ *
+ * Server-side renders in expanded state to match the SSR HTML; the effect
+ * below applies the persisted preference after hydration to avoid layout
+ * thrash on first paint.
+ */
+export function DesktopSidebarShell({ children }: { children: ReactNode }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  // Read persisted preference once on mount.
+  useEffect(() => {
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (raw === "true") setCollapsed(true);
+    } catch {
+      // localStorage may be unavailable (private mode, SSR snapshot mismatch)
+    }
+  }, []);
+
+  // Publish width to the layout so the main column can react in pure CSS.
+  useEffect(() => {
+    const w = collapsed ? COLLAPSED_W : EXPANDED_W;
+    document.documentElement.style.setProperty("--sb-w", `${w}px`);
+  }, [collapsed]);
+
+  function toggle() {
+    setCollapsed((prev) => {
+      const next = !prev;
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next ? "true" : "false");
+      } catch {
+        // ignore
+      }
+      return next;
+    });
+  }
+
+  return (
+    <aside
+      className="sb hidden lg:flex shrink-0"
+      data-collapsed={collapsed ? "true" : "false"}
+      style={{ width: collapsed ? COLLAPSED_W : EXPANDED_W }}
+    >
+      {children}
+      <button
+        type="button"
+        onClick={toggle}
+        aria-label={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        aria-expanded={!collapsed}
+        title={collapsed ? "Expand sidebar" : "Collapse sidebar"}
+        className="sb__collapse-btn"
+      >
+        {collapsed ? (
+          <ChevronsRight size={16} strokeWidth={1.7} />
+        ) : (
+          <ChevronsLeft size={16} strokeWidth={1.7} />
+        )}
+      </button>
+    </aside>
+  );
+}

--- a/web/src/app/(app)/_components/MobileSidebarDrawer.tsx
+++ b/web/src/app/(app)/_components/MobileSidebarDrawer.tsx
@@ -32,11 +32,12 @@ export function MobileDrawerProvider({
 
   return (
     <DrawerCtx.Provider value={{ open: () => setIsOpen(true) }}>
-      {/* Backdrop */}
+      {/* Backdrop — mobile/tablet only; desktop already has a permanent sidebar */}
       {isOpen && (
         <div
           onClick={() => setIsOpen(false)}
           aria-hidden="true"
+          className="lg:hidden"
           style={{
             position: "fixed",
             inset: 0,
@@ -46,11 +47,13 @@ export function MobileDrawerProvider({
         />
       )}
 
-      {/* Drawer panel */}
+      {/* Drawer panel — mobile/tablet only; hidden entirely on lg+ */}
       <div
         role="dialog"
         aria-modal="true"
         aria-label="Navigation menu"
+        aria-hidden={!isOpen}
+        className="lg:hidden"
         style={{
           position: "fixed",
           top: 0,
@@ -62,6 +65,7 @@ export function MobileDrawerProvider({
           transform: isOpen ? "translateX(0)" : "translateX(-100%)",
           transition: "transform 220ms cubic-bezier(0.25, 0.46, 0.45, 0.94)",
           willChange: "transform",
+          visibility: isOpen ? "visible" : "hidden",
         }}
       >
         {/* Close button */}

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -12,6 +12,7 @@ import { SystemRow } from "./_components/SystemRow";
 import { TopbarDate } from "./_components/TopbarDate";
 import { NewDomainButton } from "./_components/NewDomainButton";
 import { MobileSidebarDrawer, HamburgerButton } from "./_components/MobileSidebarDrawer";
+import { DesktopSidebarShell } from "./_components/DesktopSidebarShell";
 
 type NavSpec = { href: string; label: string; iconName: NavIconName; meta?: string };
 
@@ -165,20 +166,16 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
 
   return (
     <div className="flex min-h-screen">
-      {/* Sidebar — hidden on mobile, visible on lg+ */}
-      <aside className="sb hidden lg:flex w-[248px] shrink-0">
-        {sidebarContent}
-      </aside>
+      {/* Sidebar — hidden on mobile, visible on lg+ (collapsible via DesktopSidebarShell) */}
+      <DesktopSidebarShell>{sidebarContent}</DesktopSidebarShell>
 
-      {/* Mobile drawer — sidebar prop → fixed drawer panel. children → main content. */}
-      <MobileSidebarDrawer sidebar={
-        <aside className="sb" style={{ width: "100%", height: "100%" }}>
-          {sidebarContent}
-        </aside>
-      }>
+      {/* Mobile drawer — sidebar prop → fixed drawer panel. children → main content.
+          Pass the bare content; MobileSidebarDrawer wraps it in <aside class="sb">. */}
+      <MobileSidebarDrawer sidebar={sidebarContent}>
 
-      {/* Main column — full width on mobile, calc on lg+ */}
-      <div className="flex flex-col min-h-screen w-full lg:w-[calc(100%-248px)]">
+      {/* Main column — fills the remaining space next to the (collapsible) sidebar.
+          Using flex-1 + min-w-0 avoids hard-coding sidebar width here. */}
+      <div className="flex flex-col min-h-screen flex-1 min-w-0">
         {/* Topbar */}
         <header
           style={{

--- a/web/src/app/api/chat/threads/[id]/messages/route.ts
+++ b/web/src/app/api/chat/threads/[id]/messages/route.ts
@@ -5,7 +5,7 @@ import { db } from "@/lib/db/client";
 import { users, chat_threads, chat_messages, prompt_log } from "@/lib/db/schema";
 import { eq, and, gte, sum } from "drizzle-orm";
 import { z } from "zod";
-import { dashscope } from "@/lib/ai/dashscope";
+import { llm } from "@/lib/ai";
 import { retrievePages, type RetrievedPage } from "@/lib/ai/rag";
 
 export const dynamic = "force-dynamic";
@@ -103,7 +103,7 @@ async function generateSuggestedFollowups(
 ): Promise<string[]> {
   try {
     const context = `User: ${userMessage.slice(0, 500)}\nAssistant: ${assistantMessage.slice(0, 800)}`;
-    const { content } = await dashscope.chat(
+    const { content } = await llm.chat(
       [
         {
           role: "system",
@@ -259,11 +259,11 @@ export async function POST(
           messages.push({ role: h.role as "user" | "assistant", content: h.content });
         }
 
-        // Step 4: Stream from DashScope
+        // Step 4: Stream from LLM (DeepSeek)
         send({ type: "step", step: "generating" });
         let fullContent = "";
 
-        const { tokens_in, tokens_out } = await dashscope.chatStream(
+        const { tokens_in, tokens_out } = await llm.chatStream(
           messages,
           (chunk) => {
             if (closed) return;
@@ -358,7 +358,7 @@ export async function POST(
 
 async function autoTitleThread(threadId: string, userId: string, firstUserMessage: string) {
   try {
-    const { content } = await dashscope.chat([
+    const { content } = await llm.chat([
       {
         role: "system",
         content:

--- a/web/src/app/api/chat/threads/[id]/route.ts
+++ b/web/src/app/api/chat/threads/[id]/route.ts
@@ -4,7 +4,7 @@ import { db } from "@/lib/db/client";
 import { users, chat_threads, chat_messages } from "@/lib/db/schema";
 import { eq, and, asc } from "drizzle-orm";
 import { z } from "zod";
-import { dashscope } from "@/lib/ai/dashscope";
+import { llm } from "@/lib/ai";
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -141,7 +141,7 @@ export async function autoTitleThread(
 
     if (!thread || thread.title !== "New conversation") return;
 
-    const { content } = await dashscope.chat([
+    const { content } = await llm.chat([
       {
         role: "system",
         content:

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -696,6 +696,48 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
 .sb__domain-count { font-family: var(--font-mono); font-size: 10px; color: var(--fg-subtle); letter-spacing: 0.4px; }
 .sb__spacer { flex: 1; }
 
+/* ---------- Sidebar collapse (desktop icon-only mode) ---------- */
+.sb__collapse-btn {
+  position: sticky;
+  bottom: 0;
+  align-self: stretch;
+  margin-top: auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  height: 32px;
+  border: 1px solid var(--accent-border);
+  border-radius: var(--radius-small);
+  background: var(--bg-warm);
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: color 140ms ease-out, background 140ms ease-out;
+}
+.sb__collapse-btn:hover { color: var(--fg-primary); background: var(--surface-sunken); }
+.sb__collapse-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.sb[data-collapsed="true"] {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+.sb[data-collapsed="true"] .sb__brand { justify-content: center; padding-left: 0; padding-right: 0; }
+.sb[data-collapsed="true"] .sb__brand-tag,
+.sb[data-collapsed="true"] .sb__item-label,
+.sb[data-collapsed="true"] .sb__item-meta,
+.sb[data-collapsed="true"] .sb__item-badge,
+.sb[data-collapsed="true"] .sb__group-label,
+.sb[data-collapsed="true"] .sb__domain-label,
+.sb[data-collapsed="true"] .sb__domain-count {
+  display: none;
+}
+.sb[data-collapsed="true"] .sb__item,
+.sb[data-collapsed="true"] .sb__domain {
+  justify-content: center;
+  padding-left: 6px;
+  padding-right: 6px;
+  gap: 0;
+}
+
 /* ---------- Mobile drawer ---------- */
 .mobile-menu-btn { display: none; }
 @media (max-width: 1023px) {

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -38,6 +38,10 @@ export default function RootLayout({
     <html
       lang="en"
       className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} h-full antialiased`}
+      // Some browser extensions (e.g. Immersive Translate) inject attributes
+      // onto <html> before React hydrates, causing a top-level mismatch warning.
+      // Suppressing only on <html> is the React/Next recommended workaround.
+      suppressHydrationWarning
     >
       <body className="min-h-full bg-bg-warm text-fg-primary font-body">
         <QueryProvider>{children}</QueryProvider>

--- a/web/src/lib/ai/deepseek.ts
+++ b/web/src/lib/ai/deepseek.ts
@@ -1,0 +1,233 @@
+// ─── DeepSeek LLM provider (OpenAI-compatible endpoint) ──────────────────────
+// Server-only — DEEPSEEK_API_KEY is never exposed to the client.
+// Handles chat + chatStream. embed/transcribe are not supported by DeepSeek;
+// those calls live in openai.ts.
+
+import "server-only";
+import {
+  LLMProvider,
+  ChatMessage,
+  ChatResponse,
+  EmbedResponse,
+  TranscribeResponse,
+  ProviderError,
+} from "./provider";
+import { logPrompt } from "./prompt-log";
+
+const DEFAULT_BASE_URL = "https://api.deepseek.com/v1";
+const DEFAULT_CHAT_MODEL = "deepseek-chat";
+
+function getApiKey(): string {
+  const key = process.env.DEEPSEEK_API_KEY;
+  if (!key) throw new ProviderError("auth", "DEEPSEEK_API_KEY is not set");
+  return key;
+}
+
+function getBaseUrl(): string {
+  return process.env.DEEPSEEK_BASE_URL || DEFAULT_BASE_URL;
+}
+
+function getDefaultModel(): string {
+  return process.env.DEEPSEEK_MODEL || DEFAULT_CHAT_MODEL;
+}
+
+function mapHttpError(status: number, body: string): ProviderError {
+  if (status === 429)
+    return new ProviderError("rate_limit", `DeepSeek rate limit: ${body}`);
+  if (status === 401 || status === 403)
+    return new ProviderError("auth", `DeepSeek auth error (${status}): ${body}`);
+  if (status >= 500)
+    return new ProviderError("server", `DeepSeek server error (${status}): ${body}`);
+  return new ProviderError("server", `DeepSeek unexpected status ${status}: ${body}`);
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs = 30_000
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new ProviderError("timeout", `Request timed out after ${timeoutMs}ms`);
+    }
+    throw new ProviderError("server", "Network error", err);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export class DeepSeekProvider implements LLMProvider {
+  async chat(
+    messages: ChatMessage[],
+    opts: {
+      model?: string;
+      temperature?: number;
+      maxTokens?: number;
+      jsonMode?: boolean;
+    } = {}
+  ): Promise<ChatResponse> {
+    const model = opts.model ?? getDefaultModel();
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      temperature: opts.temperature ?? 0.7,
+    };
+    if (opts.maxTokens) body.max_tokens = opts.maxTokens;
+    if (opts.jsonMode) body.response_format = { type: "json_object" };
+
+    const res = await fetchWithTimeout(`${getBaseUrl()}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${getApiKey()}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const text = await res.text();
+    if (!res.ok) throw mapHttpError(res.status, text);
+
+    let json: unknown;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      throw new ProviderError("invalid_response", `Could not parse JSON: ${text}`);
+    }
+
+    const j = json as {
+      choices?: { message?: { content?: string } }[];
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+      model?: string;
+    };
+
+    const content = j.choices?.[0]?.message?.content;
+    if (typeof content !== "string") {
+      throw new ProviderError("invalid_response", `Missing content in response: ${text}`);
+    }
+
+    const tokens_in = j.usage?.prompt_tokens ?? 0;
+    const tokens_out = j.usage?.completion_tokens ?? 0;
+    const responseModel = j.model ?? model;
+
+    await logPrompt({ kind: "chat", model: responseModel, tokens_in, tokens_out }).catch(
+      () => undefined
+    );
+
+    return { content, tokens_in, tokens_out, model: responseModel };
+  }
+
+  async chatStream(
+    messages: ChatMessage[],
+    onChunk: (chunk: string) => void,
+    opts: { model?: string; temperature?: number; maxTokens?: number } = {}
+  ): Promise<{ tokens_in: number; tokens_out: number; model: string }> {
+    const model = opts.model ?? getDefaultModel();
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      temperature: opts.temperature ?? 0.7,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+    if (opts.maxTokens) body.max_tokens = opts.maxTokens;
+
+    const res = await fetchWithTimeout(
+      `${getBaseUrl()}/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${getApiKey()}`,
+        },
+        body: JSON.stringify(body),
+      },
+      60_000
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw mapHttpError(res.status, text);
+    }
+
+    if (!res.body) {
+      throw new ProviderError("server", "No response body for streaming request");
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let tokens_in = 0;
+    let tokens_out = 0;
+    let responseModel = model;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === "data: [DONE]") continue;
+        if (!trimmed.startsWith("data: ")) continue;
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(trimmed.slice(6));
+        } catch {
+          continue;
+        }
+
+        const p = parsed as {
+          choices?: { delta?: { content?: string } }[];
+          usage?: { prompt_tokens?: number; completion_tokens?: number };
+          model?: string;
+        };
+
+        if (p.model) responseModel = p.model;
+
+        const delta = p.choices?.[0]?.delta?.content;
+        if (delta) onChunk(delta);
+
+        if (p.usage) {
+          tokens_in = p.usage.prompt_tokens ?? tokens_in;
+          tokens_out = p.usage.completion_tokens ?? tokens_out;
+        }
+      }
+    }
+
+    await logPrompt({
+      kind: "chat",
+      model: responseModel,
+      tokens_in,
+      tokens_out,
+    }).catch(() => undefined);
+
+    return { tokens_in, tokens_out, model: responseModel };
+  }
+
+  async embed(_text: string, _opts?: { model?: string }): Promise<EmbedResponse> {
+    throw new ProviderError(
+      "invalid_response",
+      "DeepSeek does not provide embeddings — use the openai provider"
+    );
+  }
+
+  async transcribe(
+    _audioBuffer: ArrayBuffer,
+    _opts?: { mimeType?: string; language?: string }
+  ): Promise<TranscribeResponse> {
+    throw new ProviderError(
+      "invalid_response",
+      "DeepSeek does not provide transcription — use the openai provider"
+    );
+  }
+}
+
+export const deepseek: LLMProvider = new DeepSeekProvider();

--- a/web/src/lib/ai/index.ts
+++ b/web/src/lib/ai/index.ts
@@ -1,0 +1,24 @@
+// ─── Unified LLM façade ──────────────────────────────────────────────────────
+// Server-only — all capabilities currently route to OpenAI.
+//   chat / chatStream → OpenAI (gpt-4o-mini by default, override via OPENAI_MODEL)
+//   embed             → OpenAI text-embedding-3-small (1536-dim)
+//   transcribe        → OpenAI whisper-1
+// Callers should `import { llm } from "@/lib/ai"` and never touch backends
+// directly. DeepSeek is kept in-tree (deepseek.ts) but unused; re-route here
+// to switch back.
+
+import "server-only";
+import { LLMProvider } from "./provider";
+import { openai } from "./openai";
+
+export const llm: LLMProvider = openai;
+
+// Re-export types for convenience.
+export type {
+  LLMProvider,
+  ChatMessage,
+  ChatResponse,
+  EmbedResponse,
+  TranscribeResponse,
+} from "./provider";
+export { ProviderError } from "./provider";

--- a/web/src/lib/ai/openai.ts
+++ b/web/src/lib/ai/openai.ts
@@ -1,0 +1,332 @@
+// ─── OpenAI LLM provider (chat + embeddings + transcription) ─────────────────
+// Server-only — OPENAI_API_KEY (falls back to OPENAI_WHISPER_API_KEY) is never
+// exposed to the client.
+// Implements the full LLMProvider surface against OpenAI's official endpoints.
+
+import "server-only";
+import {
+  LLMProvider,
+  ChatMessage,
+  ChatResponse,
+  EmbedResponse,
+  TranscribeResponse,
+  ProviderError,
+} from "./provider";
+import { logPrompt } from "./prompt-log";
+
+const BASE_URL = "https://api.openai.com/v1";
+const DEFAULT_CHAT_MODEL = "gpt-4o-mini";
+const DEFAULT_EMBED_MODEL = "text-embedding-3-small"; // 1536-dim
+const DEFAULT_TRANSCRIBE_MODEL = "whisper-1";
+
+function getDefaultChatModel(): string {
+  return process.env.OPENAI_MODEL || DEFAULT_CHAT_MODEL;
+}
+
+function getApiKey(): string {
+  const key = process.env.OPENAI_API_KEY || process.env.OPENAI_WHISPER_API_KEY;
+  if (!key)
+    throw new ProviderError(
+      "auth",
+      "OPENAI_API_KEY (or OPENAI_WHISPER_API_KEY) is not set"
+    );
+  return key;
+}
+
+function mapHttpError(status: number, body: string): ProviderError {
+  if (status === 429)
+    return new ProviderError("rate_limit", `OpenAI rate limit: ${body}`);
+  if (status === 401 || status === 403)
+    return new ProviderError("auth", `OpenAI auth error (${status}): ${body}`);
+  if (status >= 500)
+    return new ProviderError("server", `OpenAI server error (${status}): ${body}`);
+  return new ProviderError("server", `OpenAI unexpected status ${status}: ${body}`);
+}
+
+async function fetchWithTimeout(
+  url: string,
+  init: RequestInit,
+  timeoutMs = 30_000
+): Promise<Response> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    return await fetch(url, { ...init, signal: controller.signal });
+  } catch (err: unknown) {
+    if (err instanceof Error && err.name === "AbortError") {
+      throw new ProviderError("timeout", `Request timed out after ${timeoutMs}ms`);
+    }
+    throw new ProviderError("server", "Network error", err);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+export class OpenAIProvider implements LLMProvider {
+  async chat(
+    messages: ChatMessage[],
+    opts: {
+      model?: string;
+      temperature?: number;
+      maxTokens?: number;
+      jsonMode?: boolean;
+    } = {}
+  ): Promise<ChatResponse> {
+    const model = opts.model ?? getDefaultChatModel();
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      temperature: opts.temperature ?? 0.7,
+    };
+    if (opts.maxTokens) body.max_tokens = opts.maxTokens;
+    if (opts.jsonMode) body.response_format = { type: "json_object" };
+
+    const res = await fetchWithTimeout(`${BASE_URL}/chat/completions`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${getApiKey()}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    const text = await res.text();
+    if (!res.ok) throw mapHttpError(res.status, text);
+
+    let json: unknown;
+    try {
+      json = JSON.parse(text);
+    } catch {
+      throw new ProviderError("invalid_response", `Could not parse JSON: ${text}`);
+    }
+
+    const j = json as {
+      choices?: { message?: { content?: string } }[];
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+      model?: string;
+    };
+
+    const content = j.choices?.[0]?.message?.content;
+    if (typeof content !== "string") {
+      throw new ProviderError("invalid_response", `Missing content in response: ${text}`);
+    }
+
+    const tokens_in = j.usage?.prompt_tokens ?? 0;
+    const tokens_out = j.usage?.completion_tokens ?? 0;
+    const responseModel = j.model ?? model;
+
+    await logPrompt({
+      kind: "chat",
+      model: responseModel,
+      tokens_in,
+      tokens_out,
+    }).catch(() => undefined);
+
+    return { content, tokens_in, tokens_out, model: responseModel };
+  }
+
+  async chatStream(
+    messages: ChatMessage[],
+    onChunk: (chunk: string) => void,
+    opts: { model?: string; temperature?: number; maxTokens?: number } = {}
+  ): Promise<{ tokens_in: number; tokens_out: number; model: string }> {
+    const model = opts.model ?? getDefaultChatModel();
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      temperature: opts.temperature ?? 0.7,
+      stream: true,
+      stream_options: { include_usage: true },
+    };
+    if (opts.maxTokens) body.max_tokens = opts.maxTokens;
+
+    const res = await fetchWithTimeout(
+      `${BASE_URL}/chat/completions`,
+      {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${getApiKey()}`,
+        },
+        body: JSON.stringify(body),
+      },
+      60_000
+    );
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw mapHttpError(res.status, text);
+    }
+
+    if (!res.body) {
+      throw new ProviderError("server", "No response body for streaming request");
+    }
+
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let tokens_in = 0;
+    let tokens_out = 0;
+    let responseModel = model;
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop() ?? "";
+
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed || trimmed === "data: [DONE]") continue;
+        if (!trimmed.startsWith("data: ")) continue;
+
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(trimmed.slice(6));
+        } catch {
+          continue;
+        }
+
+        const p = parsed as {
+          choices?: { delta?: { content?: string } }[];
+          usage?: { prompt_tokens?: number; completion_tokens?: number };
+          model?: string;
+        };
+
+        if (p.model) responseModel = p.model;
+
+        const delta = p.choices?.[0]?.delta?.content;
+        if (delta) onChunk(delta);
+
+        if (p.usage) {
+          tokens_in = p.usage.prompt_tokens ?? tokens_in;
+          tokens_out = p.usage.completion_tokens ?? tokens_out;
+        }
+      }
+    }
+
+    await logPrompt({
+      kind: "chat",
+      model: responseModel,
+      tokens_in,
+      tokens_out,
+    }).catch(() => undefined);
+
+    return { tokens_in, tokens_out, model: responseModel };
+  }
+
+  async embed(
+    text: string,
+    opts: { model?: string } = {}
+  ): Promise<EmbedResponse> {
+    const model = opts.model ?? DEFAULT_EMBED_MODEL;
+
+    const res = await fetchWithTimeout(`${BASE_URL}/embeddings`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${getApiKey()}`,
+      },
+      body: JSON.stringify({ model, input: text }),
+    });
+
+    const raw = await res.text();
+    if (!res.ok) throw mapHttpError(res.status, raw);
+
+    let json: unknown;
+    try {
+      json = JSON.parse(raw);
+    } catch {
+      throw new ProviderError("invalid_response", `Could not parse JSON: ${raw}`);
+    }
+
+    const j = json as {
+      data?: { embedding?: number[] }[];
+      usage?: { prompt_tokens?: number };
+      model?: string;
+    };
+
+    const embedding = j.data?.[0]?.embedding;
+    if (!Array.isArray(embedding)) {
+      throw new ProviderError("invalid_response", `Missing embedding in response: ${raw}`);
+    }
+
+    const tokens = j.usage?.prompt_tokens ?? 0;
+    const responseModel = j.model ?? model;
+
+    await logPrompt({
+      kind: "embed",
+      model: responseModel,
+      tokens_in: tokens,
+      tokens_out: 0,
+    }).catch(() => undefined);
+
+    return { embedding, tokens, model: responseModel };
+  }
+
+  async transcribe(
+    audioBuffer: ArrayBuffer,
+    opts: { mimeType?: string; language?: string } = {}
+  ): Promise<TranscribeResponse> {
+    const model = DEFAULT_TRANSCRIBE_MODEL;
+    const mimeType = opts.mimeType ?? "audio/m4a";
+
+    const form = new FormData();
+    form.append(
+      "file",
+      new Blob([audioBuffer], { type: mimeType }),
+      `audio.${mimeType.split("/")[1] ?? "m4a"}`
+    );
+    form.append("model", model);
+    if (opts.language) form.append("language", opts.language);
+
+    const res = await fetchWithTimeout(
+      `${BASE_URL}/audio/transcriptions`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${getApiKey()}`,
+        },
+        body: form,
+      },
+      60_000
+    );
+
+    const raw = await res.text();
+    if (!res.ok) throw mapHttpError(res.status, raw);
+
+    let json: unknown;
+    try {
+      json = JSON.parse(raw);
+    } catch {
+      throw new ProviderError("invalid_response", `Could not parse JSON: ${raw}`);
+    }
+
+    const j = json as {
+      text?: string;
+      language?: string;
+      duration?: number;
+    };
+
+    if (typeof j.text !== "string") {
+      throw new ProviderError("invalid_response", `Missing text in response: ${raw}`);
+    }
+
+    await logPrompt({
+      kind: "transcribe",
+      model,
+      tokens_in: 0,
+      tokens_out: 0,
+    }).catch(() => undefined);
+
+    return {
+      transcript: j.text,
+      language: j.language,
+      duration_sec: j.duration,
+    };
+  }
+}
+
+export const openai: LLMProvider = new OpenAIProvider();

--- a/web/src/lib/ai/rag.ts
+++ b/web/src/lib/ai/rag.ts
@@ -1,6 +1,7 @@
 // ─── RAG retrieval helper ─────────────────────────────────────────────────────
-// Server-only. Embeds a query via DashScope and retrieves the most relevant
-// pages from the user's wiki by cosine similarity.
+// Server-only. Embeds a query via the unified LLM façade (OpenAI
+// text-embedding-3-small) and retrieves the most relevant pages from the
+// user's wiki by cosine similarity.
 //
 // Note: embeddings are stored as JSON-encoded text (vector(1536) pending the
 // pgvector migration in 0006_pgvector_hnsw.sql). Once that migration is
@@ -11,7 +12,8 @@ import "server-only";
 import { db } from "@/lib/db/client";
 import { pages } from "@/lib/db/schema";
 import { and, eq, ne, sql } from "drizzle-orm";
-import { dashscope } from "./dashscope";
+import { llm } from "./index";
+import { ProviderError } from "./provider";
 
 export interface RetrievedPage {
   page_id: string;
@@ -64,8 +66,21 @@ export async function retrievePages(
 
   if (!queryText.trim()) return [];
 
-  // Embed the query
-  const { embedding: queryVec } = await dashscope.embed(queryText);
+  // Embed the query. If the embedding provider is unavailable (auth, rate limit,
+  // upstream error), gracefully degrade to "no RAG results" so chat still works.
+  let queryVec: number[];
+  try {
+    const res = await llm.embed(queryText);
+    queryVec = res.embedding;
+  } catch (err) {
+    if (err instanceof ProviderError) {
+      console.warn(
+        `[rag] embed failed (${err.code}): ${err.message} — returning no results`
+      );
+      return [];
+    }
+    throw err;
+  }
   if (queryVec.length === 0) return [];
 
   // Fetch all live pages for this user that have an embedding stored.

--- a/web/src/lib/inngest/functions/compile-memo.ts
+++ b/web/src/lib/inngest/functions/compile-memo.ts
@@ -10,9 +10,8 @@ import {
   inbox_items,
 } from "@/lib/db/schema";
 import { eq, and, gte, ne, sql } from "drizzle-orm";
-import { dashscope } from "@/lib/ai/dashscope";
+import { llm, ProviderError } from "@/lib/ai";
 import { chunkText, averageEmbeddings, hashText } from "@/lib/ai/embed-utils";
-import { ProviderError } from "@/lib/ai/provider";
 import fs from "fs";
 import path from "path";
 
@@ -291,7 +290,7 @@ export const compileMemo = inngest.createFunction(
           const chunks = chunkText(memo.body);
           const embeddings: number[][] = [];
           for (const chunk of chunks) {
-            const result = await dashscope.embed(chunk);
+            const result = await llm.embed(chunk);
             embeddings.push(result.embedding);
           }
           embedding = averageEmbeddings(embeddings);
@@ -443,7 +442,7 @@ export const compileMemo = inngest.createFunction(
 
       let conflictResult: ConflictCheckResult;
       try {
-        const res = await dashscope.chat(
+        const res = await llm.chat(
           [
             {
               role: "system",
@@ -536,7 +535,7 @@ export const compileMemo = inngest.createFunction(
 
         let raw: string;
         try {
-          const res = await dashscope.chat(
+          const res = await llm.chat(
             [
               { role: "system", content: systemPrompt },
               { role: "user", content: promptContent },
@@ -567,7 +566,7 @@ export const compileMemo = inngest.createFunction(
           const stricterPrompt = `${promptContent}\n\nIMPORTANT: Return ONLY the JSON object. No explanation. No markdown. No code fences.`;
           let raw2: string;
           try {
-            const res2 = await dashscope.chat(
+            const res2 = await llm.chat(
               [
                 { role: "system", content: systemPrompt },
                 { role: "user", content: stricterPrompt },
@@ -612,7 +611,7 @@ export const compileMemo = inngest.createFunction(
 
       let raw: string;
       try {
-        const res = await dashscope.chat(
+        const res = await llm.chat(
           [
             { role: "system", content: systemPrompt },
             { role: "user", content: promptContent },
@@ -641,7 +640,7 @@ export const compileMemo = inngest.createFunction(
         const stricterPrompt = `${promptContent}\n\nIMPORTANT: Return ONLY the JSON object. No explanation. No markdown. No code fences.`;
         let raw2: string;
         try {
-          const res2 = await dashscope.chat(
+          const res2 = await llm.chat(
             [
               { role: "system", content: systemPrompt },
               { role: "user", content: stricterPrompt },

--- a/web/src/lib/inngest/functions/daily-page.ts
+++ b/web/src/lib/inngest/functions/daily-page.ts
@@ -2,8 +2,7 @@ import { inngest } from "@/lib/inngest/client";
 import { db } from "@/lib/db/client";
 import { users, memos, pages, page_sources } from "@/lib/db/schema";
 import { eq, and, gte, lt, sql } from "drizzle-orm";
-import { dashscope } from "@/lib/ai/dashscope";
-import { ProviderError } from "@/lib/ai/provider";
+import { llm, ProviderError } from "@/lib/ai";
 import fs from "fs";
 import path from "path";
 
@@ -118,7 +117,7 @@ async function processUserDailyPage(
   let dailyResult: DailyPageResult;
 
   try {
-    const res = await dashscope.chat(
+    const res = await llm.chat(
       [
         { role: "system", content: systemPrompt },
         { role: "user", content: promptContent },
@@ -130,7 +129,7 @@ async function processUserDailyPage(
     // Retry once with stricter prompt
     if (err instanceof SyntaxError || err instanceof Error && err.message.startsWith("Invalid")) {
       const stricterPrompt = `${promptContent}\n\nIMPORTANT: Return ONLY the JSON object. No explanation. No markdown fences.`;
-      const res2 = await dashscope.chat(
+      const res2 = await llm.chat(
         [
           { role: "system", content: systemPrompt },
           { role: "user", content: stricterPrompt },

--- a/web/src/lib/inngest/functions/schema-detect.ts
+++ b/web/src/lib/inngest/functions/schema-detect.ts
@@ -7,8 +7,7 @@ import {
   schema_cluster_log,
 } from "@/lib/db/schema";
 import { eq, and, gte, sql } from "drizzle-orm";
-import { dashscope } from "@/lib/ai/dashscope";
-import { ProviderError } from "@/lib/ai/provider";
+import { llm, ProviderError } from "@/lib/ai";
 import { createHash } from "crypto";
 
 // ─── Constants ────────────────────────────────────────────────────────────────
@@ -102,7 +101,7 @@ ${titleList}
 
 Respond with JSON only: {"name": "Domain Name", "color": "blue"}`;
 
-  const res = await dashscope.chat(
+  const res = await llm.chat(
     [
       {
         role: "system",


### PR DESCRIPTION
## Summary

Two threads of changes bundled into a single PR.

### 1. LLM provider unification
- New `web/src/lib/ai/openai.ts` — full provider: `chat` / `chatStream` / `embed` / `transcribe`.
- New `web/src/lib/ai/index.ts` — light `llm` façade. Callers do `import { llm } from "@/lib/ai"` and never touch a vendor module directly.
- All capabilities now route to OpenAI:
  - chat → `gpt-4o-mini` (override via `OPENAI_MODEL`)
  - embed → `text-embedding-3-small` (1536-dim — matches existing `pages.embedding vector(1536)` schema)
  - transcribe → `whisper-1`
- Migrated every caller (chat routes, `schema-detect`, `compile-memo`, `daily-page`, `rag`) from `dashscope.*` → `llm.*`.
- `dashscope.ts` is left orphaned (no callers) to keep blast radius small; can be removed in a follow-up. `deepseek.ts` is also retained — flip one import in `index.ts` to re-route chat through it.
- `rag.retrievePages` now soft-degrades: when the embed provider throws `ProviderError` it logs a warning and returns `[]` so chat keeps working with no references instead of bubbling a 500.

### 2. Collapsible desktop sidebar + drawer cleanup
- New `DesktopSidebarShell` client component: icon-only collapse (248px ↔ 60px), state persisted in `localStorage` under `daypage.sidebarCollapsed`, broadcast to CSS via `data-collapsed` attribute.
- `globals.css`: new `.sb__collapse-btn` styling and a `[data-collapsed="true"]` rule set that hides labels / meta / badges / group labels / domain labels / brand tag and centers icons.
- Layout main column switched to `flex-1 min-w-0` so it tracks the collapsed sidebar instead of a hard-coded `calc(100% - 248px)`.
- Mobile drawer: dropped the redundant outer `<aside class="sb">` wrapper (the drawer already wraps its content in `.sb` internally — duplicate caused the "two sidebars stacked" visual reported in #273 reappearing). Backdrop + drawer panel now gated with `lg:hidden`, panel gets `aria-hidden={!isOpen}` and `visibility: hidden` when closed.

### Misc
- Root layout: `suppressHydrationWarning` on `<html>` to tolerate browser extensions (e.g. Immersive Translate) injecting attributes pre-hydration.
- `CLAUDE.md`: note that the CODEX frontend lives in `web/` (Next.js) and that env vars belong in `web/.env.local`, not the iOS-side `Config/GeneratedSecrets.swift`.

## Env-var requirements

`web/.env.local` must set (locally; nothing in this PR ships secrets):

```
OPENAI_API_KEY=sk-...     # needs chat-completions + embeddings + audio scopes
OPENAI_MODEL=gpt-4o-mini  # optional, this is the default
```

## Test plan

- [ ] `pnpm typecheck` in `web/` shows no new errors in files touched by this PR (preexisting drizzle / playwright issues unchanged).
- [ ] `pnpm dev` boots; `/chat` sends a message and streams a reply via OpenAI (verify with a wiki that has at least one compiled `pages` row — empty wiki still returns "I don't know yet" by design).
- [ ] Embed failure path: with an invalid `OPENAI_API_KEY`, hitting `/chat` produces a server warn `[rag] embed failed (auth)` and the chat surface no longer renders a 401 — RAG just returns no references.
- [ ] Desktop sidebar collapses on click, persists across reload, expands again on second click. Main column width reflows.
- [ ] Mobile drawer (viewport `< 1024px`) opens via hamburger, closes via X button / backdrop tap / Esc. No double-sidebar visual.
- [ ] No hydration mismatch warning on first paint of `/home` or `/chat`.

## Risk / blast radius

- `dashscope.ts` is now dead code but still present — safe to remove in a follow-up PR if desired.
- Existing `pages.embedding` rows generated by DashScope (1024-dim) are mathematically incompatible with new OpenAI embeddings (1536-dim) on cosine score. The DB column is already `vector(1536)`, so any old 1024-dim rows would have failed to insert anyway; if any 1024-dim JSON-text leftovers exist they will score 0 and be filtered out by RAG.
- No DB migrations.