### PR TITLE
fix(ci): create DayPageWidget provisioning profile (readonly→false)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -92,7 +92,7 @@ platform :ios do
 
     match(
       type:              "appstore",
-      readonly:          true,
+      readonly:          false,
       git_url:           ENV["MATCH_GIT_URL"] || "git@github.com:getyak/daypage-certs.git",
       app_identifier:    "com.daypage.app.DayPageWidget",
       keychain_name:     "ci_keychain",
@@ -173,7 +173,7 @@ platform :ios do
 
     match(
       type:              "appstore",
-      readonly:          true,
+      readonly:          false,
       git_url:           ENV["MATCH_GIT_URL"] || "git@github.com:getyak/daypage-certs.git",
       app_identifier:    "com.daypage.app.DayPageWidget",
       keychain_name:     "ci_keychain",


### PR DESCRIPTION
## Root Cause (confirmed)

readonly

The widget provisioning profile does NOT exist in the certs repo. Previous v3 called match with  so it couldn't create it.

## Fix

Change  →  for the  match call in both beta and release lanes.

This lets match:
1. Create the provisioning profile in Apple Developer portal
2. Download and encrypt it
3. Commit it to  repo

Main app match stays .

## Previous PRs
- #289: DayPageWidget Automatic → Manual signing
- #290: Removed xcargs (reverted, broke profile discovery)
- #291: Added second match call (correct approach but wrong readonly)