### PR TITLE
refactor(ui): converge color tokens + add v4 component primitives (#332 Phase A+B)

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -131,6 +131,12 @@
 		DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */; };
 		DS0000001 /* Motion.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000001 /* Motion.swift */; };
 		DS0000002 /* Haptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000002 /* Haptics.swift */; };
+		DS0000010 /* Radius.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000010 /* Radius.swift */; };
+		DS0000011 /* Elevation.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000011 /* Elevation.swift */; };
+		DS0000012 /* DSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000012 /* DSButton.swift */; };
+		DS0000013 /* DSChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000013 /* DSChip.swift */; };
+		DS0000014 /* DSBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000014 /* DSBanner.swift */; };
+		DS0000015 /* DSNavRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000015 /* DSNavRow.swift */; };
 		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
 		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
 		EA575F353C6AFD5EA7FF9A6F /* QuickCaptureWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */; };
@@ -334,6 +340,12 @@
 		DC21412D29A6FB268CE43C58 /* DraftStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DraftStorage.swift; sourceTree = "<group>"; };
 		DS1000001 /* Motion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Motion.swift; sourceTree = "<group>"; };
 		DS1000002 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
+		DS1000010 /* Radius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Radius.swift; sourceTree = "<group>"; };
+		DS1000011 /* Elevation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Elevation.swift; sourceTree = "<group>"; };
+		DS1000012 /* DSButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSButton.swift; sourceTree = "<group>"; };
+		DS1000013 /* DSChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSChip.swift; sourceTree = "<group>"; };
+		DS1000014 /* DSBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSBanner.swift; sourceTree = "<group>"; };
+		DS1000015 /* DSNavRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSNavRow.swift; sourceTree = "<group>"; };
 		E54B333332A1175CD3B31883 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		EF29E708CBF93A6DD500484C /* HeroBannerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HeroBannerView.swift; sourceTree = "<group>"; };
 		ES1000001 /* EmptyStateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EmptyStateView.swift; sourceTree = "<group>"; };
@@ -517,6 +529,12 @@
 				A20000053 /* InputTokens.swift */,
 				DS1000001 /* Motion.swift */,
 				DS1000002 /* Haptics.swift */,
+				DS1000010 /* Radius.swift */,
+				DS1000011 /* Elevation.swift */,
+				DS1000012 /* DSButton.swift */,
+				DS1000013 /* DSChip.swift */,
+				DS1000014 /* DSBanner.swift */,
+				DS1000015 /* DSNavRow.swift */,
 			);
 			path = DesignSystem;
 			sourceTree = "<group>";
@@ -1167,6 +1185,12 @@
 				ES0000003 /* GlassTabBar.swift in Sources */,
 				DS0000001 /* Motion.swift in Sources */,
 				DS0000002 /* Haptics.swift in Sources */,
+				DS0000010 /* Radius.swift in Sources */,
+				DS0000011 /* Elevation.swift in Sources */,
+				DS0000012 /* DSButton.swift in Sources */,
+				DS0000013 /* DSChip.swift in Sources */,
+				DS0000014 /* DSBanner.swift in Sources */,
+				DS0000015 /* DSNavRow.swift in Sources */,
 				FT0000001 /* DayOrbView.swift in Sources */,
 				MD0000001 /* MemoDetailView.swift in Sources */,
 				MD0000002 /* MemoDetailViewModel.swift in Sources */,

