### PR TITLE
fix(ci): unbreak main — Memo entityMentions unwrap + pbxproj wiring

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -137,6 +137,7 @@
 		ES0000002 /* GlassErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000002 /* GlassErrorBanner.swift */; };
 		ES0000003 /* GlassTabBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000003 /* GlassTabBar.swift */; };
 		F617270BFC704FF5BBB99FD3 /* AppSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 068FB068A000B6E61B1D8032 /* AppSettings.swift */; };
+		F66780AF157611A4283937FE /* MemoListSkeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0995108F7E2E8994F114A240 /* MemoListSkeleton.swift */; };
 		F69AA7BDCB1C041959C26EB4 /* ShareCardSystem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 986C8E3E042E690BA4CCC12D /* ShareCardSystem.swift */; };
 		F9DD1FD8D9003975FAD95E17 /* DailyPageSummarySection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4EBD94EB4FD71CC10D478F3 /* DailyPageSummarySection.swift */; };
 		FB0000001 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000001 /* FeedbackService.swift */; };
@@ -204,6 +205,7 @@
 		068FB068A000B6E61B1D8032 /* AppSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		0881AB423FF6F12FCDE27C5B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		08FF205E680406EC7E4B83DB /* DailyPageModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyPageModel.swift; sourceTree = "<group>"; };
+		0995108F7E2E8994F114A240 /* MemoListSkeleton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemoListSkeleton.swift; sourceTree = "<group>"; };
 		0CF7E0148C3A6933A903247D /* DailyPageMetadataEditView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyPageMetadataEditView.swift; sourceTree = "<group>"; };
 		12641793A8F375B34321E87A /* UndoPillView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoPillView.swift; sourceTree = "<group>"; };
 		23EA9C83B41565EDB263FB35 /* DayPageWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPageWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -815,6 +817,7 @@
 				ES1000001 /* EmptyStateView.swift */,
 				ES1000002 /* GlassErrorBanner.swift */,
 				ES1000003 /* GlassTabBar.swift */,
+				0995108F7E2E8994F114A240 /* MemoListSkeleton.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1180,6 +1183,7 @@
 				1530E7C28C23499CFC14C498 /* HapticFeedback.swift in Sources */,
 				F69AA7BDCB1C041959C26EB4 /* ShareCardSystem.swift in Sources */,
 				C80B52CC8945CDC4EE87DCBB /* PosterTemplates.swift in Sources */,
+				F66780AF157611A4283937FE /* MemoListSkeleton.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage/Models/Memo.swift
+++ b/DayPage/Models/Memo.swift
@@ -205,7 +205,10 @@ extension Memo {
         let weather = fm.scalar("weather")
         let device = fm.scalar("device")
         let mood = fm.scalar("mood")
-        let entityMentions = fm.sequence("entity_mentions")
+        // YAMLParser.sequence(_:) returns Optional<[String]>; the Memo init
+        // takes a non-optional [String], so default to an empty array when the
+        // key is missing or explicitly `entity_mentions: []`.
+        let entityMentions = fm.sequence("entity_mentions") ?? []
 
         var attachments: [Attachment] = []
         if let attList = fm.sequenceOfMappings("attachments") {


### PR DESCRIPTION
## Summary

`main` is currently red. Every push since `ee92fc4` (the PR #305 squash-merge) fails the `Xcode Build (no signing)` job. This PR makes `main` green again with two surgical fixes — no functional change beyond unblocking the build.

## Root cause

PR #305 ("Ralph 自主开发 22/25") was squash-merged in a state that does **not** match the latest commits pushed to `ralph/v7-deep-audit`. Two regressions slipped through:

### 1. `Memo.swift:231` — `[String]?` not unwrapped

```swift
let entityMentions = fm.sequence("entity_mentions")  // returns [String]?
// ...
return Memo(
    ...
    entityMentions: entityMentions,  // ← Memo.init takes non-optional [String]
    ...
)
```

CI error:
```
Memo.swift:231:29: error: value of optional type '[String]?' must be unwrapped to a value of type '[String]'
```

The version of `YAMLParser.sequence(_:)` that landed on `main` returns `Optional<[String]>`, but the call site treats the result as `[String]`. Two incompatible resolutions of the same Claude-review item ([2]) got mixed during the squash.

**Fix**: default at the call site with `?? []`. Semantically equivalent (missing key or `entity_mentions: []` both mean "no mentions"), and keeps the parser's signature aligned with the existing `sequenceOfMappings(_:) -> [[String: String]]?` convention.

### 2. `project.pbxproj` missing `MemoListSkeleton.swift`

```
TodayView.swift:237:33: error: cannot find 'MemoListSkeleton' in scope
```

The squash brought `DayPage/Components/MemoListSkeleton.swift` to disk (referenced by `TodayView` at line 237) but **did not include the pbxproj edit** that registers it in the DayPage target. Clean CI builds therefore fail with "cannot find in scope".

This is the same v6-pattern that `scripts/add_v6_missing_files.rb` was created to catch. Re-wired via the `xcodeproj` gem.

### 3. `TodayView.swift:67` — "expression too complex"

This is a downstream symptom: when `MemoListSkeleton` is undefined inside `body`, Swift's type-checker gives up on the whole tree. Fix (2) makes it disappear automatically.

## Verification

- Local clean build:
  ```
  xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' clean build
  → ** BUILD SUCCEEDED **
  ```
- Net change: **+8 / -1** — one call-site unwrap + pbxproj entries for one source file.
- Zero functional behaviour change: `entity_mentions: []` and "no `entity_mentions` key at all" both produced `nil` before and now both produce `[]` (treated identically by `Memo.init`).

## Test plan

- [ ] CI `Xcode Build (no signing)` passes on this PR
- [ ] Open a memo that has `entity_mentions:` → still parses correctly
- [ ] Open a memo without `entity_mentions:` → no crash, no warnings in console
- [ ] Today view shows `MemoListSkeleton` during initial load (no scope error)
