### PR TITLE
fix(today): unblock card swipe-to-reveal by scoping ambient drag gestures

### DIFF
--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -108,6 +108,14 @@ struct RootView: View {
 
     // MARK: - Main Content with Sidebar Overlay
 
+    // Width of the left-edge strip that opens the sidebar via swipe-from-edge.
+    // Kept narrow so the rest of the screen is free for horizontal gestures
+    // inside child views (e.g. SwipeableMemoCard's UIKit pan). Previously the
+    // open-sidebar DragGesture was attached to the entire ZStack with a 20pt
+    // minimumDistance, which fought UIKit's 10pt direction-lock inside
+    // SwipeableMemoCard and effectively froze left/right swipe-to-reveal.
+    private let edgeSwipeWidth: CGFloat = 20
+
     private var mainContent: some View {
         ZStack(alignment: .leading) {
             // 标签页内容 — 三个页面全部保持存活以保留 ViewModel 状态
@@ -182,31 +190,69 @@ struct RootView: View {
                 )
                 .frame(maxWidth: .infinity, alignment: .trailing)
                 .offset(x: nav.isFeedbackPanelOpen ? 0 : feedbackPanelWidth + 60)
-                .gesture(
-                    DragGesture(minimumDistance: 20)
-                        .onEnded { value in
-                            if value.translation.width > 60 {
-                                nav.closeFeedbackPanel()
-                            }
-                        }
+                // Close-by-swipe only attached while the panel is open.
+                // Previously the gesture was always installed; SwiftUI keeps
+                // such gestures in arbitration even when allowsHitTesting is
+                // false, which interfered with horizontal pans inside the
+                // timeline (memo cards' UIKit pan recognizer).
+                .modifier(
+                    FeedbackCloseSwipeModifier(
+                        isOpen: nav.isFeedbackPanelOpen,
+                        onClose: { nav.closeFeedbackPanel() }
+                    )
                 )
                 .allowsHitTesting(nav.isFeedbackPanelOpen)
                 .zIndex(2)
 
+            // Edge-swipe trigger: only the leftmost `edgeSwipeWidth` strip can
+            // open the sidebar. By scoping the gesture to a narrow strip we
+            // stop SwiftUI's DragGesture from competing with UIKit pan
+            // recognizers (SwipeableMemoCard) across the entire screen.
+            // simultaneousGesture keeps siblings active, so vertical timeline
+            // scroll and horizontal card swipes are no longer blocked while
+            // SwiftUI is still in the "Possible" arbitration window.
+            if !nav.isSidebarOpen {
+                Color.clear
+                    .frame(width: edgeSwipeWidth)
+                    .frame(maxHeight: .infinity)
+                    .contentShape(Rectangle())
+                    .simultaneousGesture(
+                        DragGesture(minimumDistance: 12, coordinateSpace: .local)
+                            .onEnded { value in
+                                let dx = value.translation.width
+                                let dy = value.translation.height
+                                guard abs(dx) > abs(dy) * 1.2 else { return }
+                                if dx > 30 { nav.openSidebar() }
+                            }
+                    )
+                    .allowsHitTesting(true)
+                    .accessibilityHidden(true)
+            }
         }
-        // 边缘滑动打开：仅在拖动从左侧 40pt 以内开始时触发
-        .gesture(
-            DragGesture(minimumDistance: 20, coordinateSpace: .local)
-                .onEnded { value in
-                    let dx = value.translation.width
-                    let dy = value.translation.height
-                    guard abs(dx) > abs(dy) * 1.2 else { return }
-                    if dx > 40, value.startLocation.x < 40, !nav.isSidebarOpen {
-                        nav.openSidebar()
-                    } else if dx < -40, nav.isSidebarOpen {
-                        nav.closeSidebar()
+    }
+}
+
+// MARK: - FeedbackCloseSwipeModifier
+//
+// Conditionally attaches the swipe-right-to-close gesture only while the
+// FeedbackView is open. Keeping it permanently attached (even with
+// allowsHitTesting=false) leaves the gesture in SwiftUI's arbitration pool
+// and competes with horizontal gestures elsewhere on screen (notably the
+// UIKit pan inside SwipeableMemoCard).
+private struct FeedbackCloseSwipeModifier: ViewModifier {
+    let isOpen: Bool
+    let onClose: () -> Void
+
+    func body(content: Content) -> some View {
+        if isOpen {
+            content.gesture(
+                DragGesture(minimumDistance: 20)
+                    .onEnded { value in
+                        if value.translation.width > 60 { onClose() }
                     }
-                }
-        )
+            )
+        } else {
+            content
+        }
     }
 }

--- a/DayPage/Features/Today/HorizontalPanGesture.swift
+++ b/DayPage/Features/Today/HorizontalPanGesture.swift
@@ -70,9 +70,12 @@ struct HorizontalPanGesture: UIViewRepresentable {
         var parent: HorizontalPanGesture
         weak var recognizer: UIPanGestureRecognizer?
 
-        // 10pt direction-lock matches Apple's internal swipe recognizers.
-        // Below this we stay Possible so UIScrollView keeps ownership.
-        private let directionLockDistance: CGFloat = 10
+        // 6pt direction-lock: tightened from 10pt so UIKit's pan can enter
+        // Began before SwiftUI's ambient DragGestures (sidebar edge swipe,
+        // feedback-panel close) finish their own arbitration window. Still
+        // safely below UIScrollView's vertical pan threshold, so a slow
+        // vertical drag still hands ownership to the timeline scroll.
+        private let directionLockDistance: CGFloat = 6
         // |dx| must dominate |dy| by 1.2× — slightly more permissive than
         // Mail (1.5×) because our cards are wider and a shallow horizontal
         // flick should still register.


### PR DESCRIPTION
## Summary

Card swipe-to-reveal (left swipe → delete, right swipe → pin) was effectively dead on the Today timeline. Root cause was two SwiftUI \`DragGesture\`s on the root \`ZStack\` competing with the UIKit \`UIPanGestureRecognizer\` inside \`SwipeableMemoCard\` — both attached unconditionally, both starving the UIKit recognizer.

## Root cause

- \`RootView.mainContent\` had a full-screen \`.gesture(DragGesture(minimumDistance: 20))\` for the open-sidebar edge swipe. It covered the whole ZStack, so every horizontal touch on a memo card was already held by SwiftUI's arbitration window.
- The right-side \`FeedbackView\` swipe-to-close gesture stayed mounted even when the panel was off-screen (\`allowsHitTesting(false)\` doesn't remove a gesture from arbitration).
- UIKit's \`HorizontalPanGesture\` had a 10pt direction-lock threshold; by the time it wanted to \`Begin\`, SwiftUI's still-pending gesture would cancel it.

Net effect: card panels would jitter open by a few pt and snap shut, or never open at all.

## Fix

- Open-sidebar gesture is now scoped to a 20pt-wide \`Color.clear\` left-edge strip, attached via \`.simultaneousGesture\` so siblings stay active.
- \`FeedbackCloseSwipeModifier\` conditionally mounts the close gesture only while \`nav.isFeedbackPanelOpen\` is true.
- Lowered \`HorizontalPanGesture.directionLockDistance\` from 10pt → 6pt so UIKit's pan enters \`Began\` before any ambient SwiftUI gestures finish arbitration. Still safely below \`UIScrollView\`'s vertical pan threshold.

## Test plan

- [x] \`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build\` → succeeds
- [ ] iPhone 17 simulator: left swipe a memo card → red \`Delete\` panel reveals
- [ ] iPhone 17 simulator: right swipe a memo card → \`Pin\` panel reveals
- [ ] iPhone 17 simulator: vertical drag on a card → timeline scrolls (UIScrollView keeps ownership)
- [ ] iPhone 17 simulator: drag from extreme left edge (≤20pt) → sidebar opens
- [ ] iPhone 17 simulator: drag from middle of screen → sidebar does **not** open
- [ ] iPhone 17 simulator: open feedback panel → drag right → panel closes