### PR TITLE
refactor(models): unify frontmatter field extraction in FrontmatterParser

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		A10000006 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000006 /* Typography.swift */; };
 		A10000007 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000007 /* Components.swift */; };
 		A10000008 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000008 /* Memo.swift */; };
+		A10000F00 /* FrontmatterParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000F00 /* FrontmatterParser.swift */; };
 		A10000009 /* RawStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000009 /* RawStorage.swift */; };
 		A10000010 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010 /* TodayView.swift */; };
 		A10000011 /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000011 /* ArchiveView.swift */; };
@@ -237,6 +238,7 @@
 		A20000006 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		A20000007 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
 		A20000008 /* Memo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memo.swift; sourceTree = "<group>"; };
+		A20000F00 /* FrontmatterParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmatterParser.swift; sourceTree = "<group>"; };
 		A20000009 /* RawStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorage.swift; sourceTree = "<group>"; };
 		A20000010 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		A20000011 /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
@@ -561,6 +563,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000008 /* Memo.swift */,
+				A20000F00 /* FrontmatterParser.swift */,
 				CJ1000001 /* CJKTextPolish.swift */,
 			);
 			path = Models;
@@ -1101,6 +1104,7 @@
 				A10000041 /* Spacing.swift in Sources */,
 				A10000043 /* Interactions.swift in Sources */,
 				A10000008 /* Memo.swift in Sources */,
+				A10000F00 /* FrontmatterParser.swift in Sources */,
 				A10000009 /* RawStorage.swift in Sources */,
 				A10000010 /* TodayView.swift in Sources */,
 				A10000011 /* ArchiveView.swift in Sources */,

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -183,19 +183,6 @@ final class ArchiveViewModel: ObservableObject {
                 content.components(separatedBy: "\n\n---\n\n").count
             }
 
-            func extractSummary(from content: String) -> String? {
-                for line in content.components(separatedBy: "\n") {
-                    let trimmed = line.trimmingCharacters(in: .whitespaces)
-                    if trimmed.hasPrefix("summary:") {
-                        let value = String(trimmed.dropFirst("summary:".count))
-                            .trimmingCharacters(in: .whitespaces)
-                            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                        return value.isEmpty ? nil : value
-                    }
-                }
-                return nil
-            }
-
             // DateFormatter is not Sendable; create a local instance for this task.
             let fmt = DateFormatter()
             fmt.dateFormat = "yyyy-MM-dd"
@@ -253,7 +240,7 @@ final class ArchiveViewModel: ObservableObject {
                 var dailySummary: String? = nil
                 if isDailyCompiled {
                     if let content = (try? String(contentsOf: dailyURL, encoding: .utf8)) {
-                        dailySummary = extractSummary(from: content)
+                        dailySummary = FrontmatterParser.extractField("summary", from: content)
                     }
                 }
 
@@ -410,19 +397,6 @@ final class ArchiveViewModel: ObservableObject {
 
     private func countMemoBlocks(in content: String) -> Int {
         content.components(separatedBy: "\n\n---\n\n").count
-    }
-
-    private func extractSummary(from content: String) -> String? {
-        for line in content.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("summary:") {
-                let value = String(trimmed.dropFirst("summary:".count))
-                    .trimmingCharacters(in: .whitespaces)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                return value.isEmpty ? nil : value
-            }
-        }
-        return nil
     }
 }
 

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -374,20 +374,6 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
 
         loadTask?.cancel()
         loadTask = Task.detached(priority: .userInitiated) {
-            // Inline helper — DateFormatter is not Sendable, so do not capture self.
-            func extractSummaryOffMain(from content: String) -> String? {
-                for line in content.components(separatedBy: "\n") {
-                    let trimmed = line.trimmingCharacters(in: .whitespaces)
-                    if trimmed.hasPrefix("summary:") {
-                        let value = String(trimmed.dropFirst("summary:".count))
-                            .trimmingCharacters(in: .whitespaces)
-                            .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                        return value.isEmpty ? nil : value
-                    }
-                }
-                return nil
-            }
-
             // --- Off-main disk I/O ---
             let loadResult: Result<[Memo], Error>
             do {
@@ -401,7 +387,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             var dailySummary: String? = nil
             if dailyExists {
                 if let content = try? String(contentsOf: dailyURL, encoding: .utf8) {
-                    dailySummary = extractSummaryOffMain(from: content)
+                    dailySummary = FrontmatterParser.extractField("summary", from: content)
                 }
             }
 
@@ -933,7 +919,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         // Extract summary from frontmatter if available
         do {
             let content = try String(contentsOf: dailyURL, encoding: .utf8)
-            dailyPageSummary = extractSummary(from: content)
+            dailyPageSummary = FrontmatterParser.extractField("summary", from: content)
         } catch {
             DayPageLogger.shared.error("TodayViewModel: read daily: \(error)")
         }
@@ -951,18 +937,4 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             .appendingPathComponent("\(dateStr).md")
     }
 
-    /// Parses the `summary:` frontmatter field from a Daily Page file.
-    private func extractSummary(from content: String) -> String? {
-        let lines = content.components(separatedBy: "\n")
-        for line in lines {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("summary:") {
-                let value = String(trimmed.dropFirst("summary:".count))
-                    .trimmingCharacters(in: .whitespaces)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                return value.isEmpty ? nil : value
-            }
-        }
-        return nil
-    }
 }

