### PR TITLE
docs(prd): Codex /add page polish PRD + Ralph plan

### DIFF
--- a/archive/2026-05-20-v7-deep-audit/prd-ralph-dir.json
+++ b/archive/2026-05-20-v7-deep-audit/prd-ralph-dir.json
@@ -1,0 +1,390 @@
+{
+  "project": "DayPage",
+  "branchName": "ralph/v7-deep-audit",
+  "description": "DayPage v7 深度审计与优化路线图 — 基于 UI/UX + Architecture + Features 三角度 Agent 审计。覆盖：API key 安全漏洞修复、Graph Tab 数据接通、并发安全、UI 一致性、Entity 双向链接、Archive 性能、AI 引擎透明化等 25 个 User Story。Source: tasks/prd-daypage-v7-deep-audit.md",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "立即轮换全部泄露的 API Key",
+      "description": "作为产品负责人，我需要立即撤销并重新生成 GeneratedSecrets.swift 中的所有 5 个生产密钥（DeepSeek sk-、OpenAI sk-proj-、OpenWeather、Supabase anon、GitHub PAT），防止恶意使用。",
+      "acceptanceCriteria": [
+        "在所有相关平台撤销现有密钥：DeepSeek、OpenAI Dashboard、OpenWeatherMap、Supabase、GitHub Settings",
+        "生成新密钥，不写入任何 Swift 文件或 git 跟踪目录",
+        "验证 GeneratedSecrets.swift 已被 .gitignore 正确排除（git ls-files --error-unmatch DayPage/Config/GeneratedSecrets.swift 应报错）",
+        "CI/CD（Fastlane）从环境变量或加密 secrets 注入密钥，生成该文件"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 5"
+    },
+    {
+      "id": "US-002",
+      "title": "将 API Key 从 UserDefaults 迁移到 Keychain",
+      "description": "作为用户，我的 AI API key 应存储在 iOS Keychain 中而非明文 UserDefaults，防止 iCloud UserDefaults 备份泄露。",
+      "acceptanceCriteria": [
+        "在 KeychainHelper.swift 中新增 setAPIKey(_:for:) / getAPIKey(for:) 方法，使用 kSecClassGenericPassword",
+        "SecretsRuntime.resolvedDeepSeekApiKey 等所有运行时 key 读取路径改为从 Keychain 读取",
+        "Settings 中「保存 API Key」按钮写入 Keychain 而非 UserDefaults",
+        "首次启动迁移：若 UserDefaults 中存有旧 key，静默迁移至 Keychain 并删除 UserDefaults 条目",
+        "构建通过，iPhone 17 Simulator 手动测试：输入 key → force-quit → 重启 → key 保留"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": "Theme: A-安全与可靠性, Effort: M, Impact: 4"
+    },
+    {
+      "id": "US-003",
+      "title": "修复 NotificationCenter 观察者累积泄漏",
+      "description": "作为用户，我在一次 session 中多次进出 Today 视图时，不应看到重复的 memo 提交或重复触发的编译动画。",
+      "acceptanceCriteria": [
+        "在 TodayViewModel 中添加 private var cancellables = Set<AnyCancellable>()",
+        "将 4 个 NotificationCenter.addObserver（L209, L218, L227, L236）改为 .publisher(for:).sink { }.store(in: &cancellables)",
+        "测试：模拟 10 次 push/pop TodayView，发送 1 次 compilationSucceeded 通知，验证回调只触发 1 次",
+        "构建通过"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 4"
+    },
+    {
+      "id": "US-004",
+      "title": "Task 体补 @MainActor 注解（并发安全）",
+      "description": "作为开发者，我需要 TodayViewModel 中所有 Task 闭包体明确标注 @MainActor，防止 @Published 属性在非主线程被修改导致 UI 状态撕裂。",
+      "acceptanceCriteria": [
+        "将 TodayViewModel.swift L500, L620, L634, L652, L695, L789 的 Task { 改为 Task { @MainActor in",
+        "CompilationService 中 @Published compilationProgress 的写入路径包裹 await MainActor.run { }（L113）",
+        "替换 TodayView.swift L371 的 DispatchQueue.main.asyncAfter 为 Task { try? await Task.sleep(for: .seconds(3)) }",
+        "Swift 编译器无 Sendable / data race 警告",
+        "构建通过，现有测试通过"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 3"
+    },
+    {
+      "id": "US-005",
+      "title": "修复 atomicWrite 临时文件孤儿问题",
+      "description": "作为用户，App crash 或写入失败后重启时，vault 目录下不应残留 .tmp.UUID 孤儿文件占用 iCloud 存储配额。",
+      "acceptanceCriteria": [
+        "在 atomicWrite 的 catch 块中，replaceItemAt 失败后执行 try? FileManager.default.removeItem(at: tempURL)",
+        "在 App 启动时扫描 vault 目录，删除所有匹配 *.tmp.* 的孤儿文件",
+        "添加单元测试：模拟 replaceItemAt 抛出，验证 tempURL 文件被清理",
+        "构建通过"
+      ],
+      "priority": 1,
+      "passes": false,
+      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 3"
+    },
+    {
+      "id": "US-006",
+      "title": "InputBarV4 硬编码字体 → DSType token 对齐",
+      "description": "作为设计系统维护者，InputBarV4 中 20+ 处 .font(.system(size: N, weight: W)) 应全部替换为对应 DSType token，确保下次字体迭代只改 1 个文件。",
+      "acceptanceCriteria": [
+        "建立映射表：system(size:11,weight:.semibold)→DSType.label；system(size:18)→DSType.bodyMD；system(size:19,weight:.light)→DSType.serifBody18",
+        "GlassErrorBanner.swift L111, L149 同步替换",
+        "GlassTabBar.swift L92, L100 同步替换",
+        "替换后视觉截图对比（before/after）附 PR",
+        "构建通过，iPhone 17 Simulator 目视验证"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 3"
+    },
+    {
+      "id": "US-007",
+      "title": "全局 Dynamic Type 支持（heading + body 优先）",
+      "description": "作为使用大字号的用户，我希望 DayPage 所有主要文本在「更大字号」辅助功能设置下都能正确缩放，而不仅限于正文。",
+      "acceptanceCriteria": [
+        "为 H1Modifier、H2Modifier、HeadlineMDModifier、BodyMDModifier、BodySMModifier、CaptionModifier 添加 .dynamicTypeSize(.xSmall ... .xxxLarge) 和 .minimumScaleFactor(0.8)",
+        "SerifBody16/18/20Modifier 同样处理",
+        "MonoModifier 系列使用 .dynamicTypeSize(.xSmall ... .accessibility1) 限制最大放大",
+        "iPhone 17 Simulator 开启「辅助功能 > 更大字体 > 最大」，验证 TodayView、ArchiveView、DailyPageView 文字可读无截断",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 4"
+    },
+    {
+      "id": "US-008",
+      "title": "Accessibility — 关键按钮 label + 44pt tap target",
+      "description": "作为使用 VoiceOver 的用户，我需要所有交互元素都有语义化 accessibilityLabel，且 tap target 不小于 44pt。",
+      "acceptanceCriteria": [
+        "Settings gear button 从 frame(28, 28) 改为 frame(44, 44)（或加 .contentShape(Rectangle())），添加 .accessibilityLabel(L10n.a11y.settingsButton)",
+        "LocationDraftRow 的「全部忽略」「全部确认」「单条确认」「单条忽略」按钮 frame 改为 min(44, 44) 并添加语义 label",
+        "TodayView.swift L93「Open navigation」改为 L10n.a11y.openNavigation",
+        "新增 L10n.a11y.* 枚举分支，覆盖以上所有新 label",
+        "iPhone 17 Simulator 开启 VoiceOver 手动验证：逐一聚焦按钮，描述正确",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 4"
+    },
+    {
+      "id": "US-009",
+      "title": "编译 / 语音转写 / 照片处理 Loading 指示器",
+      "description": "作为用户，当 AI 编译、Whisper 转写或批量照片处理正在进行时，我应该看到明确的 Loading 状态，而不是静默等待。",
+      "acceptanceCriteria": [
+        "语音录制停止到转写完成期间，InputBarV4 的附件 chip 显示 ProgressView() 旋转器",
+        "CompileFooterButton 在 isCompiling == true 时显示 ProgressView() + 阶段文字（「分析中…」「生成中…」），使用 CompilationService.compilationProgress 驱动",
+        "批量照片处理期间（isProcessingPhoto == true），Today 输入区顶部显示细进度条（LinearProgressView），处理完成后淡出",
+        "所有 loading 组件使用 DSColor.onSurfaceVariant tint",
+        "构建通过，iPhone 17 Simulator 目视验证三种 loading 场景"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 3"
+    },
+    {
+      "id": "US-010",
+      "title": "动效 Token 补全（InputBar / Swipe / Breathing）",
+      "description": "作为设计系统维护者，Motion.swift 应补充 3 个当前被大量硬编码绕过的动效 token，消除分散的魔法数值。",
+      "acceptanceCriteria": [
+        "新增 Motion.inputDock = Animation.spring(response: 0.42, dampingFraction: 0.78)",
+        "新增 Motion.swipeSnap = Animation.spring(response: 0.28, dampingFraction: 0.86)",
+        "新增 Motion.breathing = Animation.easeInOut(duration: 0.8).repeatForever(autoreverses: true)",
+        "InputBarV4 L91 composerSpring 改用 Motion.inputDock；L173 匿名 spring 改用 Motion.inputDock",
+        "SwipeableMemoCard L178 改用 Motion.swipeSnap",
+        "RecordingOverlayView / DayOrbView breathing 动画改用 Motion.breathing",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 2"
+    },
+    {
+      "id": "US-011",
+      "title": "硬编码字符串 → L10n key（TodayView）",
+      "description": "作为多语言用户，TodayView 中的硬编码中英文字符串应通过 L10n 系统输出，支持语言切换。",
+      "acceptanceCriteria": [
+        "L933/935：\"\\(dateStr) · 1 note\" → L10n.Archive.noteCount(1)；复数形式 L10n.Archive.noteCountPlural(count)",
+        "L965：Button(\"重试\") → Button(L10n.Error.retry)",
+        "L1035：Text(\"检测到位置到达\") → Text(L10n.Location.arrivalDetected)",
+        "L1039/1042：\"全部忽略\" / \"全部确认\" → L10n.Location.ignoreAll / L10n.Location.confirmAll",
+        "在 en.lproj/Localizable.strings 和 zh-Hans.lproj/Localizable.strings 中添加对应键值",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 2"
+    },
+    {
+      "id": "US-012",
+      "title": "Graph Tab 接通 EntityPageService 真实数据",
+      "description": "作为用户，我在 Graph Tab 中应该看到基于我实际日记数据生成的知识图谱节点（人物、地点、主题），而不是空白或样例数据。",
+      "acceptanceCriteria": [
+        "GraphViewModel 实现 loadGraph() 方法：读取 wiki/places/、wiki/people/、wiki/themes/ 目录下所有 entity 页面，解析 YAML frontmatter 提取 name、type、occurrence_count、first_seen",
+        "每个 entity 转换为图节点；若两个 entity 在同一 Daily Page 中同时出现，则生成连边（co-occurrence）",
+        "GraphView 保持现有力导向布局，仅替换数据源为 GraphViewModel.nodes / .edges",
+        "空状态：vault 无 entity 时显示 EmptyStateView",
+        "Graph Tab 在 vault 有至少 3 个 entity 时展示可交互图谱",
+        "构建通过，iPhone 17 Simulator 有数据时验证图谱节点非空"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 5 | Already implemented on main"
+    },
+    {
+      "id": "US-013",
+      "title": "Entity 双向链接（Entity Page → Related Memos）",
+      "description": "作为用户，打开一个 Entity 页面时，我应该看到所有提到过它的原始 Memo 列表，形成从知识网络回溯到原始记录的路径。",
+      "acceptanceCriteria": [
+        "EntityPageService.apply(instruction:) 在创建或更新 entity 时，将当前日期追加到 entity YAML frontmatter 的 related_dates: [] 数组",
+        "EntityPageView 实现 relatedMemos() —— 读取 related_dates，对每个日期调用 RawStorage.read(for:)，返回包含该 entity slug 的 memo 列表",
+        "Entity 页面底部新增「来源记录」Section，以精简版 MemoCardView 展示 related memos，按日期降序，最多 20 条",
+        "单元测试：构造含 entity mention 的 memo → 运行 apply() → 验证 related_dates 包含该日期",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 4"
+    },
+    {
+      "id": "US-014",
+      "title": "AI 引擎透明化 — Settings 展示当前模型",
+      "description": "作为用户，我有权知道当前处理我日记的 AI 模型是什么，并理解模型变更对编译风格的潜在影响。",
+      "acceptanceCriteria": [
+        "Settings「AI 编译引擎」Section 显示：当前模型名称、API provider、上次编译时间",
+        "CompilationService 暴露 static let modelName: String 和 static let apiProvider: String 常量",
+        "如果用户使用 DeepSeek 而非 Qwen（MVP 默认），Settings 中注明「⚠️ 当前使用非默认引擎」",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: S, Impact: 2"
+    },
+    {
+      "id": "US-015",
+      "title": "Archive 月份数据异步加载",
+      "description": "作为拥有 6 个月以上数据的用户，打开 Archive 时不应有明显卡顿，calendar grid 应先渲染骨架再填入数据。",
+      "acceptanceCriteria": [
+        "ArchiveViewModel.loadMonth() 改为 async 方法，在 Task { await loadMonth() } 中调用，不阻塞主线程",
+        "加载期间 calendar grid 的每个 day cell 显示 ProgressView() 占位或灰色矩形",
+        "月份切换时立即显示新月份的 loading 骨架，旧月份数据立即清除",
+        "有真实数据时（3+ 个月历史），Archive 打开到渲染完成 < 500ms（iPhone 17 Simulator 测量）",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 3 | Already implemented on main"
+    },
+    {
+      "id": "US-016",
+      "title": "语音附件 Retry 闭环",
+      "description": "作为用户，当 Whisper 转写失败后，我应该能在 Today 页面的语音附件 chip 上直接点击「重试」重新发起转写，而不是丢弃录音。",
+      "acceptanceCriteria": [
+        "语音附件转写失败时，Attachment 标记 transcriptionStatus: .failed（新增枚举 case）",
+        "InputBarV4 附件 chip 在 transcriptionStatus == .failed 时显示红色边框 + 「↺」重试图标",
+        "点击重试图标调用 TodayViewModel.retranscribeVoiceAttachment(id:)，触发 VoiceService.transcribeAudio(at:) 重试",
+        "重试中显示 chip 内 ProgressView()；成功后 chip 切回正常态 + transcript 显示前 20 字",
+        "构建通过，手动测试：断网录音 → 失败红边 → 联网点重试 → 成功"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: S, Impact: 3"
+    },
+    {
+      "id": "US-017",
+      "title": "Memo 数据模型补 mood + entity mentions 字段",
+      "description": "作为开发者，Memo struct 应内置 mood 和 entityMentions 字段，为知识图谱的精确双向链接和情绪时间线提供结构化数据基础。",
+      "acceptanceCriteria": [
+        "Memo struct 新增 var mood: MoodLevel? = nil（枚举：.positive/.neutral/.negative/.intense）",
+        "Memo struct 新增 var entityMentions: [String] = []（从 body 中 [[EntitySlug]] 语法提取的 slug 数组）",
+        "RawStorage YAML 解析器新增 mood: 和 entities: frontmatter 键支持",
+        "TodayViewModel.submitCombinedMemo() 在写入前从 body 文本提取 [[...]] 模式填充 entityMentions",
+        "向后兼容：旧文件无这两个字段时，解析为 nil/[]，不报错",
+        "单元测试：构造含 [[Tokyo]] 的 memo body → 验证 entityMentions == [\"Tokyo\"]",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 3"
+    },
+    {
+      "id": "US-018",
+      "title": "批量 HEIC 照片转换移离主线程",
+      "description": "作为用户，选择 5 张以上 HEIC 格式照片时，Today 页面不应出现明显卡顿或 UI 冻结。",
+      "acceptanceCriteria": [
+        "PhotoService.processPickerItem() 中 HEIC → JPEG 转换移入 Task.detached(priority: .userInitiated) { }（脱离 MainActor）",
+        "转换完成后通过 await MainActor.run { } 回主线程更新 UI 状态",
+        "测试：选择 5 张 12MP HEIC 图片，Timeline 动画帧率 ≥ 55fps（Instruments Time Profiler 验证无主线程卡顿 >16ms）",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: S, Impact: 2"
+    },
+    {
+      "id": "US-019",
+      "title": "Markdown Export（Obsidian 兼容）",
+      "description": "作为数字游民用户，我希望能将 DayPage 的 vault 内容一键导出为标准 Markdown 格式（.md 文件打包），兼容 Obsidian 导入。",
+      "acceptanceCriteria": [
+        "Settings「数据」Section 新增「导出 Vault」按钮",
+        "点击后生成 daypage-export-YYYY-MM-DD.zip，包含 raw/ 和 daily/ 所有 .md 文件，保持目录结构",
+        "导出进行中显示 ProgressView() + 「正在打包...」文字",
+        "完成后弹出系统 Share Sheet（UIActivityViewController）",
+        "导出文件中的 YAML frontmatter 格式与 Obsidian 兼容",
+        "构建通过，iPhone 17 手动验证：导出 → 文件 App 可预览 .md 内容"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 3"
+    },
+    {
+      "id": "US-020",
+      "title": "TodayViewModel 核心路径单元测试",
+      "description": "作为开发者，TodayViewModel 的 submitCombinedMemo()、load()、compile() 三条核心路径应有单元测试覆盖，以便重构时有安全网。",
+      "acceptanceCriteria": [
+        "新建 DayPageTests/TodayViewModelTests.swift（Swift Testing）",
+        "测试 submitCombinedMemo()：纯文字 memo → 验证 RawStorage 写入；语音 memo（mock VoiceService）→ 验证附件字段；location memo → 验证 location frontmatter",
+        "测试 load()：空 vault → 验证 memos 为空；有 3 条 memo 的文件 → 验证解析正确",
+        "测试 compile()：mock CompilationService 返回成功 → 验证 dailyPageModel 更新；返回失败 → 验证 compilationFailedError 设置",
+        "至少 12 个 test case，覆盖 happy path + error path",
+        "全部测试通过 (xcodebuild test -scheme DayPage)"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": "Theme: D-技术债务, Effort: L, Impact: 2"
+    },
+    {
+      "id": "US-021",
+      "title": "TodayView 拆分子视图",
+      "description": "作为开发者，1170 行的 TodayView 应拆分为独立子视图组件，每个文件不超过 300 行，减少 PR 冲突和 AI 辅助编码的上下文窗口压力。",
+      "acceptanceCriteria": [
+        "提取 TodayOrbHeaderView（Day Orb + 日期标题区，约 120 行）到独立文件",
+        "提取 TodayMemoListView（memo 列表 + SwipeableMemoCard，约 200 行）到独立文件",
+        "提取 LocationDraftCard + LocationDraftRow 到 DayPage/Features/Today/LocationDraft/ 子目录",
+        "TodayView.swift 主文件压缩到 ≤ 350 行",
+        "无功能改变：拆分前后 iPhone 17 Simulator 截图目视一致",
+        "构建通过，现有测试通过"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": "Theme: D-技术债务, Effort: L, Impact: 2"
+    },
+    {
+      "id": "US-022",
+      "title": "CompilationService.compile() 函数分解",
+      "description": "作为开发者，compile() 的 152 行单体函数应分解为 5 个职责单一的私有方法，提高可测试性。",
+      "acceptanceCriteria": [
+        "提取 prepareMemoContext() async throws -> CompilationContext",
+        "提取 buildPrompt(context:) -> [ChatMessage]",
+        "提取 callLLM(messages:) async throws -> String",
+        "提取 parseCompilationOutput(_:) throws -> DailyPageModel",
+        "提取 persistResults(_:for:) async throws",
+        "所有方法有 // throws: CompilationError.X 注释",
+        "构建通过，编译功能端到端手动测试正常"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": "Theme: D-技术债务, Effort: M, Impact: 1"
+    },
+    {
+      "id": "US-023",
+      "title": ".trash 备份文件 7 天 TTL 自动清理",
+      "description": "作为用户，iCloud Drive 中的 DayPage vault 不应随时间无限增长，每日编译备份应在 7 天后自动删除。",
+      "acceptanceCriteria": [
+        "在 BackgroundCompilationService 中新增 performTrashCleanup() 方法，扫描 vault/.trash/ 目录",
+        "删除修改时间早于 7 天前的所有 .md 备份文件",
+        "清理操作在后台 Task 中执行，不阻塞编译主流程",
+        "首次运行时若 .trash/ 超过 50 个文件，记录 warning 日志并触发全量清理",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: D-技术债务, Effort: S, Impact: 1"
+    },
+    {
+      "id": "US-024",
+      "title": "编译输出结构化增强 — mood + 日期感知",
+      "description": "作为用户，AI 编译的 Daily Page 应包含当天的情绪评估（mood），并在节假日/特殊日期时自动调整叙事语气。",
+      "acceptanceCriteria": [
+        "System prompt 增加：输出 YAML frontmatter 中必须包含 mood: positive|neutral|negative|intense",
+        "DailyPageModel 新增 var mood: MoodLevel?（与 US-017 共用枚举）",
+        "DailyPageView 在标题下方显示 mood 情绪指示器（小彩色圆点，4 种颜色对应 4 种 mood）",
+        "编译 prompt 注入当天日期（包括星期）：「今天是 {weekday}，{date}」",
+        "单元测试：mock LLM 返回含 mood: positive 的输出 → 验证 DailyPageModel.mood == .positive",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: E-AI能力升级, Effort: M, Impact: 3"
+    },
+    {
+      "id": "US-025",
+      "title": "Entity Slug 去重与模糊匹配",
+      "description": "作为用户，当 AI 先后生成 joma-coffee 和 joma_coffee 两个变体时，知识图谱不应产生重复节点，而应合并到同一 entity 页面。",
+      "acceptanceCriteria": [
+        "EntityPageService 在 apply() 前执行 slug 归一化：小写、_ → -、移除特殊字符",
+        "归一化后若目标文件已存在，执行 update 而非 create",
+        "可选增强：实现编辑距离 ≤ 2 的模糊匹配（Levenshtein），自动合并近似 slug",
+        "单元测试：apply(slug: \"joma_coffee\") + apply(slug: \"joma-coffee\") → wiki 目录中只有 1 个文件",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: E-AI能力升级, Effort: M, Impact: 2"
+    }
+  ]
+}

--- a/archive/2026-05-20-v7-deep-audit/prd.json
+++ b/archive/2026-05-20-v7-deep-audit/prd.json
@@ -1,0 +1,390 @@
+{
+  "project": "DayPage",
+  "branchName": "ralph/v7-deep-audit",
+  "description": "DayPage v7 深度审计与优化路线图 — 基于 UI/UX + Architecture + Features 三角度 Agent 审计。覆盖：API key 安全漏洞修复、Graph Tab 数据接通、并发安全、UI 一致性、Entity 双向链接、Archive 性能、AI 引擎透明化等 25 个 User Story。Source: tasks/prd-daypage-v7-deep-audit.md",
+  "userStories": [
+    {
+      "id": "US-001",
+      "title": "立即轮换全部泄露的 API Key",
+      "description": "作为产品负责人，我需要立即撤销并重新生成 GeneratedSecrets.swift 中的所有 5 个生产密钥（DeepSeek sk-、OpenAI sk-proj-、OpenWeather、Supabase anon、GitHub PAT），防止恶意使用。",
+      "acceptanceCriteria": [
+        "在所有相关平台撤销现有密钥：DeepSeek、OpenAI Dashboard、OpenWeatherMap、Supabase、GitHub Settings",
+        "生成新密钥，不写入任何 Swift 文件或 git 跟踪目录",
+        "验证 GeneratedSecrets.swift 已被 .gitignore 正确排除（git ls-files --error-unmatch DayPage/Config/GeneratedSecrets.swift 应报错）",
+        "CI/CD（Fastlane）从环境变量或加密 secrets 注入密钥，生成该文件"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 5; Engineering infra verified: GeneratedSecrets.swift gitignored, .env gitignored, CI uses placeholder (ENV_FILE secret), .env.example synced. Key rotation is an operational task for the owner to perform manually."
+    },
+    {
+      "id": "US-002",
+      "title": "将 API Key 从 UserDefaults 迁移到 Keychain",
+      "description": "作为用户，我的 AI API key 应存储在 iOS Keychain 中而非明文 UserDefaults，防止 iCloud UserDefaults 备份泄露。",
+      "acceptanceCriteria": [
+        "在 KeychainHelper.swift 中新增 setAPIKey(_:for:) / getAPIKey(for:) 方法，使用 kSecClassGenericPassword",
+        "SecretsRuntime.resolvedDeepSeekApiKey 等所有运行时 key 读取路径改为从 Keychain 读取",
+        "Settings 中「保存 API Key」按钮写入 Keychain 而非 UserDefaults",
+        "首次启动迁移：若 UserDefaults 中存有旧 key，静默迁移至 Keychain 并删除 UserDefaults 条目",
+        "构建通过，iPhone 17 Simulator 手动测试：输入 key → force-quit → 重启 → key 保留"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Theme: A-安全与可靠性, Effort: M, Impact: 4"
+    },
+    {
+      "id": "US-003",
+      "title": "修复 NotificationCenter 观察者累积泄漏",
+      "description": "作为用户，我在一次 session 中多次进出 Today 视图时，不应看到重复的 memo 提交或重复触发的编译动画。",
+      "acceptanceCriteria": [
+        "在 TodayViewModel 中添加 private var cancellables = Set<AnyCancellable>()",
+        "将 4 个 NotificationCenter.addObserver（L209, L218, L227, L236）改为 .publisher(for:).sink { }.store(in: &cancellables)",
+        "测试：模拟 10 次 push/pop TodayView，发送 1 次 compilationSucceeded 通知，验证回调只触发 1 次",
+        "构建通过"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 4"
+    },
+    {
+      "id": "US-004",
+      "title": "Task 体补 @MainActor 注解（并发安全）",
+      "description": "作为开发者，我需要 TodayViewModel 中所有 Task 闭包体明确标注 @MainActor，防止 @Published 属性在非主线程被修改导致 UI 状态撕裂。",
+      "acceptanceCriteria": [
+        "将 TodayViewModel.swift L500, L620, L634, L652, L695, L789 的 Task { 改为 Task { @MainActor in",
+        "CompilationService 中 @Published compilationProgress 的写入路径包裹 await MainActor.run { }（L113）",
+        "替换 TodayView.swift L371 的 DispatchQueue.main.asyncAfter 为 Task { try? await Task.sleep(for: .seconds(3)) }",
+        "Swift 编译器无 Sendable / data race 警告",
+        "构建通过，现有测试通过"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 3"
+    },
+    {
+      "id": "US-005",
+      "title": "修复 atomicWrite 临时文件孤儿问题",
+      "description": "作为用户，App crash 或写入失败后重启时，vault 目录下不应残留 .tmp.UUID 孤儿文件占用 iCloud 存储配额。",
+      "acceptanceCriteria": [
+        "在 atomicWrite 的 catch 块中，replaceItemAt 失败后执行 try? FileManager.default.removeItem(at: tempURL)",
+        "在 App 启动时扫描 vault 目录，删除所有匹配 *.tmp.* 的孤儿文件",
+        "添加单元测试：模拟 replaceItemAt 抛出，验证 tempURL 文件被清理",
+        "构建通过"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 3"
+    },
+    {
+      "id": "US-006",
+      "title": "InputBarV4 硬编码字体 → DSType token 对齐",
+      "description": "作为设计系统维护者，InputBarV4 中 20+ 处 .font(.system(size: N, weight: W)) 应全部替换为对应 DSType token，确保下次字体迭代只改 1 个文件。",
+      "acceptanceCriteria": [
+        "建立映射表：system(size:11,weight:.semibold)→DSType.label；system(size:18)→DSType.bodyMD；system(size:19,weight:.light)→DSType.serifBody18",
+        "GlassErrorBanner.swift L111, L149 同步替换",
+        "GlassTabBar.swift L92, L100 同步替换",
+        "替换后视觉截图对比（before/after）附 PR",
+        "构建通过，iPhone 17 Simulator 目视验证"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 3"
+    },
+    {
+      "id": "US-007",
+      "title": "全局 Dynamic Type 支持（heading + body 优先）",
+      "description": "作为使用大字号的用户，我希望 DayPage 所有主要文本在「更大字号」辅助功能设置下都能正确缩放，而不仅限于正文。",
+      "acceptanceCriteria": [
+        "为 H1Modifier、H2Modifier、HeadlineMDModifier、BodyMDModifier、BodySMModifier、CaptionModifier 添加 .dynamicTypeSize(.xSmall ... .xxxLarge) 和 .minimumScaleFactor(0.8)",
+        "SerifBody16/18/20Modifier 同样处理",
+        "MonoModifier 系列使用 .dynamicTypeSize(.xSmall ... .accessibility1) 限制最大放大",
+        "iPhone 17 Simulator 开启「辅助功能 > 更大字体 > 最大」，验证 TodayView、ArchiveView、DailyPageView 文字可读无截断",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 4"
+    },
+    {
+      "id": "US-008",
+      "title": "Accessibility — 关键按钮 label + 44pt tap target",
+      "description": "作为使用 VoiceOver 的用户，我需要所有交互元素都有语义化 accessibilityLabel，且 tap target 不小于 44pt。",
+      "acceptanceCriteria": [
+        "Settings gear button 从 frame(28, 28) 改为 frame(44, 44)（或加 .contentShape(Rectangle())），添加 .accessibilityLabel(L10n.a11y.settingsButton)",
+        "LocationDraftRow 的「全部忽略」「全部确认」「单条确认」「单条忽略」按钮 frame 改为 min(44, 44) 并添加语义 label",
+        "TodayView.swift L93「Open navigation」改为 L10n.a11y.openNavigation",
+        "新增 L10n.a11y.* 枚举分支，覆盖以上所有新 label",
+        "iPhone 17 Simulator 开启 VoiceOver 手动验证：逐一聚焦按钮，描述正确",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 4"
+    },
+    {
+      "id": "US-009",
+      "title": "编译 / 语音转写 / 照片处理 Loading 指示器",
+      "description": "作为用户，当 AI 编译、Whisper 转写或批量照片处理正在进行时，我应该看到明确的 Loading 状态，而不是静默等待。",
+      "acceptanceCriteria": [
+        "语音录制停止到转写完成期间，InputBarV4 的附件 chip 显示 ProgressView() 旋转器",
+        "CompileFooterButton 在 isCompiling == true 时显示 ProgressView() + 阶段文字（「分析中…」「生成中…」），使用 CompilationService.compilationProgress 驱动",
+        "批量照片处理期间（isProcessingPhoto == true），Today 输入区顶部显示细进度条（LinearProgressView），处理完成后淡出",
+        "所有 loading 组件使用 DSColor.onSurfaceVariant tint",
+        "构建通过，iPhone 17 Simulator 目视验证三种 loading 场景"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 3"
+    },
+    {
+      "id": "US-010",
+      "title": "动效 Token 补全（InputBar / Swipe / Breathing）",
+      "description": "作为设计系统维护者，Motion.swift 应补充 3 个当前被大量硬编码绕过的动效 token，消除分散的魔法数值。",
+      "acceptanceCriteria": [
+        "新增 Motion.inputDock = Animation.spring(response: 0.42, dampingFraction: 0.78)",
+        "新增 Motion.swipeSnap = Animation.spring(response: 0.28, dampingFraction: 0.86)",
+        "新增 Motion.breathing = Animation.easeInOut(duration: 0.8).repeatForever(autoreverses: true)",
+        "InputBarV4 L91 composerSpring 改用 Motion.inputDock；L173 匿名 spring 改用 Motion.inputDock",
+        "SwipeableMemoCard L178 改用 Motion.swipeSnap",
+        "RecordingOverlayView / DayOrbView breathing 动画改用 Motion.breathing",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 2"
+    },
+    {
+      "id": "US-011",
+      "title": "硬编码字符串 → L10n key（TodayView）",
+      "description": "作为多语言用户，TodayView 中的硬编码中英文字符串应通过 L10n 系统输出，支持语言切换。",
+      "acceptanceCriteria": [
+        "L933/935：\"\\(dateStr) · 1 note\" → L10n.Archive.noteCount(1)；复数形式 L10n.Archive.noteCountPlural(count)",
+        "L965：Button(\"重试\") → Button(L10n.Error.retry)",
+        "L1035：Text(\"检测到位置到达\") → Text(L10n.Location.arrivalDetected)",
+        "L1039/1042：\"全部忽略\" / \"全部确认\" → L10n.Location.ignoreAll / L10n.Location.confirmAll",
+        "在 en.lproj/Localizable.strings 和 zh-Hans.lproj/Localizable.strings 中添加对应键值",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 2"
+    },
+    {
+      "id": "US-012",
+      "title": "Graph Tab 接通 EntityPageService 真实数据",
+      "description": "作为用户，我在 Graph Tab 中应该看到基于我实际日记数据生成的知识图谱节点（人物、地点、主题），而不是空白或样例数据。",
+      "acceptanceCriteria": [
+        "GraphViewModel 实现 loadGraph() 方法：读取 wiki/places/、wiki/people/、wiki/themes/ 目录下所有 entity 页面，解析 YAML frontmatter 提取 name、type、occurrence_count、first_seen",
+        "每个 entity 转换为图节点；若两个 entity 在同一 Daily Page 中同时出现，则生成连边（co-occurrence）",
+        "GraphView 保持现有力导向布局，仅替换数据源为 GraphViewModel.nodes / .edges",
+        "空状态：vault 无 entity 时显示 EmptyStateView",
+        "Graph Tab 在 vault 有至少 3 个 entity 时展示可交互图谱",
+        "构建通过，iPhone 17 Simulator 有数据时验证图谱节点非空"
+      ],
+      "priority": 1,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 5 | Already implemented on main"
+    },
+    {
+      "id": "US-013",
+      "title": "Entity 双向链接（Entity Page → Related Memos）",
+      "description": "作为用户，打开一个 Entity 页面时，我应该看到所有提到过它的原始 Memo 列表，形成从知识网络回溯到原始记录的路径。",
+      "acceptanceCriteria": [
+        "EntityPageService.apply(instruction:) 在创建或更新 entity 时，将当前日期追加到 entity YAML frontmatter 的 related_dates: [] 数组",
+        "EntityPageView 实现 relatedMemos() —— 读取 related_dates，对每个日期调用 RawStorage.read(for:)，返回包含该 entity slug 的 memo 列表",
+        "Entity 页面底部新增「来源记录」Section，以精简版 MemoCardView 展示 related memos，按日期降序，最多 20 条",
+        "单元测试：构造含 entity mention 的 memo → 运行 apply() → 验证 related_dates 包含该日期",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 4"
+    },
+    {
+      "id": "US-014",
+      "title": "AI 引擎透明化 — Settings 展示当前模型",
+      "description": "作为用户，我有权知道当前处理我日记的 AI 模型是什么，并理解模型变更对编译风格的潜在影响。",
+      "acceptanceCriteria": [
+        "Settings「AI 编译引擎」Section 显示：当前模型名称、API provider、上次编译时间",
+        "CompilationService 暴露 static let modelName: String 和 static let apiProvider: String 常量",
+        "如果用户使用 DeepSeek 而非 Qwen（MVP 默认），Settings 中注明「⚠️ 当前使用非默认引擎」",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: S, Impact: 2"
+    },
+    {
+      "id": "US-015",
+      "title": "Archive 月份数据异步加载",
+      "description": "作为拥有 6 个月以上数据的用户，打开 Archive 时不应有明显卡顿，calendar grid 应先渲染骨架再填入数据。",
+      "acceptanceCriteria": [
+        "ArchiveViewModel.loadMonth() 改为 async 方法，在 Task { await loadMonth() } 中调用，不阻塞主线程",
+        "加载期间 calendar grid 的每个 day cell 显示 ProgressView() 占位或灰色矩形",
+        "月份切换时立即显示新月份的 loading 骨架，旧月份数据立即清除",
+        "有真实数据时（3+ 个月历史），Archive 打开到渲染完成 < 500ms（iPhone 17 Simulator 测量）",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 3 | Already implemented on main"
+    },
+    {
+      "id": "US-016",
+      "title": "语音附件 Retry 闭环",
+      "description": "作为用户，当 Whisper 转写失败后，我应该能在 Today 页面的语音附件 chip 上直接点击「重试」重新发起转写，而不是丢弃录音。",
+      "acceptanceCriteria": [
+        "语音附件转写失败时，Attachment 标记 transcriptionStatus: .failed（新增枚举 case）",
+        "InputBarV4 附件 chip 在 transcriptionStatus == .failed 时显示红色边框 + 「↺」重试图标",
+        "点击重试图标调用 TodayViewModel.retranscribeVoiceAttachment(id:)，触发 VoiceService.transcribeAudio(at:) 重试",
+        "重试中显示 chip 内 ProgressView()；成功后 chip 切回正常态 + transcript 显示前 20 字",
+        "构建通过，手动测试：断网录音 → 失败红边 → 联网点重试 → 成功"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: S, Impact: 3"
+    },
+    {
+      "id": "US-017",
+      "title": "Memo 数据模型补 mood + entity mentions 字段",
+      "description": "作为开发者，Memo struct 应内置 mood 和 entityMentions 字段，为知识图谱的精确双向链接和情绪时间线提供结构化数据基础。",
+      "acceptanceCriteria": [
+        "Memo struct 新增 var mood: MoodLevel? = nil（枚举：.positive/.neutral/.negative/.intense）",
+        "Memo struct 新增 var entityMentions: [String] = []（从 body 中 [[EntitySlug]] 语法提取的 slug 数组）",
+        "RawStorage YAML 解析器新增 mood: 和 entities: frontmatter 键支持",
+        "TodayViewModel.submitCombinedMemo() 在写入前从 body 文本提取 [[...]] 模式填充 entityMentions",
+        "向后兼容：旧文件无这两个字段时，解析为 nil/[]，不报错",
+        "单元测试：构造含 [[Tokyo]] 的 memo body → 验证 entityMentions == [\"Tokyo\"]",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 3"
+    },
+    {
+      "id": "US-018",
+      "title": "批量 HEIC 照片转换移离主线程",
+      "description": "作为用户，选择 5 张以上 HEIC 格式照片时，Today 页面不应出现明显卡顿或 UI 冻结。",
+      "acceptanceCriteria": [
+        "PhotoService.processPickerItem() 中 HEIC → JPEG 转换移入 Task.detached(priority: .userInitiated) { }（脱离 MainActor）",
+        "转换完成后通过 await MainActor.run { } 回主线程更新 UI 状态",
+        "测试：选择 5 张 12MP HEIC 图片，Timeline 动画帧率 ≥ 55fps（Instruments Time Profiler 验证无主线程卡顿 >16ms）",
+        "构建通过"
+      ],
+      "priority": 2,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: S, Impact: 2"
+    },
+    {
+      "id": "US-019",
+      "title": "Markdown Export（Obsidian 兼容）",
+      "description": "作为数字游民用户，我希望能将 DayPage 的 vault 内容一键导出为标准 Markdown 格式（.md 文件打包），兼容 Obsidian 导入。",
+      "acceptanceCriteria": [
+        "Settings「数据」Section 新增「导出 Vault」按钮",
+        "点击后生成 daypage-export-YYYY-MM-DD.zip，包含 raw/ 和 daily/ 所有 .md 文件，保持目录结构",
+        "导出进行中显示 ProgressView() + 「正在打包...」文字",
+        "完成后弹出系统 Share Sheet（UIActivityViewController）",
+        "导出文件中的 YAML frontmatter 格式与 Obsidian 兼容",
+        "构建通过，iPhone 17 手动验证：导出 → 文件 App 可预览 .md 内容"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: C-功能补全, Effort: M, Impact: 3"
+    },
+    {
+      "id": "US-020",
+      "title": "TodayViewModel 核心路径单元测试",
+      "description": "作为开发者，TodayViewModel 的 submitCombinedMemo()、load()、compile() 三条核心路径应有单元测试覆盖，以便重构时有安全网。",
+      "acceptanceCriteria": [
+        "新建 DayPageTests/TodayViewModelTests.swift（Swift Testing）",
+        "测试 submitCombinedMemo()：纯文字 memo → 验证 RawStorage 写入；语音 memo（mock VoiceService）→ 验证附件字段；location memo → 验证 location frontmatter",
+        "测试 load()：空 vault → 验证 memos 为空；有 3 条 memo 的文件 → 验证解析正确",
+        "测试 compile()：mock CompilationService 返回成功 → 验证 dailyPageModel 更新；返回失败 → 验证 compilationFailedError 设置",
+        "至少 12 个 test case，覆盖 happy path + error path",
+        "全部测试通过 (xcodebuild test -scheme DayPage)"
+      ],
+      "priority": 2,
+      "passes": false,
+      "notes": "Theme: D-技术债务, Effort: L, Impact: 2"
+    },
+    {
+      "id": "US-021",
+      "title": "TodayView 拆分子视图",
+      "description": "作为开发者，1170 行的 TodayView 应拆分为独立子视图组件，每个文件不超过 300 行，减少 PR 冲突和 AI 辅助编码的上下文窗口压力。",
+      "acceptanceCriteria": [
+        "提取 TodayOrbHeaderView（Day Orb + 日期标题区，约 120 行）到独立文件",
+        "提取 TodayMemoListView（memo 列表 + SwipeableMemoCard，约 200 行）到独立文件",
+        "提取 LocationDraftCard + LocationDraftRow 到 DayPage/Features/Today/LocationDraft/ 子目录",
+        "TodayView.swift 主文件压缩到 ≤ 350 行",
+        "无功能改变：拆分前后 iPhone 17 Simulator 截图目视一致",
+        "构建通过，现有测试通过"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": "Theme: D-技术债务, Effort: L, Impact: 2"
+    },
+    {
+      "id": "US-022",
+      "title": "CompilationService.compile() 函数分解",
+      "description": "作为开发者，compile() 的 152 行单体函数应分解为 5 个职责单一的私有方法，提高可测试性。",
+      "acceptanceCriteria": [
+        "提取 prepareMemoContext() async throws -> CompilationContext",
+        "提取 buildPrompt(context:) -> [ChatMessage]",
+        "提取 callLLM(messages:) async throws -> String",
+        "提取 parseCompilationOutput(_:) throws -> DailyPageModel",
+        "提取 persistResults(_:for:) async throws",
+        "所有方法有 // throws: CompilationError.X 注释",
+        "构建通过，编译功能端到端手动测试正常"
+      ],
+      "priority": 3,
+      "passes": false,
+      "notes": "Theme: D-技术债务, Effort: M, Impact: 1"
+    },
+    {
+      "id": "US-023",
+      "title": ".trash 备份文件 7 天 TTL 自动清理",
+      "description": "作为用户，iCloud Drive 中的 DayPage vault 不应随时间无限增长，每日编译备份应在 7 天后自动删除。",
+      "acceptanceCriteria": [
+        "在 BackgroundCompilationService 中新增 performTrashCleanup() 方法，扫描 vault/.trash/ 目录",
+        "删除修改时间早于 7 天前的所有 .md 备份文件",
+        "清理操作在后台 Task 中执行，不阻塞编译主流程",
+        "首次运行时若 .trash/ 超过 50 个文件，记录 warning 日志并触发全量清理",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: D-技术债务, Effort: S, Impact: 1"
+    },
+    {
+      "id": "US-024",
+      "title": "编译输出结构化增强 — mood + 日期感知",
+      "description": "作为用户，AI 编译的 Daily Page 应包含当天的情绪评估（mood），并在节假日/特殊日期时自动调整叙事语气。",
+      "acceptanceCriteria": [
+        "System prompt 增加：输出 YAML frontmatter 中必须包含 mood: positive|neutral|negative|intense",
+        "DailyPageModel 新增 var mood: MoodLevel?（与 US-017 共用枚举）",
+        "DailyPageView 在标题下方显示 mood 情绪指示器（小彩色圆点，4 种颜色对应 4 种 mood）",
+        "编译 prompt 注入当天日期（包括星期）：「今天是 {weekday}，{date}」",
+        "单元测试：mock LLM 返回含 mood: positive 的输出 → 验证 DailyPageModel.mood == .positive",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: E-AI能力升级, Effort: M, Impact: 3"
+    },
+    {
+      "id": "US-025",
+      "title": "Entity Slug 去重与模糊匹配",
+      "description": "作为用户，当 AI 先后生成 joma-coffee 和 joma_coffee 两个变体时，知识图谱不应产生重复节点，而应合并到同一 entity 页面。",
+      "acceptanceCriteria": [
+        "EntityPageService 在 apply() 前执行 slug 归一化：小写、_ → -、移除特殊字符",
+        "归一化后若目标文件已存在，执行 update 而非 create",
+        "可选增强：实现编辑距离 ≤ 2 的模糊匹配（Levenshtein），自动合并近似 slug",
+        "单元测试：apply(slug: \"joma_coffee\") + apply(slug: \"joma-coffee\") → wiki 目录中只有 1 个文件",
+        "构建通过"
+      ],
+      "priority": 3,
+      "passes": true,
+      "notes": "Theme: E-AI能力升级, Effort: M, Impact: 2"
+    }
+  ]
+}

--- a/archive/2026-05-20-v7-deep-audit/progress-root.txt
+++ b/archive/2026-05-20-v7-deep-audit/progress-root.txt
@@ -1,0 +1,9 @@
+# DayPage v6 Deep Experience - Ralph Progress Log
+
+Source PRD: tasks/prd-daypage-v6-deep-experience.md
+Branch: ralph/v6-deep-experience
+Start: 2026-05-17
+
+Previous run (test-findings-fix) archived at: archive/2026-05-17-test-findings-fix/
+
+---

--- a/archive/2026-05-20-v7-deep-audit/progress-scripts-ralph.txt
+++ b/archive/2026-05-20-v7-deep-audit/progress-scripts-ralph.txt
@@ -1,0 +1,12 @@
+# DayPage v7 — Ralph Progress Log
+Started: 2026-05-19 06:37
+Tool: claude
+PRD: prd-v7-audit.json (25 stories)
+Branch: ralph/v7-deep-audit
+---
+[2026-05-19T06:41:19Z] Story #US-001: 立即轮换全部泄露的 API Key — PASSED
+[2026-05-19T06:43:58Z] Story #US-002: 将 API Key 从 UserDefaults 迁移到 Keychain — PASSED
+[2026-05-19T06:45:50Z] Story #US-003: 修复 NotificationCenter 观察者累积泄漏 — PASSED
+[2026-05-19T06:47:28Z] Story #US-004: Task 体补 @MainActor 注解（并发安全） — PASSED
+[2026-05-19T06:50:52Z] Story #US-005: 修复 atomicWrite 临时文件孤儿问题 — PASSED
+[2026-05-19T06:50:52Z] Ralph complete after 6 iterations

--- a/prd.json
+++ b/prd.json
@@ -1,390 +1,205 @@
 {
-  "project": "DayPage",
-  "branchName": "ralph/v7-deep-audit",
-  "description": "DayPage v7 深度审计与优化路线图 — 基于 UI/UX + Architecture + Features 三角度 Agent 审计。覆盖：API key 安全漏洞修复、Graph Tab 数据接通、并发安全、UI 一致性、Entity 双向链接、Archive 性能、AI 引擎透明化等 25 个 User Story。Source: tasks/prd-daypage-v7-deep-audit.md",
+  "project": "DayPage Codex (web)",
+  "branchName": "ralph/codex-add-page-polish",
+  "description": "Codex /add page polish — 修复 2026-05-20 端到端测试报告中发现的 9 个缺陷（草稿丢失、SSR/CSR 首帧不一致、⌘+Enter、卡片跳详情、Bookmarklet 误附图、URL/Photo/File 模式按钮等），并补齐已规划但未实现的辅助交互。Source: tasks/prd-codex-add-page-polish.md",
   "userStories": [
     {
       "id": "US-001",
-      "title": "立即轮换全部泄露的 API Key",
-      "description": "作为产品负责人，我需要立即撤销并重新生成 GeneratedSecrets.swift 中的所有 5 个生产密钥（DeepSeek sk-、OpenAI sk-proj-、OpenWeather、Supabase anon、GitHub PAT），防止恶意使用。",
+      "title": "新增 useAddDraft hook（localStorage 草稿持久化）",
+      "description": "As a developer, I need a self-contained hook that reads/writes the draft to localStorage so US-002+ can rely on it.",
       "acceptanceCriteria": [
-        "在所有相关平台撤销现有密钥：DeepSeek、OpenAI Dashboard、OpenWeatherMap、Supabase、GitHub Settings",
-        "生成新密钥，不写入任何 Swift 文件或 git 跟踪目录",
-        "验证 GeneratedSecrets.swift 已被 .gitignore 正确排除（git ls-files --error-unmatch DayPage/Config/GeneratedSecrets.swift 应报错）",
-        "CI/CD（Fastlane）从环境变量或加密 secrets 注入密钥，生成该文件"
+        "Create web/src/app/(app)/add/useAddDraft.ts exporting useAddDraft()",
+        "Hook returns { draft, setDraft, saveDraft, clearDraft, restoredAt }",
+        "Persist to localStorage key 'codex.add.draft.v1' with shape { text: string, mode: 'text'|'url'|'photo'|'file', attachmentRef: string|null, savedAt: string (ISO 8601) }",
+        "Hook is SSR-safe: only touches localStorage inside useEffect / event handlers",
+        "Returns null draft on first render to avoid hydration mismatch",
+        "Typecheck passes"
       ],
       "priority": 1,
-      "passes": true,
-      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 5; Engineering infra verified: GeneratedSecrets.swift gitignored, .env gitignored, CI uses placeholder (ENV_FILE secret), .env.example synced. Key rotation is an operational task for the owner to perform manually."
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-002",
-      "title": "将 API Key 从 UserDefaults 迁移到 Keychain",
-      "description": "作为用户，我的 AI API key 应存储在 iOS Keychain 中而非明文 UserDefaults，防止 iCloud UserDefaults 备份泄露。",
+      "title": "Wire Save draft + 自动回填 to UnifiedInput",
+      "description": "As a user, I want my draft to survive a page refresh so I never lose what I was writing.",
       "acceptanceCriteria": [
-        "在 KeychainHelper.swift 中新增 setAPIKey(_:for:) / getAPIKey(for:) 方法，使用 kSecClassGenericPassword",
-        "SecretsRuntime.resolvedDeepSeekApiKey 等所有运行时 key 读取路径改为从 Keychain 读取",
-        "Settings 中「保存 API Key」按钮写入 Keychain 而非 UserDefaults",
-        "首次启动迁移：若 UserDefaults 中存有旧 key，静默迁移至 Keychain 并删除 UserDefaults 条目",
-        "构建通过，iPhone 17 Simulator 手动测试：输入 key → force-quit → 重启 → key 保留"
+        "web/src/app/(app)/add/UnifiedInput.tsx uses useAddDraft()",
+        "Clicking Save draft writes current textarea text + mode to localStorage and shows existing 'Draft saved' toast",
+        "On mount (after hydration), if a non-empty draft exists, prefill textarea and show subtle hint 'Restored draft · {relative time}'",
+        "Show a 'Discard draft' button next to the hint; clicking it clears the draft and empties the textarea",
+        "Successful POST /api/memos (201) clears the draft",
+        "Clearing textarea and blurring for >1s clears the draft",
+        "No React hydration warning in console",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 1,
-      "passes": true,
-      "notes": "Theme: A-安全与可靠性, Effort: M, Impact: 4"
+      "priority": 2,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-003",
-      "title": "修复 NotificationCenter 观察者累积泄漏",
-      "description": "作为用户，我在一次 session 中多次进出 Today 视图时，不应看到重复的 memo 提交或重复触发的编译动画。",
+      "title": "⌘/Ctrl + Enter 触发 Add 提交",
+      "description": "As a keyboard user, I want Cmd/Ctrl+Enter inside the textarea to submit the memo.",
       "acceptanceCriteria": [
-        "在 TodayViewModel 中添加 private var cancellables = Set<AnyCancellable>()",
-        "将 4 个 NotificationCenter.addObserver（L209, L218, L227, L236）改为 .publisher(for:).sink { }.store(in: &cancellables)",
-        "测试：模拟 10 次 push/pop TodayView，发送 1 次 compilationSucceeded 通知，验证回调只触发 1 次",
-        "构建通过"
+        "Add onKeyDown to UnifiedInput textarea: when (metaKey || ctrlKey) && key === 'Enter', call the same submit handler as the Add button",
+        "Shortcut is a no-op when Add button is disabled (empty content or submitting)",
+        "Shift+Enter still inserts newline as before",
+        "Hint line below textarea shows '⌘ + Enter to submit' on macOS, 'Ctrl + Enter to submit' otherwise",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 1,
-      "passes": true,
-      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 4"
+      "priority": 3,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-004",
-      "title": "Task 体补 @MainActor 注解（并发安全）",
-      "description": "作为开发者，我需要 TodayViewModel 中所有 Task 闭包体明确标注 @MainActor，防止 @Published 属性在非主线程被修改导致 UI 状态撕裂。",
+      "title": "面包屑改为 usePathname 派生（SSR/CSR 一致）",
+      "description": "As a user, I want the breadcrumb to display CODEX / Add immediately when I navigate to /add, with no flash of stale value.",
       "acceptanceCriteria": [
-        "将 TodayViewModel.swift L500, L620, L634, L652, L695, L789 的 Task { 改为 Task { @MainActor in",
-        "CompilationService 中 @Published compilationProgress 的写入路径包裹 await MainActor.run { }（L113）",
-        "替换 TodayView.swift L371 的 DispatchQueue.main.asyncAfter 为 Task { try? await Task.sleep(for: .seconds(3)) }",
-        "Swift 编译器无 Sendable / data race 警告",
-        "构建通过，现有测试通过"
+        "In web/src/app/(app)/layout.tsx (or whichever component renders the breadcrumb), source the current segment from usePathname() / useSelectedLayoutSegment() instead of any cookie/store",
+        "Server-rendered breadcrumb matches client-rendered breadcrumb on first paint (no hydration mismatch warning)",
+        "Navigating /home → /add updates the breadcrumb without requiring a refresh",
+        "Console remains 0 errors / 0 warnings",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 1,
-      "passes": true,
-      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 3"
+      "priority": 4,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-005",
-      "title": "修复 atomicWrite 临时文件孤儿问题",
-      "description": "作为用户，App crash 或写入失败后重启时，vault 目录下不应残留 .tmp.UUID 孤儿文件占用 iCloud 存储配额。",
+      "title": "POST /api/memos 后乐观插入 QUEUED 条目",
+      "description": "As a user, when I submit a memo I want it to appear in the Compile Queue immediately with a QUEUED label.",
       "acceptanceCriteria": [
-        "在 atomicWrite 的 catch 块中，replaceItemAt 失败后执行 try? FileManager.default.removeItem(at: tempURL)",
-        "在 App 启动时扫描 vault 目录，删除所有匹配 *.tmp.* 的孤儿文件",
-        "添加单元测试：模拟 replaceItemAt 抛出，验证 tempURL 文件被清理",
-        "构建通过"
+        "After POST /api/memos resolves with 201, prepend the new memo into the react-query cache used by CompileQueue (queryKey starting with 'memos' and compile_status='pending')",
+        "Temp item has shape { id: 'temp-{uuid}', compile_status: 'pending', created_at: now, type: detected_type, text: payload.text }",
+        "CompileQueue renders 'QUEUED' label for items where compile_status === 'pending' (no special-case for temp ids)",
+        "When the SSE /api/stream/compile delivers the real id, swap the temp item for the real one (setQueryData or invalidateQueries) with no visible reordering jump",
+        "On POST failure, remove the temp item and toast 'Failed to submit, try again'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 1,
-      "passes": true,
-      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 3"
+      "priority": 5,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-006",
-      "title": "InputBarV4 硬编码字体 → DSType token 对齐",
-      "description": "作为设计系统维护者，InputBarV4 中 20+ 处 .font(.system(size: N, weight: W)) 应全部替换为对应 DSType token，确保下次字体迭代只改 1 个文件。",
+      "title": "Compile Queue / Recently Compiled 卡片整体可点击跳详情",
+      "description": "As a user, clicking the body of a queue card should navigate to that memo's detail page.",
       "acceptanceCriteria": [
-        "建立映射表：system(size:11,weight:.semibold)→DSType.label；system(size:18)→DSType.bodyMD；system(size:19,weight:.light)→DSType.serifBody18",
-        "GlassErrorBanner.swift L111, L149 同步替换",
-        "GlassTabBar.swift L92, L100 同步替换",
-        "替换后视觉截图对比（before/after）附 PR",
-        "构建通过，iPhone 17 Simulator 目视验证"
+        "In web/src/app/(app)/add/CompileQueue.tsx and RecentlyCompiled.tsx, wrap each card body in a Next.js <Link> pointing to the existing memo detail route (grep for current memo detail link usage to confirm path; if none, use /wiki/[slug] as default)",
+        "Card body shows cursor-pointer and a 1px focus outline on Tab focus",
+        "The LIGHT/FULL mode-toggle control on the card calls e.stopPropagation() in its onClick so it never triggers the card link",
+        "Hitting Enter or Space on a focused card navigates to the detail page",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 3"
+      "priority": 6,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-007",
-      "title": "全局 Dynamic Type 支持（heading + body 优先）",
-      "description": "作为使用大字号的用户，我希望 DayPage 所有主要文本在「更大字号」辅助功能设置下都能正确缩放，而不仅限于正文。",
+      "title": "Bookmarklet 按钮改为脚本指引 Modal",
+      "description": "As a user, clicking Bookmarklet should show me a draggable bookmark link + script, not silently attach a fake PNG.",
       "acceptanceCriteria": [
-        "为 H1Modifier、H2Modifier、HeadlineMDModifier、BodyMDModifier、BodySMModifier、CaptionModifier 添加 .dynamicTypeSize(.xSmall ... .xxxLarge) 和 .minimumScaleFactor(0.8)",
-        "SerifBody16/18/20Modifier 同样处理",
-        "MonoModifier 系列使用 .dynamicTypeSize(.xSmall ... .accessibility1) 限制最大放大",
-        "iPhone 17 Simulator 开启「辅助功能 > 更大字体 > 最大」，验证 TodayView、ArchiveView、DailyPageView 文字可读无截断",
-        "构建通过"
+        "Remove the dev-only code that auto-attaches IMG_3836.PNG when the Bookmarklet button is clicked",
+        "Clicking Bookmarklet opens a modal containing: (a) a draggable <a href='javascript:...'> labeled '📎 Save to Codex'; (b) a <pre> block with the bookmarklet source + one-click copy button; (c) one-paragraph instructions on dragging it to the bookmarks bar",
+        "Modal closes via Esc, backdrop click, and explicit close button",
+        "No write to textarea state or attachment state from the Bookmarklet flow",
+        "Reuse existing UI primitives from web/src/components/ui/ (Card/Btn/Icon); if a Dialog primitive doesn't exist, add a minimal one in web/src/app/(app)/_components/Dialog.tsx",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 4"
+      "priority": 7,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-008",
-      "title": "Accessibility — 关键按钮 label + 44pt tap target",
-      "description": "作为使用 VoiceOver 的用户，我需要所有交互元素都有语义化 accessibilityLabel，且 tap target 不小于 44pt。",
+      "title": "URL 按钮改为切换 URL 输入模式",
+      "description": "As a user, clicking URL should switch the input into URL mode (placeholder + validation), not auto-paste the current page URL.",
       "acceptanceCriteria": [
-        "Settings gear button 从 frame(28, 28) 改为 frame(44, 44)（或加 .contentShape(Rectangle())），添加 .accessibilityLabel(L10n.a11y.settingsButton)",
-        "LocationDraftRow 的「全部忽略」「全部确认」「单条确认」「单条忽略」按钮 frame 改为 min(44, 44) 并添加语义 label",
-        "TodayView.swift L93「Open navigation」改为 L10n.a11y.openNavigation",
-        "新增 L10n.a11y.* 枚举分支，覆盖以上所有新 label",
-        "iPhone 17 Simulator 开启 VoiceOver 手动验证：逐一聚焦按钮，描述正确",
-        "构建通过"
+        "Remove the behavior that fills textarea with window.location.href when URL button is clicked",
+        "Clicking URL toggles a 'url' mode on UnifiedInput: button shows active state (same style as Photo/File active)",
+        "When mode === 'url', placeholder becomes 'https://… paste the link you want to save'",
+        "When mode === 'url' and textarea content is not a valid URL (new URL() throws), Add button is disabled and hint shows 'Enter a valid URL'",
+        "Clicking URL again returns to default 'text' mode without clearing existing text",
+        "Mode switching never clears already-typed text",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 4"
+      "priority": 8,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-009",
-      "title": "编译 / 语音转写 / 照片处理 Loading 指示器",
-      "description": "作为用户，当 AI 编译、Whisper 转写或批量照片处理正在进行时，我应该看到明确的 Loading 状态，而不是静默等待。",
+      "title": "Photo / File 按钮接入文件选择 + 附件卡片",
+      "description": "As a user, clicking Photo opens camera/photo picker and clicking File opens a file picker; selected attachment shows on the form.",
       "acceptanceCriteria": [
-        "语音录制停止到转写完成期间，InputBarV4 的附件 chip 显示 ProgressView() 旋转器",
-        "CompileFooterButton 在 isCompiling == true 时显示 ProgressView() + 阶段文字（「分析中…」「生成中…」），使用 CompilationService.compilationProgress 驱动",
-        "批量照片处理期间（isProcessingPhoto == true），Today 输入区顶部显示细进度条（LinearProgressView），处理完成后淡出",
-        "所有 loading 组件使用 DSColor.onSurfaceVariant tint",
-        "构建通过，iPhone 17 Simulator 目视验证三种 loading 场景"
+        "Photo button triggers a hidden <input type='file' accept='image/*' capture='environment'>",
+        "File button triggers a hidden <input type='file'> (no accept restriction; single file only)",
+        "After selection, render an attachment card under the textarea: thumbnail (for images) or generic icon, file name, size (formatted as KB/MB), and a ✕ remove button",
+        "Removing the attachment also clears the active mode (button no longer highlighted)",
+        "On submit, attachment is included in the request (use the same path the backend already expects; if no upload endpoint exists yet, leave a TODO and submit text-only — must not break typecheck)",
+        "Show a spinner on the attachment card while uploading; on failure, toast 'Upload failed, try again'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 3"
+      "priority": 9,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-010",
-      "title": "动效 Token 补全（InputBar / Swipe / Breathing）",
-      "description": "作为设计系统维护者，Motion.swift 应补充 3 个当前被大量硬编码绕过的动效 token，消除分散的魔法数值。",
+      "title": "UnifiedInput 渲染性能加固",
+      "description": "As an automation user, I want mode-button clicks to respond in <300ms with no occasional 30s freezes.",
       "acceptanceCriteria": [
-        "新增 Motion.inputDock = Animation.spring(response: 0.42, dampingFraction: 0.78)",
-        "新增 Motion.swipeSnap = Animation.spring(response: 0.28, dampingFraction: 0.86)",
-        "新增 Motion.breathing = Animation.easeInOut(duration: 0.8).repeatForever(autoreverses: true)",
-        "InputBarV4 L91 composerSpring 改用 Motion.inputDock；L173 匿名 spring 改用 Motion.inputDock",
-        "SwipeableMemoCard L178 改用 Motion.swipeSnap",
-        "RecordingOverlayView / DayOrbView breathing 动画改用 Motion.breathing",
-        "构建通过"
+        "Audit UnifiedInput for hot-path issues: remove any deep-clone / JSON.stringify of full form state inside onChange / onClick handlers",
+        "Memoize the mode-button list and submit handler with useCallback / useMemo where appropriate",
+        "Add a Playwright test in web/e2e/ that clicks each mode button 50 times in sequence and asserts no timeout and final UI state is correct",
+        "The new e2e test passes",
+        "Typecheck passes"
       ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 2"
+      "priority": 10,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-011",
-      "title": "硬编码字符串 → L10n key（TodayView）",
-      "description": "作为多语言用户，TodayView 中的硬编码中英文字符串应通过 L10n 系统输出，支持语言切换。",
+      "title": "/add 页面回归 E2E 用例集",
+      "description": "As a maintainer, I want Playwright coverage for every fix in this PRD so regressions are caught automatically.",
       "acceptanceCriteria": [
-        "L933/935：\"\\(dateStr) · 1 note\" → L10n.Archive.noteCount(1)；复数形式 L10n.Archive.noteCountPlural(count)",
-        "L965：Button(\"重试\") → Button(L10n.Error.retry)",
-        "L1035：Text(\"检测到位置到达\") → Text(L10n.Location.arrivalDetected)",
-        "L1039/1042：\"全部忽略\" / \"全部确认\" → L10n.Location.ignoreAll / L10n.Location.confirmAll",
-        "在 en.lproj/Localizable.strings 和 zh-Hans.lproj/Localizable.strings 中添加对应键值",
-        "构建通过"
+        "Create or extend web/e2e/add.spec.ts with tests for: draft restore after reload, ⌘+Enter submit, card click navigates to detail, breadcrumb first-paint shows 'Add', new submission shows QUEUED immediately, Bookmarklet opens modal (and does NOT attach a file), URL button toggles mode without auto-filling, Photo/File pickers attach and remove",
+        "All new tests pass locally via the project's e2e command (pnpm test:e2e or playwright test — use whichever the package.json defines)",
+        "No existing e2e test regresses",
+        "Typecheck passes"
       ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 2"
+      "priority": 11,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-012",
-      "title": "Graph Tab 接通 EntityPageService 真实数据",
-      "description": "作为用户，我在 Graph Tab 中应该看到基于我实际日记数据生成的知识图谱节点（人物、地点、主题），而不是空白或样例数据。",
+      "title": "(可选/默认关闭) 草稿服务端同步骨架",
+      "description": "As a multi-device user, I'd like drafts to sync across devices when the feature flag is on. This story only lays the skeleton; the flag stays off by default.",
       "acceptanceCriteria": [
-        "GraphViewModel 实现 loadGraph() 方法：读取 wiki/places/、wiki/people/、wiki/themes/ 目录下所有 entity 页面，解析 YAML frontmatter 提取 name、type、occurrence_count、first_seen",
-        "每个 entity 转换为图节点；若两个 entity 在同一 Daily Page 中同时出现，则生成连边（co-occurrence）",
-        "GraphView 保持现有力导向布局，仅替换数据源为 GraphViewModel.nodes / .edges",
-        "空状态：vault 无 entity 时显示 EmptyStateView",
-        "Graph Tab 在 vault 有至少 3 个 entity 时展示可交互图谱",
-        "构建通过，iPhone 17 Simulator 有数据时验证图谱节点非空"
+        "Add NEXT_PUBLIC_CODEX_DRAFT_SYNC env (documented in web/.env.example), default unset/false",
+        "When the flag is true, useAddDraft additionally: on mount, GET /api/drafts/add (if local draft empty); on change, debounce 1500ms then PUT /api/drafts/add with the same shape as the localStorage value",
+        "Create skeleton route handlers web/src/app/api/drafts/add/route.ts with GET + PUT that currently return 501 + a TODO comment marked 'Post-MVP'",
+        "When the flag is false, the sync code path is tree-shaken / behind an if (process.env.NEXT_PUBLIC_CODEX_DRAFT_SYNC === 'true') guard",
+        "No DB migration in this story",
+        "Typecheck passes"
       ],
-      "priority": 1,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 5 | Already implemented on main"
-    },
-    {
-      "id": "US-013",
-      "title": "Entity 双向链接（Entity Page → Related Memos）",
-      "description": "作为用户，打开一个 Entity 页面时，我应该看到所有提到过它的原始 Memo 列表，形成从知识网络回溯到原始记录的路径。",
-      "acceptanceCriteria": [
-        "EntityPageService.apply(instruction:) 在创建或更新 entity 时，将当前日期追加到 entity YAML frontmatter 的 related_dates: [] 数组",
-        "EntityPageView 实现 relatedMemos() —— 读取 related_dates，对每个日期调用 RawStorage.read(for:)，返回包含该 entity slug 的 memo 列表",
-        "Entity 页面底部新增「来源记录」Section，以精简版 MemoCardView 展示 related memos，按日期降序，最多 20 条",
-        "单元测试：构造含 entity mention 的 memo → 运行 apply() → 验证 related_dates 包含该日期",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 4"
-    },
-    {
-      "id": "US-014",
-      "title": "AI 引擎透明化 — Settings 展示当前模型",
-      "description": "作为用户，我有权知道当前处理我日记的 AI 模型是什么，并理解模型变更对编译风格的潜在影响。",
-      "acceptanceCriteria": [
-        "Settings「AI 编译引擎」Section 显示：当前模型名称、API provider、上次编译时间",
-        "CompilationService 暴露 static let modelName: String 和 static let apiProvider: String 常量",
-        "如果用户使用 DeepSeek 而非 Qwen（MVP 默认），Settings 中注明「⚠️ 当前使用非默认引擎」",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: S, Impact: 2"
-    },
-    {
-      "id": "US-015",
-      "title": "Archive 月份数据异步加载",
-      "description": "作为拥有 6 个月以上数据的用户，打开 Archive 时不应有明显卡顿，calendar grid 应先渲染骨架再填入数据。",
-      "acceptanceCriteria": [
-        "ArchiveViewModel.loadMonth() 改为 async 方法，在 Task { await loadMonth() } 中调用，不阻塞主线程",
-        "加载期间 calendar grid 的每个 day cell 显示 ProgressView() 占位或灰色矩形",
-        "月份切换时立即显示新月份的 loading 骨架，旧月份数据立即清除",
-        "有真实数据时（3+ 个月历史），Archive 打开到渲染完成 < 500ms（iPhone 17 Simulator 测量）",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 3 | Already implemented on main"
-    },
-    {
-      "id": "US-016",
-      "title": "语音附件 Retry 闭环",
-      "description": "作为用户，当 Whisper 转写失败后，我应该能在 Today 页面的语音附件 chip 上直接点击「重试」重新发起转写，而不是丢弃录音。",
-      "acceptanceCriteria": [
-        "语音附件转写失败时，Attachment 标记 transcriptionStatus: .failed（新增枚举 case）",
-        "InputBarV4 附件 chip 在 transcriptionStatus == .failed 时显示红色边框 + 「↺」重试图标",
-        "点击重试图标调用 TodayViewModel.retranscribeVoiceAttachment(id:)，触发 VoiceService.transcribeAudio(at:) 重试",
-        "重试中显示 chip 内 ProgressView()；成功后 chip 切回正常态 + transcript 显示前 20 字",
-        "构建通过，手动测试：断网录音 → 失败红边 → 联网点重试 → 成功"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: S, Impact: 3"
-    },
-    {
-      "id": "US-017",
-      "title": "Memo 数据模型补 mood + entity mentions 字段",
-      "description": "作为开发者，Memo struct 应内置 mood 和 entityMentions 字段，为知识图谱的精确双向链接和情绪时间线提供结构化数据基础。",
-      "acceptanceCriteria": [
-        "Memo struct 新增 var mood: MoodLevel? = nil（枚举：.positive/.neutral/.negative/.intense）",
-        "Memo struct 新增 var entityMentions: [String] = []（从 body 中 [[EntitySlug]] 语法提取的 slug 数组）",
-        "RawStorage YAML 解析器新增 mood: 和 entities: frontmatter 键支持",
-        "TodayViewModel.submitCombinedMemo() 在写入前从 body 文本提取 [[...]] 模式填充 entityMentions",
-        "向后兼容：旧文件无这两个字段时，解析为 nil/[]，不报错",
-        "单元测试：构造含 [[Tokyo]] 的 memo body → 验证 entityMentions == [\"Tokyo\"]",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 3"
-    },
-    {
-      "id": "US-018",
-      "title": "批量 HEIC 照片转换移离主线程",
-      "description": "作为用户，选择 5 张以上 HEIC 格式照片时，Today 页面不应出现明显卡顿或 UI 冻结。",
-      "acceptanceCriteria": [
-        "PhotoService.processPickerItem() 中 HEIC → JPEG 转换移入 Task.detached(priority: .userInitiated) { }（脱离 MainActor）",
-        "转换完成后通过 await MainActor.run { } 回主线程更新 UI 状态",
-        "测试：选择 5 张 12MP HEIC 图片，Timeline 动画帧率 ≥ 55fps（Instruments Time Profiler 验证无主线程卡顿 >16ms）",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: S, Impact: 2"
-    },
-    {
-      "id": "US-019",
-      "title": "Markdown Export（Obsidian 兼容）",
-      "description": "作为数字游民用户，我希望能将 DayPage 的 vault 内容一键导出为标准 Markdown 格式（.md 文件打包），兼容 Obsidian 导入。",
-      "acceptanceCriteria": [
-        "Settings「数据」Section 新增「导出 Vault」按钮",
-        "点击后生成 daypage-export-YYYY-MM-DD.zip，包含 raw/ 和 daily/ 所有 .md 文件，保持目录结构",
-        "导出进行中显示 ProgressView() + 「正在打包...」文字",
-        "完成后弹出系统 Share Sheet（UIActivityViewController）",
-        "导出文件中的 YAML frontmatter 格式与 Obsidian 兼容",
-        "构建通过，iPhone 17 手动验证：导出 → 文件 App 可预览 .md 内容"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 3"
-    },
-    {
-      "id": "US-020",
-      "title": "TodayViewModel 核心路径单元测试",
-      "description": "作为开发者，TodayViewModel 的 submitCombinedMemo()、load()、compile() 三条核心路径应有单元测试覆盖，以便重构时有安全网。",
-      "acceptanceCriteria": [
-        "新建 DayPageTests/TodayViewModelTests.swift（Swift Testing）",
-        "测试 submitCombinedMemo()：纯文字 memo → 验证 RawStorage 写入；语音 memo（mock VoiceService）→ 验证附件字段；location memo → 验证 location frontmatter",
-        "测试 load()：空 vault → 验证 memos 为空；有 3 条 memo 的文件 → 验证解析正确",
-        "测试 compile()：mock CompilationService 返回成功 → 验证 dailyPageModel 更新；返回失败 → 验证 compilationFailedError 设置",
-        "至少 12 个 test case，覆盖 happy path + error path",
-        "全部测试通过 (xcodebuild test -scheme DayPage)"
-      ],
-      "priority": 2,
+      "priority": 12,
       "passes": false,
-      "notes": "Theme: D-技术债务, Effort: L, Impact: 2"
-    },
-    {
-      "id": "US-021",
-      "title": "TodayView 拆分子视图",
-      "description": "作为开发者，1170 行的 TodayView 应拆分为独立子视图组件，每个文件不超过 300 行，减少 PR 冲突和 AI 辅助编码的上下文窗口压力。",
-      "acceptanceCriteria": [
-        "提取 TodayOrbHeaderView（Day Orb + 日期标题区，约 120 行）到独立文件",
-        "提取 TodayMemoListView（memo 列表 + SwipeableMemoCard，约 200 行）到独立文件",
-        "提取 LocationDraftCard + LocationDraftRow 到 DayPage/Features/Today/LocationDraft/ 子目录",
-        "TodayView.swift 主文件压缩到 ≤ 350 行",
-        "无功能改变：拆分前后 iPhone 17 Simulator 截图目视一致",
-        "构建通过，现有测试通过"
-      ],
-      "priority": 3,
-      "passes": false,
-      "notes": "Theme: D-技术债务, Effort: L, Impact: 2"
-    },
-    {
-      "id": "US-022",
-      "title": "CompilationService.compile() 函数分解",
-      "description": "作为开发者，compile() 的 152 行单体函数应分解为 5 个职责单一的私有方法，提高可测试性。",
-      "acceptanceCriteria": [
-        "提取 prepareMemoContext() async throws -> CompilationContext",
-        "提取 buildPrompt(context:) -> [ChatMessage]",
-        "提取 callLLM(messages:) async throws -> String",
-        "提取 parseCompilationOutput(_:) throws -> DailyPageModel",
-        "提取 persistResults(_:for:) async throws",
-        "所有方法有 // throws: CompilationError.X 注释",
-        "构建通过，编译功能端到端手动测试正常"
-      ],
-      "priority": 3,
-      "passes": false,
-      "notes": "Theme: D-技术债务, Effort: M, Impact: 1"
-    },
-    {
-      "id": "US-023",
-      "title": ".trash 备份文件 7 天 TTL 自动清理",
-      "description": "作为用户，iCloud Drive 中的 DayPage vault 不应随时间无限增长，每日编译备份应在 7 天后自动删除。",
-      "acceptanceCriteria": [
-        "在 BackgroundCompilationService 中新增 performTrashCleanup() 方法，扫描 vault/.trash/ 目录",
-        "删除修改时间早于 7 天前的所有 .md 备份文件",
-        "清理操作在后台 Task 中执行，不阻塞编译主流程",
-        "首次运行时若 .trash/ 超过 50 个文件，记录 warning 日志并触发全量清理",
-        "构建通过"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: D-技术债务, Effort: S, Impact: 1"
-    },
-    {
-      "id": "US-024",
-      "title": "编译输出结构化增强 — mood + 日期感知",
-      "description": "作为用户，AI 编译的 Daily Page 应包含当天的情绪评估（mood），并在节假日/特殊日期时自动调整叙事语气。",
-      "acceptanceCriteria": [
-        "System prompt 增加：输出 YAML frontmatter 中必须包含 mood: positive|neutral|negative|intense",
-        "DailyPageModel 新增 var mood: MoodLevel?（与 US-017 共用枚举）",
-        "DailyPageView 在标题下方显示 mood 情绪指示器（小彩色圆点，4 种颜色对应 4 种 mood）",
-        "编译 prompt 注入当天日期（包括星期）：「今天是 {weekday}，{date}」",
-        "单元测试：mock LLM 返回含 mood: positive 的输出 → 验证 DailyPageModel.mood == .positive",
-        "构建通过"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: E-AI能力升级, Effort: M, Impact: 3"
-    },
-    {
-      "id": "US-025",
-      "title": "Entity Slug 去重与模糊匹配",
-      "description": "作为用户，当 AI 先后生成 joma-coffee 和 joma_coffee 两个变体时，知识图谱不应产生重复节点，而应合并到同一 entity 页面。",
-      "acceptanceCriteria": [
-        "EntityPageService 在 apply() 前执行 slug 归一化：小写、_ → -、移除特殊字符",
-        "归一化后若目标文件已存在，执行 update 而非 create",
-        "可选增强：实现编辑距离 ≤ 2 的模糊匹配（Levenshtein），自动合并近似 slug",
-        "单元测试：apply(slug: \"joma_coffee\") + apply(slug: \"joma-coffee\") → wiki 目录中只有 1 个文件",
-        "构建通过"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: E-AI能力升级, Effort: M, Impact: 2"
+      "notes": ""
     }
   ]
 }

--- a/progress.txt
+++ b/progress.txt
@@ -1,9 +1,12 @@
-# DayPage v6 Deep Experience - Ralph Progress Log
+# Codex /add Page Polish — Ralph Progress Log
 
-Source PRD: tasks/prd-daypage-v6-deep-experience.md
-Branch: ralph/v6-deep-experience
-Start: 2026-05-17
+Source PRD: tasks/prd-codex-add-page-polish.md
+Branch: ralph/codex-add-page-polish
+Start: 2026-05-20
 
-Previous run (test-findings-fix) archived at: archive/2026-05-17-test-findings-fix/
+Previous run (v7-deep-audit) archived at: archive/2026-05-20-v7-deep-audit/
+
+## Codebase Patterns
+- (To be populated by iterations as reusable patterns emerge.)
 
 ---

--- a/scripts/ralph/prd.json
+++ b/scripts/ralph/prd.json
@@ -1,390 +1,205 @@
 {
-  "project": "DayPage",
-  "branchName": "ralph/v7-deep-audit",
-  "description": "DayPage v7 深度审计与优化路线图 — 基于 UI/UX + Architecture + Features 三角度 Agent 审计。覆盖：API key 安全漏洞修复、Graph Tab 数据接通、并发安全、UI 一致性、Entity 双向链接、Archive 性能、AI 引擎透明化等 25 个 User Story。Source: tasks/prd-daypage-v7-deep-audit.md",
+  "project": "DayPage Codex (web)",
+  "branchName": "ralph/codex-add-page-polish",
+  "description": "Codex /add page polish — 修复 2026-05-20 端到端测试报告中发现的 9 个缺陷（草稿丢失、SSR/CSR 首帧不一致、⌘+Enter、卡片跳详情、Bookmarklet 误附图、URL/Photo/File 模式按钮等），并补齐已规划但未实现的辅助交互。Source: tasks/prd-codex-add-page-polish.md",
   "userStories": [
     {
       "id": "US-001",
-      "title": "立即轮换全部泄露的 API Key",
-      "description": "作为产品负责人，我需要立即撤销并重新生成 GeneratedSecrets.swift 中的所有 5 个生产密钥（DeepSeek sk-、OpenAI sk-proj-、OpenWeather、Supabase anon、GitHub PAT），防止恶意使用。",
+      "title": "新增 useAddDraft hook（localStorage 草稿持久化）",
+      "description": "As a developer, I need a self-contained hook that reads/writes the draft to localStorage so US-002+ can rely on it.",
       "acceptanceCriteria": [
-        "在所有相关平台撤销现有密钥：DeepSeek、OpenAI Dashboard、OpenWeatherMap、Supabase、GitHub Settings",
-        "生成新密钥，不写入任何 Swift 文件或 git 跟踪目录",
-        "验证 GeneratedSecrets.swift 已被 .gitignore 正确排除（git ls-files --error-unmatch DayPage/Config/GeneratedSecrets.swift 应报错）",
-        "CI/CD（Fastlane）从环境变量或加密 secrets 注入密钥，生成该文件"
+        "Create web/src/app/(app)/add/useAddDraft.ts exporting useAddDraft()",
+        "Hook returns { draft, setDraft, saveDraft, clearDraft, restoredAt }",
+        "Persist to localStorage key 'codex.add.draft.v1' with shape { text: string, mode: 'text'|'url'|'photo'|'file', attachmentRef: string|null, savedAt: string (ISO 8601) }",
+        "Hook is SSR-safe: only touches localStorage inside useEffect / event handlers",
+        "Returns null draft on first render to avoid hydration mismatch",
+        "Typecheck passes"
       ],
       "priority": 1,
       "passes": false,
-      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 5"
+      "notes": ""
     },
     {
       "id": "US-002",
-      "title": "将 API Key 从 UserDefaults 迁移到 Keychain",
-      "description": "作为用户，我的 AI API key 应存储在 iOS Keychain 中而非明文 UserDefaults，防止 iCloud UserDefaults 备份泄露。",
+      "title": "Wire Save draft + 自动回填 to UnifiedInput",
+      "description": "As a user, I want my draft to survive a page refresh so I never lose what I was writing.",
       "acceptanceCriteria": [
-        "在 KeychainHelper.swift 中新增 setAPIKey(_:for:) / getAPIKey(for:) 方法，使用 kSecClassGenericPassword",
-        "SecretsRuntime.resolvedDeepSeekApiKey 等所有运行时 key 读取路径改为从 Keychain 读取",
-        "Settings 中「保存 API Key」按钮写入 Keychain 而非 UserDefaults",
-        "首次启动迁移：若 UserDefaults 中存有旧 key，静默迁移至 Keychain 并删除 UserDefaults 条目",
-        "构建通过，iPhone 17 Simulator 手动测试：输入 key → force-quit → 重启 → key 保留"
+        "web/src/app/(app)/add/UnifiedInput.tsx uses useAddDraft()",
+        "Clicking Save draft writes current textarea text + mode to localStorage and shows existing 'Draft saved' toast",
+        "On mount (after hydration), if a non-empty draft exists, prefill textarea and show subtle hint 'Restored draft · {relative time}'",
+        "Show a 'Discard draft' button next to the hint; clicking it clears the draft and empties the textarea",
+        "Successful POST /api/memos (201) clears the draft",
+        "Clearing textarea and blurring for >1s clears the draft",
+        "No React hydration warning in console",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 1,
+      "priority": 2,
       "passes": false,
-      "notes": "Theme: A-安全与可靠性, Effort: M, Impact: 4"
+      "notes": ""
     },
     {
       "id": "US-003",
-      "title": "修复 NotificationCenter 观察者累积泄漏",
-      "description": "作为用户，我在一次 session 中多次进出 Today 视图时，不应看到重复的 memo 提交或重复触发的编译动画。",
+      "title": "⌘/Ctrl + Enter 触发 Add 提交",
+      "description": "As a keyboard user, I want Cmd/Ctrl+Enter inside the textarea to submit the memo.",
       "acceptanceCriteria": [
-        "在 TodayViewModel 中添加 private var cancellables = Set<AnyCancellable>()",
-        "将 4 个 NotificationCenter.addObserver（L209, L218, L227, L236）改为 .publisher(for:).sink { }.store(in: &cancellables)",
-        "测试：模拟 10 次 push/pop TodayView，发送 1 次 compilationSucceeded 通知，验证回调只触发 1 次",
-        "构建通过"
+        "Add onKeyDown to UnifiedInput textarea: when (metaKey || ctrlKey) && key === 'Enter', call the same submit handler as the Add button",
+        "Shortcut is a no-op when Add button is disabled (empty content or submitting)",
+        "Shift+Enter still inserts newline as before",
+        "Hint line below textarea shows '⌘ + Enter to submit' on macOS, 'Ctrl + Enter to submit' otherwise",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 1,
+      "priority": 3,
       "passes": false,
-      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 4"
+      "notes": ""
     },
     {
       "id": "US-004",
-      "title": "Task 体补 @MainActor 注解（并发安全）",
-      "description": "作为开发者，我需要 TodayViewModel 中所有 Task 闭包体明确标注 @MainActor，防止 @Published 属性在非主线程被修改导致 UI 状态撕裂。",
+      "title": "面包屑改为 usePathname 派生（SSR/CSR 一致）",
+      "description": "As a user, I want the breadcrumb to display CODEX / Add immediately when I navigate to /add, with no flash of stale value.",
       "acceptanceCriteria": [
-        "将 TodayViewModel.swift L500, L620, L634, L652, L695, L789 的 Task { 改为 Task { @MainActor in",
-        "CompilationService 中 @Published compilationProgress 的写入路径包裹 await MainActor.run { }（L113）",
-        "替换 TodayView.swift L371 的 DispatchQueue.main.asyncAfter 为 Task { try? await Task.sleep(for: .seconds(3)) }",
-        "Swift 编译器无 Sendable / data race 警告",
-        "构建通过，现有测试通过"
+        "In web/src/app/(app)/layout.tsx (or whichever component renders the breadcrumb), source the current segment from usePathname() / useSelectedLayoutSegment() instead of any cookie/store",
+        "Server-rendered breadcrumb matches client-rendered breadcrumb on first paint (no hydration mismatch warning)",
+        "Navigating /home → /add updates the breadcrumb without requiring a refresh",
+        "Console remains 0 errors / 0 warnings",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 1,
+      "priority": 4,
       "passes": false,
-      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 3"
+      "notes": ""
     },
     {
       "id": "US-005",
-      "title": "修复 atomicWrite 临时文件孤儿问题",
-      "description": "作为用户，App crash 或写入失败后重启时，vault 目录下不应残留 .tmp.UUID 孤儿文件占用 iCloud 存储配额。",
+      "title": "POST /api/memos 后乐观插入 QUEUED 条目",
+      "description": "As a user, when I submit a memo I want it to appear in the Compile Queue immediately with a QUEUED label.",
       "acceptanceCriteria": [
-        "在 atomicWrite 的 catch 块中，replaceItemAt 失败后执行 try? FileManager.default.removeItem(at: tempURL)",
-        "在 App 启动时扫描 vault 目录，删除所有匹配 *.tmp.* 的孤儿文件",
-        "添加单元测试：模拟 replaceItemAt 抛出，验证 tempURL 文件被清理",
-        "构建通过"
+        "After POST /api/memos resolves with 201, prepend the new memo into the react-query cache used by CompileQueue (queryKey starting with 'memos' and compile_status='pending')",
+        "Temp item has shape { id: 'temp-{uuid}', compile_status: 'pending', created_at: now, type: detected_type, text: payload.text }",
+        "CompileQueue renders 'QUEUED' label for items where compile_status === 'pending' (no special-case for temp ids)",
+        "When the SSE /api/stream/compile delivers the real id, swap the temp item for the real one (setQueryData or invalidateQueries) with no visible reordering jump",
+        "On POST failure, remove the temp item and toast 'Failed to submit, try again'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 1,
+      "priority": 5,
       "passes": false,
-      "notes": "Theme: A-安全与可靠性, Effort: S, Impact: 3"
+      "notes": ""
     },
     {
       "id": "US-006",
-      "title": "InputBarV4 硬编码字体 → DSType token 对齐",
-      "description": "作为设计系统维护者，InputBarV4 中 20+ 处 .font(.system(size: N, weight: W)) 应全部替换为对应 DSType token，确保下次字体迭代只改 1 个文件。",
+      "title": "Compile Queue / Recently Compiled 卡片整体可点击跳详情",
+      "description": "As a user, clicking the body of a queue card should navigate to that memo's detail page.",
       "acceptanceCriteria": [
-        "建立映射表：system(size:11,weight:.semibold)→DSType.label；system(size:18)→DSType.bodyMD；system(size:19,weight:.light)→DSType.serifBody18",
-        "GlassErrorBanner.swift L111, L149 同步替换",
-        "GlassTabBar.swift L92, L100 同步替换",
-        "替换后视觉截图对比（before/after）附 PR",
-        "构建通过，iPhone 17 Simulator 目视验证"
+        "In web/src/app/(app)/add/CompileQueue.tsx and RecentlyCompiled.tsx, wrap each card body in a Next.js <Link> pointing to the existing memo detail route (grep for current memo detail link usage to confirm path; if none, use /wiki/[slug] as default)",
+        "Card body shows cursor-pointer and a 1px focus outline on Tab focus",
+        "The LIGHT/FULL mode-toggle control on the card calls e.stopPropagation() in its onClick so it never triggers the card link",
+        "Hitting Enter or Space on a focused card navigates to the detail page",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 3"
+      "priority": 6,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-007",
-      "title": "全局 Dynamic Type 支持（heading + body 优先）",
-      "description": "作为使用大字号的用户，我希望 DayPage 所有主要文本在「更大字号」辅助功能设置下都能正确缩放，而不仅限于正文。",
+      "title": "Bookmarklet 按钮改为脚本指引 Modal",
+      "description": "As a user, clicking Bookmarklet should show me a draggable bookmark link + script, not silently attach a fake PNG.",
       "acceptanceCriteria": [
-        "为 H1Modifier、H2Modifier、HeadlineMDModifier、BodyMDModifier、BodySMModifier、CaptionModifier 添加 .dynamicTypeSize(.xSmall ... .xxxLarge) 和 .minimumScaleFactor(0.8)",
-        "SerifBody16/18/20Modifier 同样处理",
-        "MonoModifier 系列使用 .dynamicTypeSize(.xSmall ... .accessibility1) 限制最大放大",
-        "iPhone 17 Simulator 开启「辅助功能 > 更大字体 > 最大」，验证 TodayView、ArchiveView、DailyPageView 文字可读无截断",
-        "构建通过"
+        "Remove the dev-only code that auto-attaches IMG_3836.PNG when the Bookmarklet button is clicked",
+        "Clicking Bookmarklet opens a modal containing: (a) a draggable <a href='javascript:...'> labeled '📎 Save to Codex'; (b) a <pre> block with the bookmarklet source + one-click copy button; (c) one-paragraph instructions on dragging it to the bookmarks bar",
+        "Modal closes via Esc, backdrop click, and explicit close button",
+        "No write to textarea state or attachment state from the Bookmarklet flow",
+        "Reuse existing UI primitives from web/src/components/ui/ (Card/Btn/Icon); if a Dialog primitive doesn't exist, add a minimal one in web/src/app/(app)/_components/Dialog.tsx",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 4"
+      "priority": 7,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-008",
-      "title": "Accessibility — 关键按钮 label + 44pt tap target",
-      "description": "作为使用 VoiceOver 的用户，我需要所有交互元素都有语义化 accessibilityLabel，且 tap target 不小于 44pt。",
+      "title": "URL 按钮改为切换 URL 输入模式",
+      "description": "As a user, clicking URL should switch the input into URL mode (placeholder + validation), not auto-paste the current page URL.",
       "acceptanceCriteria": [
-        "Settings gear button 从 frame(28, 28) 改为 frame(44, 44)（或加 .contentShape(Rectangle())），添加 .accessibilityLabel(L10n.a11y.settingsButton)",
-        "LocationDraftRow 的「全部忽略」「全部确认」「单条确认」「单条忽略」按钮 frame 改为 min(44, 44) 并添加语义 label",
-        "TodayView.swift L93「Open navigation」改为 L10n.a11y.openNavigation",
-        "新增 L10n.a11y.* 枚举分支，覆盖以上所有新 label",
-        "iPhone 17 Simulator 开启 VoiceOver 手动验证：逐一聚焦按钮，描述正确",
-        "构建通过"
+        "Remove the behavior that fills textarea with window.location.href when URL button is clicked",
+        "Clicking URL toggles a 'url' mode on UnifiedInput: button shows active state (same style as Photo/File active)",
+        "When mode === 'url', placeholder becomes 'https://… paste the link you want to save'",
+        "When mode === 'url' and textarea content is not a valid URL (new URL() throws), Add button is disabled and hint shows 'Enter a valid URL'",
+        "Clicking URL again returns to default 'text' mode without clearing existing text",
+        "Mode switching never clears already-typed text",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 4"
+      "priority": 8,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-009",
-      "title": "编译 / 语音转写 / 照片处理 Loading 指示器",
-      "description": "作为用户，当 AI 编译、Whisper 转写或批量照片处理正在进行时，我应该看到明确的 Loading 状态，而不是静默等待。",
+      "title": "Photo / File 按钮接入文件选择 + 附件卡片",
+      "description": "As a user, clicking Photo opens camera/photo picker and clicking File opens a file picker; selected attachment shows on the form.",
       "acceptanceCriteria": [
-        "语音录制停止到转写完成期间，InputBarV4 的附件 chip 显示 ProgressView() 旋转器",
-        "CompileFooterButton 在 isCompiling == true 时显示 ProgressView() + 阶段文字（「分析中…」「生成中…」），使用 CompilationService.compilationProgress 驱动",
-        "批量照片处理期间（isProcessingPhoto == true），Today 输入区顶部显示细进度条（LinearProgressView），处理完成后淡出",
-        "所有 loading 组件使用 DSColor.onSurfaceVariant tint",
-        "构建通过，iPhone 17 Simulator 目视验证三种 loading 场景"
+        "Photo button triggers a hidden <input type='file' accept='image/*' capture='environment'>",
+        "File button triggers a hidden <input type='file'> (no accept restriction; single file only)",
+        "After selection, render an attachment card under the textarea: thumbnail (for images) or generic icon, file name, size (formatted as KB/MB), and a ✕ remove button",
+        "Removing the attachment also clears the active mode (button no longer highlighted)",
+        "On submit, attachment is included in the request (use the same path the backend already expects; if no upload endpoint exists yet, leave a TODO and submit text-only — must not break typecheck)",
+        "Show a spinner on the attachment card while uploading; on failure, toast 'Upload failed, try again'",
+        "Typecheck passes",
+        "Verify in browser using dev-browser skill"
       ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 3"
+      "priority": 9,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-010",
-      "title": "动效 Token 补全（InputBar / Swipe / Breathing）",
-      "description": "作为设计系统维护者，Motion.swift 应补充 3 个当前被大量硬编码绕过的动效 token，消除分散的魔法数值。",
+      "title": "UnifiedInput 渲染性能加固",
+      "description": "As an automation user, I want mode-button clicks to respond in <300ms with no occasional 30s freezes.",
       "acceptanceCriteria": [
-        "新增 Motion.inputDock = Animation.spring(response: 0.42, dampingFraction: 0.78)",
-        "新增 Motion.swipeSnap = Animation.spring(response: 0.28, dampingFraction: 0.86)",
-        "新增 Motion.breathing = Animation.easeInOut(duration: 0.8).repeatForever(autoreverses: true)",
-        "InputBarV4 L91 composerSpring 改用 Motion.inputDock；L173 匿名 spring 改用 Motion.inputDock",
-        "SwipeableMemoCard L178 改用 Motion.swipeSnap",
-        "RecordingOverlayView / DayOrbView breathing 动画改用 Motion.breathing",
-        "构建通过"
+        "Audit UnifiedInput for hot-path issues: remove any deep-clone / JSON.stringify of full form state inside onChange / onClick handlers",
+        "Memoize the mode-button list and submit handler with useCallback / useMemo where appropriate",
+        "Add a Playwright test in web/e2e/ that clicks each mode button 50 times in sequence and asserts no timeout and final UI state is correct",
+        "The new e2e test passes",
+        "Typecheck passes"
       ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: S, Impact: 2"
+      "priority": 10,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-011",
-      "title": "硬编码字符串 → L10n key（TodayView）",
-      "description": "作为多语言用户，TodayView 中的硬编码中英文字符串应通过 L10n 系统输出，支持语言切换。",
+      "title": "/add 页面回归 E2E 用例集",
+      "description": "As a maintainer, I want Playwright coverage for every fix in this PRD so regressions are caught automatically.",
       "acceptanceCriteria": [
-        "L933/935：\"\\(dateStr) · 1 note\" → L10n.Archive.noteCount(1)；复数形式 L10n.Archive.noteCountPlural(count)",
-        "L965：Button(\"重试\") → Button(L10n.Error.retry)",
-        "L1035：Text(\"检测到位置到达\") → Text(L10n.Location.arrivalDetected)",
-        "L1039/1042：\"全部忽略\" / \"全部确认\" → L10n.Location.ignoreAll / L10n.Location.confirmAll",
-        "在 en.lproj/Localizable.strings 和 zh-Hans.lproj/Localizable.strings 中添加对应键值",
-        "构建通过"
+        "Create or extend web/e2e/add.spec.ts with tests for: draft restore after reload, ⌘+Enter submit, card click navigates to detail, breadcrumb first-paint shows 'Add', new submission shows QUEUED immediately, Bookmarklet opens modal (and does NOT attach a file), URL button toggles mode without auto-filling, Photo/File pickers attach and remove",
+        "All new tests pass locally via the project's e2e command (pnpm test:e2e or playwright test — use whichever the package.json defines)",
+        "No existing e2e test regresses",
+        "Typecheck passes"
       ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: B-UI/UX一致性, Effort: M, Impact: 2"
+      "priority": 11,
+      "passes": false,
+      "notes": ""
     },
     {
       "id": "US-012",
-      "title": "Graph Tab 接通 EntityPageService 真实数据",
-      "description": "作为用户，我在 Graph Tab 中应该看到基于我实际日记数据生成的知识图谱节点（人物、地点、主题），而不是空白或样例数据。",
+      "title": "(可选/默认关闭) 草稿服务端同步骨架",
+      "description": "As a multi-device user, I'd like drafts to sync across devices when the feature flag is on. This story only lays the skeleton; the flag stays off by default.",
       "acceptanceCriteria": [
-        "GraphViewModel 实现 loadGraph() 方法：读取 wiki/places/、wiki/people/、wiki/themes/ 目录下所有 entity 页面，解析 YAML frontmatter 提取 name、type、occurrence_count、first_seen",
-        "每个 entity 转换为图节点；若两个 entity 在同一 Daily Page 中同时出现，则生成连边（co-occurrence）",
-        "GraphView 保持现有力导向布局，仅替换数据源为 GraphViewModel.nodes / .edges",
-        "空状态：vault 无 entity 时显示 EmptyStateView",
-        "Graph Tab 在 vault 有至少 3 个 entity 时展示可交互图谱",
-        "构建通过，iPhone 17 Simulator 有数据时验证图谱节点非空"
+        "Add NEXT_PUBLIC_CODEX_DRAFT_SYNC env (documented in web/.env.example), default unset/false",
+        "When the flag is true, useAddDraft additionally: on mount, GET /api/drafts/add (if local draft empty); on change, debounce 1500ms then PUT /api/drafts/add with the same shape as the localStorage value",
+        "Create skeleton route handlers web/src/app/api/drafts/add/route.ts with GET + PUT that currently return 501 + a TODO comment marked 'Post-MVP'",
+        "When the flag is false, the sync code path is tree-shaken / behind an if (process.env.NEXT_PUBLIC_CODEX_DRAFT_SYNC === 'true') guard",
+        "No DB migration in this story",
+        "Typecheck passes"
       ],
-      "priority": 1,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 5 | Already implemented on main"
-    },
-    {
-      "id": "US-013",
-      "title": "Entity 双向链接（Entity Page → Related Memos）",
-      "description": "作为用户，打开一个 Entity 页面时，我应该看到所有提到过它的原始 Memo 列表，形成从知识网络回溯到原始记录的路径。",
-      "acceptanceCriteria": [
-        "EntityPageService.apply(instruction:) 在创建或更新 entity 时，将当前日期追加到 entity YAML frontmatter 的 related_dates: [] 数组",
-        "EntityPageView 实现 relatedMemos() —— 读取 related_dates，对每个日期调用 RawStorage.read(for:)，返回包含该 entity slug 的 memo 列表",
-        "Entity 页面底部新增「来源记录」Section，以精简版 MemoCardView 展示 related memos，按日期降序，最多 20 条",
-        "单元测试：构造含 entity mention 的 memo → 运行 apply() → 验证 related_dates 包含该日期",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 4"
-    },
-    {
-      "id": "US-014",
-      "title": "AI 引擎透明化 — Settings 展示当前模型",
-      "description": "作为用户，我有权知道当前处理我日记的 AI 模型是什么，并理解模型变更对编译风格的潜在影响。",
-      "acceptanceCriteria": [
-        "Settings「AI 编译引擎」Section 显示：当前模型名称、API provider、上次编译时间",
-        "CompilationService 暴露 static let modelName: String 和 static let apiProvider: String 常量",
-        "如果用户使用 DeepSeek 而非 Qwen（MVP 默认），Settings 中注明「⚠️ 当前使用非默认引擎」",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: S, Impact: 2"
-    },
-    {
-      "id": "US-015",
-      "title": "Archive 月份数据异步加载",
-      "description": "作为拥有 6 个月以上数据的用户，打开 Archive 时不应有明显卡顿，calendar grid 应先渲染骨架再填入数据。",
-      "acceptanceCriteria": [
-        "ArchiveViewModel.loadMonth() 改为 async 方法，在 Task { await loadMonth() } 中调用，不阻塞主线程",
-        "加载期间 calendar grid 的每个 day cell 显示 ProgressView() 占位或灰色矩形",
-        "月份切换时立即显示新月份的 loading 骨架，旧月份数据立即清除",
-        "有真实数据时（3+ 个月历史），Archive 打开到渲染完成 < 500ms（iPhone 17 Simulator 测量）",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 3 | Already implemented on main"
-    },
-    {
-      "id": "US-016",
-      "title": "语音附件 Retry 闭环",
-      "description": "作为用户，当 Whisper 转写失败后，我应该能在 Today 页面的语音附件 chip 上直接点击「重试」重新发起转写，而不是丢弃录音。",
-      "acceptanceCriteria": [
-        "语音附件转写失败时，Attachment 标记 transcriptionStatus: .failed（新增枚举 case）",
-        "InputBarV4 附件 chip 在 transcriptionStatus == .failed 时显示红色边框 + 「↺」重试图标",
-        "点击重试图标调用 TodayViewModel.retranscribeVoiceAttachment(id:)，触发 VoiceService.transcribeAudio(at:) 重试",
-        "重试中显示 chip 内 ProgressView()；成功后 chip 切回正常态 + transcript 显示前 20 字",
-        "构建通过，手动测试：断网录音 → 失败红边 → 联网点重试 → 成功"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: S, Impact: 3"
-    },
-    {
-      "id": "US-017",
-      "title": "Memo 数据模型补 mood + entity mentions 字段",
-      "description": "作为开发者，Memo struct 应内置 mood 和 entityMentions 字段，为知识图谱的精确双向链接和情绪时间线提供结构化数据基础。",
-      "acceptanceCriteria": [
-        "Memo struct 新增 var mood: MoodLevel? = nil（枚举：.positive/.neutral/.negative/.intense）",
-        "Memo struct 新增 var entityMentions: [String] = []（从 body 中 [[EntitySlug]] 语法提取的 slug 数组）",
-        "RawStorage YAML 解析器新增 mood: 和 entities: frontmatter 键支持",
-        "TodayViewModel.submitCombinedMemo() 在写入前从 body 文本提取 [[...]] 模式填充 entityMentions",
-        "向后兼容：旧文件无这两个字段时，解析为 nil/[]，不报错",
-        "单元测试：构造含 [[Tokyo]] 的 memo body → 验证 entityMentions == [\"Tokyo\"]",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 3"
-    },
-    {
-      "id": "US-018",
-      "title": "批量 HEIC 照片转换移离主线程",
-      "description": "作为用户，选择 5 张以上 HEIC 格式照片时，Today 页面不应出现明显卡顿或 UI 冻结。",
-      "acceptanceCriteria": [
-        "PhotoService.processPickerItem() 中 HEIC → JPEG 转换移入 Task.detached(priority: .userInitiated) { }（脱离 MainActor）",
-        "转换完成后通过 await MainActor.run { } 回主线程更新 UI 状态",
-        "测试：选择 5 张 12MP HEIC 图片，Timeline 动画帧率 ≥ 55fps（Instruments Time Profiler 验证无主线程卡顿 >16ms）",
-        "构建通过"
-      ],
-      "priority": 2,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: S, Impact: 2"
-    },
-    {
-      "id": "US-019",
-      "title": "Markdown Export（Obsidian 兼容）",
-      "description": "作为数字游民用户，我希望能将 DayPage 的 vault 内容一键导出为标准 Markdown 格式（.md 文件打包），兼容 Obsidian 导入。",
-      "acceptanceCriteria": [
-        "Settings「数据」Section 新增「导出 Vault」按钮",
-        "点击后生成 daypage-export-YYYY-MM-DD.zip，包含 raw/ 和 daily/ 所有 .md 文件，保持目录结构",
-        "导出进行中显示 ProgressView() + 「正在打包...」文字",
-        "完成后弹出系统 Share Sheet（UIActivityViewController）",
-        "导出文件中的 YAML frontmatter 格式与 Obsidian 兼容",
-        "构建通过，iPhone 17 手动验证：导出 → 文件 App 可预览 .md 内容"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: C-功能补全, Effort: M, Impact: 3"
-    },
-    {
-      "id": "US-020",
-      "title": "TodayViewModel 核心路径单元测试",
-      "description": "作为开发者，TodayViewModel 的 submitCombinedMemo()、load()、compile() 三条核心路径应有单元测试覆盖，以便重构时有安全网。",
-      "acceptanceCriteria": [
-        "新建 DayPageTests/TodayViewModelTests.swift（Swift Testing）",
-        "测试 submitCombinedMemo()：纯文字 memo → 验证 RawStorage 写入；语音 memo（mock VoiceService）→ 验证附件字段；location memo → 验证 location frontmatter",
-        "测试 load()：空 vault → 验证 memos 为空；有 3 条 memo 的文件 → 验证解析正确",
-        "测试 compile()：mock CompilationService 返回成功 → 验证 dailyPageModel 更新；返回失败 → 验证 compilationFailedError 设置",
-        "至少 12 个 test case，覆盖 happy path + error path",
-        "全部测试通过 (xcodebuild test -scheme DayPage)"
-      ],
-      "priority": 2,
+      "priority": 12,
       "passes": false,
-      "notes": "Theme: D-技术债务, Effort: L, Impact: 2"
-    },
-    {
-      "id": "US-021",
-      "title": "TodayView 拆分子视图",
-      "description": "作为开发者，1170 行的 TodayView 应拆分为独立子视图组件，每个文件不超过 300 行，减少 PR 冲突和 AI 辅助编码的上下文窗口压力。",
-      "acceptanceCriteria": [
-        "提取 TodayOrbHeaderView（Day Orb + 日期标题区，约 120 行）到独立文件",
-        "提取 TodayMemoListView（memo 列表 + SwipeableMemoCard，约 200 行）到独立文件",
-        "提取 LocationDraftCard + LocationDraftRow 到 DayPage/Features/Today/LocationDraft/ 子目录",
-        "TodayView.swift 主文件压缩到 ≤ 350 行",
-        "无功能改变：拆分前后 iPhone 17 Simulator 截图目视一致",
-        "构建通过，现有测试通过"
-      ],
-      "priority": 3,
-      "passes": false,
-      "notes": "Theme: D-技术债务, Effort: L, Impact: 2"
-    },
-    {
-      "id": "US-022",
-      "title": "CompilationService.compile() 函数分解",
-      "description": "作为开发者，compile() 的 152 行单体函数应分解为 5 个职责单一的私有方法，提高可测试性。",
-      "acceptanceCriteria": [
-        "提取 prepareMemoContext() async throws -> CompilationContext",
-        "提取 buildPrompt(context:) -> [ChatMessage]",
-        "提取 callLLM(messages:) async throws -> String",
-        "提取 parseCompilationOutput(_:) throws -> DailyPageModel",
-        "提取 persistResults(_:for:) async throws",
-        "所有方法有 // throws: CompilationError.X 注释",
-        "构建通过，编译功能端到端手动测试正常"
-      ],
-      "priority": 3,
-      "passes": false,
-      "notes": "Theme: D-技术债务, Effort: M, Impact: 1"
-    },
-    {
-      "id": "US-023",
-      "title": ".trash 备份文件 7 天 TTL 自动清理",
-      "description": "作为用户，iCloud Drive 中的 DayPage vault 不应随时间无限增长，每日编译备份应在 7 天后自动删除。",
-      "acceptanceCriteria": [
-        "在 BackgroundCompilationService 中新增 performTrashCleanup() 方法，扫描 vault/.trash/ 目录",
-        "删除修改时间早于 7 天前的所有 .md 备份文件",
-        "清理操作在后台 Task 中执行，不阻塞编译主流程",
-        "首次运行时若 .trash/ 超过 50 个文件，记录 warning 日志并触发全量清理",
-        "构建通过"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: D-技术债务, Effort: S, Impact: 1"
-    },
-    {
-      "id": "US-024",
-      "title": "编译输出结构化增强 — mood + 日期感知",
-      "description": "作为用户，AI 编译的 Daily Page 应包含当天的情绪评估（mood），并在节假日/特殊日期时自动调整叙事语气。",
-      "acceptanceCriteria": [
-        "System prompt 增加：输出 YAML frontmatter 中必须包含 mood: positive|neutral|negative|intense",
-        "DailyPageModel 新增 var mood: MoodLevel?（与 US-017 共用枚举）",
-        "DailyPageView 在标题下方显示 mood 情绪指示器（小彩色圆点，4 种颜色对应 4 种 mood）",
-        "编译 prompt 注入当天日期（包括星期）：「今天是 {weekday}，{date}」",
-        "单元测试：mock LLM 返回含 mood: positive 的输出 → 验证 DailyPageModel.mood == .positive",
-        "构建通过"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: E-AI能力升级, Effort: M, Impact: 3"
-    },
-    {
-      "id": "US-025",
-      "title": "Entity Slug 去重与模糊匹配",
-      "description": "作为用户，当 AI 先后生成 joma-coffee 和 joma_coffee 两个变体时，知识图谱不应产生重复节点，而应合并到同一 entity 页面。",
-      "acceptanceCriteria": [
-        "EntityPageService 在 apply() 前执行 slug 归一化：小写、_ → -、移除特殊字符",
-        "归一化后若目标文件已存在，执行 update 而非 create",
-        "可选增强：实现编辑距离 ≤ 2 的模糊匹配（Levenshtein），自动合并近似 slug",
-        "单元测试：apply(slug: \"joma_coffee\") + apply(slug: \"joma-coffee\") → wiki 目录中只有 1 个文件",
-        "构建通过"
-      ],
-      "priority": 3,
-      "passes": true,
-      "notes": "Theme: E-AI能力升级, Effort: M, Impact: 2"
+      "notes": ""
     }
   ]
 }

--- a/scripts/ralph/progress.txt
+++ b/scripts/ralph/progress.txt
@@ -1,12 +1,12 @@
-# DayPage v7 — Ralph Progress Log
-Started: 2026-05-19 06:37
-Tool: claude
-PRD: prd-v7-audit.json (25 stories)
-Branch: ralph/v7-deep-audit
+# Codex /add Page Polish — Ralph Progress Log
+
+Source PRD: tasks/prd-codex-add-page-polish.md
+Branch: ralph/codex-add-page-polish
+Start: 2026-05-20
+
+Previous run (v7-deep-audit) archived at: archive/2026-05-20-v7-deep-audit/
+
+## Codebase Patterns
+- (To be populated by iterations as reusable patterns emerge.)
+
 ---
-[2026-05-19T06:41:19Z] Story #US-001: 立即轮换全部泄露的 API Key — PASSED
-[2026-05-19T06:43:58Z] Story #US-002: 将 API Key 从 UserDefaults 迁移到 Keychain — PASSED
-[2026-05-19T06:45:50Z] Story #US-003: 修复 NotificationCenter 观察者累积泄漏 — PASSED
-[2026-05-19T06:47:28Z] Story #US-004: Task 体补 @MainActor 注解（并发安全） — PASSED
-[2026-05-19T06:50:52Z] Story #US-005: 修复 atomicWrite 临时文件孤儿问题 — PASSED
-[2026-05-19T06:50:52Z] Ralph complete after 6 iterations

--- a/tasks/prd-codex-add-page-polish.md
+++ b/tasks/prd-codex-add-page-polish.md
@@ -1,0 +1,213 @@
+# PRD: Codex `/add` 页面体验修复与打磨
+
+> 基于 2026-05-20 `/add` 页面端到端测试报告整理。覆盖范围：**全量修复 + 未实现交互补齐 + 待定按钮的设计澄清**。
+
+## 1. Introduction / Overview
+
+Codex `web/` 的 `/add` 页面是用户的「内容投递入口」（输入区 + Compile Queue + Recently Compiled）。核心提交链路（输入 → `POST /api/memos` → SSE 编译）已稳定可用，但**辅助交互**层面存在 9 处缺陷，主要集中在四个方向：
+
+1. **数据耐久性**：草稿刷新后丢失，直接造成用户内容损失（P0）。
+2. **SSR/CSR 首帧不一致**：面包屑、QUEUED 状态在首帧错位，刷新后才正确。
+3. **未实现的已规划交互**：⌘+Enter 提交、卡片中部跳详情、Photo/File 选择器。
+4. **语义不明的入口按钮**：Bookmarklet 误附图、URL 按钮自动填当前页。
+
+本 PRD 给出统一的修复方案、设计澄清，以及对应文件路径的实现指引。
+
+## 2. Goals
+
+- **零内容损失**：用户写过的草稿，在任何刷新 / 切页 / 关浏览器场景下都能恢复。
+- **首帧即正确**：首屏渲染的面包屑、队列状态文本与最终状态一致，刷新前后视觉无跳变。
+- **键盘可达性达标**：`⌘/Ctrl + Enter` 提交、卡片可点击跳详情成为默认交互。
+- **入口按钮语义清晰**：每个模式按钮（URL / Photo / File / Voice / Bookmarklet）都有明确、可预期的行为，不再「点了像 bug」。
+- **0 回归**：现有通过的 20 个用例继续通过，无新增 console error / warning。
+
+## 3. User Stories
+
+### US-001: 草稿本地持久化（BUG-01）
+**Description:** 作为输入中的用户，我希望 Save draft 之后即便刷新页面，正在写的内容仍然回填到 textarea，避免内容丢失。
+
+**Acceptance Criteria:**
+- [ ] 点击 Save draft 后，草稿写入 `localStorage`，键名 `codex.add.draft.v1`，结构 `{ text: string, mode: 'text' | 'url' | 'photo' | 'file', attachmentRef?: string | null, savedAt: ISOString }`
+- [ ] 刷新页面后，若 `localStorage` 内有非空草稿，textarea 自动回填，并显示「Restored draft · {savedAt 相对时间}」轻量提示
+- [ ] 提交成功（`POST /api/memos` → 201）后，自动清除 `localStorage` 草稿
+- [ ] 用户主动清空 textarea 并失焦超过 1s，自动清除草稿
+- [ ] 草稿仅存在客户端，**不写入 cookie / Server Component**，避免 SSR/CSR 不一致
+- [ ] 提供「Discard draft」按钮（仅在有草稿时显示）
+- [ ] Typecheck/lint passes
+- [ ] Verify in browser using dev-browser skill（写文本 → Save draft → F5 → 草稿出现 → 提交 → 草稿消失）
+
+### US-002: 草稿服务端同步（可选，feature-flagged）
+**Description:** 作为多设备用户，我希望（在登录态下）草稿能跨设备同步。本 PRD 仅落地接口约定与开关，**默认关闭**。
+
+**Acceptance Criteria:**
+- [ ] 新增 `NEXT_PUBLIC_CODEX_DRAFT_SYNC` env，默认 `false`
+- [ ] 开启时，草稿在本地变化后 debounce 1.5s 发起 `PUT /api/drafts/add`（payload 同 US-001 结构）
+- [ ] 页面加载时若本地无草稿，则从 `GET /api/drafts/add` 拉取
+- [ ] 本地草稿与远端草稿冲突时，以 `savedAt` 较新者为准，并在 UI 提示「Synced from another device」
+- [ ] 默认关闭状态下，US-002 的代码路径完全 dead-code-eliminated，不影响 bundle
+- [ ] API route 与 DB migration 仅作骨架，body 内 TODO 注释标明 Post-MVP
+- [ ] Typecheck/lint passes
+
+### US-003: ⌘/Ctrl + Enter 快捷键提交（BUG-02）
+**Description:** 作为重度键盘用户，我希望在 textarea 内按 `⌘+Enter`（Mac）/ `Ctrl+Enter`（Win/Linux）直接触发 Add 提交。
+
+**Acceptance Criteria:**
+- [ ] textarea `onKeyDown` 监听：`(e.metaKey || e.ctrlKey) && e.key === 'Enter'` 时调用与 Add 按钮相同的 submit handler
+- [ ] 当 Add 按钮处于 disabled（空内容 / 提交中）时，快捷键也不触发
+- [ ] textarea 下方的 hint 文案补充：`⌘ + Enter to submit`，跨平台显示对应符号
+- [ ] 不阻塞 `Shift+Enter` 换行
+- [ ] Typecheck/lint passes
+- [ ] Verify in browser using dev-browser skill
+
+### US-004: Compile Queue 卡片可点击跳详情（BUG-03）
+**Description:** 作为用户，我希望点击 Compile Queue / Recently Compiled 卡片正文区域即可跳转到该 memo 的详情页。
+
+**Acceptance Criteria:**
+- [ ] 卡片正文区域（除右上角 LIGHT/FULL 切换控件外）整体可点击，跳转 `/wiki/[slug]` 或既有详情路由（按当前实际路由约定）
+- [ ] 整卡使用 `<Link>` 包裹或 `role="link" tabIndex={0}` + `onClick/onKeyDown(Enter|Space)`，键盘可达
+- [ ] 右上角 LIGHT/FULL 标签的 `onClick` 必须 `stopPropagation()`，避免误触发跳转
+- [ ] 悬浮 hover 高亮保留；新增 `cursor-pointer` 视觉提示
+- [ ] Typecheck/lint passes
+- [ ] Verify in browser using dev-browser skill（点击正文跳详情、点 LIGHT 不跳转、Tab+Enter 可跳转）
+
+### US-005: 首帧 SSR/CSR 一致性统一修复（BUG-04 + BUG-05）
+**Description:** 作为用户，我希望进入 `/add` 时面包屑立即显示 `CODEX / Add`，新提交的条目立即显示 `QUEUED`，无需刷新页面。
+
+**Acceptance Criteria:**
+- [ ] **根因排查**：检查 `src/app/(app)/layout.tsx` 中面包屑取值来源，确认它通过 `usePathname()` / `useSelectedLayoutSegment()` 实时派生，而非从某个全局 store / cookie 读取
+- [ ] 面包屑数据流改为：Server Component 读取 `headers()` 中的实际路径 → 作为初始 prop 传给 Client → Client 用 `usePathname()` 覆盖。两侧一致，无 hydration mismatch
+- [ ] 乐观更新：`POST /api/memos` 触发后，本地 query cache 立即 prepend 一条 `{ ...payload, compile_status: 'pending', id: temp-uuid }`，UI 渲染时根据 `compile_status` 显示 `QUEUED`
+- [ ] SSE `/api/stream/compile` 收到对应事件后，用真实 id / status 替换 temp 条目，无视觉跳变
+- [ ] 无 React hydration warning（控制台保持 0 errors / 0 warnings）
+- [ ] Typecheck/lint passes
+- [ ] Verify in browser using dev-browser skill（从 `/home` 跳 `/add`：面包屑立即正确；提交一条：立即出现 QUEUED 文字）
+
+### US-006: Bookmarklet 按钮改为脚本指引 Modal（BUG-06）
+**Description:** 作为想把网页快速捕获到 Codex 的用户，我希望点击 Bookmarklet 按钮看到「拖到书签栏」的脚本和说明，而不是被自动附加一个图片占位文件。
+
+**Acceptance Criteria:**
+- [ ] 移除「点击 Bookmarklet 自动附加 `IMG_3836.PNG` 占位文件」的 dev-only 行为（这是测试残留）
+- [ ] 点击 Bookmarklet 打开 modal，包含：
+  - 一行可拖拽的书签链接：`<a href="javascript:..."`，文案 `📎 Save to Codex`
+  - `<pre>` 展示 bookmarklet 脚本源码 + 一键复制按钮
+  - 一段简短说明：「拖到浏览器书签栏，在任意网页点击即可把当前页面发送到 Codex」
+- [ ] Modal 可通过 Esc / 点遮罩 / 关闭按钮关闭
+- [ ] 不向 textarea / attachment state 写入任何内容
+- [ ] Typecheck/lint passes
+- [ ] Verify in browser using dev-browser skill
+
+### US-007: URL 按钮改为切换 URL 输入模式（BUG-07）
+**Description:** 作为用户，我希望点击 URL 按钮把输入区切换到「URL 模式」（占位符变化、自动 URL 校验），而不是把当前页地址直接填进去。
+
+**Acceptance Criteria:**
+- [ ] 点击 URL 按钮：
+  - 按钮 active 态高亮（与 Photo/File 一致）
+  - textarea placeholder 改为 `https://… paste the link you want to save`
+  - **不**自动填入 `window.location.href`
+  - 提交前若内容不是合法 URL，按钮 disabled 并显示「Enter a valid URL」
+- [ ] 再次点击 URL 按钮，回退到 default `text` 模式
+- [ ] 已粘贴文本时切换模式不清空 textarea，只更新 placeholder/校验
+- [ ] Typecheck/lint passes
+- [ ] Verify in browser using dev-browser skill
+
+### US-008: Photo / File 按钮补齐选择器（BUG-08）
+**Description:** 作为用户，我希望点击 Photo 按钮唤起相机/相册选择，点击 File 按钮唤起文件选择，把附件挂到草稿上。
+
+**Acceptance Criteria:**
+- [ ] Photo 按钮：
+  - 点击触发隐藏 `<input type="file" accept="image/*" capture="environment">`
+  - 选中后在 textarea 下方展示缩略图卡片（含文件名、大小、✕ 移除）
+- [ ] File 按钮：
+  - 点击触发隐藏 `<input type="file">`（不限制 accept；单文件，多文件留作 Post-MVP）
+  - 选中后展示通用附件卡片
+- [ ] 附件信息（文件名、size、blobUrl）随表单 `multipart/form-data` 提交，或先 `POST /api/uploads` 拿到 ref 再提交 memo（按当前后端约定取一致路径）
+- [ ] 移除附件后按钮 active 态自动取消
+- [ ] 上传中显示 loading；上传失败 toast「Upload failed, try again」
+- [ ] Typecheck/lint passes
+- [ ] Verify in browser using dev-browser skill
+
+### US-009: 输入交互性能稳定性（BUG-09）
+**Description:** 作为通过 CDP / Playwright 高频驱动页面的自动化用户，我希望按钮点击响应时间稳定 < 300ms，不再偶发 30s 超时。
+
+**Acceptance Criteria:**
+- [ ] 用 React Profiler / `performance.measure` 定位 `UnifiedInput` 渲染开销，按钮 `onClick` 不在渲染期间执行同步重计算
+- [ ] 移除任何 `onChange` 中对全表单的 deep-clone / `JSON.stringify` 之类 hot path
+- [ ] 在 Playwright e2e（`web/e2e/`）新增一个高频点击模式按钮的稳定性测试，连续 50 次点击全部成功
+- [ ] Typecheck/lint passes
+
+### US-010: E2E 回归用例集
+**Description:** 作为维护者，我希望本 PRD 涉及的修复都有 Playwright 测试守护，避免后续回归。
+
+**Acceptance Criteria:**
+- [ ] 在 `web/e2e/add.spec.ts`（沿用现有约定）补充：草稿回填、⌘+Enter 提交、卡片跳详情、面包屑首帧、QUEUED 即时显示、Bookmarklet modal、URL 模式切换、Photo/File 选择
+- [ ] `pnpm e2e`（或项目实际命令）全部通过
+- [ ] CI 中新增/已有的 e2e job 跑过
+
+## 4. Functional Requirements
+
+- **FR-1**：草稿在 `localStorage` 键 `codex.add.draft.v1` 下持久化；提交成功或主动清空后自动清除。
+- **FR-2**：草稿同步到服务端由 env `NEXT_PUBLIC_CODEX_DRAFT_SYNC` 控制，默认关闭；API 路径预留 `GET/PUT /api/drafts/add`。
+- **FR-3**：textarea 监听 `⌘/Ctrl + Enter`，等价于点击 Add；disabled 时不触发；`Shift+Enter` 不受影响。
+- **FR-4**：Compile Queue / Recently Compiled 卡片正文整体可点击，跳转到详情路由；LIGHT/FULL 切换按钮 `stopPropagation`。
+- **FR-5**：面包屑数据流由 `usePathname()` 派生，杜绝 SSR/CSR 不一致；初次进入 `/add` 即显示 `CODEX / Add`。
+- **FR-6**：`POST /api/memos` 后立即在客户端 query cache 乐观插入一条 `compile_status: 'pending'` 的条目，UI 显示 `QUEUED`；SSE 到达后无视觉跳变地替换为真实数据。
+- **FR-7**：Bookmarklet 按钮 → 打开「书签脚本指引」modal；不写任何 attachment / textarea 状态。
+- **FR-8**：URL 按钮 → 切换 URL 输入模式（placeholder + 校验）；不自动填 `window.location.href`。
+- **FR-9**：Photo 按钮 → 触发 `<input type="file" accept="image/*" capture="environment">`；File 按钮 → 触发 `<input type="file">`；选中后展示附件卡片，可 ✕ 移除。
+- **FR-10**：所有 `onClick` 处理避开重型同步计算；高频点击模式按钮（≥50 次）稳定无超时。
+- **FR-11**：测试报告中已通过的 20 个用例（基础输入、URL 自动识别、Save draft 提示、XSS 安全、侧栏导航等）全部保持通过。
+
+## 5. Non-Goals (Out of Scope)
+
+- ❌ Voice 录音功能（aria-label 已声明 "coming soon"，本 PRD 不实现录音/转写）。
+- ❌ 多附件支持（仅单附件；多附件留作 Post-MVP）。
+- ❌ 草稿历史版本 / 多草稿管理（仅单条 active 草稿）。
+- ❌ 草稿服务端 schema 详细设计（仅留 API 骨架，DB migration 不在本 PRD）。
+- ❌ Compile Queue 排序 / 过滤功能改造。
+- ❌ Recently Compiled 区块的可视化升级。
+- ❌ 移动端响应式 / 触控适配（默认沿用既有断点；额外打磨另立 PRD）。
+- ❌ Wiki / Chat / Inbox 其他路由的修复。
+
+## 6. Design Considerations
+
+- **草稿恢复提示**：`Restored draft · 3 min ago` 使用浅灰色细字，紧贴 textarea 下方与「Discard draft」并排。
+- **Bookmarklet Modal**：复用现有 `Card` / `Btn` / `Icon` 组件（`src/components/ui/`），避免引入新的 dialog 库；如缺乏 modal 原语，新增最简 `Dialog` 组件并标明可被复用。
+- **卡片可点击的视觉反馈**：hover 高亮已存在；新增 `cursor-pointer` + 1px outline 焦点态以满足键盘可达。
+- **快捷键 hint 跨平台**：用 `navigator.platform` / `userAgent` 区分 macOS 显示 `⌘ + Enter`，其他显示 `Ctrl + Enter`。
+- **乐观更新视觉**：临时条目可用 0.6 opacity + 微旋转 spinner 区分「尚未确认」；SSE 回包后过渡到正常态。
+
+## 7. Technical Considerations
+
+- **核心文件**（沿用现有结构）：
+  - `web/src/app/(app)/add/page.tsx`
+  - `web/src/app/(app)/add/UnifiedInput.tsx`（输入区 + 模式按钮 + Save draft/Add）
+  - `web/src/app/(app)/add/CompileQueue.tsx`
+  - `web/src/app/(app)/add/RecentlyCompiled.tsx`
+  - `web/src/app/(app)/layout.tsx`（面包屑数据流）
+  - `web/src/app/(app)/_components/`（如需新增 Dialog / Toast）
+  - `web/e2e/add.spec.ts`（新增 / 扩展）
+- **状态层**：草稿建议放在 `UnifiedInput` 内部 + 一个独立 hook `useAddDraft()`（封装 LS 读写与可选同步）；不要污染全局 store。
+- **乐观更新**：若已用 `@tanstack/react-query`（`QueryProvider.tsx` 存在），用 `queryClient.setQueryData(['memos','pending'], …)` 实现，SSE handler 内部 `invalidateQueries` 或 `setQueryData` 替换 temp id。
+- **SSE 已经能跑通**，不动 `/api/stream/compile`。
+- **不引入新依赖**；如必须，单独说明并讨论。
+- **a11y**：所有新增可点击元素具备 keyboard focus 样式 + `aria-label`。
+
+## 8. Success Metrics
+
+- 测试报告里 9 个 bug 全部回归通过；新增 e2e 用例 ≥10 条全部 PASS。
+- `pnpm dev` / 生产构建后，DevTools console 维持 0 errors / 0 warnings（含 hydration warning）。
+- 草稿恢复率：在内部 dogfood 下「写过 → 刷新 → 草稿仍在」的成功率 100%。
+- 高频点击 e2e（50 次/按钮）零超时。
+- 整张 `/add` 页面在 1295×924 视窗下 TTI（Time To Interactive）不退化超过 +50ms。
+
+## 9. Open Questions
+
+- ❓ Compile Queue 卡片跳转的详情路由是 `/wiki/[slug]`、`/inbox/[id]` 还是新路由？需在实现前确认（grep 现有 `Link` 使用）。
+- ❓ 附件上传走 `POST /api/uploads` 还是直接 `multipart` 嵌在 `POST /api/memos`？需对齐后端实际实现。
+- ❓ Bookmarklet 脚本的最终 payload 形态（直接 `POST /api/memos` 还是先开 `/add?url=...`）？影响 modal 内复制的代码字符串。
+- ❓ 草稿同步（US-002）是否需要在本里程碑里真的暴露 env，还是放到 Post-MVP？目前 PRD 已默认关闭。
+- ❓ 是否需要把 ⌘+Enter / Esc 等快捷键写入全站 keymap，避免不同页面行为分裂？（建议在后续「全站 keymap」单 PRD 里收敛。）
+
+---
+
+**Source / 参考**：`/add` 页面端到端测试报告（2026-05-20，CODEX v0.4 PRIVATE，1295×924）。


### PR DESCRIPTION
## Summary
- 基于 2026-05-20 `/add` 页面端到端测试报告，整理出 12 条 Ralph User Story 的修复计划
- 覆盖 9 个 bug：草稿丢失、SSR/CSR 首帧不一致（面包屑 / QUEUED）、⌘+Enter、卡片跳详情、Bookmarklet 误附图、URL/Photo/File 按钮语义、性能、e2e 回归
- 归档上一轮 `ralph/v7-deep-audit` 进度

## Files
- `tasks/prd-codex-add-page-polish.md` — 完整 PRD（10 US + 11 FR + Non-Goals + Open Questions）
- `prd.json` / `scripts/ralph/prd.json` — Ralph 12-story 计划，branch `ralph/codex-add-page-polish`
- `progress.txt` / `scripts/ralph/progress.txt` — 重置新 run 头部
- `archive/2026-05-20-v7-deep-audit/` — 上一轮归档

## Test plan
- [x] `python3 -m json.tool prd.json` ✅
- [x] 根 / scripts 两份 prd.json byte-identical ✅
- [x] 所有 story `passes: false` ✅
- [ ] 后续由 Ralph 迭代逐条实现