### PR TITLE
feat(ios): 系统级快捷语音输入入口 — Siri / Shortcuts / Widget / 控制中心 (#281)

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -7,10 +7,15 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		14188AFE740A834ADF7A41F4 /* DayPageWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B2DFF2B446D2F0AC8DE530A1 /* DayPageWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		326A14114B34412568007B4A /* DayPageWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */; };
 		347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */; };
 		457A17AB7F3B4BE7C2E77026 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */; };
+		485EFA11789212D87CB1B74B /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */; };
 		8C3DEB068D610AAB589EA680 /* TimeZonePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FCD3E2EC4D7257BA7A22BD /* TimeZonePickerView.swift */; };
 		9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B5757B488F583231EC8F6 /* RootView.swift */; };
+		97FA675FF46459D5CE5E8CF3 /* QuickCaptureControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519B9B12CB68C0E6E2A06292 /* QuickCaptureControl.swift */; };
+		9B0FAA7690FA2EEED5AB7A96 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BAC7527E8128E6A865349FB9 /* Foundation.framework */; };
 		9D559EA9D4B9F2C77D942935 /* DayPageShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD3383348F15CB7B4E82E53 /* DayPageShortcuts.swift */; };
 		A10000001 /* DayPageApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000001 /* DayPageApp.swift */; };
 		A10000002 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000002 /* RootView.swift */; };
@@ -118,6 +123,7 @@
 		DS0000002 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000002 /* Haptics.swift */; };
 		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
 		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
+		EA575F353C6AFD5EA7FF9A6F /* QuickCaptureWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */; };
 		ES0000001 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000001 /* EmptyStateView.swift */; };
 		ES0000002 /* GlassErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000002 /* GlassErrorBanner.swift */; };
 		ES0000003 /* GlassTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000003 /* GlassTabBar.swift */; };
@@ -146,6 +152,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		CBEB8ECF74B1AB7DC2D95CE9 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AB0000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F41799EE1E17028D50445A2A;
+			remoteInfo = DayPageWidget;
+		};
 		D13961FCE75D846CB11E2A04 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AB0000001 /* Project object */;
@@ -162,14 +175,31 @@
 		};
 /* End PBXContainerItemProxy section */
 
+/* Begin PBXCopyFilesBuildPhase section */
+		7C2E6E11E8E832D610477AF4 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				14188AFE740A834ADF7A41F4 /* DayPageWidget.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		068FB068A000B6E61B1D8032 /* AppSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		0881AB423FF6F12FCDE27C5B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		23EA9C83B41565EDB263FB35 /* DayPageWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPageWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2748059CC689A341C7CAAACC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
+		519B9B12CB68C0E6E2A06292 /* QuickCaptureControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureControl.swift; sourceTree = "<group>"; };
 		5FD3383348F15CB7B4E82E53 /* DayPageShortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DayPageShortcuts.swift; sourceTree = "<group>"; };
+		71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DayPageWidgetBundle.swift; sourceTree = "<group>"; };
 		73FCD3E2EC4D7257BA7A22BD /* TimeZonePickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimeZonePickerView.swift; sourceTree = "<group>"; };
+		7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureWidget.swift; sourceTree = "<group>"; };
 		A20000001 /* DayPageApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayPageApp.swift; sourceTree = "<group>"; };
 		A20000002 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		A20000003 /* VaultInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultInitializer.swift; sourceTree = "<group>"; };
@@ -271,11 +301,14 @@
 		AF1000010 /* Inter-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-Bold.ttf"; sourceTree = "<group>"; };
 		AF1000011 /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
 		AF1000012 /* JetBrainsMono-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Medium.ttf"; sourceTree = "<group>"; };
+		B2DFF2B446D2F0AC8DE530A1 /* DayPageWidget.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = DayPageWidget.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		B93ED807E07C2171E9F4234B /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
+		BAC7527E8128E6A865349FB9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		C98B5757B488F583231EC8F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		CJ1000001 /* CJKTextPolish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKTextPolish.swift; sourceTree = "<group>"; };
 		DS1000001 /* Motion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Motion.swift; sourceTree = "<group>"; };
 		DS1000002 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		E54B333332A1175CD3B31883 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		ES1000001 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
 		ES1000002 /* GlassErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassErrorBanner.swift; sourceTree = "<group>"; };
 		ES1000003 /* GlassTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassTabBar.swift; sourceTree = "<group>"; };
@@ -314,6 +347,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		6A99596F83AB190CB3A4DD27 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				9B0FAA7690FA2EEED5AB7A96 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A40000001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -348,6 +389,26 @@
 				B93ED807E07C2171E9F4234B /* RecordingView.swift */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		1FD1A3B1D736CCDDB8DD7C7E /* DayPageWidget */ = {
+			isa = PBXGroup;
+			children = (
+				71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */,
+				7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */,
+				519B9B12CB68C0E6E2A06292 /* QuickCaptureControl.swift */,
+				E54B333332A1175CD3B31883 /* Info.plist */,
+			);
+			name = DayPageWidget;
+			path = DayPageWidget;
+			sourceTree = "<group>";
+		};
+		2F3BCA9F2B06A0AA7A285E16 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				DDC3A975D8D575CF6FC10A43 /* iOS */,
+			);
+			name = Frameworks;
 			sourceTree = "<group>";
 		};
 		4D6CD27C159EBD1C3B99E5A0 /* Complication */ = {
@@ -510,6 +571,7 @@
 				A30000001 /* DayPage.app */,
 				T30000001 /* DayPageTests.xctest */,
 				23EA9C83B41565EDB263FB35 /* DayPageWatch.app */,
+				B2DFF2B446D2F0AC8DE530A1 /* DayPageWidget.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -646,6 +708,8 @@
 				A50000001 /* DayPage */,
 				T50000001 /* DayPageTests */,
 				6E1BF02CE381B436F22B52D5 /* DayPageWatch */,
+				2F3BCA9F2B06A0AA7A285E16 /* Frameworks */,
+				1FD1A3B1D736CCDDB8DD7C7E /* DayPageWidget */,
 			);
 			sourceTree = "<group>";
 		};
@@ -676,6 +740,14 @@
 			);
 			name = Intents;
 			path = Intents;
+			sourceTree = "<group>";
+		};
+		DDC3A975D8D575CF6FC10A43 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				BAC7527E8128E6A865349FB9 /* Foundation.framework */,
+			);
+			name = iOS;
 			sourceTree = "<group>";
 		};
 		E649E3AC4D392A4CEDD41728 /* Services */ = {
@@ -765,10 +837,12 @@
 				A90000001 /* Sources */,
 				A40000001 /* Frameworks */,
 				AA0000001 /* Resources */,
+				7C2E6E11E8E832D610477AF4 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				FFEEA26F4357519F4BB9DD72 /* PBXTargetDependency */,
 			);
 			name = DayPage;
 			packageProductDependencies = (
@@ -778,6 +852,23 @@
 			productName = DayPage;
 			productReference = A30000001 /* DayPage.app */;
 			productType = "com.apple.product-type.application";
+		};
+		F41799EE1E17028D50445A2A /* DayPageWidget */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = D8F19491724741839C0063D3 /* Build configuration list for PBXNativeTarget "DayPageWidget" */;
+			buildPhases = (
+				1EDB2FF3A97D15EE4AB4262A /* Sources */,
+				6A99596F83AB190CB3A4DD27 /* Frameworks */,
+				1C35A048962A1C9561696C85 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = DayPageWidget;
+			productName = DayPageWidget;
+			productReference = B2DFF2B446D2F0AC8DE530A1 /* DayPageWidget.appex */;
+			productType = "com.apple.product-type.app-extension";
 		};
 		T70000001 /* DayPageTests */ = {
 			isa = PBXNativeTarget;
@@ -836,11 +927,19 @@
 				A70000001 /* DayPage */,
 				T70000001 /* DayPageTests */,
 				69BEA0675AFA233657A8AD39 /* DayPageWatch */,
+				F41799EE1E17028D50445A2A /* DayPageWidget */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		1C35A048962A1C9561696C85 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		9E11D4E4CB1FFC4EC7D9A07A /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -893,6 +992,17 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1EDB2FF3A97D15EE4AB4262A /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				326A14114B34412568007B4A /* DayPageWidgetBundle.swift in Sources */,
+				EA575F353C6AFD5EA7FF9A6F /* QuickCaptureWidget.swift in Sources */,
+				97FA675FF46459D5CE5E8CF3 /* QuickCaptureControl.swift in Sources */,
+				485EFA11789212D87CB1B74B /* StartRecordingIntent.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		4705AC05FAC24B4000886F57 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1041,6 +1151,12 @@
 			target = 69BEA0675AFA233657A8AD39 /* DayPageWatch */;
 			targetProxy = D13961FCE75D846CB11E2A04 /* PBXContainerItemProxy */;
 		};
+		FFEEA26F4357519F4BB9DD72 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = DayPageWidget;
+			target = F41799EE1E17028D50445A2A /* DayPageWidget */;
+			targetProxy = CBEB8ECF74B1AB7DC2D95CE9 /* PBXContainerItemProxy */;
+		};
 		T75000001 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = A70000001 /* DayPage */;
@@ -1061,6 +1177,67 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		01460ECDA7F310419AA361A7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6RG2F8YY59;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = DayPageWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app.DayPageWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = EXTENSION;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		32BEBCA130BE5F4B0EF36D54 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6RG2F8YY59;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = DayPageWidget/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app.DayPageWidget;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = EXTENSION;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
 		33B764539AC733ABA92320CE /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1361,6 +1538,15 @@
 			buildConfigurations = (
 				AC0000001 /* Debug */,
 				AC0000002 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		D8F19491724741839C0063D3 /* Build configuration list for PBXNativeTarget "DayPageWidget" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				32BEBCA130BE5F4B0EF36D54 /* Release */,
+				01460ECDA7F310419AA361A7 /* Debug */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -7,19 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		SPM00001 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = SPM00002 /* Supabase */; };
-		SPM00004 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = SPM00005 /* Sentry */; };
+		347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */; };
+		457A17AB7F3B4BE7C2E77026 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */; };
 		8C3DEB068D610AAB589EA680 /* TimeZonePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FCD3E2EC4D7257BA7A22BD /* TimeZonePickerView.swift */; };
