### PR TITLE
fix(ci): add DayPageWidget provisioning profile specifier, remove global xcargs

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -1242,6 +1242,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app.DayPageWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app.DayPageWidget";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = EXTENSION;
@@ -1272,6 +1273,7 @@
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app.DayPageWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app.DayPageWidget";
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = EXTENSION;

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -99,7 +99,6 @@ platform :ios do
       clean:            false,
       output_directory: "build",
       output_name:      "DayPage.ipa",
-      xcargs:           "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",
@@ -171,7 +170,6 @@ platform :ios do
       clean:            false,
       output_directory: "build",
       output_name:      "DayPage.ipa",
-      xcargs:           "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",


### PR DESCRIPTION
## Problem (v2)

PR #289 fixed the `CODE_SIGN_STYLE` conflict but the TestFlight build still failed:

```
Provisioning profile "match AppStore com.daypage.app 1777099956" has app ID "com.daypage.app", 
which does not match the bundle ID "com.daypage.app.DayPageWidget".
```

## Root Cause

The `xcargs: "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'"` in Fastfile applies the main app's profile specifier globally to ALL targets. DayPageWidget (now Manual signing) received the wrong profile.

## Fix

1. **pbxproj**: Add `PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app.DayPageWidget"` to DayPageWidget Debug and Release configs
2. **Fastfile**: Remove the global `xcargs` line from both beta and release lanes — each target now has its own specifier baked in

## Verification

- PR #289 validated: Swift tests ✅, Xcode Build ✅
- This PR should fix the remaining profile routing issue in TestFlight