### PR TITLE
feat(share): multi-select mode + collage share card

### DIFF
--- a/DayPage/Features/Shared/ShareCard/PosterTemplates.swift
+++ b/DayPage/Features/Shared/ShareCard/PosterTemplates.swift
@@ -1560,3 +1560,178 @@ enum PolaroidVoiceTemplate: PosterTemplate {
         }
     }
 }
+
+// MARK: - MinimalCollageTemplate
+//
+// Multi-memo collage in IG-Story aspect (1080 × 1920). One template covers
+// both PosterStyle.minimal and .polaroid because the IG-tall canvas can't
+// accommodate Polaroid frame chrome around 6 stacked items without dropping
+// each thumbnail below useful size — PosterDispatcher routes both styles
+// here.
+
+enum MinimalCollageTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .collage(let s) = payload else { return UIImage() }
+        return draw(s)
+    }
+
+    private static func draw(_ s: CollageSnapshot) -> UIImage {
+        let W: CGFloat = 1080
+        let H: CGFloat = 1920
+        let inset: CGFloat = 72
+        let bodyW = W - inset * 2
+
+        let size = CGSize(width: W, height: H)
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = 1
+        format.opaque = true
+        let renderer = UIGraphicsImageRenderer(size: size, format: format)
+
+        return renderer.image { ctx in
+            let cg = ctx.cgContext
+
+            MinimalPalette.bg.setFill()
+            cg.fill(CGRect(origin: .zero, size: size))
+
+            var y: CGFloat = inset
+
+            let brand = NSAttributedString(string: "DAYPAGE", attributes: [
+                .font: UIFont.systemFont(ofSize: 42, weight: .heavy),
+                .foregroundColor: MinimalPalette.ink,
+                .kern: 7
+            ])
+            brand.draw(at: CGPoint(x: inset, y: y))
+
+            let countText = "\(s.items.count) MEMOS"
+            let count = NSAttributedString(string: countText, attributes: [
+                .font: UIFont.monospacedSystemFont(ofSize: 26, weight: .regular),
+                .foregroundColor: MinimalPalette.inkMuted,
+                .kern: 2
+            ])
+            let cSize = count.size()
+            count.draw(at: CGPoint(x: inset + bodyW - cSize.width, y: y + 12))
+
+            y += 70
+
+            let date = NSAttributedString(string: s.dateLabel, attributes: [
+                .font: UIFont.editorialTitle(size: 110),
+                .foregroundColor: MinimalPalette.ink,
+                .kern: -1
+            ])
+            date.draw(at: CGPoint(x: inset, y: y))
+            y += 130
+
+            var subParts: [String] = [s.weekday]
+            if let loc = s.primaryLocation, !loc.isEmpty {
+                subParts.append(loc.uppercased())
+            }
+            let sub = NSAttributedString(string: subParts.joined(separator: "  ·  "), attributes: [
+                .font: UIFont.monospacedSystemFont(ofSize: 24, weight: .regular),
+                .foregroundColor: MinimalPalette.inkMuted,
+                .kern: 2
+            ])
+            sub.draw(at: CGPoint(x: inset, y: y))
+            y += 50
+
+            MinimalPalette.inkFaint.setFill()
+            cg.fill(CGRect(x: inset, y: y, width: bodyW, height: 2))
+            y += 56
+
+            let bodyTop = y
+            let footerHeight: CGFloat = 200
+            let bodyBottom = H - footerHeight
+            let availableH = bodyBottom - bodyTop
+            let interGap: CGFloat = 28
+            let n = CGFloat(s.items.count)
+            let rowH = max(180, (availableH - interGap * (n - 1)) / n)
+
+            for (idx, item) in s.items.enumerated() {
+                let rowY = bodyTop + CGFloat(idx) * (rowH + interGap)
+                drawCollageRow(item: item,
+                                rect: CGRect(x: inset, y: rowY, width: bodyW, height: rowH),
+                                ctx: cg)
+            }
+
+            let wmY = H - inset - 40
+            MinimalPalette.inkFaint.setFill()
+            cg.fill(CGRect(x: inset, y: wmY - 32, width: bodyW, height: 2))
+            let wm = NSAttributedString(string: "daypage.app", attributes: [
+                .font: UIFont.monospacedSystemFont(ofSize: 22, weight: .regular),
+                .foregroundColor: MinimalPalette.inkMuted,
+                .kern: 3
+            ])
+            let wmSize = wm.size()
+            wm.draw(at: CGPoint(x: (W - wmSize.width) / 2, y: wmY))
+        }
+    }
+
+    private static func drawCollageRow(item: CollageSnapshot.Item,
+                                        rect: CGRect,
+                                        ctx cg: CGContext) {
+        let thumbSide: CGFloat = min(200, rect.height)
+        let thumbRect = CGRect(x: rect.minX, y: rect.minY, width: thumbSide, height: thumbSide)
+        let textX = thumbRect.maxX + 32
+        let textW = rect.maxX - textX
+
+        if let img = item.thumbnail {
+            drawAspectFill(img, in: thumbRect, ctx: cg)
+            cg.setStrokeColor(MinimalPalette.inkFaint.cgColor)
+            cg.setLineWidth(2)
+            cg.stroke(thumbRect)
+        } else {
+            let bg = MinimalPalette.accent.withAlphaComponent(0.08)
+            fillRoundedRect(thumbRect, radius: 12, color: bg, in: cg)
+            let glyph: String
+            switch item.kind {
+            case .text:  glyph = "\u{201C}"
+            case .photo: glyph = "\u{25A2}"
+            case .voice: glyph = "\u{25B6}"
+            case .mixed: glyph = "\u{2756}"
+            }
+            let glyphAttr = NSAttributedString(string: glyph, attributes: [
+                .font: UIFont.systemFont(ofSize: 120, weight: .medium),
+                .foregroundColor: MinimalPalette.accent.withAlphaComponent(0.35)
+            ])
+            let gSize = glyphAttr.size()
+            glyphAttr.draw(at: CGPoint(
+                x: thumbRect.midX - gSize.width / 2,
+                y: thumbRect.midY - gSize.height / 2
+            ))
+        }
+
+        let kindLabel: String = {
+            switch item.kind {
+            case .text:  return "TEXT"
+            case .photo: return "PHOTO"
+            case .voice: return "VOICE"
+            case .mixed: return "MIXED"
+            }
+        }()
+        let meta = NSAttributedString(string: "\(item.time)  ·  \(kindLabel)", attributes: [
+            .font: UIFont.monospacedSystemFont(ofSize: 22, weight: .regular),
+            .foregroundColor: MinimalPalette.inkMuted,
+            .kern: 2
+        ])
+        meta.draw(at: CGPoint(x: textX, y: rect.minY + 4))
+
+        let bodyFont = UIFont.systemFont(ofSize: 30, weight: .regular)
+        let bodyPara = NSMutableParagraphStyle()
+        bodyPara.lineHeightMultiple = 1.28
+        bodyPara.lineBreakMode = .byTruncatingTail
+        let bodyAttr = NSAttributedString(
+            string: item.preview.isEmpty ? "(no text)" : item.preview,
+            attributes: [
+                .font: bodyFont,
+                .foregroundColor: item.preview.isEmpty ? MinimalPalette.inkFaint : MinimalPalette.ink,
+                .paragraphStyle: bodyPara
+            ]
+        )
+        let bodyRect = CGRect(x: textX,
+                              y: rect.minY + 40,
+                              width: textW,
+                              height: rect.height - 40)
+        bodyAttr.draw(with: bodyRect,
+                      options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine],
+                      context: nil)
+    }
+}