--- a/DayPage/Models/FrontmatterParser.swift
+++ b/DayPage/Models/FrontmatterParser.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// Lightweight YAML frontmatter field extractor. Reads only the leading
+/// `---\n...\n---` block conceptually; does not parse the full YAML document.
+///
+/// Centralises the `summary:` (and future scalar fields like `summary_zh:`)
+/// extraction that was previously duplicated across `TodayViewModel`,
+/// `ArchiveView`, `TimelineService`, and `WeeklyRecapService`.
+enum FrontmatterParser {
+
+    /// Extracts a top-level scalar field's string value from frontmatter.
+    ///
+    /// Handles `key: value`, `key: "value"`, `key: 'value'`. Trims surrounding
+    /// whitespace and a single layer of matching single/double quotes. Returns
+    /// `nil` when the field is absent or the trimmed value is empty.
+    ///
+    /// - Note: This intentionally scans every line, not just the frontmatter
+    ///   block, to preserve the historical behaviour of the now-removed
+    ///   per-call-site `extractSummary` helpers. Daily Page files only ever
+    ///   write the field once inside the frontmatter, so the behaviour is
+    ///   equivalent in practice while remaining tolerant of files without a
+    ///   closing `---` delimiter.
+    static func extractField(_ key: String, from content: String) -> String? {
+        let prefix = "\(key):"
+        for line in content.components(separatedBy: "\n") {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix(prefix) {
+                let value = String(trimmed.dropFirst(prefix.count))
+                    .trimmingCharacters(in: .whitespaces)
+                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+                return value.isEmpty ? nil : value
+            }
+        }
+        return nil
+    }
+}