+		9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B5757B488F583231EC8F6 /* RootView.swift */; };
+		9D559EA9D4B9F2C77D942935 /* DayPageShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD3383348F15CB7B4E82E53 /* DayPageShortcuts.swift */; };
 		A10000001 /* DayPageApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000001 /* DayPageApp.swift */; };
 		A10000002 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000002 /* RootView.swift */; };
 		A10000003 /* VaultInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000003 /* VaultInitializer.swift */; };
 		A10000004 /* GeneratedSecrets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000004 /* GeneratedSecrets.swift */; };
-		A100000B4 /* SecretsRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000B4 /* SecretsRuntime.swift */; };
 		A10000005 /* Colors.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000005 /* Colors.swift */; };
 		A10000006 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000006 /* Typography.swift */; };
 		A10000007 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000007 /* Components.swift */; };
-		A100000F1 /* GlassSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000F1 /* GlassSurface.swift */; };
-		A100000F2 /* Surfaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000F2 /* Surfaces.swift */; };
 		A10000008 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000008 /* Memo.swift */; };
 		A10000009 /* RawStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000009 /* RawStorage.swift */; };
 		A10000010 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010 /* TodayView.swift */; };
@@ -36,9 +35,6 @@
 		A10000022 /* EntityPageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000022 /* EntityPageService.swift */; };
 		A10000023 /* BackgroundCompilationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000023 /* BackgroundCompilationService.swift */; };
 		A10000025 /* DailyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000025 /* DailyPageView.swift */; };
-		TH0000001 /* ThreadConversationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000001 /* ThreadConversationViewModel.swift */; };
-		TH0000002 /* ThreadConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000002 /* ThreadConversationView.swift */; };
-		TH0000003 /* InlineMicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000003 /* InlineMicButton.swift */; };
 		A10000026 /* EntityPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000026 /* EntityPageView.swift */; };
 		A10000027 /* SearchService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000027 /* SearchService.swift */; };
 		A10000028 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000028 /* SearchView.swift */; };
@@ -68,23 +64,41 @@
 		A10000054 /* RecordingOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000054 /* RecordingOverlayView.swift */; };
 		A10000055 /* PressToTalkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000055 /* PressToTalkButton.swift */; };
 		A10000056 /* VaultLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000056 /* VaultLocator.swift */; };
-		A10000079 /* iCloudSyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000079 /* iCloudSyncMonitor.swift */; };
-		A10000085 /* iCloudConflictMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000085 /* iCloudConflictMonitor.swift */; };
-		A10000080 /* AppNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000080 /* AppNavigationModel.swift */; };
-		A10000081 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000081 /* SidebarView.swift */; };
-		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
-		A10000083 /* WeeklyRecapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000083 /* WeeklyRecapService.swift */; };
-		A10000301 /* TimelineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000301 /* TimelineService.swift */; };
-		A10000084 /* WeeklyRecapSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000084 /* WeeklyRecapSection.swift */; };
-		A10000302 /* TimelineSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000302 /* TimelineSectionView.swift */; };
-		A10000200 /* ComposerStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000200 /* ComposerStateMachine.swift */; };
-		A10000201 /* SpotlightStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000201 /* SpotlightStripView.swift */; };
-		A10000202 /* SmartTemplateRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000202 /* SmartTemplateRow.swift */; };
-		A10000203 /* InlineLensStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000203 /* InlineLensStrip.swift */; };
 		A10000060 /* DailySharePosterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000060 /* DailySharePosterView.swift */; };
 		A10000061 /* PosterRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000061 /* PosterRenderer.swift */; };
 		A10000063 /* SwipeableMemoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000063 /* SwipeableMemoCard.swift */; };
 		A10000064 /* AttachmentMenuSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000064 /* AttachmentMenuSheet.swift */; };
+		A10000070 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000070 /* AuthService.swift */; };
+		A10000072 /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000072 /* AuthView.swift */; };
+		A10000073 /* EmailAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000073 /* EmailAuthView.swift */; };
+		A10000074 /* AccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000074 /* AccountSheet.swift */; };
+		A10000075 /* OTPVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000075 /* OTPVerificationView.swift */; };
+		A10000076 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000076 /* KeychainHelper.swift */; };
+		A10000077 /* ConflictMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000077 /* ConflictMerger.swift */; };
+		A10000078 /* VaultMigrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000078 /* VaultMigrationService.swift */; };
+		A10000079 /* iCloudSyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000079 /* iCloudSyncMonitor.swift */; };
+		A10000080 /* AppNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000080 /* AppNavigationModel.swift */; };
+		A10000081 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000081 /* SidebarView.swift */; };
+		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
+		A10000083 /* WeeklyRecapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000083 /* WeeklyRecapService.swift */; };
+		A10000084 /* WeeklyRecapSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000084 /* WeeklyRecapSection.swift */; };
+		A10000085 /* iCloudConflictMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000085 /* iCloudConflictMonitor.swift */; };
+		A10000086 /* OTPVerificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000086 /* OTPVerificationViewModel.swift */; };
+		A10000087 /* AuthRateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000087 /* AuthRateLimiter.swift */; };
+		A10000091 /* GrainOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000091 /* GrainOverlay.swift */; };
+		A10000093 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000093 /* AuthViewModel.swift */; };
+		A10000094 /* SidebarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000094 /* SidebarViewModel.swift */; };
+		A10000095 /* ComposerContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000095 /* ComposerContextProvider.swift */; };
+		A100000B4 /* SecretsRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000B4 /* SecretsRuntime.swift */; };
+		A100000F1 /* GlassSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000F1 /* GlassSurface.swift */; };
+		A100000F2 /* Surfaces.swift in Sources */ = {isa = PBXBuildFile; fileRef = A200000F2 /* Surfaces.swift */; };
+		A10000200 /* ComposerStateMachine.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000200 /* ComposerStateMachine.swift */; };
+		A10000201 /* SpotlightStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000201 /* SpotlightStripView.swift */; };
+		A10000202 /* SmartTemplateRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000202 /* SmartTemplateRow.swift */; };
+		A10000203 /* InlineLensStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000203 /* InlineLensStrip.swift */; };
+		A10000301 /* TimelineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000301 /* TimelineService.swift */; };
+		A10000302 /* TimelineSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000302 /* TimelineSectionView.swift */; };
+		A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */; };
 		AF0000001 /* SpaceGrotesk-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000001 /* SpaceGrotesk-Light.ttf */; };
 		AF0000002 /* SpaceGrotesk-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000002 /* SpaceGrotesk-Regular.ttf */; };
 		AF0000003 /* SpaceGrotesk-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000003 /* SpaceGrotesk-Medium.ttf */; };
@@ -97,61 +111,41 @@
 		AF0000010 /* Inter-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000010 /* Inter-Bold.ttf */; };
 		AF0000011 /* JetBrainsMono-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000011 /* JetBrainsMono-Regular.ttf */; };
 		AF0000012 /* JetBrainsMono-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000012 /* JetBrainsMono-Medium.ttf */; };
+		B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ED807E07C2171E9F4234B /* RecordingView.swift */; };
+		CJ0000001 /* CJKTextPolish.swift in Sources */ = {isa = PBXBuildFile; fileRef = CJ1000001 /* CJKTextPolish.swift */; };
+		DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */; };
+		DS0000001 /* Motion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000001 /* Motion.swift */; };
+		DS0000002 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000002 /* Haptics.swift */; };
+		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
+		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
+		ES0000001 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000001 /* EmptyStateView.swift */; };
+		ES0000002 /* GlassErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000002 /* GlassErrorBanner.swift */; };
+		ES0000003 /* GlassTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000003 /* GlassTabBar.swift */; };
 		F617270BFC704FF5BBB99FD3 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068FB068A000B6E61B1D8032 /* AppSettings.swift */; };
-		A10000070 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000070 /* AuthService.swift */; };
-		A10000072 /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000072 /* AuthView.swift */; };
-		A10000073 /* EmailAuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000073 /* EmailAuthView.swift */; };
-		A10000075 /* OTPVerificationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000075 /* OTPVerificationView.swift */; };
-		A10000076 /* KeychainHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000076 /* KeychainHelper.swift */; };
-		A10000087 /* AuthRateLimiter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000087 /* AuthRateLimiter.swift */; };
-		A10000091 /* GrainOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000091 /* GrainOverlay.swift */; };
-		A10000086 /* OTPVerificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000086 /* OTPVerificationViewModel.swift */; };
-		A10000093 /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000093 /* AuthViewModel.swift */; };
-		A10000094 /* SidebarViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000094 /* SidebarViewModel.swift */; };
-		A10000074 /* AccountSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000074 /* AccountSheet.swift */; };
-		T10000001 /* DayDetailViewStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000001 /* DayDetailViewStateTests.swift */; };
-		T10000002 /* ConflictMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000002 /* ConflictMergerTests.swift */; };
-		A10000077 /* ConflictMerger.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000077 /* ConflictMerger.swift */; };
-		A10000078 /* VaultMigrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000078 /* VaultMigrationService.swift */; };
-		T10000003 /* VaultMigrationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000003 /* VaultMigrationServiceTests.swift */; };
-		T10000004 /* VaultLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000004 /* VaultLocatorTests.swift */; };
-		T10000005 /* RawStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000005 /* RawStorageTests.swift */; };
-		T10000006 /* ComposerContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000006 /* ComposerContextProviderTests.swift */; };
-		T10000007 /* SmokeTest.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000007 /* SmokeTest.swift */; };
-		A10000095 /* ComposerContextProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000095 /* ComposerContextProvider.swift */; };
 		FB0000001 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000001 /* FeedbackService.swift */; };
 		FB0000002 /* FeedbackViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000002 /* FeedbackViewModel.swift */; };
 		FB0000003 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000003 /* FeedbackView.swift */; };
 		FB0000004 /* FeedbackContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000004 /* FeedbackContext.swift */; };
