### PR TITLE
revert: remove produce calls (not supported in CI)

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -90,13 +90,6 @@ platform :ios do
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
     )
 
-    produce(
-      api_key:        api_key,
-      app_identifier: "com.daypage.app.DayPageWidget",
-      app_name:       "DayPageWidget",
-      skip_itc:       true
-    )
-
     match(
       type:              "appstore",
       readonly:          false,
@@ -177,13 +170,6 @@ platform :ios do
       app_identifier:    "com.daypage.app",
       keychain_name:     "ci_keychain",
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
-    )
-
-    produce(
-      api_key:        api_key,
-      app_identifier: "com.daypage.app.DayPageWidget",
-      app_name:       "DayPageWidget",
-      skip_itc:       true
     )
 
     match(


### PR DESCRIPTION
Revert v6's produce calls. produce does not support api_key parameter — requires Apple ID username which is not available in CI.

The Widget extension's App ID (com.daypage.app.DayPageWidget) must be created manually in Apple Developer portal.