### PR TITLE
fix(ci): widget signing 用 target-scoped profile

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -100,7 +100,13 @@ platform :ios do
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
     )
 
-    profile_name = ENV["sigh_com.daypage.app_appstore_profile-name"] || "match AppStore com.daypage.app"
+    profile_name        = ENV["sigh_com.daypage.app_appstore_profile-name"] || "match AppStore com.daypage.app"
+    widget_profile_name = "match AppStore com.daypage.app.DayPageWidget"
+    # Per-target xcargs so the widget extension uses its own profile rather
+    # than inheriting the main app's. A bare `PROVISIONING_PROFILE_SPECIFIER`
+    # applies to every target and breaks the widget signing
+    # ("Provisioning profile ... has app ID 'com.daypage.app', which does
+    # not match the bundle ID 'com.daypage.app.DayPageWidget'").
     build_app(
       scheme:           "DayPage",
       project:          "DayPage.xcodeproj",
@@ -109,14 +115,17 @@ platform :ios do
       clean:            false,
       output_directory: "build",
       output_name:      "DayPage.ipa",
-      xcargs:           "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
+      xcargs:           [
+        "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPage]='#{profile_name}'",
+        "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPageWidget]='#{widget_profile_name}'"
+      ].join(" "),
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",
         teamID:               ENV["DEVELOPMENT_TEAM"],
         provisioningProfiles: {
           "com.daypage.app"              => profile_name,
-          "com.daypage.app.DayPageWidget" => "match AppStore com.daypage.app.DayPageWidget"
+          "com.daypage.app.DayPageWidget" => widget_profile_name
         }
       }
     )
@@ -182,7 +191,13 @@ platform :ios do
       keychain_password: ENV["MATCH_KEYCHAIN_PASSWORD"] || "ci_temp_password"
     )
 
-    profile_name = ENV["sigh_com.daypage.app_appstore_profile-name"] || "match AppStore com.daypage.app"
+    profile_name        = ENV["sigh_com.daypage.app_appstore_profile-name"] || "match AppStore com.daypage.app"
+    widget_profile_name = "match AppStore com.daypage.app.DayPageWidget"
+    # Per-target xcargs so the widget extension uses its own profile rather
+    # than inheriting the main app's. A bare `PROVISIONING_PROFILE_SPECIFIER`
+    # applies to every target and breaks the widget signing
+    # ("Provisioning profile ... has app ID 'com.daypage.app', which does
+    # not match the bundle ID 'com.daypage.app.DayPageWidget'").
     build_app(
       scheme:           "DayPage",
       project:          "DayPage.xcodeproj",
@@ -191,14 +206,17 @@ platform :ios do
       clean:            false,
       output_directory: "build",
       output_name:      "DayPage.ipa",
-      xcargs:           "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'",
+      xcargs:           [
+        "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPage]='#{profile_name}'",
+        "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPageWidget]='#{widget_profile_name}'"
+      ].join(" "),
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",
         teamID:               ENV["DEVELOPMENT_TEAM"],
         provisioningProfiles: {
           "com.daypage.app"              => profile_name,
-          "com.daypage.app.DayPageWidget" => "match AppStore com.daypage.app.DayPageWidget"
+          "com.daypage.app.DayPageWidget" => widget_profile_name
         }
       }
     )


### PR DESCRIPTION
Refs #296

## 上下文

PR #296 报告的 App ID 缺失问题，你已在 Apple Developer Portal 注册 \`com.daypage.app.DayPageWidget\`（Team: Xiong Xinwei - 6RG2F8YY59），match readonly 现在能下载到 widget profile。

但第一次试跑（[run 26076830337](https://github.com/getyak/daypage/actions/runs/26076830337)）仍 fail，进展到新错：

\`\`\`
Provisioning profile "match AppStore com.daypage.app 1777099956"
has app ID "com.daypage.app", which does not match the bundle ID
"com.daypage.app.DayPageWidget"
\`\`\`

## 根因

\`fastlane/Fastfile\` 的 \`build_app\` 用了 **bare** \`PROVISIONING_PROFILE_SPECIFIER\` xcarg：

\`\`\`ruby
xcargs: "PROVISIONING_PROFILE_SPECIFIER='#{profile_name}'"
\`\`\`

这是 **全局** xcodebuild 设置，对 archive 里所有 target 生效，包括 widget。所以 widget 被强制套上主 App 的 profile，bundle id 对不上。

\`export_options.provisioningProfiles\` 本来分 target，但只在 export 阶段读，不影响 build/archive。

## 修法

改成 target-scoped 形式（Apple Build Setting Conditional）：

\`\`\`ruby
xcargs: [
  "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPage]='#{profile_name}'",
  "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPageWidget]='#{widget_profile_name}'"
].join(" ")
\`\`\`

\`beta\` + \`release\` 两个 lane 同时改。

## 预期

build_app 用各自 target 的 profile → archive 通过 → upload_to_testflight 成功。

## Test plan

- [ ] PR merge 后手动触发 \`Deploy to TestFlight\` workflow，run 全绿
- [ ] TestFlight 出现新 build
- [ ] Issue #296 自动关闭