### PR TITLE
auto: Animate the Day Orb signal count on increment with a halo pulse + tap haptic

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -157,7 +157,7 @@ struct DayOrbView: View {
                 .font(DSFonts.spaceGrotesk(size: size * 0.36, weight: .semibold))
                 .tracking(-2)
                 .foregroundColor(DSColor.amberDeep)
-                .contentTransition(.numericText(value: Double(signalCount)))
+                .contentTransition(.numericText())
                 .animation(.snappy, value: signalCount)
 
             Text("SIGNALS TODAY")

--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -12,14 +12,28 @@ struct DayOrbView: View {
     var haloOpacity: CGFloat = 0.15
 
     @State private var breatheScale: CGFloat = 1.0
+    @State private var pulse: Bool = false
+    @State private var previous: Int = 0
 
     var body: some View {
         ZStack {
             halo
+            if pulse { pulseHalo }
             orb
         }
         .frame(width: size + 32, height: size + 32)
         .scaleEffect(breatheScale)
+        .onChange(of: signalCount) { new in
+            if new > previous {
+                pulse = true
+                withAnimation(.easeOut(duration: 0.6)) { }
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 650_000_000)
+                    pulse = false
+                }
+            }
+            previous = new
+        }
         // Drop shadow: two-layer stack matching the glass card recipe
         .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 4, x: 0, y: 2)
         .shadow(color: Color(hex: "2D1E0A").opacity(0.14), radius: 28, x: 0, y: 12)
@@ -31,6 +45,30 @@ struct DayOrbView: View {
                 breatheScale = 1.035
             }
         }
+    }
+
+    // MARK: - Pulse Halo
+
+    // One-shot amber ring that expands and fades when signalCount increments.
+    private var pulseHalo: some View {
+        Circle()
+            .fill(
+                RadialGradient(
+                    colors: [
+                        Color(red: 232/255, green: 151/255, blue: 77/255).opacity(pulse ? 0.55 : 0),
+                        Color.clear
+                    ],
+                    center: .center,
+                    startRadius: 0,
+                    endRadius: (size / 2) + 16
+                )
+            )
+            .frame(width: size + 32, height: size + 32)
+            .blur(radius: 12)
+            .scaleEffect(pulse ? 1.18 : 1.0)
+            .opacity(pulse ? 1 : 0)
+            .animation(.easeOut(duration: 0.6), value: pulse)
+            .allowsHitTesting(false)
     }
 
     // MARK: - Halo
@@ -119,6 +157,8 @@ struct DayOrbView: View {
                 .font(DSFonts.spaceGrotesk(size: size * 0.36, weight: .semibold))
                 .tracking(-2)
                 .foregroundColor(DSColor.amberDeep)
+                .contentTransition(.numericText(value: Double(signalCount)))
+                .animation(.snappy, value: signalCount)
 
             Text("SIGNALS TODAY")
                 .font(DSFonts.jetBrainsMono(size: 9, weight: .medium))

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -867,6 +867,7 @@ struct TodayView: View {
                 .tracking(1.0)
 
             Button {
+                Haptics.tapConfirm()
                 // TODO: open Day Drawer (follow-up story)
             } label: {
                 DayOrbView(signalCount: viewModel.signalCount, size: 140)


### PR DESCRIPTION
## Animate the Day Orb signal count on increment with a halo pulse + tap haptic

The signature Day Orb on the empty Today screen snaps its 'SIGNALS TODAY' count to a new value with no feedback when a memo is captured, and its tap currently fires no haptic (the action is still a TODO). Add a numeric roll transition on the count, a one-shot amber halo pulse when the value increases, and a light haptic on tap so capturing the day's first signals feels rewarding rather than silent.

### Acceptance
Building the DayPage scheme on iPhone 17 succeeds. On the empty Today screen, capturing a memo makes the orb's signal count roll up animatedly (e.g. 0→1) accompanied by a single amber halo pulse that fades out within ~0.6s; the steady-state breathing animation and orb sizing are visually unchanged. Tapping the orb produces a light haptic. No regression to the orb's appearance when signalCount is unchanged (no pulse on re-render or decrement).