-		ES0000001 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000001 /* EmptyStateView.swift */; };
-		ES0000002 /* GlassErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000002 /* GlassErrorBanner.swift */; };
-		ES0000003 /* GlassTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000003 /* GlassTabBar.swift */; };
-		DS0000001 /* Motion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000001 /* Motion.swift */; };
-		DS0000002 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000002 /* Haptics.swift */; };
 		FT0000001 /* DayOrbView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT1000001 /* DayOrbView.swift */; };
-		MD0000001 /* MemoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000001 /* MemoDetailView.swift */; };
-		MD0000002 /* MemoDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000002 /* MemoDetailViewModel.swift */; };
-		CJ0000001 /* CJKTextPolish.swift in Sources */ = {isa = PBXBuildFile; fileRef = CJ1000001 /* CJKTextPolish.swift */; };
-		WS0000001 /* WelcomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = WS1000001 /* WelcomeScreen.swift */; };
 		LS0000001 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = LS1000001 /* Localizable.strings */; };
 		LS0000002 /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = LS1000004 /* L10n.swift */; };
-		DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */; };
-		9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B5757B488F583231EC8F6 /* RootView.swift */; };
-		B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ED807E07C2171E9F4234B /* RecordingView.swift */; };
-		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
-		347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */; };
-		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
-		A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */; };
+		MD0000001 /* MemoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000001 /* MemoDetailView.swift */; };
+		MD0000002 /* MemoDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000002 /* MemoDetailViewModel.swift */; };
+		SPM00001 /* Supabase in Frameworks */ = {isa = PBXBuildFile; productRef = SPM00002 /* Supabase */; };
+		SPM00004 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = SPM00005 /* Sentry */; };
+		T10000001 /* DayDetailViewStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000001 /* DayDetailViewStateTests.swift */; };
+		T10000002 /* ConflictMergerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000002 /* ConflictMergerTests.swift */; };
+		T10000003 /* VaultMigrationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000003 /* VaultMigrationServiceTests.swift */; };
+		T10000004 /* VaultLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000004 /* VaultLocatorTests.swift */; };
+		T10000005 /* RawStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000005 /* RawStorageTests.swift */; };
+		T10000006 /* ComposerContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000006 /* ComposerContextProviderTests.swift */; };
+		TH0000001 /* ThreadConversationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000001 /* ThreadConversationViewModel.swift */; };
+		TH0000002 /* ThreadConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000002 /* ThreadConversationView.swift */; };
+		TH0000003 /* InlineMicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000003 /* InlineMicButton.swift */; };
+		WS0000001 /* WelcomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = WS1000001 /* WelcomeScreen.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		T76000001 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = AB0000001 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A70000001;
-			remoteInfo = DayPage;
-		};
 		D13961FCE75D846CB11E2A04 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = AB0000001 /* Project object */;
@@ -159,21 +153,30 @@
 			remoteGlobalIDString = 69BEA0675AFA233657A8AD39;
 			remoteInfo = DayPageWatch;
 		};