--- a/DayPage/Features/Shared/ShareCard/ShareCardSystem.swift
+++ b/DayPage/Features/Shared/ShareCard/ShareCardSystem.swift
@@ -17,6 +17,10 @@ enum SharePayload: Identifiable, Equatable {
     case quote(QuoteSnapshot)
     case photo(PhotoSnapshot)
     case voice(VoiceSnapshot)
+    // Multi-memo collage: 2–6 memos rendered as a vertical IG-Story-style
+    // stack with a shared header (date · location · count). Triggered by
+    // the Today multi-select toolbar's "分享 N 项". Issue #309 W2.
+    case collage(CollageSnapshot)
 
     var id: String {
         switch self {
@@ -26,6 +30,7 @@ enum SharePayload: Identifiable, Equatable {
         case .quote(let s):   return "quote-\(s.id.uuidString)"
         case .photo(let s):   return "photo-\(s.id.uuidString)"
         case .voice(let s):   return "voice-\(s.id.uuidString)"
+        case .collage(let s): return "collage-\(s.id.uuidString)"
         }
     }
 
@@ -44,6 +49,8 @@ enum SharePayload: Identifiable, Equatable {
             return "Photo card: \(s.caption.prefix(80))"
         case .voice(let s):
             return "Voice memo card, duration \(s.duration)"
+        case .collage(let s):
+            return "Collage card with \(s.items.count) memos from \(s.dateLabel)"
         }
     }
 
@@ -281,6 +288,107 @@ struct VoiceSnapshot: Equatable {
     }
 }
 
