### PR TITLE
fix(ci): install DayPageWidget provisioning profile via second match call

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,6 +90,15 @@ platform :ios do
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
     )
 
+    match(
+      type:              "appstore",
+      readonly:          true,
+      git_url:           ENV["MATCH_GIT_URL"] || "git@github.com:getyak/daypage-certs.git",
+      app_identifier:    "com.daypage.app.DayPageWidget",
+      keychain_name:     "ci_keychain",
+      keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
+    )
+
     profile_name = ENV["sigh_com.daypage.app_appstore_profile-name"] || "match AppStore com.daypage.app"
     build_app(
       scheme:           "DayPage",
@@ -99,6 +108,7 @@ platform :ios do
       clean:            false,
       output_directory: "build",
       output_name:      "DayPage.ipa",
+      xcargs:           "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",
@@ -161,6 +171,15 @@ platform :ios do
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
     )
 
+    match(
+      type:              "appstore",
+      readonly:          true,
+      git_url:           ENV["MATCH_GIT_URL"] || "git@github.com:getyak/daypage-certs.git",
+      app_identifier:    "com.daypage.app.DayPageWidget",
+      keychain_name:     "ci_keychain",
+      keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
+    )
+
     profile_name = ENV["sigh_com.daypage.app_appstore_profile-name"] || "match AppStore com.daypage.app"
     build_app(
       scheme:           "DayPage",
@@ -170,6 +189,7 @@ platform :ios do
       clean:            false,
       output_directory: "build",
       output_name:      "DayPage.ipa",
+      xcargs:           "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",


### PR DESCRIPTION
## Problem (v3)

After v1 and v2 fixes, TestFlight still fails. Root cause analysis from CI logs:

1. **match only installs main app profile** — `Installed Provisioning Profile` shows only `com.daypage.app` 
2. **Widget profile exists but is never installed** — `Detected mapping` shows both profiles exist in certs repo
3. **Without xcargs**, even the main app can't find its profile (pbxproj has basename `"match AppStore com.daypage.app"` but installed profile is `"match AppStore com.daypage.app 1777099956"`)

## Fix

1. **Fastfile**: Add second `match` call for `com.daypage.app.DayPageWidget` in both beta and release lanes
2. **Fastfile**: Restore `xcargs` for main app profile discovery (full name with suffix)
3. **DayPageWidget pbxproj**: Already has `CODE_SIGN_STYLE = Manual` + `PROVISIONING_PROFILE_SPECIFIER` (from v1/v2)

**Theory**: xcargs provides main app specifier at project level → DayPageWidget target-level specifier overrides it → both profiles are installed → archive succeeds.