+		T76000001 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = AB0000001 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A70000001;
+			remoteInfo = DayPage;
+		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
 		068FB068A000B6E61B1D8032 /* AppSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
+		0881AB423FF6F12FCDE27C5B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		23EA9C83B41565EDB263FB35 /* DayPageWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPageWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		2748059CC689A341C7CAAACC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
+		5FD3383348F15CB7B4E82E53 /* DayPageShortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DayPageShortcuts.swift; sourceTree = "<group>"; };
 		73FCD3E2EC4D7257BA7A22BD /* TimeZonePickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimeZonePickerView.swift; sourceTree = "<group>"; };
 		A20000001 /* DayPageApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayPageApp.swift; sourceTree = "<group>"; };
 		A20000002 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		A20000003 /* VaultInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultInitializer.swift; sourceTree = "<group>"; };
 		A20000004 /* GeneratedSecrets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneratedSecrets.swift; sourceTree = "<group>"; };
-		A200000B4 /* SecretsRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsRuntime.swift; sourceTree = "<group>"; };
 		A20000005 /* Colors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Colors.swift; sourceTree = "<group>"; };
 		A20000006 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		A20000007 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
-		A200000F1 /* GlassSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassSurface.swift; sourceTree = "<group>"; };
-		A200000F2 /* Surfaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Surfaces.swift; sourceTree = "<group>"; };
 		A20000008 /* Memo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memo.swift; sourceTree = "<group>"; };
 		A20000009 /* RawStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorage.swift; sourceTree = "<group>"; };
 		A20000010 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
@@ -190,11 +193,7 @@
 		A20000022 /* EntityPageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityPageService.swift; sourceTree = "<group>"; };
 		A20000023 /* BackgroundCompilationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BackgroundCompilationService.swift; sourceTree = "<group>"; };
 		A20000024 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		A20000071 /* DayPage.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DayPage.entitlements; sourceTree = "<group>"; };
 		A20000025 /* DailyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailyPageView.swift; sourceTree = "<group>"; };
-		TH1000001 /* ThreadConversationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationViewModel.swift; sourceTree = "<group>"; };
-		TH1000002 /* ThreadConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationView.swift; sourceTree = "<group>"; };
-		TH1000003 /* InlineMicButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineMicButton.swift; sourceTree = "<group>"; };
 		A20000026 /* EntityPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EntityPageView.swift; sourceTree = "<group>"; };
 		A20000027 /* SearchService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchService.swift; sourceTree = "<group>"; };
 		A20000028 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
@@ -226,34 +225,40 @@
 		A20000056 /* VaultLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultLocator.swift; sourceTree = "<group>"; };
 		A20000060 /* DailySharePosterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DailySharePosterView.swift; sourceTree = "<group>"; };
 		A20000061 /* PosterRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PosterRenderer.swift; sourceTree = "<group>"; };
+		A20000063 /* SwipeableMemoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMemoCard.swift; sourceTree = "<group>"; };
+		A20000064 /* AttachmentMenuSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMenuSheet.swift; sourceTree = "<group>"; };
+		A20000070 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
+		A20000071 /* DayPage.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DayPage.entitlements; sourceTree = "<group>"; };
+		A20000072 /* AuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
+		A20000073 /* EmailAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailAuthView.swift; sourceTree = "<group>"; };
+		A20000074 /* AccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheet.swift; sourceTree = "<group>"; };
+		A20000075 /* OTPVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPVerificationView.swift; sourceTree = "<group>"; };
+		A20000076 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
+		A20000077 /* ConflictMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMerger.swift; sourceTree = "<group>"; };
+		A20000078 /* VaultMigrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationService.swift; sourceTree = "<group>"; };
+		A20000079 /* iCloudSyncMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncMonitor.swift; sourceTree = "<group>"; };
+		A20000080 /* AppNavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationModel.swift; sourceTree = "<group>"; };
+		A20000081 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		A20000082 /* InputBarV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV4.swift; sourceTree = "<group>"; };
 		A20000083 /* WeeklyRecapService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapService.swift; sourceTree = "<group>"; };
-		A20000301 /* TimelineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineService.swift; sourceTree = "<group>"; };
 		A20000084 /* WeeklyRecapSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapSection.swift; sourceTree = "<group>"; };
-		A20000302 /* TimelineSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineSectionView.swift; sourceTree = "<group>"; };
+		A20000085 /* iCloudConflictMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudConflictMonitor.swift; sourceTree = "<group>"; };
+		A20000086 /* OTPVerificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPVerificationViewModel.swift; sourceTree = "<group>"; };
+		A20000087 /* AuthRateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRateLimiter.swift; sourceTree = "<group>"; };
+		A20000091 /* GrainOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrainOverlay.swift; sourceTree = "<group>"; };
+		A20000093 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
+		A20000094 /* SidebarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewModel.swift; sourceTree = "<group>"; };
+		A20000095 /* ComposerContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerContextProvider.swift; sourceTree = "<group>"; };
+		A200000B4 /* SecretsRuntime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SecretsRuntime.swift; sourceTree = "<group>"; };
+		A200000F1 /* GlassSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassSurface.swift; sourceTree = "<group>"; };
+		A200000F2 /* Surfaces.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Surfaces.swift; sourceTree = "<group>"; };
 		A20000200 /* ComposerStateMachine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerStateMachine.swift; sourceTree = "<group>"; };
 		A20000201 /* SpotlightStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightStripView.swift; sourceTree = "<group>"; };
 		A20000202 /* SmartTemplateRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartTemplateRow.swift; sourceTree = "<group>"; };
 		A20000203 /* InlineLensStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineLensStrip.swift; sourceTree = "<group>"; };
-		A20000063 /* SwipeableMemoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMemoCard.swift; sourceTree = "<group>"; };
-		A20000064 /* AttachmentMenuSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMenuSheet.swift; sourceTree = "<group>"; };
-		A20000079 /* iCloudSyncMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncMonitor.swift; sourceTree = "<group>"; };
-		A20000085 /* iCloudConflictMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudConflictMonitor.swift; sourceTree = "<group>"; };
-		A20000080 /* AppNavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationModel.swift; sourceTree = "<group>"; };
-		A20000081 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
-		A20000070 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
-		A20000072 /* AuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthView.swift; sourceTree = "<group>"; };
-		A20000073 /* EmailAuthView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmailAuthView.swift; sourceTree = "<group>"; };
-		A20000075 /* OTPVerificationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPVerificationView.swift; sourceTree = "<group>"; };
-		A20000076 /* KeychainHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelper.swift; sourceTree = "<group>"; };
-		A20000087 /* AuthRateLimiter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthRateLimiter.swift; sourceTree = "<group>"; };
-		A20000091 /* GrainOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrainOverlay.swift; sourceTree = "<group>"; };
-		A20000086 /* OTPVerificationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OTPVerificationViewModel.swift; sourceTree = "<group>"; };
-		A20000093 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
-		A20000094 /* SidebarViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewModel.swift; sourceTree = "<group>"; };
-		A20000074 /* AccountSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccountSheet.swift; sourceTree = "<group>"; };
+		A20000301 /* TimelineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineService.swift; sourceTree = "<group>"; };
+		A20000302 /* TimelineSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineSectionView.swift; sourceTree = "<group>"; };
 		A30000001 /* DayPage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPage.app; sourceTree = BUILT_PRODUCTS_DIR; };
-		23EA9C83B41565EDB263FB35 /* DayPageWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPageWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AF1000001 /* SpaceGrotesk-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Light.ttf"; sourceTree = "<group>"; };
 		AF1000002 /* SpaceGrotesk-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Regular.ttf"; sourceTree = "<group>"; };
 		AF1000003 /* SpaceGrotesk-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Medium.ttf"; sourceTree = "<group>"; };
@@ -266,46 +271,49 @@
 		AF1000010 /* Inter-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Inter-Bold.ttf"; sourceTree = "<group>"; };
 		AF1000011 /* JetBrainsMono-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Regular.ttf"; sourceTree = "<group>"; };
 		AF1000012 /* JetBrainsMono-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "JetBrainsMono-Medium.ttf"; sourceTree = "<group>"; };
-		T20000001 /* DayDetailViewStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayDetailViewStateTests.swift; sourceTree = "<group>"; };
-		T20000002 /* ConflictMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMergerTests.swift; sourceTree = "<group>"; };
-		T30000001 /* DayPageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DayPageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		A20000077 /* ConflictMerger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMerger.swift; sourceTree = "<group>"; };
-		A20000078 /* VaultMigrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationService.swift; sourceTree = "<group>"; };
-		T20000003 /* VaultMigrationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationServiceTests.swift; sourceTree = "<group>"; };
-		T20000004 /* VaultLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultLocatorTests.swift; sourceTree = "<group>"; };
-		T20000005 /* RawStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorageTests.swift; sourceTree = "<group>"; };
-		T20000006 /* ComposerContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerContextProviderTests.swift; sourceTree = "<group>"; };
-		T20000007 /* SmokeTest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmokeTest.swift; sourceTree = "<group>"; };
-		A20000095 /* ComposerContextProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerContextProvider.swift; sourceTree = "<group>"; };
+		B93ED807E07C2171E9F4234B /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
+		C98B5757B488F583231EC8F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		CJ1000001 /* CJKTextPolish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKTextPolish.swift; sourceTree = "<group>"; };
+		DS1000001 /* Motion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Motion.swift; sourceTree = "<group>"; };
+		DS1000002 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		ES1000001 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
+		ES1000002 /* GlassErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassErrorBanner.swift; sourceTree = "<group>"; };
+		ES1000003 /* GlassTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassTabBar.swift; sourceTree = "<group>"; };
+		F11E0748715A251EE4A0168A /* WatchReceiveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchReceiveService.swift; sourceTree = "<group>"; };
+		F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTransferService.swift; sourceTree = "<group>"; };
+		F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchApp.swift; sourceTree = "<group>"; };
 		FB1000001 /* FeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackService.swift; sourceTree = "<group>"; };
 		FB1000002 /* FeedbackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewModel.swift; sourceTree = "<group>"; };
 		FB1000003 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
 		FB1000004 /* FeedbackContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackContext.swift; sourceTree = "<group>"; };
-		ES1000001 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
-		ES1000002 /* GlassErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassErrorBanner.swift; sourceTree = "<group>"; };
-		ES1000003 /* GlassTabBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassTabBar.swift; sourceTree = "<group>"; };
-		DS1000001 /* Motion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Motion.swift; sourceTree = "<group>"; };
-		DS1000002 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
 		FT1000001 /* DayOrbView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOrbView.swift; sourceTree = "<group>"; };
-		MD1000001 /* MemoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailView.swift; sourceTree = "<group>"; };
-		MD1000002 /* MemoDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailViewModel.swift; sourceTree = "<group>"; };
-		CJ1000001 /* CJKTextPolish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKTextPolish.swift; sourceTree = "<group>"; };
-		WS1000001 /* WelcomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeScreen.swift; sourceTree = "<group>"; };
 		LS1000002 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		LS1000003 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
-		LS1000001 /* Localizable.strings */ = {isa = PBXVariantGroup; children = (LS1000002 /* en */, LS1000003 /* zh-Hans */); name = Localizable.strings; sourceTree = "<group>"; };
 		LS1000004 /* L10n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10n.swift; sourceTree = "<group>"; };
-		F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchApp.swift; sourceTree = "<group>"; };
-		C98B5757B488F583231EC8F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
-		B93ED807E07C2171E9F4234B /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
-		0881AB423FF6F12FCDE27C5B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
-		2748059CC689A341C7CAAACC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
-		F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTransferService.swift; sourceTree = "<group>"; };
-		F11E0748715A251EE4A0168A /* WatchReceiveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchReceiveService.swift; sourceTree = "<group>"; };
-		FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
+		MD1000001 /* MemoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailView.swift; sourceTree = "<group>"; };
+		MD1000002 /* MemoDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailViewModel.swift; sourceTree = "<group>"; };
+		T20000001 /* DayDetailViewStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayDetailViewStateTests.swift; sourceTree = "<group>"; };
+		T20000002 /* ConflictMergerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConflictMergerTests.swift; sourceTree = "<group>"; };
+		T20000003 /* VaultMigrationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationServiceTests.swift; sourceTree = "<group>"; };
+		T20000004 /* VaultLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultLocatorTests.swift; sourceTree = "<group>"; };
+		T20000005 /* RawStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorageTests.swift; sourceTree = "<group>"; };
+		T20000006 /* ComposerContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerContextProviderTests.swift; sourceTree = "<group>"; };
+		T30000001 /* DayPageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DayPageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		TH1000001 /* ThreadConversationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationViewModel.swift; sourceTree = "<group>"; };
+		TH1000002 /* ThreadConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationView.swift; sourceTree = "<group>"; };
+		TH1000003 /* InlineMicButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineMicButton.swift; sourceTree = "<group>"; };
+		WS1000001 /* WelcomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		3EB5769AA1DE988ED54D7EAF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A40000001 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -322,16 +330,46 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3EB5769AA1DE988ED54D7EAF /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		169A033458595BA06BEA3D5F /* App */ = {
+			isa = PBXGroup;
+			children = (
+				F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */,
+				C98B5757B488F583231EC8F6 /* RootView.swift */,
+			);
+			path = App;
+			sourceTree = "<group>";
+		};
+		199F425FF62768ECA9FD1FB9 /* Features */ = {
+			isa = PBXGroup;
+			children = (
+				B93ED807E07C2171E9F4234B /* RecordingView.swift */,
+			);
+			path = Features;
+			sourceTree = "<group>";
+		};
+		4D6CD27C159EBD1C3B99E5A0 /* Complication */ = {
+			isa = PBXGroup;
+			children = (
+				FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */,
+			);
+			path = Complication;
+			sourceTree = "<group>";
+		};
+		6E1BF02CE381B436F22B52D5 /* DayPageWatch */ = {
+			isa = PBXGroup;
+			children = (
+				169A033458595BA06BEA3D5F /* App */,
+				199F425FF62768ECA9FD1FB9 /* Features */,
+				E8860B4D47FA22FF858763A5 /* Resources */,
+				4D6CD27C159EBD1C3B99E5A0 /* Complication */,
+				E649E3AC4D392A4CEDD41728 /* Services */,
+			);
+			path = DayPageWatch;
+			sourceTree = "<group>";
+		};
 		A50000001 /* DayPage */ = {
 			isa = PBXGroup;
 			children = (
@@ -346,27 +384,9 @@
 				A50000020 /* Utilities */,
 				ES5000002 /* Resources */,
 				A50000009 /* Products */,
+				CACBEB57B683CFE3B3FC434A /* Intents */,
 			);
 			path = DayPage;
-			sourceTree = "<group>";
-		};
-		ES5000001 /* Components */ = {
-			isa = PBXGroup;
-			children = (
-				ES1000001 /* EmptyStateView.swift */,
-				ES1000002 /* GlassErrorBanner.swift */,
-				ES1000003 /* GlassTabBar.swift */,
-			);
-			path = Components;
-			sourceTree = "<group>";
-		};
-		ES5000002 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				LS1000001 /* Localizable.strings */,
-				LS1000004 /* L10n.swift */,
-			);
-			path = Resources;
 			sourceTree = "<group>";
 		};
 		A50000002 /* App */ = {
@@ -419,38 +439,6 @@
 				MD5000001 /* MemoDetail */,
 			);
 			path = Features;
