### PR TITLE
fix(today): swipe / scroll on memo card no longer mis-routes into detail

### DIFF
--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -25,8 +25,30 @@ struct SwipeableMemoCard: View {
     // Settled resting offset: -panelW = trailing open, 0 = closed, +panelW = leading open
     @State private var settledOffset: CGFloat = 0
 
-    // Live drag translation applied on top of settledOffset
-    @GestureState private var dragDelta: CGFloat = 0
+    // Combined gesture state.
+    //
+    // `delta` is the live horizontal translation that rides on top of
+    // settledOffset (the visible card offset).
+    //
+    // `moved` is true once the finger has moved past touchSlop in any
+    // direction. It disables the NavigationLink mid-touch so that finger-up
+    // after a near-vertical drag, a sub-threshold horizontal swipe, or a
+    // pure ScrollView pan no longer mis-routes into the memo detail page.
+    //
+    // Both live in a single GestureState tuple so they are guaranteed to
+    // update from the same .updating callback and reset together when the
+    // gesture ends (GestureState reset is automatic — no race with view
+    // rebuilds).
+    //
+    // Why we need `moved`: the swipe DragGesture sits on the same view tree
+    // as NavigationLink via .simultaneousGesture. SwiftUI's internal tap
+    // recognizer inside NavigationLink does not respect our horizontal-
+    // dominance guard — to it, any press-and-release is a tap. We have to
+    // disable the link before it sees the up event.
+    @GestureState private var drag: (delta: CGFloat, moved: Bool) = (0, false)
+
+    private var dragDelta: CGFloat { drag.delta }
+    private var isDraggingTouch: Bool { drag.moved }
 
     private enum Side { case leading, trailing }
 
@@ -70,7 +92,14 @@ struct SwipeableMemoCard: View {
                 MemoCardView(memo: memo, onDelete: onDelete)
             }
             .buttonStyle(.plain)
-            .disabled(revealedSide != nil)
+            // Disable the NavigationLink while a touch is being dragged or a
+            // side panel is open. Disabling the link makes its internal tap
+            // recognizer inert, so finger-up after a near-vertical scroll or
+            // a sub-threshold horizontal swipe no longer mis-routes into the
+            // memo detail page. Without this guard, simultaneousGesture lets
+            // both the swipe and the NavigationLink tap fire from the same
+            // touch sequence.
+            .disabled(revealedSide != nil || isDraggingTouch)
             .offset(x: currentOffset)
             // simultaneousGesture (not highPriorityGesture): the parent
             // ScrollView must keep ownership of vertical drags. highPriority
@@ -147,34 +176,50 @@ struct SwipeableMemoCard: View {
 
     // MARK: - Gesture
 
-    // Direction filter constants.
+    // Direction & activation thresholds.
     //
-    // minimumDistance 12: large enough that brief taps and the start of a
-    // vertical scroll don't register as a horizontal swipe attempt. 8 was
-    // too eager — paired with simultaneousGesture below, ScrollView still
-    // wins vertical gestures, but a higher threshold keeps casual touches
-    // from briefly tugging the card.
+    // touchSlop 4: once a finger has moved at least 4 pt in any direction,
+    // we treat the interaction as a drag, not a tap. This is what disables
+    // the NavigationLink mid-touch so finger-up doesn't mis-route. 4 pt
+    // matches UIKit's UIScrollView pan slop and is below the iOS tap
+    // tolerance (~10 pt for system tap recognizers), so legitimate taps —
+    // which barely move — still register.
+    //
+    // swipeMinDistance 12: |dx| must reach this before we actually start
+    // translating the card. Lower values made the card visibly tug during
+    // brief touches.
     //
     // horizontalDominance 1.5: |dx| must be 1.5× |dy| before we treat the
-    // touch as a horizontal swipe. The previous 0.85 ratio meant a 45° drag
-    // would still pull the card sideways, fighting vertical scrolling. 1.5
-    // corresponds to roughly 56° from vertical — gestures shallower than
-    // that are forwarded to ScrollView.
+    // touch as a horizontal swipe (≈56° from vertical). Shallower drags
+    // are forwarded to the parent ScrollView (see simultaneousGesture).
+    private static let touchSlop: CGFloat = 4
     private static let swipeMinDistance: CGFloat = 12
     private static let horizontalDominance: CGFloat = 1.5
 
     private var swipeGesture: some Gesture {
-        DragGesture(minimumDistance: Self.swipeMinDistance, coordinateSpace: .local)
-            .updating($dragDelta) { value, state, _ in
+        // minimumDistance 0 so .updating fires from the very first move
+        // event — we need the chance to flip `moved` to true before
+        // NavigationLink's internal tap recognizer can fire on touch-up.
+        // The touchSlop guard inside the closure filters out finger-press-
+        // without-movement so genuine taps still register.
+        DragGesture(minimumDistance: 0, coordinateSpace: .local)
+            .updating($drag) { value, state, _ in
                 let dx = value.translation.width
                 let dy = value.translation.height
-                guard abs(dx) > abs(dy) * Self.horizontalDominance else { return }
-                state = dx
+                let exceededSlop = abs(dx) > Self.touchSlop || abs(dy) > Self.touchSlop
+                let isHorizontalSwipe =
+                    abs(dx) > Self.swipeMinDistance &&
+                    abs(dx) > abs(dy) * Self.horizontalDominance
+                state = (
+                    delta: isHorizontalSwipe ? dx : 0,
+                    moved: exceededSlop
+                )
             }
             .onEnded { value in
                 let dx = value.translation.width
                 let dy = value.translation.height
-                guard abs(dx) > abs(dy) * Self.horizontalDominance else { return }
+                guard abs(dx) > Self.swipeMinDistance,
+                      abs(dx) > abs(dy) * Self.horizontalDominance else { return }
                 let vel = value.predictedEndTranslation.width - value.translation.width
                 decideSnap(dx: dx, velocity: vel)
             }


### PR DESCRIPTION
## Summary

Regression from #308. Switching \`.highPriorityGesture\` → \`.simultaneousGesture\` unblocked vertical ScrollView scrolling on tall voice cards, but it also let \`NavigationLink\`'s internal tap recognizer fire on the same touch sequence. Any finger-up after a vertical drag, a sub-threshold horizontal nudge, or even a near-vertical scroll attempt would push the memo detail view.

User report: *"现在还是更有问题了，因为现在它不管左滑和右滑，或者是上下滑和下滑，我明明没有点击这个卡片，但是还是很容易去点进去。"*

## Root cause

- \`simultaneousGesture\` lets both gestures see every event.
- DragGesture's direction guard only filters \`dragDelta\` — it doesn't tell NavigationLink anything.
- NavigationLink uses an **internal** tap recognizer (not \`.onTapGesture\`); \`.simultaneousGesture(TapGesture())\` can't intercept it.
- Every press-and-release on the card therefore became a tap, regardless of the drag in between.

## Fix

Drop DragGesture \`minimumDistance\` from 12 → 0 so \`.updating\` fires from the very first move event. Track a \`moved\` flag in a single \`GestureState\` tuple alongside \`delta\`. \`moved\` flips true once the finger has traveled past a 4 pt touchSlop in any direction — at which point the inner NavigationLink gets \`.disabled(true)\`, making its internal tap recognizer inert. \`GestureState\` (not \`@State\`) means reset is automatic when the gesture ends.

## Behavior matrix

| Touch pattern | Before this PR | After |
|---|---|---|
| Pure tap (no movement) | ✅ navigates to detail | ✅ navigates to detail |
| Vertical scroll over card | ❌ pushes detail | ✅ scrolls only |
| Sub-threshold horizontal nudge | ❌ pushes detail | ✅ no-op |
| Near-vertical diagonal drag | ❌ pushes detail | ✅ scrolls only |
| Clear horizontal swipe (>12 pt, dominant) | ✅ reveals panel | ✅ reveals panel |

## Net diff
+63 / -18 in a single file. Zero public-API changes.

## Test plan
- [x] \`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build\` → BUILD SUCCEEDED
- [ ] Manual: vertical scroll over voice card → only scrolls (no nav push)
- [ ] Manual: horizontal swipe → still reveals Pin / Delete panels
- [ ] Manual: pure tap → still navigates to detail
- [ ] Manual: diagonal drag → routes to ScrollView (no nav push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)