### PR TITLE
feat(share): tappable share button on raw memo cards + smart payload dispatch

### DIFF
--- a/DayPage/Features/Shared/ShareCard/PosterTemplates.swift
+++ b/DayPage/Features/Shared/ShareCard/PosterTemplates.swift
@@ -705,21 +705,51 @@ enum PolaroidMemoTemplate: PosterTemplate {
             fillRoundedRect(frameRect, radius: 8, color: PolaroidPalette.frame, in: cg)
             cg.restoreGState()
 
-            // Photo
+            // Photo (or text-only fallback when memo has no photo attachment)
             let photoRect = CGRect(x: photoX, y: photoTop, width: photoW, height: photoH)
             if let cover = s.coverImage {
                 drawAspectFill(cover, in: photoRect, ctx: cg)
             } else {
-                PolaroidPalette.placeholderBg.setFill()
+                // Issue #309 W1-③: instead of a grey placeholder with just an
+                // initial letter, give text-only memos a real visual hook —
+                // soft accent wash + giant first letter (kept as anchor) +
+                // an emphasised first sentence so the card carries content,
+                // not emptiness. Polaroid still reads as "frame + caption"
+                // below, this just makes the "photo" area meaningful.
+                let wash = PolaroidPalette.accent.withAlphaComponent(0.08)
+                wash.setFill()
                 cg.fill(photoRect)
-                let initial = s.body.first.map { String($0) } ?? "·"
+
+                let trimmed = s.body.trimmingCharacters(in: .whitespacesAndNewlines)
+                let initial = trimmed.first.map { String($0) } ?? "·"
                 let initAttr = NSAttributedString(string: initial, attributes: [
-                    .font: UIFont.editorialTitle(size: 320),
-                    .foregroundColor: PolaroidPalette.ink.withAlphaComponent(0.20)
+                    .font: UIFont.editorialTitle(size: 360),
+                    .foregroundColor: PolaroidPalette.accent.withAlphaComponent(0.22)
                 ])
                 let isz = initAttr.size()
                 initAttr.draw(at: CGPoint(x: photoRect.midX - isz.width / 2,
-                                           y: photoRect.midY - isz.height / 2))
+                                           y: photoRect.midY - isz.height / 2 - 40))
+
+                // First sentence, centred under the initial. Truncated to fit
+                // one line so we never blow out the square photo region.
+                let firstSentence = trimmed
+                    .components(separatedBy: CharacterSet(charactersIn: "。.!?！？\n"))
+                    .first(where: { !$0.trimmingCharacters(in: .whitespaces).isEmpty }) ?? ""
+                let quoteText = truncate(firstSentence.trimmingCharacters(in: .whitespaces), to: 28)
+                if !quoteText.isEmpty {
+                    let quotePara = NSMutableParagraphStyle()
+                    quotePara.alignment = .center
+                    let quoteAttr = NSAttributedString(string: "\u{201C}\(quoteText)\u{201D}", attributes: [
+                        .font: UIFont.systemFont(ofSize: 38, weight: .medium),
+                        .foregroundColor: PolaroidPalette.ink.withAlphaComponent(0.62),
+                        .paragraphStyle: quotePara
+                    ])
+                    let qrect = CGRect(x: photoRect.minX + 24,
+                                       y: photoRect.maxY - 120,
+                                       width: photoRect.width - 48,
+                                       height: 80)
+                    quoteAttr.draw(with: qrect, options: [.usesLineFragmentOrigin], context: nil)
+                }
             }
 
             var y = photoRect.maxY + 56
@@ -941,6 +971,16 @@ enum PolaroidDailyTemplate: PosterTemplate {
                 ])
             let esz = statsAttr.size()
             statsAttr.draw(at: CGPoint(x: frameRect.maxX - photoSide - esz.width, y: y + 30))
+
+            // Brand watermark — left side, mirrors the stats line on the right
+            // so a shared Daily card is unambiguously DayPage (issue #309 W1-④).
+            // The other 11 templates already render this; Daily was the gap.
+            let wm = NSAttributedString(string: "daypage.app", attributes: [
+                .font: UIFont.monospacedSystemFont(ofSize: 20, weight: .regular),
+                .foregroundColor: PolaroidPalette.inkMuted.withAlphaComponent(0.7),
+                .kern: 1.5
+            ])
+            wm.draw(at: CGPoint(x: photoX, y: y + 30))
         }
     }
 }

--- a/DayPage/Features/Shared/ShareCard/ShareCardSystem.swift
+++ b/DayPage/Features/Shared/ShareCard/ShareCardSystem.swift
@@ -46,6 +46,28 @@ enum SharePayload: Identifiable, Equatable {
             return "Voice memo card, duration \(s.duration)"
         }
     }
+
+    // MARK: - Smart dispatch
+    //
+    // Pick the most visually compelling default template for a memo, ranked
+    // by sharability: photo > voice > plain text. Falls back to .memo if
+    // the richer snapshots can't be built (missing files, decode failures).
+    //
+    // Users can still switch poster style inside ShareCardSheet — this only
+    // chooses the *initial* payload so a tap stops forcing a content-type
+    // decision before the sheet opens (issue #309 W1-②).
+    static func auto(from memo: Memo) -> SharePayload {
+        let hasPhoto = memo.attachments.contains { $0.kind == "photo" }
+        let hasVoice = memo.attachments.contains { $0.kind == "audio" }
+
+        if hasPhoto, let snap = PhotoSnapshot.from(memo) {
+            return .photo(snap)
+        }
+        if hasVoice, let snap = VoiceSnapshot.from(memo) {
+            return .voice(snap)
+        }
+        return .memo(MemoSnapshot.from(memo))
+    }
 }
 
 // MARK: - Snapshots

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -279,6 +279,23 @@ struct MemoCardView: View {
                     }
                     .foregroundColor(DSColor.inkSubtle)
                 }
