### PR TITLE
fix(observability): guard Sentry breadcrumbs when SDK is disabled

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -113,6 +113,7 @@
 		A10000203 /* InlineLensStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000203 /* InlineLensStrip.swift */; };
 		A10000301 /* TimelineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000301 /* TimelineService.swift */; };
 		A10000350 /* TimelineIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000350 /* TimelineIndex.swift */; };
+		A10000360 /* SentryReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000360 /* SentryReporter.swift */; };
 		A10000302 /* TimelineSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000302 /* TimelineSectionView.swift */; };
 		A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */; };
 		AF0000001 /* SpaceGrotesk-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000001 /* SpaceGrotesk-Light.ttf */; };
@@ -320,6 +321,7 @@
 		A20000203 /* InlineLensStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineLensStrip.swift; sourceTree = "<group>"; };
 		A20000301 /* TimelineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineService.swift; sourceTree = "<group>"; };
 		A20000350 /* TimelineIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineIndex.swift; sourceTree = "<group>"; };
+		A20000360 /* SentryReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReporter.swift; sourceTree = "<group>"; };
 		A20000302 /* TimelineSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineSectionView.swift; sourceTree = "<group>"; };
 		A30000001 /* DayPage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPage.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A381FA327A37AE0DD740D61D /* PosterTemplates.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PosterTemplates.swift; path = ShareCard/PosterTemplates.swift; sourceTree = "<group>"; };
@@ -603,6 +605,7 @@
 				A20000083 /* WeeklyRecapService.swift */,
 				A20000301 /* TimelineService.swift */,
 				A20000350 /* TimelineIndex.swift */,
+				A20000360 /* SentryReporter.swift */,
 				A20000095 /* ComposerContextProvider.swift */,
 				BB12D96218034D3E4555B8AA /* HapticFeedback.swift */,
 			);
@@ -1153,6 +1156,7 @@
 				A10000083 /* WeeklyRecapService.swift in Sources */,
 				A10000301 /* TimelineService.swift in Sources */,
 				A10000350 /* TimelineIndex.swift in Sources */,
+				A10000360 /* SentryReporter.swift in Sources */,
 				A10000084 /* WeeklyRecapSection.swift in Sources */,
 				A10000302 /* TimelineSectionView.swift in Sources */,
 				A10000200 /* ComposerStateMachine.swift in Sources */,

--- a/DayPage/Services/ConflictMerger.swift
+++ b/DayPage/Services/ConflictMerger.swift
@@ -172,11 +172,11 @@ enum ConflictMerger {
                 }
             }
             let afterCount = original.count
