### PR TITLE
docs(claude-md): reflect GraphView's current state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,7 +12,7 @@ DayPage: a personal logging tool centered on daily raw data capture. Users dump,
 |---|---|---|
 | Platform | **iOS 16.0+**, Swift 5 | Single Xcode target `DayPage.app`; direct SPM deps: **Supabase** (supabase-swift), **Sentry** (sentry-cocoa); transitive: swift-clocks, swift-concurrency-extras, swift-http-types, xctest-dynamic-overlay |
 | UI | **SwiftUI** (pure) | `UITabBarAppearance` is the primary UIKit touchpoint (`RootView.swift`). `UIViewControllerRepresentable` wrappers (`ShareSheet`, `CameraPickerView`, `DocumentPickerView`) are used where SwiftUI has no native equivalent (`UIActivityViewController`, `UIImagePickerController`, `UIDocumentPickerViewController`). |
-| Navigation | **Sidebar** | Left drawer (280pt) — Today / Archive / Graph (disabled, Post-MVP); no bottom TabBar |
+| Navigation | **Sidebar** | Left drawer (280pt) — Today / Archive / Graph; no bottom TabBar |
 | State | `ObservableObject` + `@Published` + `@StateObject`, `@MainActor` services | No `@Observable` macro (Swift 5 constraint) |
 | Persistence | **File system** — YAML front-matter + Markdown | `vault/raw/YYYY-MM-DD.md`, multi-memo separated by `\n\n---\n\n`. Atomic writes via `FileManager.replaceItem`. No Core Data / SwiftData |
 | YAML / Markdown | Hand-written parser in `Models/Memo.swift` | No external Markdown library |
@@ -40,7 +40,7 @@ DayPage/
   Features/
     Today/          TodayView + TodayViewModel (268 lines)
     Archive/        ArchiveView (655 lines, calendar + list)
-    Graph/          GraphView (18-line placeholder — Post-MVP, see PRD NG-3)
+    Graph/          GraphView + GraphViewModel (force-layout knowledge graph, node tap → EntityPage, search + date filter; ~594 lines)
   Models/           Memo, Attachment, YAML parser
   Services/         RawStorage, Location, Weather, Photo, Voice, Compilation, BackgroundCompilation
   Config/           GeneratedSecrets (gitignored)
@@ -48,7 +48,7 @@ DayPage/
 
 **CODEX frontend**: lives in this repo's `web/` directory (Next.js) — the same app served at `localhost:3000`. Its env vars (e.g. `DASHSCOPE_API_KEY`) must be configured in `web/.env.local`, not in the iOS-side `Config/GeneratedSecrets.swift`.
 
-**Pipeline**: Today (raw input) → AI compilation → Daily Page (structured diary) → Entity Pages → Graph (Post-MVP knowledge network).
+**Pipeline**: Today (raw input) → AI compilation → Daily Page (structured diary) → Entity Pages → Graph (knowledge graph view).
 
 ## Coding Conventions
 
@@ -66,8 +66,6 @@ Design assets have been removed. **Use the current source code as the authoritat
 
 - Navigation: left sidebar drawer (`RootView.swift`), no bottom TabBar
 - For new design decisions, discuss with the user first, then open a GitHub issue, implement on a branch, and PR
-
-Graph Tab has **no design** (Post-MVP, PRD NG-3) — keep the placeholder.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
Align CLAUDE.md with reality: GraphView is no longer an 18-line
placeholder and the Graph tab is no longer Post-MVP — both have been
true since #30 closed on 2026-04-17, but the doc was never updated.

## Why now?
claude-review on #328 flagged a Graph-related change as a CLAUDE.md
violation because the doc still mandated the placeholder. The review
was correct given the source of truth, so the right fix is to update
the doc — not bypass the review.

This is **docs-only**. A separate feature PR will actually open the
tab in `SidebarView.swift`, following the discuss → docs → feature
sequence laid out in #329.

## Changes (CLAUDE.md, 4 references)

| Line | Before | After |
|---|---|---|
| L15 | `Today / Archive / Graph (disabled, Post-MVP)` | `Today / Archive / Graph` |
| L43 | `Graph/  GraphView (18-line placeholder — Post-MVP, see PRD NG-3)` | `Graph/  GraphView + GraphViewModel (force-layout knowledge graph, node tap → EntityPage, search + date filter; ~594 lines)` |
| L51 | `Graph (Post-MVP knowledge network)` | `Graph (knowledge graph view)` |
| L70 | `Graph Tab has no design (Post-MVP, PRD NG-3) — keep the placeholder.` | removed |

## Evidence

- `wc -l DayPage/Features/Graph/GraphView.swift` → 309
- `wc -l DayPage/Features/Graph/GraphViewModel.swift` → 285
- Feature commits already on `main`: `40b11e3` (US-024 visualization), `f31f416` (US-025 tap + filter + search)
- Closed issue #30 — "Graph Tab — 完整图谱视图实现"

## Test plan
- [x] `grep -nE "Post-MVP|placeholder" CLAUDE.md` → no Graph-related hits remain
- [ ] CI green (this PR touches no code; Xcode build should be cache hit)

Refs #329 #327