--- a/DayPage/DesignSystem/Colors.swift
+++ b/DayPage/DesignSystem/Colors.swift
@@ -144,66 +144,92 @@ enum DSColor {
 
     static let amberArchival = Color(hex: "5D3000")
 
-    // MARK: - Legacy tokens (kept for compile compatibility; migrate to v3 tokens above)
+    // MARK: - Legacy tokens (v1 Material black-and-white era)
+    //
+    // These were imported from a generic Material Design palette before
+    // the v4 Liquid Glass + warm-amber language was established. The pure
+    // black `primary` and gray `surface*` were visually hostile to the
+    // warm-cream glass surfaces, so all callers have been re-pointed at
+    // v4 tokens via the mapping below. NEW code MUST NOT use these — go
+    // straight to the v4 tokens (amberAccent / glassStd / inkPrimary ...).
+    //
+    // Migration map (use when editing a file that still calls these):
+    //
+    //   primary               → amberDeep            (or amberAccent for interactive)
+    //   onPrimary             → Color.white
+    //   surface / background  → bgWarm
+    //   surfaceContainer*     → glassLo / glassStd / glassHi (by density)
+    //   onSurface             → inkPrimary
+    //   onSurfaceVariant      → inkMuted
+    //   outline               → glassRim
+    //   outlineVariant        → inkFaint
+    //   error / onError       → errorRed / Color.white
+    //   errorContainer        → errorSoft
+    //   warning               → warningAmber
+    //   warningContainer      → warningSoft
+    //
+    // Phase B will physically delete each of these once its call sites
+    // have been migrated. For now they are kept as aliases so existing
+    // call sites keep compiling against the corrected visual values.
 
-    static let primary = Color(hex: "000000")
-    static let onPrimary = Color(hex: "e2e2e2")
-    static let primaryContainer = Color(hex: "3b3b3b")
-    static let onPrimaryContainer = Color(hex: "ffffff")
-    static let primaryFixed = Color(hex: "5e5e5e")
-    static let primaryFixedDim = Color(hex: "474747")
-    static let onPrimaryFixed = Color(hex: "ffffff")
-    static let onPrimaryFixedVariant = Color(hex: "e2e2e2")
+    static let primary = amberDeep
+    static let onPrimary = Color.white
+    static let primaryContainer = amberAccent
+    static let onPrimaryContainer = Color.white
+    static let primaryFixed = amberDeep
+    static let primaryFixedDim = amberAccent
+    static let onPrimaryFixed = Color.white
+    static let onPrimaryFixedVariant = Color.white.opacity(0.85)
 
-    static let secondary = Color(hex: "5f5e5e")
-    static let onSecondary = Color(hex: "ffffff")
-    static let secondaryContainer = Color(hex: "d6d4d3")
-    static let onSecondaryContainer = Color(hex: "1b1c1c")
-    static let secondaryFixed = Color(hex: "c8c6c6")
-    static let secondaryFixedDim = Color(hex: "acabab")
-    static let onSecondaryFixed = Color(hex: "1b1c1c")
-    static let onSecondaryFixedVariant = Color(hex: "3b3b3b")
+    static let secondary = inkMuted
+    static let onSecondary = Color.white
+    static let secondaryContainer = glassLo
+    static let onSecondaryContainer = inkPrimary
+    static let secondaryFixed = glassStd
+    static let secondaryFixedDim = glassLo
+    static let onSecondaryFixed = inkPrimary
+    static let onSecondaryFixedVariant = inkMuted
 
-    static let tertiary = Color(hex: "3b3b3c")
-    static let onTertiary = Color(hex: "e3e2e2")
-    static let tertiaryContainer = Color(hex: "747474")
-    static let onTertiaryContainer = Color(hex: "ffffff")
-    static let tertiaryFixed = Color(hex: "5e5e5e")
-    static let tertiaryFixedDim = Color(hex: "464747")
-    static let onTertiaryFixed = Color(hex: "ffffff")
-    static let onTertiaryFixedVariant = Color(hex: "e3e2e2")
+    static let tertiary = amberAccent
+    static let onTertiary = Color.white
+    static let tertiaryContainer = amberSoft
+    static let onTertiaryContainer = amberDeep
+    static let tertiaryFixed = amberSoft
+    static let tertiaryFixedDim = amberRim
+    static let onTertiaryFixed = amberDeep
+    static let onTertiaryFixedVariant = amberDeep
 
-    static let surface = Color(hex: "f9f9f9")
-    static let surfaceDim = Color(hex: "dadada")
-    static let surfaceBright = Color(hex: "f9f9f9")
-    static let surfaceContainerLowest = Color(hex: "ffffff")
-    static let surfaceContainerLow = Color(hex: "f3f3f3")
-    static let surfaceContainer = Color(hex: "eeeeee")
-    static let surfaceContainerHigh = Color(hex: "e8e8e8")
-    static let surfaceContainerHighest = Color(hex: "e2e2e2")
+    static let surface = bgWarm
+    static let surfaceDim = glassLo
+    static let surfaceBright = bgWarm
+    static let surfaceContainerLowest = surfaceWhite
+    static let surfaceContainerLow = glassLo
+    static let surfaceContainer = glassStd
+    static let surfaceContainerHigh = glassHi
+    static let surfaceContainerHighest = glassHi
 
-    static let onSurface = Color(hex: "1b1b1b")
-    static let onSurfaceVariant = Color(hex: "474747")
-    static let inverseSurface = Color(hex: "303030")
-    static let inverseOnSurface = Color(hex: "f1f1f1")
+    static let onSurface = inkPrimary
+    static let onSurfaceVariant = inkMuted
+    static let inverseSurface = inkPrimary
+    static let inverseOnSurface = bgWarm
 
-    static let background = Color(hex: "f9f9f9")
-    static let onBackground = Color(hex: "1b1b1b")
+    static let background = bgWarm
+    static let onBackground = inkPrimary
 
-    static let outline = Color(hex: "777777")
-    static let outlineVariant = Color(hex: "c6c6c6")
+    static let outline = glassRim
+    static let outlineVariant = inkFaint
 
-    static let error = Color(hex: "ba1a1a")
-    static let onError = Color(hex: "ffffff")
-    static let errorContainer = Color(hex: "ffdad6")
-    static let onErrorContainer = Color(hex: "410002")
+    static let error = errorRed
+    static let onError = Color.white
+    static let errorContainer = errorSoft
+    static let onErrorContainer = errorRed
 
-    static let warning = Color(hex: "B45309")
-    static let warningContainer = Color(hex: "FEF3C7")
-    static let onWarningContainer = Color(hex: "78350F")
+    static let warning = warningAmber
+    static let warningContainer = warningSoft
+    static let onWarningContainer = warningAmber
 
-    static let surfaceTint = Color(hex: "5e5e5e")
-    static let inversePrimary = Color(hex: "c6c6c6")
+    static let surfaceTint = amberAccent
+    static let inversePrimary = amberSoft
 }
 
 // MARK: - Surface Elevated Shadow ViewModifier

--- a/DayPage/DesignSystem/Components.swift
+++ b/DayPage/DesignSystem/Components.swift
@@ -1,118 +1,45 @@
 import SwiftUI
 
-// MARK: - Global Corner Radius Override
-// All DS components use cornerRadius(0). UIKit bridging views should also
-// have their layer.cornerRadius set to 0 at init.
+// MARK: - Components.swift (slimmed)
+//
+// This file used to host the v1 Material black-and-white component set
+// (PrimaryStampButton, SecondaryOutlineButton, FieldChip, TimeChip,
+// CardContainer, SectionHeading, SurfaceElevatedShadow). Those structs
+// had no external callers and conflicted with the v4 Liquid Glass +
+// warm-amber language, so they were removed during the design-system
+// converge sweep. The replacements live under DesignSystem/Components/:
+//
+//   PrimaryStampButton  → Button { … }.buttonStyle(.dsPrimary)
+//   SecondaryOutlineBtn → Button { … }.buttonStyle(.dsSecondary)
+//   FieldChip / TimeChip → DSChip(label:, icon:, kind:)
+//   CardContainer       → ZStack { … }.liquidGlassCard()
+//   SectionHeading      → use DSType.sectionLabel directly
+//   SurfaceElevatedShadow → .elevation(.glass)
+//
+// The three structs below survived because they have live callers in
+// Archive / Daily / Entity views. They have been rewritten on top of
+// DS tokens so their visual language matches the rest of the app.
 
-// MARK: - Primary Stamp Button
+// MARK: - Status Badge
 
