### PR TITLE
fix(voice): don't retry Whisper transcription on user cancellation

### DIFF
--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -406,6 +406,13 @@ final class VoiceService: NSObject, ObservableObject {
                 // 不可重试的错误或重试次数已耗尽
                 return nil
             } catch {
+                // Cancellation should not be retried — the caller (user
+                // backgrounding the app, view dismounting) explicitly asked
+                // for this work to stop. Without this guard we'd burn 2-8s
+                // sleeping before another doomed attempt.
+                if (error as? URLError)?.code == .cancelled || Task.isCancelled {
+                    return nil
+                }
                 if attempt < maxAttempts {
                     try? await Task.sleep(nanoseconds: delaySeconds * 1_000_000_000)
                     delaySeconds *= 2


### PR DESCRIPTION
## Summary
The catch-all retry block in `transcribeAudioWhisper` swallowed every `URLSession` error and slept 2/4/8s before the next attempt — including when the error was `URLError.cancelled` (user dismissed the recording sheet, switched app, or the enclosing Task was explicitly cancelled).

A cancelled request would still burn the full retry budget in the background and could fire follow-up requests against the Whisper API after the user had moved on, wasting API quota and delaying any new in-flight work.

Add an early-return guard: if the error is `URLError.cancelled` or `Task.isCancelled`, return nil immediately without retrying. Other retryable errors (network timeout, `networkConnectionLost`, server 429/5xx) keep their existing retry behavior.

## Found via
`/loop R4` (Add/Composer end-to-end verification). Reading the Whisper transcription path while preparing to drive the voice → transcribe flow surfaced the unconditional retry.

## Test plan
- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [ ] Manual: start a voice recording, transcribe, dismiss the sheet mid-flight — no follow-up Whisper API call after dismissal
- [ ] Manual: trigger a 429 or 500 from Whisper — retry/backoff still happens