### PR TITLE
refactor(ui): converge page surfaces to Liquid Glass (#332 Phase C)

### DIFF
--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -150,9 +150,12 @@ struct RootView: View {
                 .shadow(color: Color.black.opacity(0.10), radius: 20, x: 6, y: 0)
                 .offset(x: nav.isSidebarOpen ? 0 : -sidebarWidth)
 
-            // Right-side feedback panel — overlay + sliding panel
+            // Right-side feedback panel — same scrim treatment as the sidebar
+            // so both drawers feel like they belong to the same elevation tier.
             if nav.isFeedbackPanelOpen {
-                Color.black.opacity(0.28)
+                Rectangle()
+                    .fill(Color.black.opacity(0.42))
+                    .background(.ultraThinMaterial)
                     .ignoresSafeArea()
                     .onTapGesture { nav.closeFeedbackPanel() }
                     .transition(.opacity)

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -13,7 +13,25 @@ struct SidebarView: View {
 
     var body: some View {
         ZStack(alignment: .topLeading) {
-            DSColor.bgWarm.ignoresSafeArea()
+            // Liquid Glass drawer — warm cream base + ultraThinMaterial blur
+            // gives the sidebar the "floating panel above the timeline" feel
+            // that matches Today's ambient glass language. RootView's scrim
+            // sits behind this layer so the drawer reads as elevated.
+            ZStack {
+                DSColor.bgWarm
+                Rectangle()
+                    .fill(DSColor.glassHi)
+                    .background(.ultraThinMaterial)
+            }
+            .ignoresSafeArea()
+            .overlay(alignment: .trailing) {
+                // Hairline rim along the right edge — separates the drawer
+                // from the dimmed timeline behind the scrim.
+                Rectangle()
+                    .fill(DSColor.glassRimD)
+                    .frame(width: 0.5)
+                    .ignoresSafeArea(edges: .vertical)
+            }
 
             VStack(alignment: .leading, spacing: 0) {
                 brandHeader

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -29,41 +29,49 @@ struct GraphView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // MARK: Header bar
+            // MARK: Header bar — Liquid Glass strip on the warm canvas
             VStack(spacing: 0) {
-                HStack(spacing: 8) {
-                    // Search field
+                HStack(spacing: DSSpacing.sm) {
+                    // Search field — glass-tinted capsule
                     HStack(spacing: 6) {
                         Image(systemName: "magnifyingglass")
                             .font(.system(size: 13))
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                         TextField("搜索节点...", text: $viewModel.searchQuery)
-                            .font(.custom("JetBrainsMono-Regular", fixedSize: 12))
-                            .foregroundColor(DSColor.onSurface)
+                            .font(DSFonts.jetBrainsMono(size: 12))
+                            .foregroundColor(DSColor.inkPrimary)
                     }
-                    .padding(.horizontal, 10)
+                    .padding(.horizontal, DSSpacing.md)
                     .padding(.vertical, 7)
-                    .background(DSColor.surfaceContainerLow)
+                    .background(DSColor.glassLo)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous)
+                            .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous))
 
-                    // Filter toggle
+                    // Filter toggle — amber when active
                     Button {
                         withAnimation(.easeInOut) { showFilters.toggle() }
                     } label: {
                         Image(systemName: showFilters ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
                             .font(.system(size: 20))
-                            .foregroundColor(hasActiveFilter ? DSColor.primary : DSColor.onSurfaceVariant)
+                            .foregroundColor(hasActiveFilter ? DSColor.amberAccent : DSColor.inkMuted)
+                            .frame(width: 44, height: 44)
+                            .contentShape(Rectangle())
                     }
+                    .accessibilityLabel(showFilters ? "Hide filters" : "Show filters")
                 }
-                .padding(.horizontal, 16)
-                .padding(.vertical, 10)
+                .padding(.horizontal, DSSpacing.lg)
+                .padding(.vertical, DSSpacing.sm)
 
-                // Date range filter panel
                 if showFilters {
                     VStack(alignment: .leading, spacing: 6) {
-                        HStack(spacing: 8) {
+                        HStack(spacing: DSSpacing.sm) {
                             Text("开始")
-                                .font(.custom("JetBrainsMono-Regular", fixedSize: 11))
-                                .foregroundColor(DSColor.onSurfaceVariant)
+                                .font(DSFonts.jetBrainsMono(size: 11))
+                                .foregroundColor(DSColor.inkMuted)
                                 .frame(width: 30)
                             DatePicker(
                                 "",
@@ -79,14 +87,15 @@ struct GraphView: View {
 
                             if viewModel.filterStartDate != nil {
                                 Button("清除") { viewModel.filterStartDate = nil }
-                                    .font(.custom("Inter-Regular", size: 11))
-                                    .foregroundColor(DSColor.onSurfaceVariant)
+                                    .font(DSFonts.inter(size: 11))
+                                    .foregroundColor(DSColor.amberAccent)
+                                    .frame(minHeight: 44)
                             }
                         }
-                        HStack(spacing: 8) {
+                        HStack(spacing: DSSpacing.sm) {
                             Text("结束")
-                                .font(.custom("JetBrainsMono-Regular", fixedSize: 11))
-                                .foregroundColor(DSColor.onSurfaceVariant)
+                                .font(DSFonts.jetBrainsMono(size: 11))
+                                .foregroundColor(DSColor.inkMuted)
                                 .frame(width: 30)
                             DatePicker(
                                 "",
@@ -102,24 +111,28 @@ struct GraphView: View {
 
                             if viewModel.filterEndDate != nil {
                                 Button("清除") { viewModel.filterEndDate = nil }
-                                    .font(.custom("Inter-Regular", size: 11))
-                                    .foregroundColor(DSColor.onSurfaceVariant)
+                                    .font(DSFonts.inter(size: 11))
+                                    .foregroundColor(DSColor.amberAccent)
+                                    .frame(minHeight: 44)
                             }
                         }
                     }
-                    .padding(.horizontal, 16)
-                    .padding(.bottom, 10)
-                    .background(DSColor.surfaceContainerLow)
+                    .padding(.horizontal, DSSpacing.lg)
+                    .padding(.vertical, DSSpacing.md)
+                    .background(DSColor.glassLo)
+                    .background(.ultraThinMaterial)
                     .transition(.opacity.combined(with: .move(edge: .top)))
                 }
 
-                Divider().background(DSColor.outline)
+                Rectangle()
+                    .fill(DSColor.glassRim)
+                    .frame(height: 0.5)
             }
-            .background(DSColor.surfaceContainerLow)
+            .background(DSColor.bgWarm)
 
-            // MARK: Graph area
+            // MARK: Graph area — warm canvas
             ZStack {
-                DSColor.background.ignoresSafeArea()
+                DSColor.bgWarm.ignoresSafeArea()
 
                 if viewModel.isLoading {
                     ProgressView()
@@ -156,18 +169,18 @@ struct GraphView: View {
     // MARK: - Empty State
 
     private var emptyState: some View {
-        VStack(spacing: 12) {
+        VStack(spacing: DSSpacing.md) {
             Image(systemName: "point.3.connected.trianglepath.dotted")
                 .font(.system(size: 48, weight: .thin))
-                .foregroundColor(DSColor.outlineVariant)
+                .foregroundColor(DSColor.inkFaint)
             Text(viewModel.nodes.isEmpty ? "尚无知识图谱" : "无匹配节点")
-                .displayLGStyle()
-                .foregroundColor(DSColor.outlineVariant)
+                .font(DSType.h2)
+                .foregroundColor(DSColor.inkMuted)
             Text(viewModel.nodes.isEmpty ? "编译日记后，实体节点将在此出现" : "调整搜索或筛选条件以查看节点")
                 .bodySMStyle()
-                .foregroundColor(DSColor.onSurfaceVariant)
+                .foregroundColor(DSColor.inkMuted)
                 .multilineTextAlignment(.center)
-                .padding(.horizontal, 40)
+                .padding(.horizontal, DSSpacing.xl4)
         }
     }
 
@@ -192,7 +205,7 @@ struct GraphView: View {
                         var path = Path()
                         path.move(to: CGPoint(x: sx, y: sy))
                         path.addLine(to: CGPoint(x: ex, y: ey))
-                        ctx.stroke(path, with: .color(DSColor.outlineVariant.opacity(0.5)), lineWidth: 1)
+                        ctx.stroke(path, with: .color(DSColor.inkFaint.opacity(0.7)), lineWidth: 1)
                     }
 
                     // Draw all nodes (dim non-matching)
@@ -219,7 +232,7 @@ struct GraphView: View {
                         && node.name.localizedCaseInsensitiveContains(viewModel.searchQuery)
                     Text(node.name)
                         .font(.custom("JetBrainsMono-Regular", fixedSize: max(8, 10 * scale)))
-                        .foregroundColor(isSearchMatch ? DSColor.primary : DSColor.onSurface)
+                        .foregroundColor(isSearchMatch ? DSColor.amberDeep : DSColor.inkPrimary)
                         .fontWeight(isSearchMatch ? .bold : .regular)
                         .lineLimit(1)
                         .fixedSize()
@@ -264,14 +277,15 @@ struct GraphView: View {
 
     private var legend: some View {
         VStack(alignment: .leading, spacing: 6) {
-            legendRow(color: DSColor.amberArchival, label: "地点")
-            legendRow(color: DSColor.secondary, label: "人物")
-            legendRow(color: DSColor.tertiary, label: "主题")
+            legendRow(color: DSColor.amberDeep, label: "地点")
+            legendRow(color: DSColor.inkMuted, label: "人物")
+            legendRow(color: DSColor.amberAccent, label: "主题")
         }
-        .padding(10)
-        .background(DSColor.surfaceContainer.opacity(0.9))
+        .padding(DSSpacing.md)
+        .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
+        .fixedSize()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
-        .padding(16)
+        .padding(DSSpacing.lg)
     }
 
     private func legendRow(color: Color, label: String) -> some View {
@@ -280,8 +294,8 @@ struct GraphView: View {
                 .fill(color)
                 .frame(width: 10, height: 10)
             Text(label)
-                .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
-                .foregroundColor(DSColor.onSurface)
+                .font(DSFonts.jetBrainsMono(size: 10))
+                .foregroundColor(DSColor.inkPrimary)
         }
     }
 

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -111,9 +111,14 @@ struct SettingsView: View {
                 SecureField("sk-... 或直接粘贴", text: $editingKeyValue)
                     .textInputAutocapitalization(.never)
                     .autocorrectionDisabled()
-                    .padding(12)
-                    .background(Color(.systemGray6))
-                    .cornerRadius(8)
+                    .padding(DSSpacing.md)
+                    .background(DSColor.glassLo)
+                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous)
+                            .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
+                    )
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous))
                     .padding(.horizontal)
 
                 HStack {

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -655,27 +655,27 @@ struct TodayView: View {
     }
 
     private var syncBanner: some View {
-        Text("Sync your journal across devices →")
-            .font(DSType.bodySM)
-            .foregroundColor(DSColor.inkMuted)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 10)
-            .padding(.horizontal, 20)
-            .background(DSColor.glassStd)
-            .background(.ultraThinMaterial)
-            .overlay(Rectangle().frame(height: 0.5).foregroundColor(DSColor.glassRim), alignment: .bottom)
-            .gesture(
-                DragGesture(minimumDistance: 20)
-                    .onEnded { value in
-                        if value.translation.height < -10 {
-                            withAnimation { showSyncBanner = false }
-                            UserDefaults.standard.set(Date(), forKey: AppSettings.Keys.lastSyncBannerDate)
-                        }
-                    }
-            )
-            .onTapGesture {
-                showAuthSheet = true
+        DSBanner(
+            kind: .info,
+            title: "Sync your journal across devices",
+            subtitle: "Sign in to back up your notes",
+            primaryAction: (label: "Sync", action: { showAuthSheet = true }),
+            onDismiss: {
+                withAnimation { showSyncBanner = false }
+                UserDefaults.standard.set(Date(), forKey: AppSettings.Keys.lastSyncBannerDate)
             }
+        )
+        .padding(.horizontal, DSSpacing.pageMargin)
+        .padding(.bottom, DSSpacing.xs)
+        .gesture(
+            DragGesture(minimumDistance: 20)
+                .onEnded { value in
+                    if value.translation.height < -10 {
+                        withAnimation { showSyncBanner = false }
+                        UserDefaults.standard.set(Date(), forKey: AppSettings.Keys.lastSyncBannerDate)
+                    }
+                }
+        )
     }
 
     // MARK: - Fallback Content (zero-memo today)
@@ -1102,48 +1102,22 @@ private struct OnThisDayNavTarget: Identifiable {
 // MARK: - CompilationFailedBanner
 
 /// Red banner shown when background compilation failed after all retries.
+/// Delegates to the shared DSBanner so the visual language matches every
+/// other banner in the app (syncBanner, LocationDraftCard header, etc.).
 struct CompilationFailedBanner: View {
     let message: String
     let onRetry: () -> Void
     let onDismiss: () -> Void
 
     var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "xmark.circle.fill")
-                .foregroundColor(DSColor.errorRed)
-                .font(.system(size: 14))
-            Text(message)
-                .font(DSType.bodySM)
-                .foregroundColor(DSColor.inkPrimary)
-                .lineLimit(2)
-            Spacer()
-            Button("重试") {
-                onRetry()
-            }
-            .font(DSType.caption)
-            .foregroundColor(DSColor.errorRed)
-            .accessibilityLabel("重试编译")
-            .frame(minWidth: 44, minHeight: 44)
-            .contentShape(Rectangle())
-            Button {
-                onDismiss()
-            } label: {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundColor(DSColor.inkMuted)
-                    .frame(width: 44, height: 44)
-                    .contentShape(Rectangle())
-            }
-            .accessibilityLabel("关闭错误提示")
-        }
-        .padding(.horizontal, 16)
-        .padding(.vertical, 10)
-        .background(DSColor.errorSoft)
-        .background(.ultraThinMaterial)
-        .overlay(RoundedRectangle(cornerRadius: 10, style: .continuous).strokeBorder(DSColor.glassRim, lineWidth: 0.5))
-        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
-        .padding(.horizontal, 20)
-        .padding(.bottom, 4)
+        DSBanner(
+            kind: .error,
+            title: message,
+            primaryAction: (label: "重试", action: onRetry),
+            onDismiss: onDismiss
+        )
+        .padding(.horizontal, DSSpacing.pageMargin)
+        .padding(.bottom, DSSpacing.xs)
     }
 }
 


### PR DESCRIPTION
> Stage **two** of the Liquid Glass converge sweep (issue #332).
> Phase A+B (#333) shipped the token + component foundation; this PR
> integrates it at the page level for the five files that had the most
> visible v1 Material residue or hosted the legacy banner implementations
> that DSBanner replaces.

## GraphView (the biggest cosmetic gap pre-converge)

- Search field is now a glass-tinted capsule (\`DSColor.glassLo\` + \`ultraThinMaterial\` + \`glassRim\` hairline) instead of legacy \`surfaceContainerLow\` flat gray
- Filter toggle button: 44pt hit target, \`amberAccent\` when active (was \`DSColor.primary\` which used to mean pure black)
- Date range filter panel: glass background matching the search field
- Canvas edges: \`inkFaint\` instead of \`outlineVariant\` — visible without competing with the data
- Search-match label color: \`amberDeep\` (was \`DSColor.primary\` = pure black)
- Legend: \`liquidGlassCard\` \`fixedSize\` floating in bottom-leading (was \`surfaceContainer.opacity(0.9)\` full-bleed gray block)
- Empty state ink colors all on the v4 ink ramp
- Graph background swapped from \`DSColor.background\` → \`bgWarm\` so the view inherits the same warm canvas as Today / Archive

## SidebarView

Drawer fill is now \`bgWarm\` + \`glassHi\` + \`ultraThinMaterial\`, giving it the "floating panel above the timeline" feel that pairs with the stronger scrim shipped in RootView. A 0.5pt \`glassRimD\` hairline on the right edge separates it from the dimmed timeline.

## RootView

Both scrims (sidebar + feedback panel) bumped from \`Color.black.opacity(0.28)\` flat to \`opacity(0.42)\` + \`ultraThinMaterial\`, so the underlying timeline visibly recedes when a drawer is open.

## TodayView — banner unification

- \`syncBanner\`: was a custom Text + glassStd background + drag-gesture dismiss. Now \`DSBanner(.info)\` with an explicit primary "Sync" action and a 44pt dismiss control. The swipe-up gesture is kept for muscle memory.
- \`CompilationFailedBanner\`: was a hand-rolled HStack with its own red icon + retry button + close button + ultraThinMaterial bg. Collapsed to \`DSBanner(.error, primaryAction:, onDismiss:)\` — 45 lines → 12 lines, no behavior change.

## SettingsView

API key SecureField background: \`Color(.systemGray6)\` → \`glassLo\` + \`ultraThinMaterial\` — the last UIKit system color leak in the codebase.

## Pages NOT touched in this PR

- **DailyPage / Archive / Onboarding / Welcome / Feedback / MemoDetail**: their legacy token references (\`DSColor.primary\`, \`surface\`, \`outline\`, etc.) were already re-pointed by Phase A's \`Colors.swift\` sweep, so the visual values are correct without source edits. Migrating the names to v4 spellings is a follow-up cleanup PR, not a visual fix.
- **EmailAuthView / OTPVerificationView**: these are intentional dark-theme surfaces (#0A0A0A bg + #F5F0E8 ink). They are NOT residue — leave the deliberate visual decision alone.

## Test plan

- [x] \`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build\` → BUILD SUCCEEDED on top of latest main (which already includes #333).
- [x] Cherry-picked cleanly onto the post-#333 main, no merge conflicts.

## Refs

Closes the page-integration portion of #332.