### PR TITLE
fix(ci): add api_key to widget match call for profile creation

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -93,6 +93,7 @@ platform :ios do
     match(
       type:              "appstore",
       readonly:          false,
+      api_key:           api_key,
       git_url:           ENV["MATCH_GIT_URL"] || "git@github.com:getyak/daypage-certs.git",
       app_identifier:    "com.daypage.app.DayPageWidget",
       keychain_name:     "ci_keychain",
@@ -174,6 +175,7 @@ platform :ios do
     match(
       type:              "appstore",
       readonly:          false,
+      api_key:           api_key,
       git_url:           ENV["MATCH_GIT_URL"] || "git@github.com:getyak/daypage-certs.git",
       app_identifier:    "com.daypage.app.DayPageWidget",
       keychain_name:     "ci_keychain",


### PR DESCRIPTION
## Problem

v4's match call with readonly:false failed because match needs authentication to create provisioning profiles. In non-interactive CI, Apple ID login is not available.

## Fix

Add  to the widget match call. The  method uses the ASC API key (already configured in CI via APP_STORE_CONNECT_API_KEY_ID/ISSUER_ID/CONTENT env vars).