-            let crumb = Breadcrumb()
-            crumb.category = "conflict_merger"
-            crumb.message = "merged \(primaryURL.lastPathComponent): \(beforeCount) primary + conflict versions → \(afterCount) memos"
-            crumb.level = afterCount < beforeCount ? .warning : .info
-            SentrySDK.addBreadcrumb(crumb)
+            SentryReporter.breadcrumb(
+                category: "conflict_merger",
+                level: afterCount < beforeCount ? .warning : .info,
+                message: "merged \(primaryURL.lastPathComponent): \(beforeCount) primary + conflict versions → \(afterCount) memos"
+            )
             if afterCount < beforeCount {
                 DayPageLogger.log(
                     level: "WARN",

--- a/DayPage/Services/DayPageLogger.swift
+++ b/DayPage/Services/DayPageLogger.swift
@@ -27,25 +27,19 @@ final class DayPageLogger {
 
     func error(_ message: String, file: String = #file, line: Int = #line) {
         write(level: "ERROR", message: message, file: file, line: line)
-        let crumb = Breadcrumb(level: .error, category: "app")
-        crumb.message = message
-        SentrySDK.addBreadcrumb(crumb)
+        SentryReporter.breadcrumb(category: "app", level: .error, message: message)
         // Breadcrumb only — no per-call SentrySDK.capture(). Call sites that need a
         // full Sentry event (unhandled exceptions) should invoke SentrySDK directly.
     }
 
     func warn(_ message: String, file: String = #file, line: Int = #line) {
         write(level: "WARN", message: message, file: file, line: line)
-        let crumb = Breadcrumb(level: .warning, category: "app")
-        crumb.message = message
-        SentrySDK.addBreadcrumb(crumb)
+        SentryReporter.breadcrumb(category: "app", level: .warning, message: message)
     }
 
     func info(_ message: String, file: String = #file, line: Int = #line) {
         write(level: "INFO", message: message, file: file, line: line)
-        let crumb = Breadcrumb(level: .info, category: "app")
-        crumb.message = message
-        SentrySDK.addBreadcrumb(crumb)
+        SentryReporter.breadcrumb(category: "app", level: .info, message: message)
     }
 
     private func write(level: String, message: String, file: String, line: Int) {

--- a/DayPage/Services/SentryReporter.swift
+++ b/DayPage/Services/SentryReporter.swift
@@ -1,0 +1,45 @@
+import Foundation
+import Sentry
+
+/// Thin wrapper around `SentrySDK.addBreadcrumb(...)` that no-ops when the SDK
+/// is not started (i.e. when `Secrets.sentryDSN` is empty — typical for local
+/// dev / CI builds without a configured DSN).
+///
+/// Why this exists: calling `SentrySDK.addBreadcrumb(...)` against a disabled
+/// SDK floods the console with `[Sentry] [fatal] The SDK is disabled, so
+/// addBreadcrumb doesn't work.` lines — once per call site, on every write —
+/// which drowns out the actual diagnostic logs we ship breadcrumbs for.
+///
+/// `nonisolated` and free of any UI dependency so it can be called from any
+/// thread, actor, or background queue (matching the existing breadcrumb call
+/// sites in `RawStorage`, `ConflictMerger`, `DayPageLogger`, …).
+enum SentryReporter {
+
+    /// Skips breadcrumb dispatch when the SDK was never started. Cheap O(1)
+    /// string check — no Sentry runtime call is made in the disabled path.
+    static var isSentryEnabled: Bool {
+        !Secrets.sentryDSN.isEmpty
+    }
+
+    /// Convenience wrapper: build a `Breadcrumb` and forward it to Sentry only
+    /// when the SDK is enabled. Mirrors the existing `Breadcrumb()` +
+    /// `category` + `message` + `level` pattern used at every call site.
+    static func breadcrumb(category: String,
+                           level: SentryLevel = .info,
+                           message: String) {
+        guard isSentryEnabled else { return }
+        let crumb = Breadcrumb()
+        crumb.category = category
+        crumb.message = message
+        crumb.level = level
+        SentrySDK.addBreadcrumb(crumb)
+    }
+
+    /// Escape hatch for the few call sites that build a pre-populated
+    /// `Breadcrumb` (e.g. with extra fields like `data`/`type`). Drops the
+    /// breadcrumb silently when Sentry is disabled.
+    static func add(_ crumb: Breadcrumb) {
+        guard isSentryEnabled else { return }
+        SentrySDK.addBreadcrumb(crumb)
+    }
+}

--- a/DayPage/Storage/RawStorage.swift
+++ b/DayPage/Storage/RawStorage.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Sentry
 import WidgetKit
 
 // MARK: - RawStorage
@@ -65,11 +64,10 @@ enum RawStorage {
 
             try atomicWrite(string: combined, to: url)
 
-            let crumb = Breadcrumb()
-            crumb.category = "rawstorage"
-            crumb.message = "append memo \(memo.id) to \(url.lastPathComponent)"
-            crumb.level = .info
-            SentrySDK.addBreadcrumb(crumb)
+            SentryReporter.breadcrumb(
+                category: "rawstorage",
+                message: "append memo \(memo.id) to \(url.lastPathComponent)"
+            )
 
             WidgetCenter.shared.reloadAllTimelines()
             notifyDidWrite(for: memo.created)
@@ -122,11 +120,10 @@ enum RawStorage {
                     try fm.removeItem(at: url)
                 }
 
-                let crumb = Breadcrumb()
-                crumb.category = "rawstorage"
-                crumb.message = "rewrite: removed empty file \(url.lastPathComponent)"
-                crumb.level = .info
-                SentrySDK.addBreadcrumb(crumb)
+                SentryReporter.breadcrumb(
+                    category: "rawstorage",
+                    message: "rewrite: removed empty file \(url.lastPathComponent)"
+                )
 
                 WidgetCenter.shared.reloadAllTimelines()
                 notifyDidWrite(for: date)
@@ -136,11 +133,10 @@ enum RawStorage {
             let content = serialize(memos)
             try atomicWrite(string: content, to: url)
 
-            let crumb = Breadcrumb()
-            crumb.category = "rawstorage"
-            crumb.message = "rewrite \(memos.count) memos to \(url.lastPathComponent)"
-            crumb.level = .info
-            SentrySDK.addBreadcrumb(crumb)
+            SentryReporter.breadcrumb(
+                category: "rawstorage",
+                message: "rewrite \(memos.count) memos to \(url.lastPathComponent)"
+            )
 
             WidgetCenter.shared.reloadAllTimelines()
             notifyDidWrite(for: date)
@@ -154,22 +150,21 @@ enum RawStorage {
     static func read(for date: Date) throws -> [Memo] {
         let url = fileURL(for: date)
         guard FileManager.default.fileExists(atPath: url.path) else {
-            let crumb = Breadcrumb()
-            crumb.category = "rawstorage"
-            crumb.message = "read: file not found \(url.lastPathComponent)"
-            crumb.level = .warning
-            SentrySDK.addBreadcrumb(crumb)
+            SentryReporter.breadcrumb(
+                category: "rawstorage",
+                level: .warning,
+                message: "read: file not found \(url.lastPathComponent)"
+            )
             return []
         }
 
         let content = try String(contentsOf: url, encoding: .utf8)
         let memos = parse(fileContent: content)
 
-        let crumb = Breadcrumb()
-        crumb.category = "rawstorage"
-        crumb.message = "read \(memos.count) memos from \(url.lastPathComponent)"
-        crumb.level = .info
-        SentrySDK.addBreadcrumb(crumb)
+        SentryReporter.breadcrumb(
+            category: "rawstorage",
+            message: "read \(memos.count) memos from \(url.lastPathComponent)"
+        )
 
         return memos
     }


### PR DESCRIPTION
## Summary
Cold-launch console was flooded with `[Sentry] [fatal] The SDK is disabled, so addBreadcrumb doesn't work.` on every `RawStorage` read/write (and every `DayPageLogger.info/warn/error`, and every `ConflictMerger` merge) because the SDK never starts when `Secrets.sentryDSN` is empty — typical for local dev / CI builds with no DSN. The transaction call sites (`WeatherService`, `CompilationService`, `VoiceService`, `BackgroundCompilationService`) already guarded on `isEmpty`; the breadcrumb call sites did not.

## Approach
Extract a `SentryReporter` helper that:
- exposes `breadcrumb(category:level:message:)` and `add(crumb)` wrappers that no-op when `Secrets.sentryDSN.isEmpty`
- centralises `Breadcrumb` construction so every call site is a single line

Update the 9 existing call sites:
- `RawStorage.swift` × 5 (append / rewrite-empty / rewrite / read-missing / read)
- `DayPageLogger.swift` × 3 (info / warn / error)
- `ConflictMerger.swift` × 1 (merge result)

## Found via
`/loop R1` (Today page end-to-end verification). Console log analysis after `xcrun simctl launch` surfaced the breadcrumb spam as the highest-signal issue on the Today cold-launch path.

## Test plan
- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [x] Reinstall and `xcrun simctl launch` → zero `[Sentry] [fatal]` lines in console (was 4–5 per launch)
- [ ] Manually test Sentry-enabled build (set `Secrets.sentryDSN` in Keychain) → breadcrumbs still arrive in Sentry dashboard
- [ ] CI: existing `RawStorageTests` still passes