### PR TITLE
perf(archive): drop redundant disk read in monthly stats loop

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -214,25 +214,34 @@ final class ArchiveViewModel: ObservableObject {
                 var voiceSeconds = 0
                 var uniqueLocations = Set<String>()
 
-                if let content = (try? String(contentsOf: rawURL, encoding: .utf8)) {
-                    let memos: [Memo]?
-                    do { memos = try RawStorage.read(for: date) }
-                    catch { memos = nil }
-                    memoCount = memos?.count ?? countMemoBlocks(in: content)
-                    for memo in (memos ?? []) {
-                        if memo.type == .photo || memo.type == .mixed {
-                            photoCount += memo.attachments.filter { $0.kind == "photo" }.count
-                        }
-                        if memo.type == .voice || memo.type == .mixed {
-                            for att in memo.attachments where att.kind == "audio" {
-                                if let dur = att.duration {
-                                    voiceSeconds += Int(dur)
-                                }
+                // RawStorage.read returns [] when the file is missing and parses
+                // the day's memos in one pass. Calling it directly avoids a redundant
+                // disk read (the previous `String(contentsOf:)` guard only existed
+                // to provide a fallback when read threw — handled below).
+                let memos: [Memo]
+                do {
+                    memos = try RawStorage.read(for: date)
+                } catch {
+                    // Fallback: parse-failure should not zero the day. Read raw and
+                    // count blocks so the calendar density still reflects activity.
+                    let raw = (try? String(contentsOf: rawURL, encoding: .utf8)) ?? ""
+                    memoCount = raw.isEmpty ? 0 : countMemoBlocks(in: raw)
+                    memos = []
+                }
+                if !memos.isEmpty { memoCount = memos.count }
+                for memo in memos {
+                    if memo.type == .photo || memo.type == .mixed {
+                        photoCount += memo.attachments.filter { $0.kind == "photo" }.count
+                    }
+                    if memo.type == .voice || memo.type == .mixed {
+                        for att in memo.attachments where att.kind == "audio" {
+                            if let dur = att.duration {
+                                voiceSeconds += Int(dur)
                             }
                         }
-                        if let loc = memo.location, let name = loc.name, !name.isEmpty {
-                            uniqueLocations.insert(name)
-                        }
+                    }
+                    if let loc = memo.location, let name = loc.name, !name.isEmpty {
+                        uniqueLocations.insert(name)
                     }
                 }
 


### PR DESCRIPTION
## Summary
`ArchiveView.loadDayStats()` read each day's raw file **twice** on every month switch:
1. `String(contentsOf: rawURL)` as a file-existence guard
2. `RawStorage.read(for: date)` to actually parse memos

The first read was only used to feed `countMemoBlocks(in:)` as a fallback when read threw — a code path that almost never fires.

Inline the fallback so it only reads the file when `RawStorage.read` actually throws. For a 31-day month with memos this **halves the number of file syscalls** during calendar navigation, and removes a redundant parse pass on each day.

Behavior unchanged: `memoCount` still equals `memos.count` on success and the legacy block count on parse failure.

## Found via
`/loop R2` (Archive page end-to-end verification). Reading `loadDayStats()` while preparing to drive the month picker surfaced the redundant `contentsOf` read.

## Test plan
- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [ ] Manual: navigate between months on a vault with ≥10 days/month; calendar density colors and per-day counts unchanged
- [ ] Manual: corrupt one day's raw file (truncate frontmatter), confirm fallback `memoCount` is non-zero (legacy block count path)