### PR TITLE
fix(today): voice memo cards no longer block vertical scroll

### DIFF
--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -562,14 +562,16 @@ struct VoiceMemoPlayerRow: View {
                 .buttonStyle(.plain)
                 .disabled(fileError)
 
-                ZStack(alignment: .leading) {
-                    waveformBars(count: 40, color: DSColor.inkFaint)
-                    waveformBars(count: 40, color: DSColor.amberAccent)
-                        .mask(alignment: .leading) {
-                            Rectangle()
-                                .scaleEffect(x: CGFloat(playbackProgress), y: 1, anchor: .leading)
-                        }
-                }
+                // Waveform is split into a static base layer + a progress-driven
+                // mask layer. The base layer never re-renders during playback;
+                // only the Rectangle inside the mask updates its scaleEffect
+                // every 100 ms. Without this split, both 40-bar ForEach layers
+                // were diffed on every progressTimer tick, dominating scroll
+                // jank on tall voice memo cards.
+                WaveformView(
+                    heights: waveformHeights,
+                    progress: playbackProgress
+                )
                 .frame(height: 24)
                 .allowsHitTesting(false)
 
@@ -650,14 +652,6 @@ struct VoiceMemoPlayerRow: View {
         return (0..<40).map { i in CGFloat(3 + ((seed >> i) & 0x1F) % 20) }
     }
 
-    private func waveformBars(count: Int, color: Color) -> some View {
-        HStack(spacing: 2) {
-            ForEach(Array(waveformHeights.prefix(count).enumerated()), id: \.offset) { _, h in
-                RoundedRectangle(cornerRadius: 1).fill(color).frame(width: 2.5, height: h)
-            }
-        }
-    }
-
     private func togglePlayback() {
         isPlaying ? stopPlayback() : startPlayback()
     }
@@ -675,7 +669,16 @@ struct VoiceMemoPlayerRow: View {
             progressTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [self] _ in
                 Task { @MainActor in
                     guard let p = player, p.isPlaying else { stopPlayback(); return }
-                    playbackProgress = p.currentTime / p.duration
+                    // Disable implicit animation: if a parent withAnimation()
+                    // block is still in flight when this assignment runs (e.g.
+                    // a swipe spring), SwiftUI would otherwise interpolate
+                    // playbackProgress across multiple frames per tick and
+                    // schedule extra layout passes during the swipe.
+                    var tx = Transaction()
+                    tx.disablesAnimations = true
+                    withTransaction(tx) {
+                        playbackProgress = p.currentTime / p.duration
+                    }
                 }
             }
         } catch { fileError = true }