-			sourceTree = "<group>";
-		};
-		MD5000001 /* MemoDetail */ = {
-			isa = PBXGroup;
-			children = (
-				MD1000001 /* MemoDetailView.swift */,
-				MD1000002 /* MemoDetailViewModel.swift */,
-			);
-			path = MemoDetail;
-			sourceTree = "<group>";
-		};
-		A50000021 /* Auth */ = {
-			isa = PBXGroup;
-			children = (
-				A20000072 /* AuthView.swift */,
-				A20000093 /* AuthViewModel.swift */,
-				A20000073 /* EmailAuthView.swift */,
-				A20000075 /* OTPVerificationView.swift */,
-				A20000086 /* OTPVerificationViewModel.swift */,
-				A20000074 /* AccountSheet.swift */,
-			);
-			path = Auth;
-			sourceTree = "<group>";
-		};
-		A50000022 /* Feedback */ = {
-			isa = PBXGroup;
-			children = (
-				FB1000002 /* FeedbackViewModel.swift */,
-				FB1000003 /* FeedbackView.swift */,
-				FB1000004 /* FeedbackContext.swift */,
-			);
-			path = Feedback;
 			sourceTree = "<group>";
 		};
 		A50000005 /* Models */ = {
@@ -629,6 +617,29 @@
 			path = Utilities;
 			sourceTree = "<group>";
 		};
+		A50000021 /* Auth */ = {
+			isa = PBXGroup;
+			children = (
+				A20000072 /* AuthView.swift */,
+				A20000093 /* AuthViewModel.swift */,
+				A20000073 /* EmailAuthView.swift */,
+				A20000075 /* OTPVerificationView.swift */,
+				A20000086 /* OTPVerificationViewModel.swift */,
+				A20000074 /* AccountSheet.swift */,
+			);
+			path = Auth;
+			sourceTree = "<group>";
+		};
+		A50000022 /* Feedback */ = {
+			isa = PBXGroup;
+			children = (
+				FB1000002 /* FeedbackViewModel.swift */,
+				FB1000003 /* FeedbackView.swift */,
+				FB1000004 /* FeedbackContext.swift */,
+			);
+			path = Feedback;
+			sourceTree = "<group>";
+		};
 		A60000001 = {
 			isa = PBXGroup;
 			children = (
@@ -657,6 +668,61 @@
 			path = Fonts;
 			sourceTree = "<group>";
 		};
+		CACBEB57B683CFE3B3FC434A /* Intents */ = {
+			isa = PBXGroup;
+			children = (
+				2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */,
+				5FD3383348F15CB7B4E82E53 /* DayPageShortcuts.swift */,
+			);
+			name = Intents;
+			path = Intents;
+			sourceTree = "<group>";
+		};
+		E649E3AC4D392A4CEDD41728 /* Services */ = {
+			isa = PBXGroup;
+			children = (
+				F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */,
+			);
+			path = Services;
+			sourceTree = "<group>";
+		};
+		E8860B4D47FA22FF858763A5 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				2748059CC689A341C7CAAACC /* Info.plist */,
+				0881AB423FF6F12FCDE27C5B /* Assets.xcassets */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		ES5000001 /* Components */ = {
+			isa = PBXGroup;
+			children = (
+				ES1000001 /* EmptyStateView.swift */,
+				ES1000002 /* GlassErrorBanner.swift */,
+				ES1000003 /* GlassTabBar.swift */,
+			);
+			path = Components;
+			sourceTree = "<group>";
+		};
+		ES5000002 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				LS1000001 /* Localizable.strings */,
+				LS1000004 /* L10n.swift */,
+			);
+			path = Resources;
+			sourceTree = "<group>";
+		};
+		MD5000001 /* MemoDetail */ = {
+			isa = PBXGroup;
+			children = (
+				MD1000001 /* MemoDetailView.swift */,
+				MD1000002 /* MemoDetailViewModel.swift */,
+			);
+			path = MemoDetail;
+			sourceTree = "<group>";
+		};
 		T50000001 /* DayPageTests */ = {
 			isa = PBXGroup;
 			children = (
@@ -670,63 +736,27 @@
 			path = DayPageTests;
 			sourceTree = "<group>";
 		};
-		6E1BF02CE381B436F22B52D5 /* DayPageWatch */ = {
-			isa = PBXGroup;
-			children = (
-				169A033458595BA06BEA3D5F /* App */,
-				199F425FF62768ECA9FD1FB9 /* Features */,
-				E8860B4D47FA22FF858763A5 /* Resources */,
-				4D6CD27C159EBD1C3B99E5A0 /* Complication */,
-				E649E3AC4D392A4CEDD41728 /* Services */,
-			);
-			path = DayPageWatch;
-			sourceTree = "<group>";
-		};
-		169A033458595BA06BEA3D5F /* App */ = {
-			isa = PBXGroup;
-			children = (
-				F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */,
-				C98B5757B488F583231EC8F6 /* RootView.swift */,
-			);
-			path = App;
-			sourceTree = "<group>";
-		};
-		199F425FF62768ECA9FD1FB9 /* Features */ = {
-			isa = PBXGroup;
-			children = (
-				B93ED807E07C2171E9F4234B /* RecordingView.swift */,
-			);
-			path = Features;
-			sourceTree = "<group>";
-		};
-		E8860B4D47FA22FF858763A5 /* Resources */ = {
-			isa = PBXGroup;
-			children = (
-				2748059CC689A341C7CAAACC /* Info.plist */,
-				0881AB423FF6F12FCDE27C5B /* Assets.xcassets */,
-			);
-			path = Resources;
-			sourceTree = "<group>";
-		};
-		4D6CD27C159EBD1C3B99E5A0 /* Complication */ = {
-			isa = PBXGroup;
-			children = (
-				FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */,
-			);
-			path = Complication;
-			sourceTree = "<group>";
-		};
-		E649E3AC4D392A4CEDD41728 /* Services */ = {
-			isa = PBXGroup;
-			children = (
-				F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */,
-			);
-			path = Services;
-			sourceTree = "<group>";
-		};
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		69BEA0675AFA233657A8AD39 /* DayPageWatch */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 0D6D80FCABFECB20FC046750 /* Build configuration list for PBXNativeTarget "DayPageWatch" */;
+			buildPhases = (
+				4705AC05FAC24B4000886F57 /* Sources */,
+				3EB5769AA1DE988ED54D7EAF /* Frameworks */,
+				9E11D4E4CB1FFC4EC7D9A07A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				AF08A5AA36824D34EF184641 /* PBXTargetDependency */,
+			);
+			name = DayPageWatch;
+			productName = DayPageWatch;
+			productReference = 23EA9C83B41565EDB263FB35 /* DayPageWatch.app */;
+			productType = "com.apple.product-type.application.watchapp2";
+		};
 		A70000001 /* DayPage */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = A80000001 /* Build configuration list for PBXNativeTarget "DayPage" */;
@@ -765,24 +795,6 @@
 			productName = DayPageTests;
 			productReference = T30000001 /* DayPageTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
-		};
-		69BEA0675AFA233657A8AD39 /* DayPageWatch */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 0D6D80FCABFECB20FC046750 /* Build configuration list for PBXNativeTarget "DayPageWatch" */;
-			buildPhases = (
-				4705AC05FAC24B4000886F57 /* Sources */,
-				3EB5769AA1DE988ED54D7EAF /* Frameworks */,
-				9E11D4E4CB1FFC4EC7D9A07A /* Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				AF08A5AA36824D34EF184641 /* PBXTargetDependency */,
-			);
-			name = DayPageWatch;
-			productName = DayPageWatch;
-			productReference = 23EA9C83B41565EDB263FB35 /* DayPageWatch.app */;
-			productType = "com.apple.product-type.application.watchapp2";
 		};
 /* End PBXNativeTarget section */
 
@@ -829,6 +841,14 @@
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		9E11D4E4CB1FFC4EC7D9A07A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		AA0000001 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -847,14 +867,6 @@
 				AF0000012 /* JetBrainsMono-Medium.ttf in Resources */,
 				A10000029 /* Assets.xcassets in Resources */,
 				LS0000001 /* Localizable.strings in Resources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9E11D4E4CB1FFC4EC7D9A07A /* Resources */ = {
-			isa = PBXResourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -881,6 +893,18 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		4705AC05FAC24B4000886F57 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */,
+				9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */,
+				B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */,
+				347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */,
+				A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A90000001 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -991,6 +1015,8 @@
 				CJ0000001 /* CJKTextPolish.swift in Sources */,
 				WS0000001 /* WelcomeScreen.swift in Sources */,
 				A10000095 /* ComposerContextProvider.swift in Sources */,
+				457A17AB7F3B4BE7C2E77026 /* StartRecordingIntent.swift in Sources */,
+				9D559EA9D4B9F2C77D942935 /* DayPageShortcuts.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1007,66 +1033,61 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		4705AC05FAC24B4000886F57 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */,
-				9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */,
-				B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */,
-				347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */,
-				A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
-		T75000001 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = A70000001 /* DayPage */;
-			targetProxy = T76000001 /* PBXContainerItemProxy */;
-		};
 		AF08A5AA36824D34EF184641 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 69BEA0675AFA233657A8AD39 /* DayPageWatch */;
 			targetProxy = D13961FCE75D846CB11E2A04 /* PBXContainerItemProxy */;
 		};
+		T75000001 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = A70000001 /* DayPage */;
+			targetProxy = T76000001 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
-/* Begin XCRemoteSwiftPackageReference section */
-		SPM00003 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/supabase/supabase-swift";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 2.0.0;
-			};
+/* Begin PBXVariantGroup section */
+		LS1000001 /* Localizable.strings */ = {
+			isa = PBXVariantGroup;
+			children = (
+				LS1000002 /* en */,
+				LS1000003 /* zh-Hans */,
+			);
+			name = Localizable.strings;
+			sourceTree = "<group>";
 		};