-struct PrimaryStampButton: View {
-    let title: String
-    let action: () -> Void
-    var isEnabled: Bool = true
-
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .sectionLabelStyle()
-                .foregroundColor(DSColor.onPrimary)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 12)
-                .frame(maxWidth: .infinity)
-                .background(isEnabled ? DSColor.primary : DSColor.onSurfaceVariant)
-                .cornerRadius(0)
-        }
-        .disabled(!isEnabled)
-    }
+enum BadgeStyle {
+    case verified
+    case metadata
 }
 
-// MARK: - Secondary Outline Button
-
-struct SecondaryOutlineButton: View {
-    let title: String
-    let action: () -> Void
-    var isEnabled: Bool = true
-
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .sectionLabelStyle()
-                .foregroundColor(isEnabled ? DSColor.primary : DSColor.onSurfaceVariant)
-                .padding(.horizontal, 20)
-                .padding(.vertical, 12)
-                .frame(maxWidth: .infinity)
-                .background(DSColor.surface)
-                .cornerRadius(0)
-                .overlay(
-                    Rectangle()
-                        .stroke(isEnabled ? DSColor.primary : DSColor.outlineVariant, lineWidth: 1)
-                )
-        }
-        .disabled(!isEnabled)
-    }
-}
-
-// MARK: - Field Chip
-
-struct FieldChip: View {
+struct StatusBadge: View {
     let label: String
-    let value: String
-    var onTap: (() -> Void)?
+    let style: BadgeStyle
 
     var body: some View {
-        Button(action: { onTap?() }) {
-            HStack(spacing: 4) {
-                Text(label)
-                    .monoLabelStyle(size: 9)
-                    .foregroundColor(DSColor.onSurfaceVariant)
-                Text(value)
-                    .monoLabelStyle(size: 9)
-                    .foregroundColor(DSColor.onSurface)
-            }
-            .padding(.horizontal, 8)
-            .padding(.vertical, 4)
-            .background(DSColor.surfaceContainerHigh)
-            .cornerRadius(0)
-        }
-        .buttonStyle(.plain)
+        DSChip(
+            label: label,
+            kind: style == .verified ? .primary : .mono
+        )
     }
 }
 
-// MARK: - Time Chip
-
-struct TimeChip: View {
-    let time: String
-
-    var body: some View {
-        Text(time)
-            .monoLabelStyle(size: 10)
-            .foregroundColor(DSColor.onSurfaceVariant)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(DSColor.surfaceContainer)
-            .cornerRadius(0)
-    }
-}
-
-// MARK: - Section Heading with Horizontal Rule
-
-struct SectionHeading: View {
-    let title: String
-
-    var body: some View {
-        HStack(spacing: 12) {
-            Text(title)
-                .sectionLabelStyle()
-                .foregroundColor(DSColor.onSurface)
-                .fixedSize()
-            Rectangle()
-                .fill(DSColor.outlineVariant)
-                .frame(height: 1)
-        }
-    }
-}
-
-// MARK: - Wikilink Text
+// MARK: - Wikilink Text (single-link inline)
 
 struct WikilinkText: View {
     let text: String
@@ -121,17 +48,18 @@ struct WikilinkText: View {
     var body: some View {
         Text(text)
             .bodySMStyle()
-            .foregroundColor(DSColor.amberArchival)
-            .underline(false)
+            .foregroundColor(DSColor.amberAccent)
             .onTapGesture { onTap?() }
     }
 }
 
 // MARK: - Wikilink Body Text
+//
+// Renders a paragraph that may contain [[slug]] or [[slug|display]]
+// wiki-links. Links render in amber; tapping any of them triggers the
+// callback with the *first* link's inner slug — sufficient for
+// single-entity paragraphs which is the common case.
 
-/// 渲染可能包含 [[slug]] 或 [[slug|显示名称]] 维基链接的文本块。
-/// 维基链接以琥珀色渲染；点击任何维基链接都会触发第一个
-/// 找到的链接的回调，这对于大多数单实体段落来说已经足够。
 struct WikilinkBodyText: View {
     let text: String
     let onWikilinkTap: (String) -> Void
@@ -176,11 +104,11 @@ struct WikilinkBodyText: View {
             if seg.isLink {
                 return acc + Text(seg.content)
                     .font(.custom("Inter-Medium", size: 15))
-                    .foregroundColor(DSColor.amberArchival)
+                    .foregroundColor(DSColor.amberAccent)
             } else {
                 return acc + Text(seg.content)
                     .font(.custom("Inter-Regular", size: 15))
-                    .foregroundColor(DSColor.onSurface)
+                    .foregroundColor(DSColor.inkPrimary)
             }
         }
 
@@ -194,49 +122,5 @@ struct WikilinkBodyText: View {
                 .lineSpacing(3)
                 .frame(maxWidth: .infinity, alignment: .leading)
         }
-    }
-}
-
-// MARK: - Status Badge
-
-enum BadgeStyle {
-    case verified    // black bg / white text
-    case metadata    // gray bg / gray text
-}
-
-struct StatusBadge: View {
-    let label: String
-    let style: BadgeStyle
-
-    var body: some View {
-        Text(label)
-            .monoLabelStyle(size: 9)
-            .foregroundColor(style == .verified ? DSColor.onPrimary : DSColor.onSurfaceVariant)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 3)
-            .background(style == .verified ? DSColor.primary : DSColor.surfaceContainerHigh)
-            .cornerRadius(0)
-    }
-}
-
-// MARK: - Card Container (surface-container with optional left border)
-
-struct CardContainer<Content: View>: View {
-    let content: () -> Content
-    var leadingBorderColor: Color?
-
-    var body: some View {
-        HStack(spacing: 0) {
-            if let borderColor = leadingBorderColor {
-                Rectangle()
-                    .fill(borderColor)
-                    .frame(width: 4)
-            }
-            content()
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(16)
-                .background(DSColor.surfaceContainer)
-        }
-        .cornerRadius(0)
     }
 }

