### PR TITLE
fix(storage): serialize rewrite through writeQueue and move off main thread

### DIFF
--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -269,17 +269,20 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
     // MARK: - Delete / Pin Memo
 
     /// Removes a memo from today's file and refreshes the in-memory list.
+    ///
+    /// UI updates optimistically on the MainActor (so the delete animation
+    /// stays snappy), then the rewrite is dispatched off-main through
+    /// `RawStorage.rewrite` — which goes through `writeQueue.sync` and
+    /// therefore cannot race with `append()`. If the write fails, the UI
+    /// state is rolled back and an error is surfaced.
     func deleteMemo(_ memo: Memo) {
+        let previous = memos
         let remaining = memos.filter { $0.id != memo.id }
-        do {
-            try rewrite(memos: remaining)
-            // Optimistic UI update
-            withAnimation(Motion.rise) {
-                memos = remaining
-            }
-        } catch {
-            submitError = "删除失败：\(error.localizedDescription)"
+        // Optimistic UI update
+        withAnimation(Motion.rise) {
+            memos = remaining
         }
+        persistMemos(remaining, capturedDate: date, previous: previous, failureMessagePrefix: "删除失败")
     }
 
     /// Replaces the body text of an existing memo and writes through to disk.
@@ -289,15 +292,12 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         updated.body = body
         var newMemos = memos
         newMemos[idx] = updated
-        do {
-            try rewrite(memos: newMemos)
-            withAnimation(Motion.rise) {
-                memos = newMemos
-            }
-            Haptics.commit()
-        } catch {
-            submitError = "保存失败：\(error.localizedDescription)"
+        let previous = memos
+        withAnimation(Motion.rise) {
+            memos = newMemos
         }
+        Haptics.commit()
+        persistMemos(newMemos, capturedDate: date, previous: previous, failureMessagePrefix: "保存失败")
     }
 
     /// Pins a memo to the top of today's list without changing its original timestamp.
@@ -309,14 +309,11 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         var updated = memos
         updated.remove(at: idx)
         updated.insert(pinned, at: 0)
-        do {
-            try rewrite(memos: updated)
-            withAnimation(.easeInOut(duration: 0.25)) {
-                memos = updated
-            }
-        } catch {
-            submitError = "置顶失败：\(error.localizedDescription)"
+        let previous = memos
+        withAnimation(.easeInOut(duration: 0.25)) {
+            memos = updated
         }
+        persistMemos(updated, capturedDate: date, previous: previous, failureMessagePrefix: "置顶失败")
     }
 
     /// Unpins a memo, restoring it to its natural position based on original `created` time.
@@ -328,30 +325,39 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         updated.remove(at: idx)
         let insertIdx = updated.firstIndex(where: { $0.created < unpinned.created }) ?? updated.endIndex
         updated.insert(unpinned, at: insertIdx)
-        do {
-            try rewrite(memos: updated)
-            withAnimation(.easeInOut(duration: 0.25)) {
-                memos = updated
-            }
-        } catch {
-            submitError = "取消置顶失败：\(error.localizedDescription)"
+        let previous = memos
+        withAnimation(.easeInOut(duration: 0.25)) {
+            memos = updated
         }
+        persistMemos(updated, capturedDate: date, previous: previous, failureMessagePrefix: "取消置顶失败")
     }
 
-    /// Overwrites today's raw storage file with the given ordered memo list.
-    private func rewrite(memos: [Memo]) throws {
-        let url = RawStorage.fileURL(for: date)
-        if memos.isEmpty {
-            // Remove the file entirely if no memos remain
-            if FileManager.default.fileExists(atPath: url.path) {
-                try FileManager.default.removeItem(at: url)
+    /// Dispatches a `RawStorage.rewrite` off the MainActor so disk I/O never
+    /// blocks the UI thread, and so the rewrite is serialized with `append()`
+    /// through `RawStorage.writeQueue`.
+    ///
+    /// On failure, restores `memos` to `previous` and surfaces an error
+    /// banner via `submitError`. Memo arrays are value types, so capturing
+    /// them across the actor boundary is safe.
+    private func persistMemos(
+        _ memosToWrite: [Memo],
+        capturedDate: Date,
+        previous: [Memo],
+        failureMessagePrefix: String
+    ) {
+        Task.detached(priority: .userInitiated) { [weak self] in
+            do {
+                try RawStorage.rewrite(memosToWrite, for: capturedDate)
+            } catch {
+                await MainActor.run {
+                    guard let self = self else { return }
+                    withAnimation(Motion.rise) {
+                        self.memos = previous
+                    }
+                    self.submitError = "\(failureMessagePrefix)：\(error.localizedDescription)"
+                }
             }
-            return
         }
-        // Write newest-last so the file is chronological (parser sorts later)
-        let ordered = memos.sorted { $0.created < $1.created }
-        let content = ordered.map { $0.toMarkdown() }.joined(separator: RawStorage.memoSeparator)
-        try RawStorage.atomicWrite(string: content, to: url)
     }
 
     // MARK: - Load Memos
@@ -562,8 +568,9 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             updated.attachments = atts
             var newMemos = memos
             newMemos[memoIdx] = updated
-            try? rewrite(memos: newMemos)
+            let previous = memos
             withAnimation { memos = newMemos }
+            persistMemos(newMemos, capturedDate: date, previous: previous, failureMessagePrefix: "重新转写失败")
         }
     }
 

--- a/DayPage/Storage/RawStorage.swift
+++ b/DayPage/Storage/RawStorage.swift
@@ -75,6 +75,64 @@ enum RawStorage {
         }
     }
 
+    // MARK: - Serialization
+
+    /// Serializes an ordered list of memos into the on-disk format for a single
+    /// day's file: each memo's markdown joined by `memoSeparator`, written
+    /// newest-last so the file is chronological (parser sorts later anyway).
+    ///
+    /// Pure function — no I/O, safe to call from any thread/actor.
+    static func serialize(_ memos: [Memo]) -> String {
+        let ordered = memos.sorted { $0.created < $1.created }
+        return ordered.map { $0.toMarkdown() }.joined(separator: memoSeparator)
+    }
+
+    // MARK: - Rewrite
+
+    /// Replaces the contents of `date`'s raw file with the given memo list.
+    /// If `memos` is empty, the file is deleted.
+    ///
+    /// Runs through `writeQueue.sync` so that it cannot interleave with
+    /// `append()` — without this, a concurrent rewrite + append against the
+    /// same day's file would race (e.g. user pins a memo while a voice
+    /// transcript callback appends another), and the last writer would silently
+    /// overwrite the other's changes.
+    ///
+    /// Safe to call from any thread/actor. Performs disk I/O inline, so callers
+    /// on `@MainActor` should dispatch via `Task.detached` to avoid blocking
+    /// the UI thread (see TodayViewModel for the canonical pattern).
+    static func rewrite(_ memos: [Memo], for date: Date) throws {
+        try writeQueue.sync {
+            let url = fileURL(for: date)
+            if memos.isEmpty {
+                let fm = FileManager.default
+                if fm.fileExists(atPath: url.path) {
+                    try fm.removeItem(at: url)
+                }
+
+                let crumb = Breadcrumb()
+                crumb.category = "rawstorage"
+                crumb.message = "rewrite: removed empty file \(url.lastPathComponent)"
+                crumb.level = .info
+                SentrySDK.addBreadcrumb(crumb)
+
+                WidgetCenter.shared.reloadAllTimelines()
+                return
+            }
+
+            let content = serialize(memos)
+            try atomicWrite(string: content, to: url)
+
+            let crumb = Breadcrumb()
+            crumb.category = "rawstorage"
+            crumb.message = "rewrite \(memos.count) memos to \(url.lastPathComponent)"
+            crumb.level = .info
+            SentrySDK.addBreadcrumb(crumb)
+
+            WidgetCenter.shared.reloadAllTimelines()
+        }
+    }
+
     // MARK: - Read
 
     /// 读取给定日期日文件中的所有 Memo。


### PR DESCRIPTION
## Problem (P0 from audit)

TodayViewModel.rewrite(memos:) ran synchronously on @MainActor. Every delete / edit / pin / unpin / re-transcribe blocked the UI thread on disk I/O (NSFileCoordinator + replaceItemAt). Worse, the call deliberately bypassed RawStorage.writeQueue while RawStorage.append() does use it — so the two paths could race on the same day's file:

> User pins a memo at the same instant a voice transcript callback appends one → one of the two writes silently overwrites the other (last-writer-wins, no error surfaced).

This is the classic optimistic-UI-without-serialization bug, and iCloud sync amplifies it (atomicWrite latency spikes increase the race window).

## Fix

- RawStorage.serialize(_:) — pure, thread-safe helper.
- RawStorage.rewrite(_:for:) — goes through writeQueue.sync, mirroring append()'s contract. Empty list deletes the file.
- TodayViewModel.persistMemos(...) wraps the call in Task.detached(priority: .userInitiated) so disk I/O never blocks the main actor.
- All four mutating UI paths (deleteMemo, update, pinMemo, unpinMemo) apply the optimistic UI update first, then dispatch the write. On failure the previous memo list is restored and submitError is surfaced — the user sees a banner instead of an inconsistent list.
- reTranscribe adopts the new pathway too.

## Files

- DayPage/Storage/RawStorage.swift — +58
- DayPage/Features/Today/TodayViewModel.swift — +52 / -45

## Test plan

- [x] xcodebuild on iPhone 17 simulator — green.
- [ ] Manual: delete a memo, force-quit before iCloud sync, relaunch — file matches the UI state.
- [ ] Manual: pin a memo while voice transcript callback appends another — both changes survive (regression check for the race).
- [ ] Manual: induce a write failure (e.g. revoke vault dir permissions) — banner appears, memo list rolls back.

## Related

Part of the P0 fixes from the deep audit. Independent of #337 (voice timeout) and the upcoming P0-1 (secrets) / P0-2 (BGTask) PRs.
