### PR TITLE
feat(web/add): Photo chip + textarea polish

### DIFF
--- a/web/src/app/(app)/add/UnifiedInput.tsx
+++ b/web/src/app/(app)/add/UnifiedInput.tsx
@@ -1,10 +1,32 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { Link2, FileText, Mic, Bookmark, Sparkles, Send } from "lucide-react";
+import {
+  Link2,
+  FileText,
+  Image as ImageIcon,
+  Mic,
+  Bookmark,
+  Sparkles,
+  Send,
+  X,
+} from "lucide-react";
 
 const URL_RE = /^https?:\/\//;
+const TEXTAREA_MAX = 320;
+
+type Attachment = {
+  id: string;
+  file: File;
+  previewUrl?: string;
+};
+
+function formatSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${Math.round(bytes / 102.4) / 10} KB`;
+  return `${Math.round(bytes / 1024 / 102.4) / 10} MB`;
+}
 
 async function createMemo(body: string) {
   const type = URL_RE.test(body.trim()) ? "url" : "text";
@@ -24,10 +46,55 @@ export function UnifiedInput() {
   const [body, setBody] = useState("");
   const [savedDraftAt, setSavedDraftAt] = useState<number | null>(null);
   const [dragging, setDragging] = useState(false);
+  const [attachments, setAttachments] = useState<Attachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const photoInputRef = useRef<HTMLInputElement>(null);
   const taRef = useRef<HTMLTextAreaElement>(null);
   const queryClient = useQueryClient();
-  const empty = body.trim().length === 0;
+  const empty = body.trim().length === 0 && attachments.length === 0;
+
+  // Autosize textarea on mount and whenever body changes — avoids the
+  // first-keystroke jump from CSS min-height to scrollHeight.
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = Math.min(ta.scrollHeight, TEXTAREA_MAX) + "px";
+  }, [body]);
+
+  // Revoke any remaining object URLs on unmount.
+  // Per-item revoke also runs in removeAttachment / mutation success.
+  const attachmentsRef = useRef<Attachment[]>([]);
+  useEffect(() => {
+    attachmentsRef.current = attachments;
+  }, [attachments]);
+  useEffect(() => {
+    return () => {
+      for (const a of attachmentsRef.current) {
+        if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
+      }
+    };
+  }, []);
+
+  function addFiles(files: File[]) {
+    if (files.length === 0) return;
+    const next: Attachment[] = files.map((file) => ({
+      id: `${file.name}-${file.size}-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+      file,
+      previewUrl: file.type.startsWith("image/")
+        ? URL.createObjectURL(file)
+        : undefined,
+    }));
+    setAttachments((prev) => [...prev, ...next]);
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((prev) => {
+      const target = prev.find((a) => a.id === id);
+      if (target?.previewUrl) URL.revokeObjectURL(target.previewUrl);
+      return prev.filter((a) => a.id !== id);
+    });
+  }
 
   function handleSaveDraft() {
     if (typeof window !== "undefined") {
@@ -44,6 +111,10 @@ export function UnifiedInput() {
     mutationFn: createMemo,
     onSuccess: (newMemo) => {
       setBody("");
+      for (const a of attachments) {
+        if (a.previewUrl) URL.revokeObjectURL(a.previewUrl);
+      }
+      setAttachments([]);
       // Prepend the new pending memo to the compile queue cache
       queryClient.setQueryData<{ items: unknown[] }>(
         ["memos", "pending"],
@@ -58,7 +129,11 @@ export function UnifiedInput() {
 
   function handleSubmit() {
     if (empty) return;
-    mutation.mutate(body);
+    // Append attachment filenames to body — server contract is text-only;
+    // real binary upload is tracked separately.
+    const attachmentLines = attachments.map((a) => `file: ${a.file.name}`);
+    const combined = [body.trim(), ...attachmentLines].filter(Boolean).join("\n");
+    mutation.mutate(combined);
   }
 
   return (
@@ -77,28 +152,55 @@ export function UnifiedInput() {
         e.preventDefault();
         setDragging(false);
         const files = Array.from(e.dataTransfer.files);
-        if (files.length > 0) {
-          setBody(
-            (b) =>
-              (b ? b + "\n" : "") +
-              files.map((f) => `file: ${f.name}`).join("\n"),
-          );
-        }
+        addFiles(files);
       }}
     >
-      {/* Textarea — auto-grow on input */}
+      {/* Textarea — height is driven by useEffect to avoid first-keystroke jump */}
       <textarea
         ref={taRef}
         value={body}
-        onChange={(e) => {
-          setBody(e.target.value);
-          const t = e.target;
-          t.style.height = "auto";
-          t.style.height = Math.min(t.scrollHeight, 320) + "px";
-        }}
+        onChange={(e) => setBody(e.target.value)}
         placeholder="Paste a URL, drop a file, or just type something…"
         rows={3}
       />
+
+      {/* Attachment preview row */}
+      {attachments.length > 0 && (
+        <div className="add-input__attachments">
+          {attachments.map((a) => (
+            <div key={a.id} className="add-input__attachment">
+              {a.previewUrl ? (
+                /* eslint-disable-next-line @next/next/no-img-element */
+                <img
+                  src={a.previewUrl}
+                  alt={a.file.name}
+                  className="add-input__attachment-thumb"
+                />
+              ) : (
+                <div className="add-input__attachment-thumb add-input__attachment-thumb--file">
+                  <FileText size={18} />
+                </div>
+              )}
+              <div className="add-input__attachment-meta">
+                <span className="add-input__attachment-name" title={a.file.name}>
+                  {a.file.name}
+                </span>
+                <span className="add-input__attachment-size">
+                  {formatSize(a.file.size)}
+                </span>
+              </div>
+              <button
+                type="button"
+                className="add-input__attachment-remove"
+                aria-label={`Remove ${a.file.name}`}
+                onClick={() => removeAttachment(a.id)}
+              >
+                <X size={14} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
 
       {/* Inline error */}
       {mutation.isError && (
@@ -132,18 +234,27 @@ export function UnifiedInput() {
         </div>
       )}
 
-      {/* Hidden file input — triggered by the File hint chip */}
+      {/* Hidden file inputs — triggered by Photo / File hint chips */}
+      <input
+        ref={photoInputRef}
+        type="file"
+        accept="image/*"
+        multiple
+        style={{ display: "none" }}
+        onChange={(e) => {
+          const files = Array.from(e.target.files ?? []);
+          addFiles(files);
+          if (e.target) e.target.value = "";
+        }}
+      />
       <input
         ref={fileInputRef}
         type="file"
+        multiple
         style={{ display: "none" }}
         onChange={(e) => {
-          // Minimum viable: announce the picked file name in textarea so user sees a response.
-          const f = e.target.files?.[0];
-          if (f) {
-            setBody((prev) => (prev ? prev + "\n" : "") + `file: ${f.name}`);
-          }
-          // Reset so picking the same file twice still fires onChange
+          const files = Array.from(e.target.files ?? []);
+          addFiles(files);
           if (e.target) e.target.value = "";
         }}
       />
@@ -163,7 +274,16 @@ export function UnifiedInput() {
             <Link2 size={12} />
             URL
           </button>
-          {/* File — triggers hidden file input */}
+          {/* Photo — triggers image picker (with mobile camera capture) */}
+          <button
+            type="button"
+            className="chip chip--ghost chip--interactive"
+            onClick={() => photoInputRef.current?.click()}
+          >
+            <ImageIcon size={12} />
+            Photo
+          </button>
+          {/* File — triggers any-type file picker */}
           <button
             type="button"
             className="chip chip--ghost chip--interactive"

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -501,8 +501,8 @@ body {
 .grid-4 { display: grid; grid-template-columns: repeat(4, 1fr); gap: 16px; }
 
 /* === Add page input === */
-.add-input { position: relative; background: var(--surface-white); border: 1.5px solid var(--accent-border); border-radius: var(--radius-card); padding: 18px 20px; transition: border-color 140ms ease-out, background 140ms ease-out; }
-.add-input:focus-within { border-color: var(--accent); box-shadow: 0 0 0 3px var(--accent-soft); }
+.add-input { position: relative; background: var(--surface-white); border: 1.5px solid var(--accent-border); border-radius: var(--radius-card); padding: 18px 20px; transition: border-color 140ms ease-out, background 140ms ease-out, box-shadow 140ms ease-out; }
+.add-input:focus-within { border-color: var(--accent); box-shadow: 0 0 0 2px var(--accent-soft); }
 .add-input.is-dragging { border-color: var(--accent); border-style: dashed; background: var(--accent-soft); }
 .add-input.is-dragging textarea::placeholder { color: var(--accent); }
 .add-input.is-dragging::after {
@@ -524,7 +524,7 @@ body {
 }
 .add-input__hints .chip { transition: background 120ms ease-out, border-color 120ms ease-out, color 120ms ease-out; }
 .add-input__hints .chip:not(:disabled):hover { background: var(--accent-soft); border-color: var(--accent-border); color: var(--accent); }
-.add-input textarea { width: 100%; border: none; outline: none; resize: none; min-height: 72px; max-height: 320px; font-family: var(--font-body); font-size: 16px; line-height: 1.55; color: var(--fg-primary); background: transparent; overflow-y: auto; }
+.add-input textarea { width: 100%; border: none; outline: none; resize: none; max-height: 320px; font-family: var(--font-body); font-size: 16px; line-height: 1.55; color: var(--fg-primary); background: transparent; overflow-y: auto; display: block; transition: height 120ms ease-out; }
 .add-input textarea::placeholder { color: var(--fg-subtle); }
 .add-input__row { display: flex; justify-content: space-between; align-items: center; margin-top: 12px; gap: 12px; }
 .add-input__hints { display: flex; gap: 6px; flex-wrap: wrap; }
@@ -544,6 +544,74 @@ body {
 }
 .add-input__meta svg { flex-shrink: 0; }
 .add-input__meta span { flex: 1; min-width: 0; }
+
+/* Attachment preview row */
+.add-input__attachments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin-top: 12px;
+}
+.add-input__attachment {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 6px 10px 6px 6px;
+  background: var(--surface-sunken, var(--accent-soft));
+  border: 1px solid var(--accent-border);
+  border-radius: 999px;
+  max-width: 100%;
+}
+.add-input__attachment-thumb {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  object-fit: cover;
+  flex-shrink: 0;
+  background: var(--surface-white);
+}
+.add-input__attachment-thumb--file {
+  display: grid;
+  place-items: center;
+  color: var(--fg-muted);
+  border: 1px solid var(--accent-border);
+}
+.add-input__attachment-meta {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  line-height: 1.2;
+}
+.add-input__attachment-name {
+  font-size: 13px;
+  color: var(--fg-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 180px;
+}
+.add-input__attachment-size {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--fg-subtle);
+  letter-spacing: 0.4px;
+}
+.add-input__attachment-remove {
+  display: grid;
+  place-items: center;
+  width: 22px;
+  height: 22px;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: background 120ms ease-out, color 120ms ease-out;
+}
+.add-input__attachment-remove:hover {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
 
 /* === Add page: empty states === */
 .empty-card {


### PR DESCRIPTION
## Summary

The "File" chip on `/add` felt broken in two ways the user called out — clicking the photo affordance had no visible effect, and the textarea visibly jumped when it expanded.

- **Photo button now does something.** Split the single `File` chip into a **Photo** chip (`accept="image/*"`, supports multi-select) and a **File** chip (any type). Selected items render as a real attachment row with thumbnail/name/size and a remove button, instead of silently appending `file: <name>` to the textarea.
- **Textarea no longer jumps on first keystroke.** Height is now driven from a `useEffect(body)` instead of the inline `onChange` handler — so the initial mount sizes correctly. Removed the redundant CSS `min-height: 72px` (`rows={3}` already sets initial height) and added `transition: height 120ms ease-out`. Tightened the `:focus-within` ring from 3px → 2px and added `box-shadow` to the wrapper transition so the focus state fades in.
- **Server contract unchanged.** Attachments still get their filenames appended to the POSTed `body`; true binary upload is tracked separately (`memos` API + `/api/memos/bulk` already have the schema, but `route.ts` has unrelated type errors on main).

## Test plan

- [ ] `/add` → click **Photo**: native picker opens with image filter
- [ ] Select an image: thumbnail + filename + size render in the attachment row
- [ ] **X** button removes the attachment (and revokes the object URL)
- [ ] **File** chip opens picker without image filter; non-image files show the document icon
- [ ] Type into the textarea: no first-character jump; expansion animates smoothly
- [ ] Focus the textarea: ring fades in instead of popping
- [ ] Submit with attachment: memo body contains `file: <name>` line(s); attachments clear after success
- [ ] Drag-and-drop files onto the wrapper: same preview behavior as picker

## Notes

- `next/image` is intentionally not used for the thumbnail — `URL.createObjectURL(blob:…)` is incompatible with `next/image`'s remote-loader contract. Single `eslint-disable-next-line` on the `<img>`.
- Did not touch the disabled Voice chip (still `MediaRecorder` TODO).
- main's pre-existing `tsc` errors in `e2e/`, `route.test.ts`, and `memos/bulk/route.ts` are not from this PR.