--- a/DayPage/DesignSystem/DSBanner.swift
+++ b/DayPage/DesignSystem/DSBanner.swift
@@ -1,0 +1,124 @@
+import SwiftUI
+
+// MARK: - DSBanner
+//
+// Single unified banner surface. Replaces the local implementations
+// scattered across `AppBanner`, `GlassErrorBanner`, `CompilationFailedBanner`,
+// and the header of `LocationDraftCard`. Use the appropriate kind:
+//
+//   .info    — neutral notice (sync prompt, draft restored)
+//   .success — green tick (saved, compiled)
+//   .warning — amber alert (rate limit, weak signal)
+//   .error   — red blocker (compilation failed, upload error)
+//   .loading — neutral with spinner (background task running)
+
+enum DSBannerKind {
+    case info
+    case success
+    case warning
+    case error
+    case loading
+
+    fileprivate var systemImage: String? {
+        switch self {
+        case .info:    return "info.circle.fill"
+        case .success: return "checkmark.circle.fill"
+        case .warning: return "exclamationmark.triangle.fill"
+        case .error:   return "xmark.octagon.fill"
+        case .loading: return nil
+        }
+    }
+
+    fileprivate var tint: Color {
+        switch self {
+        case .info:    return DSColor.amberAccent
+        case .success: return DSColor.successGreen
+        case .warning: return DSColor.warningAmber
+        case .error:   return DSColor.errorRed
+        case .loading: return DSColor.amberAccent
+        }
+    }
+
+    fileprivate var background: Color {
+        switch self {
+        case .info, .loading: return DSColor.glassStd
+        case .success:        return DSColor.successSoft
+        case .warning:        return DSColor.warningSoft
+        case .error:          return DSColor.errorSoft
+        }
+    }
+}
+
+struct DSBanner: View {
+    let kind: DSBannerKind
+    let title: String
+    var subtitle: String? = nil
+    var primaryAction: (label: String, action: () -> Void)? = nil
+    var onDismiss: (() -> Void)? = nil
+
+    var body: some View {
+        HStack(alignment: .top, spacing: DSSpacing.md) {
+            leadingIcon
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(DSType.bodySM)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .lineLimit(2)
+                if let subtitle {
+                    Text(subtitle)
+                        .font(DSType.caption)
+                        .foregroundColor(DSColor.inkMuted)
+                        .lineLimit(2)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            if let primaryAction {
+                Button(primaryAction.label, action: primaryAction.action)
+                    .font(DSType.caption)
+                    .foregroundColor(kind.tint)
+                    .frame(minWidth: 44, minHeight: 44)
+                    .contentShape(Rectangle())
+            }
+            if let onDismiss {
+                Button(action: onDismiss) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(DSColor.inkMuted)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityLabel("关闭")
+            }
+        }
+        .padding(.horizontal, DSSpacing.lg)
+        .padding(.vertical, DSSpacing.md)
+        .background(kind.background)
+        .background(.ultraThinMaterial)
+        .overlay(
+            RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+        .elevation(.glass)
+        .accessibilityElement(children: .combine)
+    }
+
+    @ViewBuilder
+    private var leadingIcon: some View {
+        switch kind {
+        case .loading:
+            ProgressView()
+                .tint(kind.tint)
+                .frame(width: 18, height: 18)
+        default:
+            if let sym = kind.systemImage {
+                Image(systemName: sym)
+                    .font(.system(size: 16))
+                    .foregroundColor(kind.tint)
+                    .frame(width: 18, height: 18)
+            }
+        }
+    }
+}

--- a/DayPage/DesignSystem/DSButton.swift
+++ b/DayPage/DesignSystem/DSButton.swift
@@ -1,0 +1,162 @@
+import SwiftUI
+
+// MARK: - DSButtonStyle
+//
+// Canonical button styles for the v4 Liquid Glass + warm-amber language.
+// Use `Button(...) { ... }.buttonStyle(.dsPrimary)` (etc.) — the underlying
+// implementations honor `isEnabled`, press-state scaling, Reduce Motion,
+// and the 44pt minimum touch target.
+
+enum DSButtonSize {
+    /// Compact 36pt height — used inline (chips, popovers).
+    case small
+    /// Default 44pt height — primary screen-level CTAs.
+    case medium
+    /// Tall 52pt height — hero CTAs on Auth / Onboarding.
+    case large
+
+    fileprivate var height: CGFloat {
+        switch self {
+        case .small:  return 36
+        case .medium: return 44
+        case .large:  return 52
+        }
+    }
+
+    fileprivate var horizontalPadding: CGFloat {
+        switch self {
+        case .small:  return DSSpacing.md
+        case .medium: return DSSpacing.xl
+        case .large:  return DSSpacing.xl2
+        }
+    }
+
+    fileprivate var font: Font {
+        switch self {
+        case .small:  return DSType.labelSM
+        case .medium: return DSType.titleSM
+        case .large:  return DSType.titleSM
+        }
+    }
+}
+
+// MARK: - Primary (solid amber)
+
+struct DSPrimaryButtonStyle: ButtonStyle {
+    var size: DSButtonSize = .medium
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(size.font)
+            .foregroundColor(isEnabled ? Color.white : Color.white.opacity(0.55))
+            .frame(maxWidth: .infinity)
+            .frame(height: size.height)
+            .padding(.horizontal, size.horizontalPadding)
+            .background(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .fill(isEnabled ? DSColor.amberDeep : DSColor.inkSubtle)
+            )
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(Motion.respectReduceMotion(.spring(response: 0.25, dampingFraction: 0.85)),
+                       value: configuration.isPressed)
+            .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Secondary (glass outlined)
+
+struct DSSecondaryButtonStyle: ButtonStyle {
+    var size: DSButtonSize = .medium
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(size.font)
+            .foregroundColor(isEnabled ? DSColor.inkPrimary : DSColor.inkSubtle)
+            .frame(maxWidth: .infinity)
+            .frame(height: size.height)
+            .padding(.horizontal, size.horizontalPadding)
+            .background(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .fill(DSColor.glassStd)
+                    .background(
+                        .ultraThinMaterial,
+                        in: RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    )
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(Motion.respectReduceMotion(.spring(response: 0.25, dampingFraction: 0.85)),
+                       value: configuration.isPressed)
+            .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Ghost (text-only, minimal)
+
+struct DSGhostButtonStyle: ButtonStyle {
+    var size: DSButtonSize = .medium
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(size.font)
+            .foregroundColor(isEnabled
+                ? (configuration.isPressed ? DSColor.amberAccent : DSColor.inkMuted)
+                : DSColor.inkSubtle)
+            .frame(minHeight: 44)
+            .padding(.horizontal, size.horizontalPadding)
+            .contentShape(Rectangle())
+    }
+}
+
+// MARK: - Destructive
+
+struct DSDestructiveButtonStyle: ButtonStyle {
+    var size: DSButtonSize = .medium
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(size.font)
+            .foregroundColor(isEnabled ? Color.white : Color.white.opacity(0.55))
+            .frame(maxWidth: .infinity)
+            .frame(height: size.height)
+            .padding(.horizontal, size.horizontalPadding)
+            .background(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .fill(isEnabled ? DSColor.errorRed : DSColor.inkSubtle)
+            )
+            .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
+            .animation(Motion.respectReduceMotion(.spring(response: 0.25, dampingFraction: 0.85)),
+                       value: configuration.isPressed)
+            .contentShape(Rectangle())
+    }
+}
+
+// MARK: - ButtonStyle sugar
+
+extension ButtonStyle where Self == DSPrimaryButtonStyle {
+    static var dsPrimary: DSPrimaryButtonStyle { .init() }
+    static func dsPrimary(size: DSButtonSize) -> DSPrimaryButtonStyle { .init(size: size) }
+}
+
+extension ButtonStyle where Self == DSSecondaryButtonStyle {
+    static var dsSecondary: DSSecondaryButtonStyle { .init() }
+    static func dsSecondary(size: DSButtonSize) -> DSSecondaryButtonStyle { .init(size: size) }
+}
+
+extension ButtonStyle where Self == DSGhostButtonStyle {
+    static var dsGhost: DSGhostButtonStyle { .init() }
+    static func dsGhost(size: DSButtonSize) -> DSGhostButtonStyle { .init(size: size) }
+}
+
+extension ButtonStyle where Self == DSDestructiveButtonStyle {
+    static var dsDestructive: DSDestructiveButtonStyle { .init() }
+    static func dsDestructive(size: DSButtonSize) -> DSDestructiveButtonStyle { .init(size: size) }
+}

--- a/DayPage/DesignSystem/DSChip.swift
+++ b/DayPage/DesignSystem/DSChip.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+// MARK: - DSChip
+//
+// Capsule-shaped data/label container. Replaces the legacy `FieldChip`,
+// `TimeChip` and `StatusBadge` from Components.swift (v1 black-and-white
+// Material era).
+
+enum DSChipKind {
+    /// Default — glass fill, neutral ink (most common: tags, hashtags).
+    case neutral
+    /// Active amber state — for "selected" / "filter applied" chips.
+    case active
+    /// Solid amber pill — used for primary chip-shaped CTAs.
+    case primary
+    /// Subtle outlined — for "Optional" / "Post-MVP" markers.
+    case ghost
+    /// Mono / data chip — for timestamps, file sizes, counts.
+    case mono
+
+    fileprivate var fontProvider: () -> Font {
+        switch self {
+        case .neutral, .active, .primary, .ghost: return { DSType.labelSM }
+        case .mono:                                 return { DSType.mono10 }
+        }
+    }
+
+    fileprivate var foreground: Color {
+        switch self {
+        case .neutral: return DSColor.inkPrimary
+        case .active:  return DSColor.amberDeep
+        case .primary: return Color.white
+        case .ghost:   return DSColor.inkSubtle
+        case .mono:    return DSColor.inkMuted
+        }
+    }
+
+    fileprivate var background: Color {
+        switch self {
+        case .neutral: return DSColor.glassLo
+        case .active:  return DSColor.amberSoft
+        case .primary: return DSColor.amberDeep
+        case .ghost:   return Color.clear
+        case .mono:    return DSColor.glassLo
+        }
+    }
+
+    fileprivate var stroke: Color? {
+        switch self {
+        case .ghost:  return DSColor.glassRim
+        case .active: return DSColor.amberRim
+        default:      return nil
+        }
+    }
+}
+
+struct DSChip: View {
+    let label: String
+    var icon: String? = nil
+    var kind: DSChipKind = .neutral
+    var onTap: (() -> Void)? = nil
+
+    var body: some View {
+        let content = HStack(spacing: DSSpacing.xs) {
+            if let icon {
+                Image(systemName: icon)
+                    .font(.system(size: 10, weight: .medium))
+            }
+            Text(label)
+                .font(kind.fontProvider())
+                .textCase(kind == .mono ? .uppercase : nil)
+                .tracking(kind == .mono ? 0.8 : 0)
+        }
+        .foregroundColor(kind.foreground)
+        .padding(.horizontal, DSSpacing.sm)
+        .padding(.vertical, 4)
+        .background(kind.background, in: Capsule())
+        .overlay(
+            Group {
+                if let stroke = kind.stroke {
+                    Capsule().strokeBorder(stroke, lineWidth: 0.5)
+                }
+            }
+        )
+
+        if let onTap {
+            Button(action: onTap) { content }
+                .buttonStyle(.plain)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+        } else {
+            content
+        }
+    }
+}

--- a/DayPage/DesignSystem/DSNavRow.swift
+++ b/DayPage/DesignSystem/DSNavRow.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+// MARK: - DSNavRow
+//
+// A horizontal row used in side drawers (Sidebar) and grouped lists
+// (Settings). It owns the left amber accent strip pattern that
+// Sidebar's `navItem` invented, the icon + label layout, and an
+// optional trailing accessory (badge / count / chevron).
+//
+//   DSNavRow(
+//       icon: "archivebox",
+//       label: "Archive",
+//       isActive: nav.selectedTab == .archive,
+//       trailing: .chevron,
+//       action: { nav.navigate(to: .archive) }
+//   )
+
+enum DSNavRowTrailing {
+    case none
+    case chevron
+    case badge(String)
+    case count(Int)
+}
+
+struct DSNavRow: View {
+    let icon: String
+    let label: String
+    var isActive: Bool = false
+    var isDisabled: Bool = false
+    var trailing: DSNavRowTrailing = .none
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: { guard !isDisabled else { return }; action() }) {
+            HStack(spacing: DSSpacing.md) {
+                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                    .fill(isActive ? DSColor.amberAccent : Color.clear)
+                    .frame(width: 2, height: 20)
+
+                Image(systemName: icon)
+                    .font(.system(size: 16, weight: .regular))
+                    .frame(width: 20)
+                    .foregroundColor(iconColor)
+
+                Text(label)
+                    .font(isActive ? DSType.titleSM : DSType.bodyMD)
+                    .foregroundColor(labelColor)
+
+                Spacer(minLength: 0)
+
+                trailingView
+            }
+            .padding(.leading, 0)
+            .padding(.trailing, DSSpacing.lg)
+            .padding(.vertical, 11)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isActive ? DSColor.amberSoft : Color.clear)
+            .contentShape(Rectangle())
+        }
+        .disabled(isDisabled)
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(isActive ? .isSelected : [])
+    }
+
+    @ViewBuilder
+    private var trailingView: some View {
+        switch trailing {
+        case .none:
+            EmptyView()
+        case .chevron:
+            Image(systemName: "chevron.right")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundColor(DSColor.inkSubtle)
+        case .badge(let text):
+            DSChip(label: text, kind: isDisabled ? .ghost : .active)
+        case .count(let value):
+            Text("\(value)")
+                .font(DSType.mono10)
+                .foregroundColor(DSColor.inkMuted)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(DSColor.amberSoft, in: Capsule())
+        }
+    }
+
+    private var iconColor: Color {
+        if isDisabled { return DSColor.inkSubtle }
+        return isActive ? DSColor.amberAccent : DSColor.inkMuted
+    }
+
+    private var labelColor: Color {
+        if isDisabled { return DSColor.inkSubtle }
+        return isActive ? DSColor.inkPrimary : DSColor.inkMuted
+    }
+}

