### PR TITLE
fix(ci): 也预设 hasSeenWelcome — RootView 真正的第二个 gate (Maestro)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -222,13 +222,21 @@ jobs:
       # works around this without touching app source.
       - name: Preset onboarding / auth flags for Maestro
         run: |
+          # RootView.initialPhase() checks THREE gates in order:
+          #   hasOnboarded → hasSeenWelcome → (authSkipped || session)
+          # All three must pass to land on TodayView. Missing any one and
+          # Maestro can't reach sidebar-menu-button / memo-input.
           xcrun simctl spawn "$SIMULATOR_UDID" \
             defaults write com.daypage.app hasOnboarded -bool YES
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults write com.daypage.app hasSeenWelcome -bool YES
           xcrun simctl spawn "$SIMULATOR_UDID" \
             defaults write com.daypage.app authSkipped -bool YES
           # Sanity print so the CI log shows the values that took effect.
           xcrun simctl spawn "$SIMULATOR_UDID" \
             defaults read com.daypage.app hasOnboarded || true
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults read com.daypage.app hasSeenWelcome || true
           xcrun simctl spawn "$SIMULATOR_UDID" \
             defaults read com.daypage.app authSkipped || true
 


### PR DESCRIPTION
## 背景

PR #284 把 \`hasOnboarded\` + \`authSkipped\` 预设到 simulator UserDefaults，但 Maestro 仍然 4/5 fail。

CI 日志确认 \`defaults read\` 输出 \`1\`，说明预设 ✅ 生效，但 \`sidebar-menu-button\` 还是找不到。

## 根因

重读 [\`RootView.initialPhase()\`](https://github.com/getyak/daypage/blob/main/DayPage/App/RootView.swift#L20-L28)：

\`\`\`swift
private static func initialPhase() -> AppPhase {
    let hasOnboarded = UserDefaults.standard.bool(forKey: AppSettings.Keys.hasOnboarded)
    guard hasOnboarded else { return .onboarding }
    let hasSeenWelcome = UserDefaults.standard.bool(forKey: "hasSeenWelcome")  // ← 漏了
    guard hasSeenWelcome else { return .welcome }
    let authSkipped = UserDefaults.standard.bool(forKey: AppSettings.Keys.authSkipped)
    if AuthService.shared.session == nil && !authSkipped { return .auth }
    return .ready
}
\`\`\`

有 **三个** gate：\`hasOnboarded → hasSeenWelcome → authSkipped\`。PR #284 只预设了 1 和 3，App 卡在 **WelcomeScreen**，所以 TodayView 的 ID 都不存在。

## 修复

在 \`Preset onboarding / auth flags for Maestro\` step 追加：

\`\`\`yaml
xcrun simctl spawn "$SIMULATOR_UDID" defaults write com.daypage.app hasSeenWelcome -bool YES
\`\`\`

外加 sanity \`defaults read\` 一句。

## 验证

等 CI 跑完 Maestro 4 个 iOS flow 全绿（flow 05 watch 与本 PR 无关）。