-		SPM00006 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 8.36.0;
-			};
-		};
-/* End XCRemoteSwiftPackageReference section */
-
-/* Begin XCSwiftPackageProductDependency section */
-		SPM00002 /* Supabase */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = SPM00003 /* XCRemoteSwiftPackageReference "supabase-swift" */;
-			productName = Supabase;
-		};
-		SPM00005 /* Sentry */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = SPM00006 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
-			productName = Sentry;
-		};
-/* End XCSwiftPackageProductDependency section */
+/* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		33B764539AC733ABA92320CE /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEVELOPMENT_TEAM = 6RG2F8YY59;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = DayPageWatch/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
 		AC0000001 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1220,7 +1241,6 @@
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 6RG2F8YY59;
-				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app";
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = DayPage/App/Info.plist;
@@ -1232,9 +1252,36 @@
 				MARKETING_VERSION = 0.0.1;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		EE270A0C68FDC7F8C8261410 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = 6RG2F8YY59;
+				ENABLE_PREVIEWS = YES;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = DayPageWatch/Resources/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 0.0.1;
+				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.watchkitapp;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = watchos;
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 9.0;
 			};
 			name = Release;
 		};
@@ -1288,62 +1335,18 @@
 			};
 			name = Release;
 		};
-		33B764539AC733ABA92320CE /* Debug */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEBUG_INFORMATION_FORMAT = dwarf;
-				DEVELOPMENT_TEAM = 6RG2F8YY59;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = DayPageWatch/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 0.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.watchkitapp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 9.0;
-			};
-			name = Debug;
-		};
-		EE270A0C68FDC7F8C8261410 /* Release */ = {
-			isa = XCBuildConfiguration;
-			buildSettings = {
-				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 6RG2F8YY59;
-				ENABLE_PREVIEWS = YES;
-				GENERATE_INFOPLIST_FILE = NO;
-				INFOPLIST_FILE = DayPageWatch/Resources/Info.plist;
-				LD_RUNPATH_SEARCH_PATHS = (
-					"$(inherited)",
-					"@executable_path/Frameworks",
-				);
-				MARKETING_VERSION = 0.0.1;
-				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.watchkitapp;
-				PRODUCT_NAME = "$(TARGET_NAME)";
-				SDKROOT = watchos;
-				SKIP_INSTALL = YES;
-				SWIFT_EMIT_LOC_STRINGS = YES;
-				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 4;
-				WATCHOS_DEPLOYMENT_TARGET = 9.0;
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		0D6D80FCABFECB20FC046750 /* Build configuration list for PBXNativeTarget "DayPageWatch" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				33B764539AC733ABA92320CE /* Debug */,
+				EE270A0C68FDC7F8C8261410 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		A80000001 /* Build configuration list for PBXNativeTarget "DayPage" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1371,16 +1374,39 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		0D6D80FCABFECB20FC046750 /* Build configuration list for PBXNativeTarget "DayPageWatch" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				33B764539AC733ABA92320CE /* Debug */,
-				EE270A0C68FDC7F8C8261410 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		SPM00003 /* XCRemoteSwiftPackageReference "supabase-swift" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/supabase/supabase-swift";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.0.0;
+			};
+		};
+		SPM00006 /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/getsentry/sentry-cocoa";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 8.36.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		SPM00002 /* Supabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = SPM00003 /* XCRemoteSwiftPackageReference "supabase-swift" */;
+			productName = Supabase;
+		};
+		SPM00005 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = SPM00006 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = AB0000001 /* Project object */;
 }

--- a/DayPage/App/AppNavigationModel.swift
+++ b/DayPage/App/AppNavigationModel.swift
@@ -24,6 +24,13 @@ final class AppNavigationModel: ObservableObject {
     /// sidebar still triggers the navigation.
     @Published var pendingArchiveDate: String? = nil
 
+    /// Bumped to a new UUID by system-level entry points (URL scheme,
+    /// AppIntent, Widget, ControlWidget, Siri) that want to immediately
+    /// open the voice recorder on Today. TodayView observes the change and
+    /// flips its `isShowingVoiceRecorder` flag. We use a UUID instead of a
+    /// bool so repeated triggers from the same widget tap re-fire.
+    @Published var pendingRecordingTrigger: UUID? = nil
+
     init() {}
 
     func openSidebar() {

--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -98,9 +98,20 @@ struct DayPageApp: App {
                 .environmentObject(authService)
                 .environmentObject(navModel)
                 .onOpenURL { url in
-                    // Handle Magic Link / OTP deep-link callbacks (daypage://...).
-                    // Session updates are emitted by authStateChanges — no manual assignment needed.
                     guard url.scheme?.lowercased() == "daypage" else { return }
+
+                    // System-level Quick Capture entry points (Widget / Control
+                    // Center / Siri / Shortcuts / AppIntent) open the App via
+                    // daypage://record. Switch to Today and bump the trigger so
+                    // TodayView opens the voice recorder.
+                    if url.host?.lowercased() == "record" {
+                        navModel.navigate(to: .today)
+                        navModel.pendingRecordingTrigger = UUID()
+                        return
+                    }
+
+                    // Handle Magic Link / OTP deep-link callbacks.
+                    // Session updates are emitted by authStateChanges — no manual assignment needed.
                     Task {
                         do {
                             try await authService.supabase.auth.session(from: url)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -465,9 +465,20 @@ struct TodayView: View {
             }
             .onAppear {
                 evaluateSyncBanner()
+                // Handle a Quick Capture trigger that fired before TodayView
+                // appeared (cold launch via Widget / Siri / URL scheme).
+                if nav.pendingRecordingTrigger != nil {
+                    viewModel.isShowingVoiceRecorder = true
+                    nav.pendingRecordingTrigger = nil
+                }
             }
             .onChange(of: authService.session) { _ in
                 evaluateSyncBanner()
+            }
+            .onChange(of: nav.pendingRecordingTrigger) { newValue in
+                guard newValue != nil else { return }
+                viewModel.isShowingVoiceRecorder = true
+                nav.pendingRecordingTrigger = nil
             }
         }
     }

--- a/DayPage/Intents/DayPageShortcuts.swift
+++ b/DayPage/Intents/DayPageShortcuts.swift
@@ -1,0 +1,30 @@
+import AppIntents
+
+// MARK: - DayPageShortcuts
+//
+// Registers Siri / Spotlight / Shortcuts.app phrases that all resolve to
+// `StartRecordingIntent`. iOS picks up `AppShortcutsProvider` automatically;
+// no Info.plist entry is required.
+//
+// Phrases include "DayPage" so Siri can disambiguate the app — Apple requires
+// at least one phrase per shortcut to mention the app name.
+
+@available(iOS 16.0, *)
+struct DayPageShortcuts: AppShortcutsProvider {
+
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: StartRecordingIntent(),
+            phrases: [
+                "在 \(.applicationName) 里记一条",
+                "用 \(.applicationName) 录音",
+                "\(.applicationName) 快速记录",
+                "记一条到 \(.applicationName)",
+                "Record a memo in \(.applicationName)",
+                "New \(.applicationName) memo"
+            ],
+            shortTitle: "记一条",
+            systemImageName: "mic.fill"
+        )
+    }
+}

--- a/DayPage/Intents/StartRecordingIntent.swift
+++ b/DayPage/Intents/StartRecordingIntent.swift
@@ -1,6 +1,6 @@
 import AppIntents
 import Foundation
-#if canImport(UIKit)
+#if canImport(UIKit) && !EXTENSION
 import UIKit
 #endif
 
@@ -20,11 +20,21 @@ import UIKit
 // kicked off by TodayView observing `AppNavigationModel.pendingRecordingTrigger`
 // after the URL is handled in DayPageApp.onOpenURL.
 //
-// We deliberately route through the existing daypage://record URL scheme
-// rather than calling the recorder directly so:
-//   1. The Widget extension never has to link the full app target.
-//   2. There is a single deep-link handler in DayPageApp to maintain.
-//   3. The same code path works when the user manually pastes the URL.
+// Behaviour by call site:
+//   • Inside the main app process — `UIApplication.shared.open` is available;
+//     we open the deep link explicitly so the URL handler runs uniformly.
+//   • Inside the Widget extension process — `UIApplication.shared` is banned
+//     by the linker. We rely on `openAppWhenRun = true` plus WidgetKit's
+//     built-in behaviour: tapping a `Button(intent:)` or `ControlWidgetButton`
+//     foregrounds the app, and `DayPageApp.onAppear` / cold-launch flow can
+//     pick up the pending trigger via the URL scheme set by the Widget's
+//     `widgetURL(_:)` modifier (or, for the parameter-less control widget,
+//     we just rely on the app being foregrounded plus a one-shot trigger
+//     stored in shared UserDefaults — see WidgetBridge).
+//
+// Routing everything through the daypage://record URL keeps a single
+// deep-link handler in DayPageApp.onOpenURL to maintain, and the same code
+// path works when the user manually pastes the URL.
 
 @available(iOS 16.0, *)
 struct StartRecordingIntent: AppIntent {
@@ -43,13 +53,18 @@ struct StartRecordingIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        // Route through the deep-link handler. URL scheme is registered in
-        // the main app's Info.plist (CFBundleURLSchemes = ["daypage"]).
+        // When invoked from inside the main app process (Siri / Shortcuts /
+        // Spotlight) we can open the URL ourselves so the handler runs
+        // immediately. In the extension process `UIApplication.shared` is
+        // unavailable; `openAppWhenRun = true` plus the widget's `widgetURL`
+        // (set on the Button surface) take care of foregrounding + deep link.
+        #if !EXTENSION
         if let url = URL(string: "daypage://record") {
             #if canImport(UIKit)
             await UIApplication.shared.open(url)
             #endif
         }
+        #endif
         return .result()
     }
 }

--- a/DayPage/Intents/StartRecordingIntent.swift
+++ b/DayPage/Intents/StartRecordingIntent.swift
@@ -1,0 +1,55 @@
+import AppIntents
+import Foundation
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - StartRecordingIntent
+//
+// Single AppIntent shared across every system-level Quick Capture entry point:
+//
+//   • Siri ("Hey Siri, DayPage 记一条")
+//   • Spotlight search
+//   • Shortcuts.app & Automations
+//   • Action Button (iPhone 15 Pro+)
+//   • Home Screen / Lock Screen Widget tap (WidgetKit)
+//   • Control Center / Lock Screen Control button (iOS 18+ ControlWidget)
+//
+// Microphone access requires the app to be foregrounded, so this intent
+// always opens the app (`openAppWhenRun = true`). The actual recording is
+// kicked off by TodayView observing `AppNavigationModel.pendingRecordingTrigger`
+// after the URL is handled in DayPageApp.onOpenURL.
+//
+// We deliberately route through the existing daypage://record URL scheme
+// rather than calling the recorder directly so:
+//   1. The Widget extension never has to link the full app target.
+//   2. There is a single deep-link handler in DayPageApp to maintain.
+//   3. The same code path works when the user manually pastes the URL.
+
+@available(iOS 16.0, *)
+struct StartRecordingIntent: AppIntent {
+
+    static var title: LocalizedStringResource = "记一条 DayPage"
+
+    static var description = IntentDescription(
+        "打开 DayPage 并立即开始语音录音。",
+        categoryName: "Capture",
+        searchKeywords: ["record", "voice", "memo", "录音", "记一条", "快速记录", "daypage"]
+    )
+
+    /// Opens the main app, bringing it to the foreground. Required for
+    /// microphone access.
+    static var openAppWhenRun: Bool = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        // Route through the deep-link handler. URL scheme is registered in
+        // the main app's Info.plist (CFBundleURLSchemes = ["daypage"]).
+        if let url = URL(string: "daypage://record") {
+            #if canImport(UIKit)
+            await UIApplication.shared.open(url)
+            #endif
+        }
+        return .result()
+    }
+}

