### PR TITLE
feat(web): rebrand Codex → DayPage

### DIFF
--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -117,12 +117,13 @@ struct SidebarView: View {
 
     // MARK: - Nav Items
 
-    /// Primary nav: Today / Archive / Graph.
+    /// Primary nav: Today / Archive / Graph. Graph is gated behind a Post-MVP
+    /// chip until the knowledge-graph feature ships (PRD NG-3).
     private var navSection: some View {
         VStack(alignment: .leading, spacing: 2) {
             navItem(tab: .today, icon: "square.and.pencil", label: "Today")
             navItem(tab: .archive, icon: "archivebox", label: "Archive")
-            navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted", label: "Graph")
+            navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted", label: "Graph", disabled: true)
         }
         .padding(.horizontal, 12)
     }

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -117,13 +117,12 @@ struct SidebarView: View {
 
     // MARK: - Nav Items
 
-    /// Primary nav: Today / Archive / Graph. Graph is gated behind a Post-MVP
-    /// chip until the knowledge-graph feature ships (PRD NG-3).
+    /// Primary nav: Today / Archive / Graph.
     private var navSection: some View {
         VStack(alignment: .leading, spacing: 2) {
             navItem(tab: .today, icon: "square.and.pencil", label: "Today")
             navItem(tab: .archive, icon: "archivebox", label: "Archive")
-            navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted", label: "Graph", disabled: true)
+            navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted", label: "Graph")
         }
         .padding(.horizontal, 12)
     }

--- a/web/src/app/(app)/add/UnifiedInput.tsx
+++ b/web/src/app/(app)/add/UnifiedInput.tsx
@@ -599,10 +599,10 @@ export function UnifiedInput() {
       <Dialog
         open={bookmarkletOpen}
         onClose={() => setBookmarkletOpen(false)}
-        title="Save to Codex — Bookmarklet"
+        title="Save to DayPage — Bookmarklet"
       >
         <p style={{ margin: "0 0 1rem", fontSize: "0.875rem", color: "var(--fg-secondary, #555)" }}>
-          Drag the link below to your bookmarks bar. Then click it on any page to send it to Codex.
+          Drag the link below to your bookmarks bar. Then click it on any page to send it to DayPage.
         </p>
         {/* Draggable bookmarklet link */}
         <div style={{ marginBottom: "1rem", textAlign: "center" }}>
@@ -624,7 +624,7 @@ export function UnifiedInput() {
               cursor: "grab",
             }}
           >
-            📎 Save to Codex
+            📎 Save to DayPage
           </a>
         </div>
         {/* Source code block + copy button */}

--- a/web/src/app/(app)/chat/[id]/ChatView.tsx
+++ b/web/src/app/(app)/chat/[id]/ChatView.tsx
@@ -225,7 +225,7 @@ export function ChatView({ threadId, threadTitle, initialMessages, threads }: Ch
           )}
           {messages.map((msg) => (
             <div key={msg.id} className={`msg msg--${msg.role}`}>
-              <div className="msg__role">{msg.role === "user" ? "You" : "Codex"}</div>
+              <div className="msg__role">{msg.role === "user" ? "You" : "DayPage"}</div>
               <div className="msg__body">
                 <p>
                   {renderContent(

--- a/web/src/app/(app)/domain/[slug]/page.tsx
+++ b/web/src/app/(app)/domain/[slug]/page.tsx
@@ -157,7 +157,7 @@ export default async function DomainPage({
           style={{ color: "var(--fg-subtle)", marginBottom: "1.25rem" }}
         >
           <Link href="/home" style={{ color: "inherit", textDecoration: "none" }}>
-            Codex
+            DayPage
           </Link>
           {" / Domains"}
         </p>
@@ -249,7 +249,7 @@ export default async function DomainPage({
           href="/home"
           style={{ color: "inherit", textDecoration: "none" }}
         >
-          Codex
+          DayPage
         </Link>
         {" / Domains"}
       </p>

--- a/web/src/app/(app)/home/page.tsx
+++ b/web/src/app/(app)/home/page.tsx
@@ -6,7 +6,7 @@ import { Btn, Card, Chip, Icon, SectionLabel, Sparkline } from "@/components/ui"
 
 const openInboxCount = 4;
 
-// ── Mock data (mirrors design's CODEX namespace) ──────────────────────
+// ── Mock data (mirrors design's DayPage namespace) ────────────────────
 type Observation = {
   lead: string;
   body: string[];

--- a/web/src/app/(app)/layout.tsx
+++ b/web/src/app/(app)/layout.tsx
@@ -80,7 +80,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
     <>
       {/* Brand */}
       <div className="sb__brand">
-        <div className="sb__brand-mark">CODEX</div>
+        <div className="sb__brand-mark">DAYPAGE</div>
         <div className="sb__brand-tag">v0.4 · private</div>
       </div>
 
@@ -181,7 +181,7 @@ export default async function AppLayout({ children }: { children: ReactNode }) {
           <div style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}>
             {/* Hamburger — visible on mobile only, inside MobileSidebarDrawer context */}
             <HamburgerButton />
-            <span className="ds-section-label">Codex</span>
+            <span className="ds-section-label">DayPage</span>
             <span style={{ color: "var(--fg-subtle)", fontSize: "0.75rem" }}>/</span>
             <BreadcrumbLabel />
           </div>

--- a/web/src/app/(app)/settings/SettingsClient.tsx
+++ b/web/src/app/(app)/settings/SettingsClient.tsx
@@ -190,7 +190,7 @@ export function SettingsClient({ user, signOutAction }: SettingsClientProps) {
       const url = URL.createObjectURL(blob);
       const a = document.createElement("a");
       a.href = url;
-      a.download = `codex-settings-${new Date().toISOString().slice(0, 10)}.json`;
+      a.download = `daypage-settings-${new Date().toISOString().slice(0, 10)}.json`;
       a.click();
       URL.revokeObjectURL(url);
     } catch {
@@ -229,7 +229,7 @@ export function SettingsClient({ user, signOutAction }: SettingsClientProps) {
           <h1 className="hero-headline" style={{ fontSize: 36 }}>
             Settings
             <br />
-            <span className="accent">tune Codex to your rhythm.</span>
+            <span className="accent">tune DayPage to your rhythm.</span>
           </h1>
           <p className="hero-sub">
             Changes are saved instantly on this device. Account-wide sync is on the roadmap.
@@ -262,7 +262,7 @@ export function SettingsClient({ user, signOutAction }: SettingsClientProps) {
       </header>
 
       {/* Profile */}
-      <Section icon={UserIcon} title="Profile" hint="Your account on Codex.">
+      <Section icon={UserIcon} title="Profile" hint="Your account on DayPage.">
         <Card>
           <div className="settings-profile">
             <div className="settings-avatar" aria-hidden>
@@ -288,7 +288,7 @@ export function SettingsClient({ user, signOutAction }: SettingsClientProps) {
       </Section>
 
       {/* Appearance */}
-      <Section icon={Palette} title="Appearance" hint="How Codex looks on this device.">
+      <Section icon={Palette} title="Appearance" hint="How DayPage looks on this device.">
         <Card>
           <Row
             label="Theme"
@@ -487,7 +487,7 @@ export function SettingsClient({ user, signOutAction }: SettingsClientProps) {
       <Section icon={Info} title="About">
         <Card>
           <Row
-            label="Codex"
+            label="DayPage"
             description="v0.4 · private build · built on Next.js"
             control={
               <Chip tone="default">

--- a/web/src/app/(app)/settings/page.tsx
+++ b/web/src/app/(app)/settings/page.tsx
@@ -3,7 +3,7 @@ import { redirect } from "next/navigation";
 import { SettingsClient } from "./SettingsClient";
 
 export const metadata = {
-  title: "Settings · Codex",
+  title: "Settings · DayPage",
 };
 
 export default async function SettingsPage() {

--- a/web/src/app/design-demo/page.tsx
+++ b/web/src/app/design-demo/page.tsx
@@ -4,7 +4,7 @@ import { Btn, Chip, Card, Icon, Sparkline, SectionLabel } from "@/components/ui"
 export default function DesignDemo() {
   return (
     <div className="min-h-screen bg-bg-warm p-10 flex flex-col gap-10 max-w-2xl mx-auto">
-      <h1 className="ds-h1">Codex UI Primitives</h1>
+      <h1 className="ds-h1">DayPage UI Primitives</h1>
 
       {/* Btn */}
       <section className="flex flex-col gap-3">

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1,6 +1,6 @@
 @import "tailwindcss";
 
-/* ─── Codex Design Tokens ───────────────────────────────────────── */
+/* ─── DayPage Design Tokens ─────────────────────────────────────── */
 :root {
   /* Backgrounds */
   --bg-warm:        #FAF8F6;

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -25,8 +25,8 @@ const jetbrainsMono = JetBrains_Mono({
 });
 
 export const metadata: Metadata = {
-  title: "DayPage — Codex",
-  description: "Your personal AI knowledge system",
+  title: "DayPage",
+  description: "AI-assisted journaling for anyone who wants to record their day.",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary
Unify the web product name with the iOS app: every user-visible "Codex" /
"CODEX" string is now "DayPage" / "DAYPAGE".

**Why?** The product positioning is now broader — **「为任何想要记录日常的
人提供的 AI 辅助记录工具」**. The "Codex" name carried a knowledge-base /
power-user vibe that no longer fits. Single brand (matching the iOS app)
lowers the cognitive barrier.

> Note: This PR originally also opened the iOS Graph tab. claude-review
> flagged that as a CLAUDE.md violation (Graph is mandated Post-MVP).
> The Graph change was reverted in `57a85ec`; net diff is web-only.
> Opening Graph will go through its own discuss → issue → branch → PR
> cycle after a separate docs PR updates CLAUDE.md to reflect that
> GraphView is no longer an 18-line placeholder.

## Changes (web, 10 files)

| Where | What |
|---|---|
| `(app)/layout.tsx` | sidebar brand mark `CODEX` → `DAYPAGE`; topbar `Codex` → `DayPage` |
| `app/layout.tsx` | `<title>` and `<meta description>` updated to broader product framing |
| `settings/page.tsx` + `SettingsClient.tsx` | hero copy, Profile/Appearance hints, About row, download filename |
| `chat/[id]/ChatView.tsx` | AI sender renamed `Codex` → `DayPage` |
| `add/UnifiedInput.tsx` | bookmarklet dialog title, copy, button |
| `domain/[slug]/page.tsx` | breadcrumb |
| `design-demo/page.tsx` | heading |
| `home/page.tsx` + `globals.css` | comments |

**Preserved** (avoid losing user data):
- `localStorage` keys `codex.settings.v1`, `codex.add.draft.v1`
- env var `NEXT_PUBLIC_CODEX_DRAFT_SYNC`

A future migration can rename these with a one-shot read-then-write.

## Test plan
- [x] `npx tsc --noEmit` clean on src
- [x] `npx eslint` on changed files: 0 errors
- [x] `xcodebuild` — BUILD SUCCEEDED (only doc comment touched in iOS, now reverted)
- [ ] CI green
- [ ] Manual: load web `/settings`, confirm hero says "tune DayPage to your rhythm" and About row shows "DayPage"
- [ ] Manual: load web sidebar, confirm `DAYPAGE` brand mark