### PR TITLE
fix(today): wire popover 相册 tile to system photo picker (#334)

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -61,6 +61,14 @@ struct InputBarV4: View {
     @FocusState private var isFocused: Bool
     @State private var showAttachmentMenu: Bool = false
     @State private var photosPickerItems: [PhotosPickerItem] = []
+    /// Triggers the system Photos picker from the "+" attachment menu.
+    /// The inline 相册 button in the bottom strip uses its own
+    /// `PhotosPicker { … }` wrapper, but the popover's 相册 tile is a
+    /// plain Button — we can't wrap a PhotosPicker around a tile inside
+    /// the popover (a Sheet inside a Sheet behaves badly), so we use
+    /// the `.photosPicker(isPresented:)` modifier instead and let the
+    /// popover flip this flag after dismissing itself.
+    @State private var showPhotosPicker: Bool = false
     @State private var pressToTalkPhase: PressToTalkPhase = .idle
     @State private var composerState: ComposerState = .idle
     /// True while a "录音太短" hint is visible. Prevents committing a
@@ -266,13 +274,32 @@ struct InputBarV4: View {
         .sheet(isPresented: $showAttachmentMenu) {
             AttachmentMenuPopover(
                 onCapturePhoto: { showAttachmentMenu = false; onCapturePhoto() },
-                onPickPhoto: { showAttachmentMenu = false },
+                onPickPhoto: {
+                    // Bug fix (#332 follow-up): the popover's 相册 tile used to
+                    // close the sheet and do nothing else, which is why uploads
+                    // never started. We can't wrap a PhotosPicker around the tile
+                    // (sheet-in-sheet behaves badly), so we dismiss the popover
+                    // and then flip a flag that the `.photosPicker(isPresented:)`
+                    // modifier below picks up. The 0.35s delay lets the popover's
+                    // dismiss animation finish before iOS tries to present the
+                    // photo picker on top of it.
+                    showAttachmentMenu = false
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.35) {
+                        showPhotosPicker = true
+                    }
+                },
                 onAddFile: { showAttachmentMenu = false; onAddFile() },
                 onAddLocation: { showAttachmentMenu = false; onFetchLocation() },
                 isLocating: isLocating,
                 hasPendingLocation: pendingLocation != nil
             )
         }
+        .photosPicker(
+            isPresented: $showPhotosPicker,
+            selection: $photosPickerItems,
+            matching: .images,
+            photoLibrary: .shared()
+        )
         .onChange(of: photosPickerItems) { newItems in
             guard !newItems.isEmpty else { return }
             onAddPhoto(newItems)


### PR DESCRIPTION
Closes #334.

## What was broken

Tapping the **+** button in the input bar opens an attachment popover with four tiles: 拍照 / 相册 / 位置 / 附件. Three of them work, but **相册 does nothing visible** — the popover closes, and that's it. The user gets no feedback, no picker, no error.

This is despite the **inline 相册 button** at the bottom of the input bar working perfectly fine. So users can still attach photos, but the more discoverable + obvious entry point silently dropped their intent.

## Why

\`InputBarV4.swift\` line 269:

```swift
.sheet(isPresented: \$showAttachmentMenu) {
    AttachmentMenuPopover(
        onCapturePhoto: { showAttachmentMenu = false; onCapturePhoto() },
        onPickPhoto:    { showAttachmentMenu = false },                    // ← bug
        onAddFile:      { showAttachmentMenu = false; onAddFile() },
        onAddLocation:  { showAttachmentMenu = false; onFetchLocation() },
        …
    )
}
```

The other three tiles dismiss the popover *and* call their handler. \`onPickPhoto\` only dismisses — the actual photo picker trigger was never wired up. Looks like a placeholder closure that slipped through review.

## Why the inline button works but the popover one didn't

The inline button is a \`PhotosPicker { … } label\` wrapper, so SwiftUI presents the system picker when the label is tapped — no closure needed. We can't use the same pattern in the popover because the popover is itself a Sheet, and Sheet-in-Sheet on iOS is unreliable (the inner sheet often refuses to present, or steals the dismiss gesture). So we have to use the modifier form: \`.photosPicker(isPresented:selection:…)\`.

## The fix

Three small changes, all in \`InputBarV4.swift\`:

1. Add a new \`@State private var showPhotosPicker: Bool = false\` next to the existing \`showAttachmentMenu\`.
2. Change the popover's \`onPickPhoto\` to dismiss the popover, then flip \`showPhotosPicker = true\` after a 0.35s delay. The delay lets the popover's dismiss animation finish — without it, iOS tries to present the picker on top of the still-animating popover and silently cancels.
3. Attach \`.photosPicker(isPresented: \$showPhotosPicker, selection: \$photosPickerItems, matching: .images, photoLibrary: .shared())\` next to the existing sheet modifier.

\`photosPickerItems\` is the **same** state the inline button writes to, so the existing \`.onChange(of: photosPickerItems)\` handler routes the selection through \`onAddPhoto\` to the view model — zero downstream changes. \`matching: .images\` and no \`maxSelectionCount\` match the inline button exactly, so the popover entry and the inline entry now feel identical.

## Test plan

- [x] \`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build\` → BUILD SUCCEEDED.
- [ ] Manual: tap +, tap 相册 → system photo picker appears → selected image attaches to the draft memo.
- [ ] Regression: inline 相册 button still works (shares the same \`photosPickerItems\` state).
- [ ] Regression: 拍照 / 位置 / 附件 tiles still work.