### PR TITLE
fix(ci): create DayPageWidget App ID via produce before match

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,6 +90,13 @@ platform :ios do
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
     )
 
+    produce(
+      api_key:        api_key,
+      app_identifier: "com.daypage.app.DayPageWidget",
+      app_name:       "DayPageWidget",
+      skip_itc:       true
+    )
+
     match(
       type:              "appstore",
       readonly:          false,
@@ -170,6 +177,13 @@ platform :ios do
       app_identifier:    "com.daypage.app",
       keychain_name:     "ci_keychain",
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
+    )
+
+    produce(
+      api_key:        api_key,
+      app_identifier: "com.daypage.app.DayPageWidget",
+      app_name:       "DayPageWidget",
+      skip_itc:       true
     )
 
     match(


### PR DESCRIPTION
## Problem

v5 match failed: 

The Widget extension's App ID doesn't exist in Apple Developer portal. Match can't create a provisioning profile without the App ID.

## Fix

Add  BEFORE the widget match call in both lanes.

This creates the App ID (no-op if already exists) so match can then create the provisioning profile.