### PR TITLE
fix(graph): correct frontmatter break in parseName + cache wikilink regex

### DIFF
--- a/DayPage/Features/Graph/GraphViewModel.swift
+++ b/DayPage/Features/Graph/GraphViewModel.swift
@@ -181,11 +181,18 @@ final class GraphViewModel: ObservableObject {
         let name: String
     }
 
+    // Cached once at file scope — NSRegularExpression compilation is expensive
+    // and the pattern is invariant. Previously rebuilt on every Daily Page scan,
+    // which on a vault with hundreds of dailies meant hundreds of pattern compiles
+    // per graph load.
+    nonisolated private static let wikilinkRegex: NSRegularExpression? = try? NSRegularExpression(
+        pattern: #"\[\[wiki/(places|people|themes)/([^\]|]+)(?:\|([^\]]+))?\]\]"#
+    )
+
     nonisolated private static func extractWikilinks(from content: String) -> [WikiRef] {
         // Matches [[wiki/places/slug|Name]] or [[wiki/places/slug]]
         var results: [WikiRef] = []
-        let pattern = #"\[\[wiki/(places|people|themes)/([^\]|]+)(?:\|([^\]]+))?\]\]"#
-        guard let regex = try? NSRegularExpression(pattern: pattern) else { return [] }
+        guard let regex = wikilinkRegex else { return [] }
         let nsContent = content as NSString
         let matches = regex.matches(in: content, range: NSRange(location: 0, length: nsContent.length))
         for match in matches {
@@ -204,15 +211,25 @@ final class GraphViewModel: ObservableObject {
     }
 
     nonisolated private static func parseName(from content: String) -> String? {
+        // Walks the frontmatter only — stops at the closing `---`. The previous
+        // implementation tried to detect the closer with `!content.hasPrefix("---")`,
+        // which is always false for well-formed frontmatter (file starts with `---`),
+        // so the loop kept scanning the entire body. Track the frontmatter boundary
+        // explicitly instead.
+        var sawOpener = false
         for line in content.components(separatedBy: "\n") {
             let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" {
+                if sawOpener { break }  // closing fence — name: must have appeared by now
+                sawOpener = true
+                continue
+            }
             if trimmed.hasPrefix("name:") {
                 let val = String(trimmed.dropFirst("name:".count))
                     .trimmingCharacters(in: .whitespaces)
                     .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
                 return val.isEmpty ? nil : val
             }
-            if trimmed == "---" && !content.hasPrefix(trimmed) { break }
         }
         return nil
     }


### PR DESCRIPTION
## Summary
Two issues in `GraphViewModel` found while reviewing entity-page parsing during the Graph end-to-end loop:

### 1. `parseName` scanned the entire file body, not just the frontmatter
The intended break condition was `trimmed == "---" && !content.hasPrefix(trimmed)` — but well-formed frontmatter always starts with `---`, so the `hasPrefix` check is always true and the break never fires. On a place/people/theme entity file with a long body, the scan walked every line looking for `name:` even though the field is always in frontmatter. Tracked the frontmatter boundary with an explicit `sawOpener` state machine.

### 2. `extractWikilinks` rebuilt the regex on every file
Built a fresh `NSRegularExpression` on every Daily Page scanned. Pattern compilation is the expensive part of `NSRegularExpression`; the pattern is invariant. Cached it once at file scope as `nonisolated private static let wikilinkRegex`. On a vault with hundreds of dailies this avoids hundreds of redundant pattern compiles per graph load.

## Behavior
- `parseName` returns identical results on well-formed entity files (the `name:` field is always within the frontmatter); the change only prevents wasted scanning when the field is absent.
- `extractWikilinks` returns identical wikilink list.

## Found via
`/loop R3` (Graph page end-to-end verification). Source review while preparing to drive the Graph search + date filter.

## Test plan
- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [ ] Manual: open Graph on a vault with ≥10 entity pages and a long body in one of them — node names render correctly
- [ ] Manual: search and filter in Graph — node list updates