### PR TITLE
fix(settings): strip newlines from pasted API keys before saving

### DIFF
--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -147,7 +147,13 @@ struct SettingsView: View {
                 }
                 ToolbarItem(placement: .confirmationAction) {
                     Button("保存") {
-                        let trimmed = editingKeyValue.trimmingCharacters(in: .whitespaces)
+                        // Trim whitespace AND newlines — pasted API keys frequently
+                        // carry a trailing `\n` from the source (terminal copy,
+                        // password manager export), which silently makes the
+                        // Authorization header invalid (`Bearer sk-…\n`) and the
+                        // request 401s with no clue why.
+                        let trimmed = editingKeyValue
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
                         if trimmed.isEmpty {
                             KeychainHelper.deleteAPIKey(for: editingKeyID)
                         } else {


### PR DESCRIPTION
## Summary
API keys pasted from terminals, password managers, or web pages frequently carry a trailing `\n`. The "保存" button in the API Key editor trimmed only `.whitespaces`, so the newline survived into Keychain. Downstream HTTP headers then became `Authorization: Bearer sk-…\n`, which OpenAI and DashScope reject with a 401 and no clue to the user why.

Switch the trim to `.whitespacesAndNewlines` so pasted keys are normalised before persistence.

## Found via
`/loop R5` (Sidebar / Settings end-to-end verification). Source review of the API key save path while preparing to drive the Settings sheet.

## Test plan
- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- [ ] Manual: open Settings → API Keys → 编辑 → paste a key with a trailing newline → 保存 → use any AI feature (compilation / Whisper / weather) — request succeeds
- [ ] Manual: paste a leading-newline key — also normalised correctly