--- a/DayPage/Services/TimelineService.swift
+++ b/DayPage/Services/TimelineService.swift
@@ -116,7 +116,7 @@ enum TimelineService {
             var summary: String? = nil
             let dailyURL = dailyDir.appendingPathComponent("\(stem).md")
             if let dailyContent = try? String(contentsOf: dailyURL, encoding: .utf8) {
-                summary = extractSummary(from: dailyContent)
+                summary = FrontmatterParser.extractField("summary", from: dailyContent)
             }
 
             result.append(TimelineDayEntry(
@@ -223,20 +223,4 @@ enum TimelineService {
         return cal
     }
 
-    /// Parse `summary:` from a Daily Page frontmatter. Same surface as
-    /// `WeeklyRecapService.extractSummary` and `TodayViewModel.extractSummary`
-    /// — duplicated rather than shared to avoid creating a public API surface
-    /// on those types just for parsing.
-    private static func extractSummary(from content: String) -> String? {
-        for line in content.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("summary:") {
-                let value = String(trimmed.dropFirst("summary:".count))
-                    .trimmingCharacters(in: .whitespaces)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                return value.isEmpty ? nil : value
-            }
-        }
-        return nil
-    }
 }

--- a/DayPage/Services/WeeklyRecapService.swift
+++ b/DayPage/Services/WeeklyRecapService.swift
@@ -90,7 +90,7 @@ final class WeeklyRecapService {
 
             let summary: String?
             if let content = try? String(contentsOf: url, encoding: .utf8) {
-                summary = Self.extractSummary(from: content)
+                summary = FrontmatterParser.extractField("summary", from: content)
             } else {
                 summary = nil
             }
@@ -114,20 +114,4 @@ final class WeeklyRecapService {
         return calendar.dateInterval(of: .weekOfYear, for: date)?.start
     }
 
-    /// Extract `summary:` from a daily page's frontmatter. Behaviour matches
-    /// `ArchiveView.extractSummary` and `TodayViewModel.extractSummary`; kept
-    /// local so Phase 2 (weekly/monthly compilations with different schemas)
-    /// can extend parsing here without touching unrelated callers.
-    static func extractSummary(from content: String) -> String? {
-        for line in content.components(separatedBy: "\n") {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if trimmed.hasPrefix("summary:") {
-                let value = String(trimmed.dropFirst("summary:".count))
-                    .trimmingCharacters(in: .whitespaces)
-                    .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
-                return value.isEmpty ? nil : value
-            }
-        }
-        return nil
-    }
 }


### PR DESCRIPTION
## Problem (P1-5 from audit)

The `extractSummary(from content:)` helper was duplicated across five sites:

- DayPage/Features/Today/TodayViewModel.swift L378 and L955
- DayPage/Features/Archive/ArchiveView.swift L186 and L415
- DayPage/Services/TimelineService.swift L230
- DayPage/Services/WeeklyRecapService.swift L121

All four implementations were behaviourally identical: scan lines, match `summary:` prefix, strip surrounding whitespace + matching quotes, return nil on empty/missing. Any future field addition (e.g. `summary_zh:` for localised compilations) had to land in five places at once.

## Fix

- Add `DayPage/Models/FrontmatterParser.swift` with a single static `extractField(_ key:, from content:)` that preserves the exact behaviour of all five removed copies.
- Replace all five call sites with `FrontmatterParser.extractField("summary", from: content)`.
- Delete the now-unused `private static func extractSummary` helpers (and the `static` one on WeeklyRecapService — confirmed no external callers via grep).
- Register the new file in `DayPage.xcodeproj/project.pbxproj` (PBXBuildFile + PBXFileReference + Models group + Sources phase).

## Behavioural equivalence

Each removed helper used the same line-scan / prefix-match / quote-strip / empty-to-nil algorithm. The new `FrontmatterParser` is a verbatim hoist — no semantic change, no user-visible diff.

## Files

- `DayPage/Models/FrontmatterParser.swift` — new (+36)
- `DayPage/Features/Today/TodayViewModel.swift` — removes private helper, two call sites
- `DayPage/Features/Archive/ArchiveView.swift` — call site swap + helper delete
- `DayPage/Services/TimelineService.swift` — call site swap + helper delete
- `DayPage/Services/WeeklyRecapService.swift` — call site swap + helper delete
- `DayPage.xcodeproj/project.pbxproj` — register new source file

Net: +45 / -91.

## Test plan

- [x] xcodebuild on iPhone 17 simulator — green.
- [ ] Manual: open Archive → confirm month summary lines render unchanged.
- [ ] Manual: open Today → confirm yesterday's recap card pulls the same summary text.
- [ ] Manual: open weekly recap → entries show their summaries.

## Related

Part of the deep audit P1 wave. Unblocks future P1-3 (Archive monthly stats) and P1-4 (Timeline incremental cache) which want a cheap frontmatter reader.