@@ -690,6 +693,66 @@ struct VoiceMemoPlayerRow: View {
     private func formatDur(_ secs: TimeInterval) -> String {
         let t = Int(secs)
         return String(format: "%02d:%02d", t / 60, t % 60)
+    }
+}
+
+// MARK: - WaveformView
+//
+// Extracted from VoiceMemoPlayerRow so that the 40-bar base layer is built
+// once per cell (Equatable diff on `heights`) and only the progress mask
+// re-renders on the 100 ms playback timer. The .transaction modifier strips
+// any implicit animation propagated from the parent (cell mount, list
+// shuffle, layout pass), keeping the mask scale change instantaneous and
+// preventing SwiftUI from interpolating progress between ticks — which used
+// to interleave dozens of intermediate render passes with scroll gestures.
+private struct WaveformView: View, Equatable {
+
+    let heights: [CGFloat]
+    let progress: Double
+
+    // Equatable: only re-diff when progress or the underlying heights change.
+    // heights is a value-typed [CGFloat], so == is structural; cheap because
+    // we have 40 elements.
+    static func == (lhs: WaveformView, rhs: WaveformView) -> Bool {
+        lhs.heights == rhs.heights && lhs.progress == rhs.progress
+    }
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            WaveformBars(heights: heights, color: DSColor.inkFaint)
+                .equatable()
+            WaveformBars(heights: heights, color: DSColor.amberAccent)
+                .equatable()
+                .mask(alignment: .leading) {
+                    GeometryReader { geo in
+                        Rectangle()
+                            .frame(width: max(0, geo.size.width * CGFloat(progress)))
+                    }
+                }
+                .transaction { $0.animation = nil }
+        }
+    }
+}
+
+// Base bar layer — Equatable so SwiftUI skips the ForEach diff when the
+// heights array is unchanged (always, for a given fileURL).
+private struct WaveformBars: View, Equatable {
+
+    let heights: [CGFloat]
+    let color: Color
+
+    static func == (lhs: WaveformBars, rhs: WaveformBars) -> Bool {
+        lhs.color == rhs.color && lhs.heights == rhs.heights
+    }
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(Array(heights.enumerated()), id: \.offset) { _, h in
+                RoundedRectangle(cornerRadius: 1)
+                    .fill(color)
+                    .frame(width: 2.5, height: h)
+            }
+        }
     }
 }
 

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -72,13 +72,26 @@ struct SwipeableMemoCard: View {
             .buttonStyle(.plain)
             .disabled(revealedSide != nil)
             .offset(x: currentOffset)
-            .drawingGroup(opaque: false, colorMode: .extendedLinear)
-            .highPriorityGesture(swipeGesture)
+            // simultaneousGesture (not highPriorityGesture): the parent
+            // ScrollView must keep ownership of vertical drags. highPriority
+            // locks gesture ownership on first touch — even with a direction
+            // guard in .updating, ScrollView never gets a chance to claim a
+            // vertical swipe, so the timeline freezes on tall voice memo
+            // cards. simultaneous lets both recognizers see the touch; the
+            // .updating closure below filters to horizontal-dominant deltas.
+            //
+            // drawingGroup removed: it forced Metal offscreen rasterization
+            // on every Timer-driven waveform progress tick (0.1 s) while a
+            // voice memo was playing — compounding scroll jank instead of
+            // improving it.
+            .simultaneousGesture(swipeGesture)
 
             // Invisible tap/drag-to-close overlay: only active when a panel is open.
             // Lives above the card so it intercepts both taps and drags
             // independently of `.disabled` on the NavigationLink (which would
             // otherwise swallow gestures attached to the disabled subtree).
+            // When a panel is already revealed, horizontal interaction is the
+            // expected mode, so highPriority is appropriate here.
             if revealedSide != nil {
                 Color.clear
                     .contentShape(Rectangle())
@@ -134,18 +147,34 @@ struct SwipeableMemoCard: View {
 
     // MARK: - Gesture
 
+    // Direction filter constants.
+    //
+    // minimumDistance 12: large enough that brief taps and the start of a
+    // vertical scroll don't register as a horizontal swipe attempt. 8 was
+    // too eager — paired with simultaneousGesture below, ScrollView still
+    // wins vertical gestures, but a higher threshold keeps casual touches
+    // from briefly tugging the card.
+    //
+    // horizontalDominance 1.5: |dx| must be 1.5× |dy| before we treat the
+    // touch as a horizontal swipe. The previous 0.85 ratio meant a 45° drag
+    // would still pull the card sideways, fighting vertical scrolling. 1.5
+    // corresponds to roughly 56° from vertical — gestures shallower than
+    // that are forwarded to ScrollView.
+    private static let swipeMinDistance: CGFloat = 12
+    private static let horizontalDominance: CGFloat = 1.5
+
     private var swipeGesture: some Gesture {
-        DragGesture(minimumDistance: 8, coordinateSpace: .local)
+        DragGesture(minimumDistance: Self.swipeMinDistance, coordinateSpace: .local)
             .updating($dragDelta) { value, state, _ in
                 let dx = value.translation.width
                 let dy = value.translation.height
-                guard abs(dx) > abs(dy) * 0.85 else { return }
+                guard abs(dx) > abs(dy) * Self.horizontalDominance else { return }
                 state = dx
             }
             .onEnded { value in
                 let dx = value.translation.width
                 let dy = value.translation.height
-                guard abs(dx) > abs(dy) * 0.85 else { return }
+                guard abs(dx) > abs(dy) * Self.horizontalDominance else { return }
                 let vel = value.predictedEndTranslation.width - value.translation.width
                 decideSnap(dx: dx, velocity: vel)
             }


### PR DESCRIPTION
## Summary

Fixes a critical interaction bug: after recording + transcribing a voice memo, the Today timeline became unscrollable wherever a voice card was under the finger. Only horizontal drags responded; vertical scroll was dead on tall (≈150-200pt) voice cells with transcripts.

Reported verbatim by the user: *"上传语音之后，转录为文字… 滑动这个屏幕已经滑动不了了… 只能左右滑动，不能上下滑动。滑动卡片的时候动画效果也非常有问题。"*

## Root causes (4, all overlapping)

| # | File | Issue |
|---|------|-------|
| 1 | `SwipeableMemoCard.swift:76` | `.highPriorityGesture` locked gesture ownership on first touch — ScrollView never got a chance to claim vertical drags, even with a direction guard. |
| 2 | `SwipeableMemoCard.swift:142,148` | Horizontal-dominance ratio `0.85` (≈40° from vertical) treated near-vertical drags as swipes. |
| 3 | `SwipeableMemoCard.swift:75` | `.drawingGroup` forced Metal offscreen rasterization on every 100 ms playback-timer tick — entire card re-rasterized 10×/sec while audio played. |
| 4 | `MemoCardView.swift:544-549` | Waveform was two 40-bar `ForEach` layers inline in `body`, re-diffed every 100 ms by `playbackProgress` updates. |

## Fixes

**`SwipeableMemoCard.swift`**
- `.highPriorityGesture` → `.simultaneousGesture` (key fix — ScrollView now wins vertical drags)
- Direction ratio `0.85` → `1.5` (≈56° threshold), `minimumDistance` `8` → `12`
- Removed `.drawingGroup`

**`MemoCardView.swift`**
- Extracted `WaveformView` + `WaveformBars` as `Equatable` subviews — static bars diff once, only the mask layer updates per tick
- Swapped `Rectangle().scaleEffect` for a `GeometryReader`-sized `Rectangle().frame(width:)` (cheaper than transform matrix recalc)
- Wrapped the mask layer in `.transaction { \$0.animation = nil }`
- `playbackProgress` assignment wrapped in `withTransaction(tx.disablesAnimations=true)` to prevent cross-animation interpolation during swipe springs

## Net diff
+114 / -22 across 2 files. Zero public-API changes. No data-model touches.

## Test plan
- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → BUILD SUCCEEDED
- [ ] Manual: record a voice memo → wait for transcription → vertical scroll over the voice cell (should be smooth)
- [ ] Manual: horizontal swipe on voice cell → Pin/Delete panel still reveals
- [ ] Manual: play audio while scrolling → no jank
- [ ] Manual: diagonal-but-mostly-vertical drag forwards to ScrollView (no false swipe)

🤖 Generated with [Claude Code](https://claude.com/claude-code)