--- a/DayPageWidget/DayPageWidgetBundle.swift
+++ b/DayPageWidget/DayPageWidgetBundle.swift
@@ -1,0 +1,23 @@
+import WidgetKit
+import SwiftUI
+
+// MARK: - DayPageWidgetBundle
+//
+// Single @main entry point for the Widget Extension. Bundles:
+//   • QuickCaptureWidget — Home Screen / Lock Screen (iOS 16+)
+//   • QuickCaptureControl — Control Center / Lock Screen (iOS 18+)
+//
+// Both widgets fire the same StartRecordingIntent which routes through
+// the daypage://record URL scheme to wake the main app and open the
+// voice recorder.
+
+@main
+struct DayPageWidgetBundle: WidgetBundle {
+    var body: some Widget {
+        QuickCaptureWidget()
+
+        if #available(iOS 18.0, *) {
+            QuickCaptureControl()
+        }
+    }
+}

--- a/DayPageWidget/Info.plist
+++ b/DayPageWidget/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>DayPage</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/DayPageWidget/QuickCaptureControl.swift
+++ b/DayPageWidget/QuickCaptureControl.swift
@@ -1,0 +1,25 @@
+import WidgetKit
+import SwiftUI
+import AppIntents
+
+// MARK: - QuickCaptureControl
+//
+// iOS 18+ Control Widget: shows up in Control Center, Lock Screen control
+// area, and is assignable to the Action Button. Tapping fires the shared
+// `StartRecordingIntent`.
+
+@available(iOS 18.0, *)
+struct QuickCaptureControl: ControlWidget {
+
+    var body: some ControlWidgetConfiguration {
+        StaticControlConfiguration(
+            kind: "com.daypage.control.quickcapture"
+        ) {
+            ControlWidgetButton(action: StartRecordingIntent()) {
+                Label("记一条", systemImage: "mic.fill")
+            }
+        }
+        .displayName("DayPage 录音")
+        .description("一键开启语音录音。")
+    }
+}

--- a/DayPageWidget/QuickCaptureWidget.swift
+++ b/DayPageWidget/QuickCaptureWidget.swift
@@ -1,0 +1,104 @@
+import WidgetKit
+import SwiftUI
+import AppIntents
+
+// MARK: - QuickCaptureWidget
+//
+// Home Screen / Lock Screen widget that opens DayPage straight into the
+// voice recorder. The whole widget surface is a single Button bound to
+// `StartRecordingIntent` so iOS treats it as a one-tap action — no preview
+// expansion, no list of options.
+
+@available(iOS 17.0, *)
+struct QuickCaptureWidget: Widget {
+
+    let kind: String = "com.daypage.widget.quickcapture"
+
+    var body: some WidgetConfiguration {
+        StaticConfiguration(kind: kind, provider: QuickCaptureProvider()) { _ in
+            QuickCaptureWidgetView()
+                .containerBackground(.fill.tertiary, for: .widget)
+                // Fallback path: even if the Button(intent:) wiring fails for
+                // some reason, tapping anywhere on the widget surface opens
+                // the deep link, which DayPageApp.onOpenURL converts into a
+                // recording trigger.
+                .widgetURL(URL(string: "daypage://record"))
+        }
+        .configurationDisplayName("快速记录")
+        .description("一键开启 DayPage 语音录音。")
+        .supportedFamilies([.systemSmall, .accessoryCircular, .accessoryRectangular])
+    }
+}
+
+// MARK: - Provider
+
+private struct QuickCaptureProvider: TimelineProvider {
+    func placeholder(in context: Context) -> QuickCaptureEntry {
+        QuickCaptureEntry(date: Date())
+    }
+
+    func getSnapshot(in context: Context, completion: @escaping (QuickCaptureEntry) -> Void) {
+        completion(QuickCaptureEntry(date: Date()))
+    }
+
+    func getTimeline(in context: Context, completion: @escaping (Timeline<QuickCaptureEntry>) -> Void) {
+        completion(Timeline(entries: [QuickCaptureEntry(date: Date())], policy: .never))
+    }
+}
+
+private struct QuickCaptureEntry: TimelineEntry {
+    let date: Date
+}
+
+// MARK: - View
+
+private struct QuickCaptureWidgetView: View {
+
+    @Environment(\.widgetFamily) private var family
+
+    var body: some View {
+        Button(intent: StartRecordingIntent()) {
+            content
+        }
+        .buttonStyle(.plain)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch family {
+        case .accessoryCircular:
+            ZStack {
+                AccessoryWidgetBackground()
+                Image(systemName: "mic.fill")
+                    .font(.title3)
+            }
+
+        case .accessoryRectangular:
+            HStack(spacing: 8) {
+                Image(systemName: "mic.fill")
+                    .font(.title2)
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("DayPage")
+                        .font(.caption.weight(.semibold))
+                    Text("记一条")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer(minLength: 0)
+            }
+
+        default:
+            VStack(spacing: 10) {
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 36, weight: .semibold))
+                    .foregroundStyle(.tint)
+                Text("记一条")
+                    .font(.headline)
+                Text("DayPage")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        }
+    }
+}

--- a/scripts/add_intents_to_target.rb
+++ b/scripts/add_intents_to_target.rb
@@ -1,0 +1,58 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# add_intents_to_target.rb
+#
+# Adds the new App Intents source files (Intents/StartRecordingIntent.swift,
+# Intents/DayPageShortcuts.swift) into the DayPage Xcode target.
+#
+# Idempotent: re-running is a no-op if the files are already wired up.
+#
+# Usage:
+#   ruby scripts/add_intents_to_target.rb
+
+require "xcodeproj"
+
+PROJECT_PATH = File.expand_path("../DayPage.xcodeproj", __dir__)
+TARGET_NAME  = "DayPage"
+GROUP_NAME   = "Intents"
+FILE_PATHS   = %w[
+  DayPage/Intents/StartRecordingIntent.swift
+  DayPage/Intents/DayPageShortcuts.swift
+].freeze
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+target  = project.targets.find { |t| t.name == TARGET_NAME }
+raise "Target #{TARGET_NAME} not found" unless target
+
+# Resolve / create the "Intents" group under the top-level DayPage group.
+daypage_group = project.main_group.find_subpath("DayPage", false)
+raise "Top-level DayPage group not found" unless daypage_group
+intents_group = daypage_group.find_subpath(GROUP_NAME, true)
+intents_group.set_source_tree("<group>")
+intents_group.path ||= "Intents"
+
+added = []
+skipped = []
+
+FILE_PATHS.each do |rel_path|
+  basename = File.basename(rel_path)
+  abs_path = File.expand_path("../#{rel_path}", __dir__)
+
+  existing_ref = intents_group.files.find { |f| f.path == basename || f.path == rel_path }
+  file_ref = existing_ref || intents_group.new_file(abs_path)
+
+  already_built = target.source_build_phase.files_references.include?(file_ref)
+  if already_built
+    skipped << basename
+  else
+    target.add_file_references([file_ref])
+    added << basename
+  end
+end
+
+project.save
+
+puts "added: #{added.join(', ')}" unless added.empty?
+puts "already wired: #{skipped.join(', ')}" unless skipped.empty?
+puts "done."

