### PR TITLE
fix(voice): prevent SFSpeechRecognizer continuation hang with 30s timeout

### DIFF
--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -284,12 +284,25 @@ final class VoiceService: NSObject, ObservableObject {
         final class TaskBox {
             let lock = NSLock()
             var task: SFSpeechRecognitionTask?
+            var continuation: CheckedContinuation<String?, Never>?
             var didResume: Bool = false
         }
         let box = TaskBox()
 
         return await Self.withTimeout(seconds: 30) {
             await withCheckedContinuation { (cont: CheckedContinuation<String?, Never>) in
+                box.lock.lock()
+                box.continuation = cont
+                // If the timeout already fired before we stored the continuation
+                // (extremely unlikely but possible), resume immediately.
+                let raceLost = box.didResume
+                box.lock.unlock()
+
+                if raceLost {
+                    cont.resume(returning: nil)
+                    return
+                }
+
                 let task = recognizer.recognitionTask(with: request) { result, error in
                     let resumeValue: String?
                     if let result, result.isFinal {
@@ -304,28 +317,27 @@ final class VoiceService: NSObject, ObservableObject {
                     box.lock.lock()
                     let alreadyResumed = box.didResume
                     if !alreadyResumed { box.didResume = true }
+                    let cont = box.continuation
                     box.lock.unlock()
 
-                    if !alreadyResumed {
+                    if !alreadyResumed, let cont {
                         cont.resume(returning: resumeValue)
                     }
                 }
                 box.lock.lock()
                 box.task = task
-                // If the timeout already fired before we stored the task (extremely
-                // unlikely but possible), cancel immediately so we don't leak it.
-                let raceLost = box.didResume
                 box.lock.unlock()
-                if raceLost { task.cancel() }
             }
         } onTimeout: {
-            // Timeout fired: cancel the recognition task. Any subsequent callback
-            // will see `didResume == true` and skip resuming.
+            // Timeout fired: cancel the recognition task and resume the continuation
+            // directly so `withCheckedContinuation` doesn't hang forever.
             box.lock.lock()
             let task = box.task
+            let cont = box.continuation
             box.didResume = true
             box.lock.unlock()
             task?.cancel()
+            cont?.resume(returning: nil)
         }
     }
 

--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -275,14 +275,57 @@ final class VoiceService: NSObject, ObservableObject {
         request.shouldReportPartialResults = false
         request.requiresOnDeviceRecognition = true
 
-        return await withCheckedContinuation { cont in
-            recognizer.recognitionTask(with: request) { result, error in
-                if let result, result.isFinal {
-                    cont.resume(returning: result.bestTranscription.formattedString)
-                } else if error != nil {
-                    cont.resume(returning: nil)
+        // Hold the recognition task on a NSLock-protected box so the recognitionTask
+        // callback (any thread) and the timeout path can coordinate cancellation
+        // without double-resuming the continuation or leaking the task.
+        // Without this, audio that produces only partial results (or no terminal
+        // callback at all) would hang `stopAndTranscribe()` forever and freeze
+        // the UI in `.processing`.
+        final class TaskBox {
+            let lock = NSLock()
+            var task: SFSpeechRecognitionTask?
+            var didResume: Bool = false
+        }
+        let box = TaskBox()
+
+        return await Self.withTimeout(seconds: 30) {
+            await withCheckedContinuation { (cont: CheckedContinuation<String?, Never>) in
+                let task = recognizer.recognitionTask(with: request) { result, error in
+                    let resumeValue: String?
+                    if let result, result.isFinal {
+                        resumeValue = result.bestTranscription.formattedString
+                    } else if error != nil {
+                        resumeValue = nil
+                    } else {
+                        // Non-terminal callback (partial result without isFinal). Wait for next.
+                        return
+                    }
+
+                    box.lock.lock()
+                    let alreadyResumed = box.didResume
+                    if !alreadyResumed { box.didResume = true }
+                    box.lock.unlock()
+
+                    if !alreadyResumed {
+                        cont.resume(returning: resumeValue)
+                    }
                 }
+                box.lock.lock()
+                box.task = task
+                // If the timeout already fired before we stored the task (extremely
+                // unlikely but possible), cancel immediately so we don't leak it.
+                let raceLost = box.didResume
+                box.lock.unlock()
+                if raceLost { task.cancel() }
             }
+        } onTimeout: {
+            // Timeout fired: cancel the recognition task. Any subsequent callback
+            // will see `didResume == true` and skip resuming.
+            box.lock.lock()
+            let task = box.task
+            box.didResume = true
+            box.lock.unlock()
+            task?.cancel()
         }
     }
 
@@ -420,6 +463,38 @@ final class VoiceService: NSObject, ObservableObject {
     private func stopMeteringTimer() {
         meteringTimer?.invalidate()
         meteringTimer = nil
+    }
+}
+
+// MARK: - Timeout Helper
+
+extension VoiceService {
+    /// Race `operation` against a timeout. Returns the operation's result if it
+    /// completes within `seconds`, otherwise invokes `onTimeout` (for cleanup
+    /// such as cancelling an in-flight task) and returns `nil`.
+    ///
+    /// The losing branch is cancelled via Swift structured concurrency so the
+    /// caller never has to manage task lifetimes manually.
+    static func withTimeout<T>(
+        seconds: TimeInterval,
+        operation: @escaping @Sendable () async -> T?,
+        onTimeout: @escaping @Sendable () -> Void = {}
+    ) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask {
+                await operation()
+            }
+            group.addTask {
+                let ns = UInt64(max(0, seconds) * 1_000_000_000)
+                try? await Task.sleep(nanoseconds: ns)
+                onTimeout()
+                return nil
+            }
+            // Take the first finished branch and cancel the rest.
+            let first = await group.next() ?? nil
+            group.cancelAll()
+            return first
+        }
     }
 }
 


### PR DESCRIPTION
## Problem (P0 from audit)

VoiceService.transcribeWithSpeechRecognizer wraps recognitionTask in a non-throwing withCheckedContinuation whose callback only resumes on result.isFinal == true or error != nil. Real-world failure modes that hit neither branch:

- Corrupted / unsupported-format M4A — the recognizer emits a partial result and then silently stops without isFinal or error.
- Mid-pipeline interruption (route change, audio session loss) — same shape.

When that happens the continuation hangs forever, stopAndTranscribe() never returns, VoiceService.state stays in .processing, and the entire UI freezes. Only an app restart recovers.

## Fix

- Race the recognition against a 30-second withTimeout helper (mirrors the Whisper path's budget).
- Track the SFSpeechRecognitionTask so the timeout branch can call .cancel() and free the audio engine.
- Guard the continuation with an NSLock-protected didResume flag — late terminal callbacks after a timeout (or vice versa) cannot double-resume.
- Add an explicit else { return } for non-terminal callbacks so the intent is clear.

## Files

- DayPage/Services/VoiceService.swift — +81 / -6

## Test plan

- [x] xcodebuild build on iPhone 17 simulator — green.
- [ ] Manual: record a 2s clip with airplane mode on (forces on-device path) — transcript resolves or fails within 30s, recorder UI returns to .idle.
- [ ] Manual: artificially truncate an M4A and feed it through the same path — confirms timeout path cancels and UI recovers.

## Related

Part of the P0 fixes from the deep audit. Independent of the other P0 PRs (BGTask budget, rewrite race, secrets fallback).
