### PR TITLE
fix(ci): 去掉 xcargs PROVISIONING_PROFILE_SPECIFIER — pbxproj 已写各 target

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -102,11 +102,17 @@ platform :ios do
 
     profile_name        = ENV["sigh_com.daypage.app_appstore_profile-name"] || "match AppStore com.daypage.app"
     widget_profile_name = "match AppStore com.daypage.app.DayPageWidget"
-    # Per-target xcargs so the widget extension uses its own profile rather
-    # than inheriting the main app's. A bare `PROVISIONING_PROFILE_SPECIFIER`
-    # applies to every target and breaks the widget signing
-    # ("Provisioning profile ... has app ID 'com.daypage.app', which does
-    # not match the bundle ID 'com.daypage.app.DayPageWidget'").
+    # Do NOT pass a bare `PROVISIONING_PROFILE_SPECIFIER` via xcargs — it
+    # applies globally and forces the widget target to use the main app's
+    # profile (mismatched bundle id, fails). The project.pbxproj already has
+    # `PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app.DayPageWidget"`
+    # on the DayPageWidget target's Release config, so per-target signing is
+    # already correct. We only need export_options.provisioningProfiles to
+    # tell -exportArchive which profile to embed for each bundle id.
+    #
+    # Conditional xcargs syntax `PROVISIONING_PROFILE_SPECIFIER[target=...]=...`
+    # is an .xcconfig-only form; xcodebuild on the command line interprets the
+    # whole `[target=...]=value` as the *value*, so we can't use it that way.
     build_app(
       scheme:           "DayPage",
       project:          "DayPage.xcodeproj",
@@ -115,10 +121,6 @@ platform :ios do
       clean:            false,
       output_directory: "build",
       output_name:      "DayPage.ipa",
-      xcargs:           [
-        "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPage]='#{profile_name}'",
-        "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPageWidget]='#{widget_profile_name}'"
-      ].join(" "),
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",
@@ -193,11 +195,17 @@ platform :ios do
 
     profile_name        = ENV["sigh_com.daypage.app_appstore_profile-name"] || "match AppStore com.daypage.app"
     widget_profile_name = "match AppStore com.daypage.app.DayPageWidget"
-    # Per-target xcargs so the widget extension uses its own profile rather
-    # than inheriting the main app's. A bare `PROVISIONING_PROFILE_SPECIFIER`
-    # applies to every target and breaks the widget signing
-    # ("Provisioning profile ... has app ID 'com.daypage.app', which does
-    # not match the bundle ID 'com.daypage.app.DayPageWidget'").
+    # Do NOT pass a bare `PROVISIONING_PROFILE_SPECIFIER` via xcargs — it
+    # applies globally and forces the widget target to use the main app's
+    # profile (mismatched bundle id, fails). The project.pbxproj already has
+    # `PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app.DayPageWidget"`
+    # on the DayPageWidget target's Release config, so per-target signing is
+    # already correct. We only need export_options.provisioningProfiles to
+    # tell -exportArchive which profile to embed for each bundle id.
+    #
+    # Conditional xcargs syntax `PROVISIONING_PROFILE_SPECIFIER[target=...]=...`
+    # is an .xcconfig-only form; xcodebuild on the command line interprets the
+    # whole `[target=...]=value` as the *value*, so we can't use it that way.
     build_app(
       scheme:           "DayPage",
       project:          "DayPage.xcodeproj",
@@ -206,10 +214,6 @@ platform :ios do
       clean:            false,
       output_directory: "build",
       output_name:      "DayPage.ipa",
-      xcargs:           [
-        "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPage]='#{profile_name}'",
-        "PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPageWidget]='#{widget_profile_name}'"
-      ].join(" "),
       export_options:   {
         method:               "app-store",
         signingStyle:         "manual",


### PR DESCRIPTION
Refs #296

## 上一轮（PR #297）的问题

我改成 target-scoped 形式：

\`\`\`ruby
xcargs: [
  \"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPage]='...'\",
  \"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*][target=DayPageWidget]='...'\"
].join(\" \")
\`\`\`

[Run 26077852447](https://github.com/getyak/daypage/actions/runs/26077852447) 报错：

\`\`\`
No profile for team '***' matching
'iphoneos*][target=DayPageWidget]=match AppStore com.daypage.app.DayPageWidget' found
\`\`\`

xcodebuild 把 \`[target=...]=value\` 当成 profile 名了。

## 真正的根因

\`PROVISIONING_PROFILE_SPECIFIER[sdk=...][target=...]=...\` 这种 conditional 语法**只在 .xcconfig 文件里有效**，xcodebuild 命令行不解析方括号过滤器。命令行上只能传 bare \`KEY=value\`，但 bare 形式会把值套到所有 target —— 这就是最早的 widget signing fail。

## 正确修法

**根本不用 xcargs**。\`project.pbxproj\` 里两个 target 的 Release config 已经分别写好：

\`\`\`
DayPage:         PROVISIONING_PROFILE_SPECIFIER = \"match AppStore com.daypage.app\"
DayPageWidget:   PROVISIONING_PROFILE_SPECIFIER = \"match AppStore com.daypage.app.DayPageWidget\"
\`\`\`

\`export_options.provisioningProfiles\` 已经在 export 阶段分 target 写好。两条都对，删 xcargs 是最干净的修法。

## Test plan

- [ ] PR merge 触发 main TestFlight workflow
- [ ] Build 阶段 widget 用自己的 profile，不冲突
- [ ] TestFlight 出现新 build
- [ ] Issue #296 关闭