### PR TITLE
auto: Countdown ring on the Undo Send pill

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -7,11 +7,20 @@ import SwiftUI
 struct UndoPillView: View {
     let onUndo: () -> Void
 
+    @State private var countdownProgress: CGFloat = 1.0
+
     var body: some View {
         Button(action: onUndo) {
             HStack(spacing: 8) {
-                Image(systemName: "arrow.uturn.backward")
-                    .font(.system(size: 13, weight: .semibold))
+                ZStack {
+                    Image(systemName: "arrow.uturn.backward")
+                        .font(.system(size: 13, weight: .semibold))
+                    Circle()
+                        .trim(from: 0, to: countdownProgress)
+                        .stroke(DSColor.accentAmber, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+                        .rotationEffect(.degrees(-90))
+                        .frame(width: 22, height: 22)
+                }
                 Text("Undo send")
                     .font(.custom("Inter-Medium", size: 13))
             }
@@ -30,5 +39,10 @@ struct UndoPillView: View {
             .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
         }
         .buttonStyle(.plain)
+        .onAppear {
+            withAnimation(.linear(duration: 5)) {
+                countdownProgress = 0
+            }
+        }
     }
 }


### PR DESCRIPTION
## Auto-Dev: Countdown ring on the Undo Send pill

The Undo Send pill currently appears for 5 seconds then vanishes with no indication of how much time is left, so users can't tell whether tapping is still possible. Add a thin amber countdown ring around the pill's leading icon that animates from full to empty over the 5-second window, giving a clear visual cue of the shrinking undo window before the pill disappears.

### Acceptance
Build the DayPage scheme and run on iPhone 17 simulator. Submit a memo from Today; the Undo Send pill appears with a full amber ring around its leading icon that smoothly drains to empty over ~5 seconds, then the pill auto-dismisses. Tapping the pill mid-countdown still restores the draft text and dismisses the pill. The ring animation does not stutter or restart on unrelated view updates.