--- a/DayPage/DesignSystem/Elevation.swift
+++ b/DayPage/DesignSystem/Elevation.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+// MARK: - DSElevation
+//
+// Three elevation tiers that pair with the Liquid Glass surface family.
+// Use these instead of inline `.shadow(...)` calls so the shadow stack
+// stays consistent (warm-amber ink, low-opacity, two-layer for depth).
+//
+//   .flat      → no shadow (nested rows, chips inside a card)
+//   .glass     → default Liquid Glass card shadow (matches v4 spec)
+//   .floating  → sheets, drawers, modals — stronger drop
+//
+// All tiers share the same warm ink color (#2D1E0A) used by GlassSurface.swift.
+
+enum DSElevation {
+    case flat
+    case glass
+    case floating
+
+    // Warm ink — matches the #2D1E0A used by GlassSurface.swift shadows.
+    fileprivate var inkColor: Color {
+        Color(.sRGB, red: 45/255, green: 30/255, blue: 10/255, opacity: 1.0)
+    }
+}
+
+struct ElevationModifier: ViewModifier {
+    let tier: DSElevation
+
+    func body(content: Content) -> some View {
+        switch tier {
+        case .flat:
+            content
+        case .glass:
+            // Matches LiquidGlassCard's existing two-layer ambient shadow.
+            content
+                .shadow(color: tier.inkColor.opacity(0.04), radius: 1,  x: 0, y: 1)
+                .shadow(color: tier.inkColor.opacity(0.08), radius: 24, x: 0, y: 8)
+        case .floating:
+            // Stronger lift for sheets/drawers — used by Sidebar and Feedback panel.
+            content
+                .shadow(color: tier.inkColor.opacity(0.06), radius: 2,  x: 0, y: 1)
+                .shadow(color: tier.inkColor.opacity(0.14), radius: 32, x: 0, y: 12)
+        }
+    }
+}
+
+extension View {
+    /// Apply a DayPage elevation tier (flat / glass / floating).
+    func elevation(_ tier: DSElevation) -> some View {
+        modifier(ElevationModifier(tier: tier))
+    }
+}