+
+                Spacer(minLength: 4)
+
+                // Primary share entry — issue #309 W1-①.
+                // contextMenu below stays as a power-user override that lets
+                // you force a specific card type or send plain text.
+                Button {
+                    sharePayload = SharePayload.auto(from: memo)
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(DSColor.inkSubtle)
+                        .frame(width: 28, height: 28)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("分享这条 memo")
             }
             .padding(.horizontal, 14)
             .padding(.top, 10)
@@ -287,23 +304,25 @@ struct MemoCardView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .liquidGlassCard(cornerRadius: 18)
         .contextMenu {
+            // Tap the button above for the smart default; long-press here to
+            // override the template or send plain text.
             let shareText = shareableText
             if !shareText.isEmpty {
                 ShareLink(item: shareText) {
-                    Label("分享文本", systemImage: "square.and.arrow.up")
+                    Label("分享文本", systemImage: "doc.plaintext")
                 }
             }
             Button {
                 sharePayload = .memo(MemoSnapshot.from(memo))
             } label: {
-                Label("分享为卡片", systemImage: "rectangle.on.rectangle")
+                Label("强制文字卡", systemImage: "rectangle.on.rectangle")
             }
             if memo.attachments.contains(where: { $0.kind == "photo" }),
                let snap = PhotoSnapshot.from(memo) {
                 Button {
                     sharePayload = .photo(snap)
                 } label: {
-                    Label("分享照片卡", systemImage: "photo.on.rectangle")
+                    Label("强制照片卡", systemImage: "photo.on.rectangle")
                 }
             }
             if memo.attachments.contains(where: { $0.kind == "audio" }),
@@ -311,7 +330,7 @@ struct MemoCardView: View {
                 Button {
                     sharePayload = .voice(snap)
                 } label: {
-                    Label("分享语音卡", systemImage: "mic.badge.plus")
+                    Label("强制语音卡", systemImage: "mic.badge.plus")
                 }
             }
         }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -267,7 +267,9 @@ struct TodayView: View {
                                         },
                                         onRetranscribe: { m, att in viewModel.retranscribe(memo: m, attachment: att) },
                                         onShare: {
-                                            sharePayload = .memo(MemoSnapshot.from(memo))
+                                            // Smart default — auto picks photo/voice/memo
+                                            // based on attachments (issue #309 W1-②).
+                                            sharePayload = SharePayload.auto(from: memo)
                                         },
                                         onShareAsQuote: {
                                             // Build attribution from date + location.


### PR DESCRIPTION
## Summary

Closes part of #309 (Wave 1). Raw memos (text / photo / voice / mixed) in the Today timeline can now be shared in **one tap** — no long-press required — and the share sheet opens with the most visually compelling template for that memo's content type by default.

User request (verbatim): *"我希望就是这个卡片，哪怕是Raw的模式，他也应该是可以去分享的，比如说，就算是语音或者是普通的图片或者是发送的文字，这些东西应该也是可以分享的"*

## Changes

### 1. Tappable share entry on every memo card
\`MemoCardView.swift\` — adds an \`square.and.arrow.up\` button to the meta row (next to date / location). The existing long-press \`contextMenu\` stays as a power-user override (force text-only, force photo card, etc.) — entries renamed "强制文字卡" / "强制照片卡" / "强制语音卡" to make the override semantics explicit.

### 2. Smart payload dispatch — \`SharePayload.auto(from:)\`
\`ShareCardSystem.swift\` — picks the richest template available for the memo:
- \`.photo\` if the memo has a photo attachment (most visually shareable)
- \`.voice\` if it has audio
- \`.memo\` otherwise
- Falls back to \`.memo\` if richer snapshots can't be built (missing files, decode failures)

### 3. One source of truth for "share this memo"
\`TodayView.swift\` — the existing \`onShare\` callback in \`TimelineRow\` now uses \`SharePayload.auto(from:)\` too. Tap button → contextMenu top item → swipe action: all converge.

### 4. Polaroid memo template — meaningful "photo" area for text-only memos
\`PosterTemplates.swift\` — text-only memos previously got a grey square with a tiny initial. Now: accent-tinted wash + 360pt first letter as visual anchor + the memo's first sentence rendered as a centred pull-quote inside the polaroid frame.

### 5. Daily template — brand watermark
The other 11 PosterDispatcher templates already render a \`daypage.app\` watermark; the Polaroid Daily template was the only one missing it.

## Net diff
\`+94 / -11\` across 4 files. Zero data-model changes.

## Test plan
- [x] \`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build\` → BUILD SUCCEEDED
- [ ] Tap the share button on a **text-only** memo → sheet opens with text card template, content matches
- [ ] Tap the share button on a **photo** memo → sheet defaults to photo card
- [ ] Tap the share button on a **voice** memo → sheet defaults to voice card
- [ ] Tap the share button on a **mixed** memo → sheet defaults to photo card (highest priority)
- [ ] Long-press a memo → contextMenu shows "强制文字卡 / 强制照片卡 / 强制语音卡 / 分享文本" override options
- [ ] Polaroid text-only memo card renders with quote + initial, not empty grey square
- [ ] Polaroid daily card shows \`daypage.app\` watermark

🤖 Generated with [Claude Code](https://claude.com/claude-code)