### PR TITLE
fix(ci): 用 simctl defaults 预设状态修 Maestro UI Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -232,6 +232,21 @@ jobs:
           xcrun simctl spawn "$SIMULATOR_UDID" \
             defaults read com.daypage.app authSkipped || true
 
+      # Diagnostic: cold-launch the app once and screenshot what the user
+      # actually sees. Maestro's debug-output only captures snapshots on
+      # element-not-found, so when the issue is "wrong screen rendered" we
+      # have nothing to debug from. This step writes diag-after-launch.png
+      # which the upload-artifact step at the bottom always picks up.
+      - name: Diagnostic — screenshot first-launch state
+        run: |
+          mkdir -p maestro-results
+          xcrun simctl launch "$SIMULATOR_UDID" com.daypage.app || true
+          sleep 4
+          xcrun simctl io "$SIMULATOR_UDID" screenshot \
+            maestro-results/diag-after-launch.png || true
+          xcrun simctl terminate "$SIMULATOR_UDID" com.daypage.app || true
+          ls -la maestro-results/
+
       - name: Run Maestro flows
         id: maestro
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,6 +213,25 @@ jobs:
           echo "Installing: $APP"
           xcrun simctl install "$SIMULATOR_UDID" "$APP"
 
+      # Preset UserDefaults so the Maestro flows skip onboarding + auth and land
+      # directly on TodayView. Maestro's iOS LaunchAppHandler.swift (in the
+      # XCUITest runner) only calls XCUIApplication.activate() — it does NOT
+      # forward `launchApp.arguments` from the YAML, so the values that flows
+      # 01/02/04 pass (`hasOnboarded: "true"`, `authSkipped: "true"`) are
+      # silently dropped. Writing directly to the simulator's defaults database
+      # works around this without touching app source.
+      - name: Preset onboarding / auth flags for Maestro
+        run: |
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults write com.daypage.app hasOnboarded -bool YES
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults write com.daypage.app authSkipped -bool YES
+          # Sanity print so the CI log shows the values that took effect.
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults read com.daypage.app hasOnboarded || true
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults read com.daypage.app authSkipped || true
+
       - name: Run Maestro flows
         id: maestro
         env:


### PR DESCRIPTION
## 真正的根因（PR #283 没修好）

PR #283 在 App 端加了 launch-args bridge，但 **Maestro 根本不传 launch arguments 给 iOS app**。

看 Maestro 1.39 的 iOS XCTest runner 源码（[LaunchAppHandler.swift](https://github.com/mobile-dev-inc/maestro/blob/main/maestro-ios-xctest-runner/maestro-driver-iosUITests/Routes/Handlers/LaunchAppHandler.swift)）：

\`\`\`swift
func handleRequest(_ request: HTTPRequest) async throws -> HTTPResponse {
    guard let requestBody = try? await JSONDecoder().decode(LaunchAppRequest.self, from: request.bodyData) else { ... }
    NSLog("[Start] Launching app with bundle ID: \(requestBody.bundleId)")
    XCUIApplication(bundleIdentifier: requestBody.bundleId).activate()  // ← 这里！
    NSLog("[Done] Launching app with bundle ID: \(requestBody.bundleId)")
    return HTTPResponse(statusCode: .ok)
}
\`\`\`

\`activate()\` 只用 bundleId，不消费 \`launchApp.arguments\`。Kotlin 端 \`IOSLaunchArguments.toIOSLaunchArguments()\` 把 args 转成 \`["-key", "value"]\` 数组发到 HTTP server，但 Swift handler 解码后**直接丢掉**。

所以 PR #283 的 \`bridgeLaunchArgumentsToDefaults()\` 永远收不到 args —— bridge 实现没错，但前提条件就不成立。

参考 maestro issue [#2015](https://github.com/mobile-dev-inc/maestro/issues/2015)：用户也是字符串 \"true\" 在 iOS RN 端读不到。

## 这个 PR 的修法

跳过 App 层。直接在 CI install 完 App 后，用 \`xcrun simctl spawn defaults write\` 把两个 key 预写入 simulator 的 defaults 数据库：

\`\`\`yaml
- name: Preset onboarding / auth flags for Maestro
  run: |
    xcrun simctl spawn "$SIMULATOR_UDID" \\
      defaults write com.daypage.app hasOnboarded -bool YES
    xcrun simctl spawn "$SIMULATOR_UDID" \\
      defaults write com.daypage.app authSkipped -bool YES
\`\`\`

App 启动时 \`RootView.initialPhase()\` 读 UserDefaults，看到 \`hasOnboarded=YES + authSkipped=YES\`，返回 \`.ready\`，直接进 TodayView。

## 优点

- **零 App 代码改动**（PR #283 的 bridge 也保留着，作为本地 \`simctl launch -hasOnboarded YES\` 调试通道）
- **零真实用户影响**：只在 CI 临时 runner 的 simulator 上写，不进 git
- **不依赖 Maestro 行为**：即使 Maestro 1.40 修了 launchArguments，本方案仍然有效

## Test plan

- [ ] 等待 CI Maestro UI Tests 4/5 → 5/5 绿（flow 05 watch 不在范围）
- [ ] CI 日志里能看到 \`hasOnboarded = 1\` / \`authSkipped = 1\` 的 sanity print