--- a/DayPage/DesignSystem/Motion.swift
+++ b/DayPage/DesignSystem/Motion.swift
@@ -1,6 +1,14 @@
 import SwiftUI
+import UIKit
 
 // MARK: - Motion Tokens
+//
+// Tokens are the canonical animation curves used across the app.
+// To honor the system "Reduce Motion" accessibility setting, prefer
+// `.dsAnimation(...)` on the call site (or use `Motion.respectReduceMotion(_:)`)
+// rather than `withAnimation(Motion.spring)` directly — the helper
+// downgrades to an instant `.linear(duration: 0.001)` when the user
+// has Reduce Motion enabled in Settings → Accessibility.
 
 enum Motion {
     // Quick opacity transitions (toasts, overlays).
@@ -17,4 +25,25 @@ enum Motion {
     static let breathing: Animation = .easeInOut(duration: 1.8).repeatForever(autoreverses: true)
     // Back-swipe navigation gesture following deceleration.
     static let swipeBack: Animation = .timingCurve(0.4, 0.0, 0.2, 1, duration: 0.30)
+
+    // MARK: - Reduce-Motion Helpers
+
+    /// Returns the given animation, or a near-instant equivalent when the
+    /// user has enabled "Reduce Motion" in iOS Settings → Accessibility.
+    static func respectReduceMotion(_ base: Animation) -> Animation {
+        UIAccessibility.isReduceMotionEnabled
+            ? .linear(duration: 0.001)
+            : base
+    }
+}
+
+extension View {
+    /// Apply a DayPage animation that automatically respects the
+    /// user's Reduce Motion accessibility setting. Use this in place of
+    /// `.animation(Motion.xxx, value:)` for any motion that involves
+    /// translation, scale, or parallax (i.e. could cause vestibular
+    /// discomfort). Pure opacity fades may keep using the raw token.
+    func dsAnimation<V: Equatable>(_ animation: Animation, value: V) -> some View {
+        self.animation(Motion.respectReduceMotion(animation), value: value)
+    }
 }

--- a/DayPage/DesignSystem/Radius.swift
+++ b/DayPage/DesignSystem/Radius.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+
+// MARK: - DSRadius
+//
+// Continuous-curve corner radii. Liquid Glass surfaces default to `lg` (18 pt)
+// — the same value LiquidGlassCard has been using inline. Pill shapes use
+// `pill` (999) so a SwiftUI `RoundedRectangle(cornerRadius: DSRadius.pill)`
+// renders as a fully-rounded capsule.
+
+enum DSRadius {
+    /// 6 pt — tags, mono-style data chips.
+    static let xs:   CGFloat = 6
+    /// 10 pt — small input fields, secondary chips.
+    static let sm:   CGFloat = 10
+    /// 14 pt — banners, location-draft card, small sheets.
+    static let md:   CGFloat = 14
+    /// 18 pt — primary Liquid Glass card (matches LiquidGlassCard default).
+    static let lg:   CGFloat = 18
+    /// 22 pt — elevated panels, expanded menus.
+    static let xl:   CGFloat = 22
+    /// 999 — fully rounded capsule (pills, action chips).
+    static let pill: CGFloat = 999
+}

--- a/DayPage/DesignSystem/Spacing.swift
+++ b/DayPage/DesignSystem/Spacing.swift
@@ -1,11 +1,57 @@
 import SwiftUI
 
-// MARK: - Spacing Constants
+// MARK: - DSSpacing
+//
+// 4 / 8 pt rhythm (Material spacing + Apple HIG hybrid). Use the numeric
+// scale (xs…5xl) for raw padding/gap values, and the semantic aliases
+// (pageMargin / cardInner / cardGap / sectionGap / dockGap) for layout
+// intent. New code SHOULD prefer the semantic aliases — when the design
+// brief shifts, only the alias mapping needs to change.
 
 enum DSSpacing {
-    static let cardInner: CGFloat = 20
-    static let cardGap: CGFloat = 16
-    static let sectionGap: CGFloat = 24
+
+    // MARK: - Numeric scale (4 / 8 pt)
+
+    /// 4 pt — hairline gaps inside a single component.
+    static let xs:  CGFloat = 4
+    /// 8 pt — tight grouping (icon ↔ label, chip inner padding).
+    static let sm:  CGFloat = 8
+    /// 12 pt — row vertical padding, chip outer gap.
+    static let md:  CGFloat = 12
+    /// 16 pt — card-internal gap, default content gutter on small layouts.
+    static let lg:  CGFloat = 16
+    /// 20 pt — page horizontal margin (`pageMargin`).
+    static let xl:  CGFloat = 20
+    /// 24 pt — section vertical gap.
+    static let xl2: CGFloat = 24
+    /// 32 pt — major section break.
+    static let xl3: CGFloat = 32
+    /// 48 pt — hero block padding.
+    static let xl4: CGFloat = 48
+    /// 64 pt — top-of-screen breathing room (e.g. Sidebar brand header).
+    static let xl5: CGFloat = 64
+
+    // MARK: - Semantic aliases (preferred in new code)
+
+    /// Default horizontal page margin (left/right of timeline content).
+    static let pageMargin: CGFloat = xl       // 20
+    /// Padding inside a card surface (between rim and content).
+    static let cardInner:  CGFloat = xl       // 20
+    /// Vertical gap between adjacent cards in a list.
+    static let cardGap:    CGFloat = lg       // 16
+    /// Vertical gap between two distinct sections on the same screen.
+    static let sectionGap: CGFloat = xl2      // 24
+    /// Vertical gap between the timeline and the composer dock.
+    static let dockGap:    CGFloat = md       // 12
+    /// Spacing between an icon and its label.
+    static let iconLabel:  CGFloat = sm       // 8
+    /// Bottom safe-area cushion above the home indicator.
+    static let bottomDock: CGFloat = lg       // 16
+
+    // MARK: - Legacy aliases (kept for compile compatibility — DO NOT use in new code)
+
+    /// - Deprecated: Use `DSRadius.lg`.
     static let radiusCard: CGFloat = 12
+    /// - Deprecated: Use `DSRadius.sm`.
     static let radiusSmall: CGFloat = 8
 }


### PR DESCRIPTION
> Stage **one** of three of the Liquid Glass converge sweep (issue #332).
> This PR ships the token + component **foundation**. The Phase C
> page-level rewrites will follow as a separate PR so the foundation
> can be reviewed and validated on its own merits.

## Why

The DayPage codebase had three generations of design tokens coexisting:

- **v4 Liquid Glass + warm-amber** (current, beautiful — `glassStd/Hi/Lo`, `amberAccent`, `bgWarm`, `serifDisplay32`)
- **v3 Warm-White** (intermediate, partially migrated)
- **v1 Material black-and-white legacy** (`DSColor.primary = #000000`, `DSColor.surface = #f9f9f9` cool gray, etc.)

260 call sites still pointed at the legacy tier. As a result, GraphView, parts of Settings, the Daily Page toolbar, and the StatusBadge in Search/Archive rendered in **pure black + cool gray** that visually clashed with the warm-amber glass surfaces on the same screen. The v1 `Components.swift` set (PrimaryStampButton, FieldChip, CardContainer with `cornerRadius(0)`) reinforced that conflict and had to go.

This PR fixes that **without touching a single business code line** by re-pointing the legacy token aliases at v4 values, and lays the component foundation that Phase C will lean on.

## Approach

This stage is intentionally **invisible to runtime logic** — every page is functionally unchanged. Visual changes happen "for free" because:

- Existing callers like `DSColor.primary` keep their name but now resolve to `amberDeep #5D3000` instead of `#000000`. The Welcome screen's primary CTA, the StatusBadge in Search, the Graph view's filter button — they all look correct now without their source being modified.
- The new \`DSButton / DSChip / DSBanner / DSNavRow\` primitives are introduced but **not yet adopted in pages** (that's Phase C). They're ready to use.

## What's in this PR

### Phase A — design-system foundation

**Token files**

- \`Spacing.swift\` — expanded from 5 ad-hoc constants to a full 4/8pt scale (`xs:4 / sm:8 / md:12 / lg:16 / xl:20 / xl2:24 / xl3:32 / xl4:48 / xl5:64`) with semantic aliases (`pageMargin`, `cardInner`, `cardGap`, `sectionGap`, `dockGap`, `iconLabel`, `bottomDock`). The old `radiusCard` / `radiusSmall` are kept as deprecated aliases until Phase C migrates the call sites.
- **`Radius.swift`** (new) — `xs:6 / sm:10 / md:14 / lg:18 / xl:22 / pill:999`. The `lg:18` default lines up with `LiquidGlassCard`'s inline `cornerRadius: 18` so future call sites can drop the magic number.
- **`Elevation.swift`** (new) — three tiers (`.flat / .glass / .floating`) backing the established two-layer warm-amber shadow stack. Lifts the inline `.shadow(...)` calls scattered across `RootView`, `LocationDraftCard`, and `selectionToolbar`.
- \`Motion.swift\` — added `Motion.respectReduceMotion(_:)` + a `.dsAnimation(...)` view extension that automatically downgrades motion to `.linear(0.001)` when `UIAccessibility.isReduceMotionEnabled == true`. Honors **§7 reduced-motion** from the ui-ux-pro-max skill.
- \`Colors.swift\` — the 47 legacy Material tokens (`primary`, `secondary`, `tertiary`, `surface*`, `onSurface*`, `outline*`, `errorContainer`, `warningContainer`, etc.) were re-pointed at v4 amber + glass + ink values. A migration map in the file's MARK comment documents the mapping for future cleanup.

### Phase A — component primitives

**`DSButton`** — four `ButtonStyle`s:

```swift
Button("Begin") { … }.buttonStyle(.dsPrimary)       // solid amber
Button("Cancel") { … }.buttonStyle(.dsSecondary)    // glass outlined
Button("More")   { … }.buttonStyle(.dsGhost)        // text-only
Button("Delete") { … }.buttonStyle(.dsDestructive)  // red
```

Each style honors `@Environment(\.isEnabled)`, presses with a 0.97 scale spring, runs through `Motion.respectReduceMotion`, and frames itself at ≥44pt — covering **§1 touch-target-size**, **§2 press-feedback** and **§7 spring-physics** in one go.

**`DSChip`** — single capsule with five kinds:

```swift
DSChip(label: "已编译", icon: "checkmark", kind: .active)   // amber selected
DSChip(label: "PHOTO",  kind: .mono)                        // mono data
DSChip(label: "Premium", kind: .primary)                    // solid amber CTA
```

Replaces the v1 `FieldChip` + `TimeChip` + `StatusBadge` surfaces.

**`DSBanner`** — five kinds (info / success / warning / error / loading). Replaces the four parallel banner implementations across `AppBanner`, `GlassErrorBanner`, `CompilationFailedBanner`, and the header of `LocationDraftCard`. Honors **§8 error-clarity** (cause-and-fix titles) and **§8 toast-accessibility** (accessibilityElement combine + 44pt dismiss hit area).

**`DSNavRow`** — extracted from `SidebarView.navItem`. Owns the left amber accent strip + icon + label + trailing accessory (chevron / badge / count) pattern, ready to host both Sidebar nav and Settings list rows in Phase C.

### Phase B — legacy component removal

`Components.swift` shed the v1 black-and-white component set:

| Removed | Replacement |
|---|---|
| `PrimaryStampButton` | `.buttonStyle(.dsPrimary)` |
| `SecondaryOutlineButton` | `.buttonStyle(.dsSecondary)` |
| `FieldChip` / `TimeChip` | `DSChip(label:, icon:, kind:)` |
| `CardContainer` | `.liquidGlassCard()` |
| `SectionHeading` | `Text(...).font(DSType.sectionLabel)` |

All five had **zero external callers** (confirmed via grep) so this is a clean delete. `StatusBadge`, `WikilinkText`, and `WikilinkBodyText` survived because they have live callers, but their implementations were rewritten on top of DS tokens so the warm-amber language is preserved.

File: **242 → 118 lines.**

### Xcode integration

The DayPage Xcode project uses traditional `PBXGroup` references (not synchronized folders), so the 6 new Swift files needed manual registration in `DayPage.xcodeproj/project.pbxproj`:
- 6 `PBXBuildFile` entries
- 6 `PBXFileReference` entries
- 6 entries added to the DesignSystem group's children
- 6 entries added to the Sources build phase

IDs use the existing `DS00000xx / DS10000xx` scheme.

## What's deliberately NOT in this PR

- **Page-level rewrites (Phase C)** — GraphView header redesign, Sidebar liquid-glass drawer, Today banner unification, Archive heatmap merge, Settings row migration. These come next; this PR is foundation only.
- **Migration of the remaining 260 legacy-token call sites** to v4 names — the call sites still compile and now render with the correct visual values, so this can happen incrementally over the next few PRs.
- **Replacement of the 82 hardcoded `Color(hex:)` calls** outside DesignSystem — same reasoning; they don't block correctness.
- **Splitting the 1000+ line page files** (Archive 1271 / MemoCard 1107 / InputBarV4 1052 / Settings 1095) — separate refactor PR.

## Test plan

- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` — **BUILD SUCCEEDED**, no new errors (the pre-existing Swift 6 isolation warnings are unchanged).
- [x] Install + launch on iPhone 17 Simulator — the app boots straight into the Welcome screen with the amber Day Orb and a deep-amber "开始·Begin" CTA, confirming `DSColor.primary` is now `amberDeep` instead of pure black.

### Visual evidence

A representative Welcome screenshot is attached below. It demonstrates the zero-business-change token re-point:

- The "开始·Begin" button is filled with `amberDeep #5D3000` (was `#000000` before this PR)
- The page background is `bgWarm #FAF7F2` (was `#f9f9f9` cool gray before this PR)
- The orb's amber bloom is unchanged (it was already v4)

## Refs

Closes the foundation portion of #332. Phase C and Phase D issues will reference this PR.