+// MARK: - CollageSnapshot
+//
+// One CollageSnapshot bundles 2–6 memos plus a shared header (date / primary
+// location / total count) so a renderer can produce a single composite share
+// image instead of N separate cards.
+//
+// Each item is a thin preview: 80-char body excerpt, optional thumbnail
+// (first photo, downsampled), short type label, time. The full MemoSnapshot
+// is intentionally NOT carried — Collage cards are designed for at-a-glance
+// readability at IG-Story size, not for reproducing every byte of every memo.
+
+struct CollageSnapshot: Equatable {
+    let id: UUID
+    let dateLabel: String      // e.g. "2026·05·20"
+    let weekday: String        // e.g. "WEDNESDAY"
+    let primaryLocation: String?
+    let items: [Item]
+
+    struct Item: Equatable {
+        let id: UUID
+        let preview: String     // 80-char excerpt of memo body / transcript
+        let kind: Kind          // text / photo / voice / mixed
+        let time: String        // HH:mm
+        let thumbnail: UIImage? // first photo if any, downsampled
+
+        enum Kind: String, Equatable {
+            case text, photo, voice, mixed
+        }
+    }
+
+    /// Maximum number of memos a single collage can hold. Beyond this the
+    /// IG-story canvas runs out of vertical room before the watermark and
+    /// individual items shrink below readable thumbnail size. The caller
+    /// (Today multi-select toolbar) gates the share button on `.items.count
+    /// >= 2 && .items.count <= maxItems`.
+    static let maxItems = 6
+
+    static func from(_ memos: [Memo]) -> CollageSnapshot {
+        // Sort by created date ascending so the collage reads chronologically
+        // top-to-bottom — matches the timeline order users see in Today.
+        let sorted = memos.sorted { $0.created < $1.created }
+
+        let primary = sorted
+            .compactMap { $0.location?.name }
+            .first { !$0.isEmpty }
+
+        let df = DateFormatter()
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.dateFormat = "yyyy·MM·dd"
+        let weekdayDF = DateFormatter()
+        weekdayDF.locale = Locale(identifier: "en_US_POSIX")
+        weekdayDF.dateFormat = "EEEE"
+        let timeDF = DateFormatter()
+        timeDF.locale = Locale(identifier: "en_US_POSIX")
+        timeDF.dateFormat = "HH:mm"
+
+        let firstDate = sorted.first?.created ?? Date()
+
+        let items: [Item] = sorted.prefix(maxItems).map { memo in
+            let hasPhoto = memo.attachments.contains { $0.kind == "photo" }
+            let hasAudio = memo.attachments.contains { $0.kind == "audio" }
+            let kind: Item.Kind = {
+                if hasPhoto && hasAudio { return .mixed }
+                if hasPhoto { return .photo }
+                if hasAudio { return .voice }
+                return .text
+            }()
+
+            // For voice memos prefer transcript over body if transcript exists
+            // and body is empty (the typical capture shape).
+            let rawText: String = {
+                if hasAudio, memo.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+                   let t = memo.attachments.first(where: { $0.kind == "audio" })?.transcript {
+                    return t
+                }
+                return memo.body
+            }()
+            let trimmed = rawText.trimmingCharacters(in: .whitespacesAndNewlines)
+            let preview = trimmed.count > 80
+                ? String(trimmed.prefix(80)) + "\u{2026}"
+                : trimmed
+
+            return Item(
+                id: memo.id,
+                preview: preview,
+                kind: kind,
+                time: timeDF.string(from: memo.created),
+                thumbnail: hasPhoto ? ShareCardImageLoader.firstPhoto(in: memo) : nil
+            )
+        }
+
+        return CollageSnapshot(
+            id: UUID(),
+            dateLabel: df.string(from: firstDate),
+            weekday: weekdayDF.string(from: firstDate).uppercased(),
+            primaryLocation: primary,
+            items: items
+        )
+    }
+}
+
 // MARK: - PosterStyle
 
 enum PosterStyle: String, CaseIterable, Identifiable {
@@ -310,6 +418,12 @@ enum PosterDispatcher {
     /// Routes (payload, style) → concrete `PosterTemplate.render`. Adding a new
     /// style means: extend `PosterStyle`, add 4 new template enums, add a row
     /// in this switch.
+    ///
+    /// Collage currently only has one template (Minimal). Selecting Polaroid
+    /// from the style picker on a collage payload falls back to the Minimal
+    /// renderer — the IG-Story-tall canvas doesn't have room for the
+    /// Polaroid frame chrome around 6 stacked items, and trying to honour
+    /// the style would shrink each item below readable thumbnail size.
     static func render(payload: SharePayload, style: PosterStyle) -> UIImage {
         switch (style, payload) {
         case (.minimal,  .memo):    return MinimalMemoTemplate.render(payload)
@@ -318,12 +432,14 @@ enum PosterDispatcher {
         case (.minimal,  .quote):   return MinimalQuoteTemplate.render(payload)
         case (.minimal,  .photo):   return MinimalPhotoTemplate.render(payload)
         case (.minimal,  .voice):   return MinimalVoiceTemplate.render(payload)
+        case (.minimal,  .collage): return MinimalCollageTemplate.render(payload)
         case (.polaroid, .memo):    return PolaroidMemoTemplate.render(payload)
         case (.polaroid, .daily):   return PolaroidDailyTemplate.render(payload)
         case (.polaroid, .monthly): return PolaroidMonthlyTemplate.render(payload)
         case (.polaroid, .quote):   return PolaroidQuoteTemplate.render(payload)
         case (.polaroid, .photo):   return PolaroidPhotoTemplate.render(payload)
         case (.polaroid, .voice):   return PolaroidVoiceTemplate.render(payload)
+        case (.polaroid, .collage): return MinimalCollageTemplate.render(payload)
         }
     }
 }

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -21,6 +21,11 @@ struct SwipeableMemoCard: View {
     var onDelete: (() -> Void)? = nil
     var onPin: (() -> Void)? = nil
     var onRetranscribe: ((Memo, Memo.Attachment) -> Void)? = nil
+    /// Issue #309 W2: in multi-select mode, both the NavigationLink tap
+    /// and the swipe gesture must be inert — the only valid interaction is
+    /// the tap-to-toggle handled by the parent TimelineRow. Both panels
+    /// are also auto-closed when entering this mode.
+    var isSelectionMode: Bool = false
 
     // Settled resting offset: -panelW = trailing open, 0 = closed, +panelW = leading open
     @State private var settledOffset: CGFloat = 0
@@ -99,8 +104,8 @@ struct SwipeableMemoCard: View {
             // memo detail page. Without this guard, simultaneousGesture lets
             // both the swipe and the NavigationLink tap fire from the same
             // touch sequence.
-            .disabled(revealedSide != nil || isDraggingTouch)
-            .offset(x: currentOffset)
+            .disabled(revealedSide != nil || isDraggingTouch || isSelectionMode)
+            .offset(x: isSelectionMode ? 0 : currentOffset)
             // simultaneousGesture (not highPriorityGesture): the parent
             // ScrollView must keep ownership of vertical drags. highPriority
             // locks gesture ownership on first touch — even with a direction
@@ -113,7 +118,14 @@ struct SwipeableMemoCard: View {
             // on every Timer-driven waveform progress tick (0.1 s) while a
             // voice memo was playing — compounding scroll jank instead of
             // improving it.
-            .simultaneousGesture(swipeGesture)
+            // Suppress the swipe entirely in selection mode — the parent
+            // TimelineRow handles tap-to-toggle and a stray drag would feel
+            // wrong against the selection chrome. SwiftUI's
+            // simultaneousGesture(_:including:) takes a GestureMask, and
+            // .subviews lets the gesture exist in the view tree but never
+            // claim input — cleaner than wrapping the whole NavigationLink
+            // in a conditional branch which would tear down state.
+            .simultaneousGesture(swipeGesture, including: isSelectionMode ? .subviews : .all)
 
             // Invisible tap/drag-to-close overlay: only active when a panel is open.
             // Lives above the card so it intercepts both taps and drags
@@ -132,6 +144,15 @@ struct SwipeableMemoCard: View {
         .accessibilityLabel(accessibilityMemoLabel)
         .accessibilityAction(named: "Delete") { onDelete?() }
         .accessibilityAction(named: memo.pinnedAt != nil ? "Unpin" : "Pin") { onPin?() }
+        // Entering selection mode mid-swipe (panel revealed) would leave a
+        // dangling open panel that the user can't close — selection-mode
+        // gestures don't reach the close overlay. Force-close on transition
+        // so the card is visually flush when selection chrome appears.
+        .onChange(of: isSelectionMode) { newValue in
+            if newValue, revealedSide != nil {
+                snapClose()
+            }
+        }
     }
 
     // MARK: - Panels

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -55,6 +55,18 @@ struct TodayView: View {
     // Issue #302: share-card sheet payload. Set by long-press on a memo.
     @State private var sharePayload: SharePayload? = nil
 
+    // Issue #309 W2: multi-select mode. When non-nil, the timeline is in
+    // selection mode: card taps toggle membership instead of navigating,
+    // swipe panels are disabled, and a top action bar lets the user share
+    // the selection as a collage. Reset to nil to leave the mode.
+    //
+    // Set is session-scoped — switching tabs or backgrounding the app
+    // clears it implicitly (TodayView re-renders fresh). We don't persist
+    // across launches; selection is always an immediate action.
+    @State private var selectedMemoIds: Set<UUID>? = nil
+
+    private var isInSelectionMode: Bool { selectedMemoIds != nil }
+
     /// Live drag offset for the daily page card (negative = pulled left).
     @GestureState private var dailyPageDrag: CGFloat = 0
 
@@ -207,6 +219,19 @@ struct TodayView: View {
                             .animation(Motion.dismiss, value: viewModel.memos.isEmpty)
                     }
 
+                    // MARK: Selection toolbar (issue #309 W2)
+                    // Renders only while in multi-select mode, between the
+                    // header and the timeline. Lifted out of the ScrollView
+                    // so it stays pinned during scroll and never overlaps a
+                    // selected card's chrome.
+                    if let selected = selectedMemoIds {
+                        selectionToolbar(selectedIds: selected)
+                            .padding(.horizontal, 20)
+                            .padding(.top, 8)
+                            .padding(.bottom, 4)
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                    }
+
                     // MARK: Timeline
                     // Plain ScrollView — no GeometryReader. The previous wrapper
                     // (`GeometryReader { ScrollView { ... }.frame(minHeight: geo.size.height * 0.75) }
@@ -283,6 +308,25 @@ struct TodayView: View {
                                                 text: memo.body,
                                                 attribution: attrib
                                             ))
+                                        },
+                                        onEnterSelectionMode: {
+                                            Haptics.tapConfirm()
+                                            selectedMemoIds = [memo.id]
+                                        },
+                                        isSelectionMode: isInSelectionMode,
+                                        isSelected: selectedMemoIds?.contains(memo.id) ?? false,
+                                        onToggleSelection: {
+                                            guard var set = selectedMemoIds else { return }
+                                            if set.contains(memo.id) {
+                                                set.remove(memo.id)
+                                            } else if set.count < CollageSnapshot.maxItems {
+                                                set.insert(memo.id)
+                                            } else {
+                                                // At cap — buzz to let the user know and skip the toggle.
+                                                Haptics.warn()
+                                                return
+                                            }
+                                            selectedMemoIds = set
                                         }
                                     )
                                     .padding(.horizontal, 20)
@@ -835,6 +879,70 @@ struct TodayView: View {
         .padding(.vertical, 12)
     }
 
+    /// Issue #309 W2: top action bar shown while in multi-select mode.
+    /// Layout:
+    ///   [Cancel]  N selected  [Share N]
+    ///
+    /// Share is disabled unless 2 ≤ count ≤ maxItems. The "selected" count
+    /// uses an explicit `selected.count` argument rather than reading the
+    /// optional state again so the view recomputes when the set changes.
+    @ViewBuilder
+    private func selectionToolbar(selectedIds selected: Set<UUID>) -> some View {
+        let count = selected.count
+        let canShare = count >= 2 && count <= CollageSnapshot.maxItems
+        HStack(spacing: 12) {
+            Button("取消") {
+                Haptics.soft()
+                selectedMemoIds = nil
+            }
+            .font(DSType.mono10)
+            .tracking(1.0)
+            .textCase(.uppercase)
+            .foregroundColor(DSColor.inkSubtle)
+
+            Spacer()
+
+            Text(count == 0 ? "选择 memo" : "已选 \(count)")
+                .font(DSType.mono10)
+                .tracking(1.5)
+                .textCase(.uppercase)
+                .foregroundColor(DSColor.inkPrimary)
+
+            Spacer()
+
+            Button {
+                guard canShare else { return }
+                Haptics.tapConfirm()
+                let memos = viewModel.memos.filter { selected.contains($0.id) }
+                sharePayload = .collage(CollageSnapshot.from(memos))
+                // Exit selection mode after triggering — sheet replaces the
+                // foreground; keeping the toolbar around would feel orphaned.
+                selectedMemoIds = nil
+            } label: {
+                Text(count >= 2 ? "分享 \(count) 项" : "至少 2 项")
+                    .font(DSType.mono10)
+                    .tracking(1.0)
+                    .textCase(.uppercase)
+                    .foregroundColor(canShare ? .white : DSColor.inkSubtle)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 9)
+                    .background(
+                        canShare ? DSColor.amberDeep : DSColor.glassLo,
+                        in: Capsule()
+                    )
+            }
+            .buttonStyle(.plain)
+            .disabled(!canShare)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(DSColor.inkFaint.opacity(0.6), lineWidth: 0.5)
+        )
+    }
+
     private func orbKicker(_ date: Date) -> String {
         let f = DateFormatter()
         f.dateFormat = "d MMM"
@@ -1282,11 +1390,58 @@ struct TimelineRow: View {
     var onShare: (() -> Void)? = nil
     /// Issue #302: long-press → "分享为引用"
     var onShareAsQuote: (() -> Void)? = nil
+    /// Issue #309 W2: long-press → "多选". Enters selection mode and
+    /// seeds the selection with the long-pressed memo. nil hides the menu
+    /// item (e.g. when already in selection mode).
+    var onEnterSelectionMode: (() -> Void)? = nil
+    /// Issue #309 W2: selection mode props. When isSelectionMode is true,
+    /// the card renders with a selection indicator overlay and a tap
+    /// toggles membership instead of navigating to the detail view.
+    var isSelectionMode: Bool = false
+    var isSelected: Bool = false
+    var onToggleSelection: (() -> Void)? = nil
 
     var body: some View {
-        SwipeableMemoCard(memo: memo, onDelete: onDelete, onPin: onPin, onRetranscribe: onRetranscribe)
+        ZStack(alignment: .topTrailing) {
+            // In selection mode the inner NavigationLink must be disabled
+            // (otherwise a tap routes to detail). We pass isSelectionMode
+            // down so SwipeableMemoCard can mute its swipe gesture too —
+            // both behaviors live on a single flag at the card root.
+            SwipeableMemoCard(
+                memo: memo,
+                onDelete: onDelete,
+                onPin: onPin,
+                onRetranscribe: onRetranscribe,
+                isSelectionMode: isSelectionMode
+            )
             .frame(maxWidth: .infinity)
-            .contextMenu {
+            // Selection mode taps anywhere on the row toggle membership.
+            // contentShape is the row's full bounding rect — without it the
+            // glass card's rounded corners would leak taps through gaps.
+            .contentShape(Rectangle())
+            .onTapGesture {
+                guard isSelectionMode else { return }
+                Haptics.soft()
+                onToggleSelection?()
+            }
+            // Dimmer when in selection mode but not selected — pulls focus
+            // toward the picked memos without hiding the others completely.
+            .opacity(isSelectionMode && !isSelected ? 0.55 : 1)
+            .animation(.easeInOut(duration: 0.18), value: isSelected)
+            .animation(.easeInOut(duration: 0.18), value: isSelectionMode)
+
+            // Selection circle indicator, top-trailing.
+            if isSelectionMode {
+                selectionIndicator
+                    .padding(.top, 14)
+                    .padding(.trailing, 18)
+                    .transition(.opacity)
+            }
+        }
+        .contextMenu {
+            // Hide the menu while in selection mode — long-pressing a card
+            // mid-selection should not open another menu over the toolbar.
+            if !isSelectionMode {
                 if let onShare {
                     Button {
                         onShare()
@@ -1301,6 +1456,33 @@ struct TimelineRow: View {
                         Label("分享为引用", systemImage: "quote.opening")
                     }
                 }
+                if let onEnterSelectionMode {
+                    Button {
+                        onEnterSelectionMode()
+                    } label: {
+                        Label("多选", systemImage: "checkmark.circle")
+                    }
+                }
             }
+        }
+    }
+
+    private var selectionIndicator: some View {
+        ZStack {
+            Circle()
+                .fill(isSelected ? DSColor.amberDeep : Color.white.opacity(0.9))
+                .frame(width: 26, height: 26)
+                .shadow(color: Color.black.opacity(0.15), radius: 3, x: 0, y: 1)
+            if isSelected {
+                Image(systemName: "checkmark")
+                    .font(.system(size: 13, weight: .heavy))
+                    .foregroundColor(.white)
+            } else {
+                Circle()
+                    .strokeBorder(DSColor.inkSubtle.opacity(0.4), lineWidth: 1.5)
+                    .frame(width: 26, height: 26)
+            }
+        }
+        .accessibilityLabel(isSelected ? "已选中" : "未选中")
     }
 }


### PR DESCRIPTION
## Summary

Closes #309 Wave 2. Users can now **long-press a Today memo card → "多选" → pick 2–6 memos → "分享 N 项"** to share them as a single IG-Story-tall collage card.

User request (verbatim): *"我希望可以多选，多选可以一起分享"*

Builds on PR #311 (single-card share). Stacks on the same SharePayload / PosterTemplate / ShareCardSheet plumbing — just adds one more payload case and one more renderer.

## Interaction model

**Entry**: long-press any memo → \`contextMenu\` → "多选". The pressed memo is seeded as the first selection so the user doesn't lose context.

**In selection mode**:
- A pill-shaped toolbar appears between the header and the timeline: \`[取消]  已选 N  [分享 N 项]\`
- Cards under the finger no longer navigate to detail or pan with swipe — tap toggles membership. Non-selected cards dim to 0.55 opacity.
- A circular checkmark indicator sits in each card's top-trailing corner (white empty ring → filled amber ring with white checkmark).
- \`maxItems = 6\`. Trying to pick a 7th memo plays a warning haptic and silently no-ops, so the user discovers the cap without an alert.

**Exit**: tap "取消", or trigger "分享 N 项" (sheet replaces the foreground and selection mode clears in the same turn).

## Renderer

New \`PosterTemplate\`: \`MinimalCollageTemplate\` (1080 × 1920 IG-Story aspect). \`PosterDispatcher\` routes both \`.minimal\` and \`.polaroid\` styles here — the tall canvas can't fit Polaroid frame chrome around 6 stacked items without making thumbnails illegible.

Layout:
- **Header (~240pt)**: \`DAYPAGE\` wordmark · \`N MEMOS\` count · date · weekday · primary location
- **Body (~1480pt)**: N stacked rows. Each row: 200×200 thumbnail (first photo) or accent-tinted kind glyph (\`"\` / \`▢\` / \`▶\` / \`❖\` for text / photo / voice / mixed), time + kind chip, up to 4 lines of truncated body preview.
- **Footer (~200pt)**: \`daypage.app\` watermark, centered.

Row height adapts to N: \`(availableH − interGap × (N−1)) / N\`, clamped to 180pt minimum.

## Data plumbing

- New \`SharePayload.collage(CollageSnapshot)\` case
- New \`CollageSnapshot\` struct with \`[Item]\` + shared header metadata. \`CollageSnapshot.from(_ memos:)\` sorts by date asc, picks first non-empty location as primary, builds Items with type detection (photo > voice > mixed > text), and downsamples first photo per item to a thumbnail.
- \`TimelineRow\` extended with \`onEnterSelectionMode\` / \`isSelectionMode\` / \`isSelected\` / \`onToggleSelection\` — props default to nil/false so every existing call site stays untouched.
- \`SwipeableMemoCard\` takes \`isSelectionMode\` and:
  - disables the inner NavigationLink (no detail push on tap)
  - parks the offset at 0 (no half-open panel)
  - masks the swipe DragGesture with \`.subviews\` (gesture in tree but never claims input)
  - auto-closes any panel revealed mid-press via \`onChange\`

## Net diff
\`+499 / -5\` across 4 files. Zero data-model changes.

## Test plan
- [x] \`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build\` → BUILD SUCCEEDED
- [ ] Long-press a memo → contextMenu shows "多选"
- [ ] Tapping "多选" enters selection mode with the pressed memo selected
- [ ] Toolbar appears, "分享 N 项" disabled at count < 2
- [ ] Tapping more cards adds them; checkmark indicator appears
- [ ] Tapping selected card removes it
- [ ] Selecting 7th memo → warning haptic, no addition
- [ ] In selection mode, swipe on card does nothing (no Pin / Delete panel)
- [ ] In selection mode, tap on card does NOT navigate to detail
- [ ] Tapping "分享 N 项" → ShareCardSheet opens with collage preview
- [ ] Collage renders: header (date + N MEMOS + location), N rows with thumbnails / glyphs, footer watermark
- [ ] Tapping "取消" exits selection mode without sharing

🤖 Generated with [Claude Code](https://claude.com/claude-code)