### PR TITLE
feat(sidebar): open Graph tab

### DIFF
--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -117,13 +117,12 @@ struct SidebarView: View {
 
     // MARK: - Nav Items
 
-    /// Primary nav: Today / Archive / Graph. Graph is gated behind a Post-MVP
-    /// chip until the knowledge-graph feature ships (PRD NG-3).
+    /// Primary nav: Today / Archive / Graph.
     private var navSection: some View {
         VStack(alignment: .leading, spacing: 2) {
             navItem(tab: .today, icon: "square.and.pencil", label: "Today")
             navItem(tab: .archive, icon: "archivebox", label: "Archive")
-            navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted", label: "Graph", disabled: true)
+            navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted", label: "Graph")
         }
         .padding(.horizontal, 12)
     }


### PR DESCRIPTION
## Summary
Remove the `disabled: true` flag from the Graph nav row. The
GraphView implementation has been complete since #30 closed on
2026-04-17, and CLAUDE.md (the prior blocker) was updated in #330
to reflect that reality.

## Why this is now safe
1. **Source of truth aligned** — #330 updated CLAUDE.md L15 / L43 / L51 / L70 to drop the Post-MVP / placeholder language; the doc no longer mandates Graph stay disabled.
2. **Functionality verified** — `GraphView.swift` (309 lines) + `GraphViewModel.swift` (285 lines) implement force-directed layout, node tap → EntityPage, search, date filter. No new code needed.
3. **Process followed** — discuss (#329) → docs PR (#330, merged) → feature PR (this one). The order claude-review asked for in #328.

## Changes (1 file, +2 / -3)
- `DayPage/App/SidebarView.swift:126` — drop `disabled: true`
- doc comment simplified (no more "gated behind Post-MVP chip")
- GraphView itself **unchanged**

## Test plan
- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` — BUILD SUCCEEDED
- [ ] dogfood on iPhone 17 simulator:
  - [ ] Sidebar Graph row is enabled (no "Post-MVP" chip)
  - [ ] Tapping Graph routes to GraphView
  - [ ] Empty vault: no crash, empty state shown
  - [ ] With memos containing `[[wiki/concept/X|X]]` wikilinks: nodes appear
  - [ ] Tap a node → EntityPage opens
  - [ ] Search + date filter both work
- [ ] CI green

Closes #329
Refs #327 (EPIC Step 1)