--- a/scripts/add_widget_extension.rb
+++ b/scripts/add_widget_extension.rb
@@ -1,0 +1,152 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# add_widget_extension.rb
+#
+# Creates the DayPageWidget extension target and wires it up:
+#   • PBXNativeTarget of type com.apple.product-type.app-extension
+#   • Sources phase with the 3 widget Swift files + StartRecordingIntent
+#     (the intent file is shared with the main app via dual target membership)
+#   • Build settings cloned from the main DayPage target, tuned for an
+#     app-extension product (SKIP_INSTALL, bundle id, info plist path, etc.)
+#   • CopyFiles "Embed Foundation Extensions" phase on the DayPage target so
+#     the .appex is embedded into the .app on build
+#   • Target dependency: DayPage → DayPageWidget
+#
+# Idempotent: re-running detects the existing target and exits.
+#
+# Usage:
+#   ruby scripts/add_widget_extension.rb
+
+require "xcodeproj"
+
+PROJECT_PATH = File.expand_path("../DayPage.xcodeproj", __dir__)
+APP_TARGET   = "DayPage"
+EXT_TARGET   = "DayPageWidget"
+EXT_BUNDLE   = "com.daypage.app.DayPageWidget"
+WIDGET_DIR   = "DayPageWidget"
+
+WIDGET_SOURCES = %w[
+  DayPageWidgetBundle.swift
+  QuickCaptureWidget.swift
+  QuickCaptureControl.swift
+].freeze
+
+SHARED_INTENT_FILE = "DayPage/Intents/StartRecordingIntent.swift"
+
+project = Xcodeproj::Project.open(PROJECT_PATH)
+app_target = project.targets.find { |t| t.name == APP_TARGET }
+raise "Main target '#{APP_TARGET}' not found" unless app_target
+
+existing = project.targets.find { |t| t.name == EXT_TARGET }
+if existing
+  puts "target '#{EXT_TARGET}' already exists — nothing to do."
+  exit 0
+end
+
+project_dir = File.expand_path("..", PROJECT_PATH)
+widget_disk = File.join(project_dir, WIDGET_DIR)
+raise "Widget folder '#{widget_disk}' missing" unless Dir.exist?(widget_disk)
+
+# --- 1. Create the extension target -----------------------------------------
+
+ext_target = project.new_target(
+  :application,
+  EXT_TARGET,
+  :ios,
+  "16.0",
+  project.products_group,
+  :swift
+)
+ext_target.product_type = "com.apple.product-type.app-extension"
+
+ext_product = ext_target.product_reference
+ext_product.path = "#{EXT_TARGET}.appex"
+ext_product.explicit_file_type = "wrapper.app-extension"
+ext_product.include_in_index = "0"
+
+# --- 2. Tune build settings --------------------------------------------------
+
+app_release = app_target.build_configurations.find { |c| c.name == "Release" }
+inherited_signing_team = app_release&.build_settings&.dig("DEVELOPMENT_TEAM")
+
+ext_target.build_configurations.each do |cfg|
+  bs = cfg.build_settings
+  bs["PRODUCT_BUNDLE_IDENTIFIER"] = EXT_BUNDLE
+  bs["PRODUCT_NAME"] = "$(TARGET_NAME)"
+  bs["INFOPLIST_FILE"] = "#{WIDGET_DIR}/Info.plist"
+  # WidgetKit Button(intent:) + containerBackground require iOS 17. The main
+  # app stays on iOS 16; users on iOS 16 simply won't see the widget.
+  bs["IPHONEOS_DEPLOYMENT_TARGET"] = "17.0"
+  bs["TARGETED_DEVICE_FAMILY"] = "1,2"
+  bs["SKIP_INSTALL"] = "YES"
+  bs["SWIFT_VERSION"] = "5.0"
+  bs["SWIFT_EMIT_LOC_STRINGS"] = "YES"
+  bs["MARKETING_VERSION"] = "1.0"
+  bs["CURRENT_PROJECT_VERSION"] = "1"
+  bs["GENERATE_INFOPLIST_FILE"] = "NO"
+  bs["CODE_SIGN_STYLE"] = "Automatic"
+  bs["DEVELOPMENT_TEAM"] = inherited_signing_team if inherited_signing_team
+  bs["LD_RUNPATH_SEARCH_PATHS"] = "$(inherited) @executable_path/Frameworks @executable_path/../../Frameworks"
+  # Lets shared sources guard extension-incompatible APIs (UIApplication.shared,
+  # etc.) with `#if EXTENSION`.
+  bs["SWIFT_ACTIVE_COMPILATION_CONDITIONS"] = "EXTENSION"
+  # APPLICATION_EXTENSION_API_ONLY prevents accidental links to non-extension
+  # safe APIs across the whole compilation unit.
+  bs["APPLICATION_EXTENSION_API_ONLY"] = "YES"
+end
+
+# --- 3. Create the DayPageWidget PBXGroup and add Swift sources -------------
+
+widget_group = project.main_group.find_subpath(WIDGET_DIR, true)
+widget_group.set_source_tree("<group>")
+widget_group.path ||= WIDGET_DIR
+
+source_refs = WIDGET_SOURCES.map do |basename|
+  abs = File.join(widget_disk, basename)
+  ref = widget_group.files.find { |f| f.path == basename } || widget_group.new_file(abs)
+  ref
+end
+
+info_ref = widget_group.files.find { |f| f.path == "Info.plist" } ||
+           widget_group.new_file(File.join(widget_disk, "Info.plist"))
+_ = info_ref
+
+# --- 4. Add sources to the extension target ----------------------------------
+
+ext_target.add_file_references(source_refs)
+
+# --- 5. Dual-membership: compile StartRecordingIntent.swift in extension too -
+
+shared_basename = File.basename(SHARED_INTENT_FILE)
+intents_group = project.main_group.find_subpath("DayPage", false)&.find_subpath("Intents", false)
+shared_ref = intents_group&.files&.find { |f| f.path == shared_basename }
+raise "Shared intent file ref not found — run add_intents_to_target.rb first" unless shared_ref
+
+unless ext_target.source_build_phase.files_references.include?(shared_ref)
+  ext_target.add_file_references([shared_ref])
+end
+
+# --- 6. Embed the extension into the main app -------------------------------
+
+embed_phase = app_target.copy_files_build_phases.find { |p| p.name == "Embed Foundation Extensions" }
+embed_phase ||= app_target.new_copy_files_build_phase("Embed Foundation Extensions")
+embed_phase.symbol_dst_subfolder_spec = :plug_ins
+embed_phase.dst_path = ""
+
+unless embed_phase.files_references.include?(ext_product)
+  build_file = embed_phase.add_file_reference(ext_product, true)
+  build_file.settings = { "ATTRIBUTES" => ["RemoveHeadersOnCopy"] }
+end
+
+# --- 7. Target dependency ---------------------------------------------------
+
+app_target.add_dependency(ext_target)
+
+project.save
+
+puts "created target '#{EXT_TARGET}' (bundle id: #{EXT_BUNDLE})"
+puts "sources: #{WIDGET_SOURCES.join(', ')}"
+puts "shared: #{shared_basename} (dual membership)"
+puts "embedded into: #{APP_TARGET}.app/PlugIns/"
+puts "done."


### PR DESCRIPTION
Closes #281

## Summary
DayPage 现在拥有完整的系统级快速录音入口矩阵 — 无需打开 App 即可开录。

## 入口矩阵（已实现）

| # | 入口 | iOS | 实现 |
|---|---|---|---|
| 1 | Siri 语音「在 DayPage 里记一条」 | 16+ | `StartRecordingIntent` + `AppShortcutsProvider` |
| 2 | Shortcuts.app / 自动化 | 16+ | 同上 |
| 3 | Spotlight 搜索 | 16+ | 同上 |
| 4 | Action Button (iPhone 15 Pro+) | 16+ | Shortcut → `StartRecordingIntent` |
| 5 | URL Scheme `daypage://record` | 16+ | `DayPageApp.onOpenURL` |
| 6 | 主屏 / 锁屏 Widget | 17+ | `QuickCaptureWidget` (`systemSmall` + `accessoryCircular` + `accessoryRectangular`) |
| 7 | 控制中心 / 锁屏快捷按钮 | 18+ | `QuickCaptureControl` (`ControlWidget`) |

全部入口最终通过同一个 `daypage://record` 深链触发 `AppNavigationModel.pendingRecordingTrigger`，由 `TodayView` 自动打开录音 sheet — 单一职责，单一调试点。

## 架构

```
Siri / Shortcuts / Widget tap / Control tap
                  │
                  ▼
       StartRecordingIntent.perform
       (openAppWhenRun = true)
                  │
                  ▼
       daypage://record  (URL Scheme)
                  │
                  ▼
       DayPageApp.onOpenURL
                  │
                  ▼
       AppNavigationModel.pendingRecordingTrigger = UUID()
                  │
                  ▼
       TodayView.onChange → isShowingVoiceRecorder = true
                  │
                  ▼
       VoiceRecordingView 弹出
```

## 工程改动
- **新 target** `DayPageWidget` (app-extension, iOS 17+)
- **StartRecordingIntent.swift 双 target membership**：主 App + Widget Extension 共享
- **DayPage 主 target 部署目标保持 iOS 16**；Widget Extension 单独 iOS 17
- **`#if EXTENSION`** 编译标志区分 `UIApplication.shared` 在主 App / 扩展内的可用性
- **fallback：** widget 表面加 `widgetURL(daypage://record)`，AppIntent 失效时仍可 tap-to-open
- **`scripts/add_intents_to_target.rb`** + **`scripts/add_widget_extension.rb`** 两个幂等的 xcodeproj 维护脚本

## 验证
- `xcodebuild -scheme DayPage -destination 'iPhone 17'` → BUILD SUCCEEDED
- `appintentsmetadataprocessor` 在主 App 和 Widget 各自生成 `Metadata.appintents`
- `DayPage.app/PlugIns/DayPageWidget.appex` 正确嵌入
- `xcrun simctl openurl booted daypage://record` 触发系统级深链跳转

## Test plan
- [ ] 模拟器：跑 Shortcuts.app，看到 DayPage 的「记一条」/「快速记录」短语
- [ ] 模拟器：Spotlight 搜「DayPage 录音」/「记一条」可见
- [ ] 模拟器：主屏长按 → 添加 widget → 选 DayPage → 选择"快速记录" → tap 后 App 打开并自动弹录音 sheet
- [ ] 真机 (iOS 18)：控制中心 → 编辑 → 添加「DayPage 录音」→ tap 后 App 打开并自动弹录音 sheet
- [ ] 真机 (iPhone 15 Pro+)：Action Button 绑 Shortcut "记一条"，按下后 App 打开并录音
- [ ] URL Scheme：`xcrun simctl openurl booted daypage://record` 在已登录 App 上能自动弹录音

## 待办（后续 PR）
- Live Activity / 灵动岛 录音状态显示（录音过程中）
- iOS 16 设备的 Widget 适配（当前 widget 要求 iOS 17，iOS 16 用户走 Shortcuts/Siri/URL）