### PR TITLE
auto: Add breathing pulse animation to the empty-state orb accent

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -10,6 +10,7 @@ struct EmptyStateView: View {
     var showOrbAccent: Bool = false
 
     @State private var appeared = false
+    @State private var breathing = false
 
     var body: some View {
         VStack(spacing: 20) {
@@ -29,7 +30,12 @@ struct EmptyStateView: View {
             }
         }
         .padding(.horizontal, 32)
-        .onAppear { appeared = true }
+        .onAppear {
+            appeared = true
+            if !UIAccessibility.isReduceMotionEnabled {
+                breathing = true
+            }
+        }
     }
 
     // MARK: - Private
@@ -51,7 +57,8 @@ struct EmptyStateView: View {
     }
 
     private var orbAccent: some View {
-        Circle()
+        let reduceMotion = UIAccessibility.isReduceMotionEnabled
+        return Circle()
             .fill(
                 RadialGradient(
                     colors: [
@@ -66,6 +73,12 @@ struct EmptyStateView: View {
             )
             .frame(width: 60, height: 60)
             .blur(radius: 10)
+            .scaleEffect(reduceMotion ? 1.0 : (breathing ? 1.12 : 0.92))
+            .opacity(reduceMotion ? 0.85 : (breathing ? 1.0 : 0.7))
+            .animation(
+                reduceMotion ? nil : .easeInOut(duration: 2.4).repeatForever(autoreverses: true),
+                value: breathing
+            )
             .allowsHitTesting(false)
     }
 

--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -9,6 +9,8 @@ struct EmptyStateView: View {
     var ctaAction: (() -> Void)?
     var showOrbAccent: Bool = false
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var appeared = false
     @State private var breathing = false
 
@@ -32,7 +34,7 @@ struct EmptyStateView: View {
         .padding(.horizontal, 32)
         .onAppear {
             appeared = true
-            if !UIAccessibility.isReduceMotionEnabled {
+            if !reduceMotion {
                 breathing = true
             }
         }
@@ -57,8 +59,7 @@ struct EmptyStateView: View {
     }
 
     private var orbAccent: some View {
-        let reduceMotion = UIAccessibility.isReduceMotionEnabled
-        return Circle()
+        Circle()
             .fill(
                 RadialGradient(
                     colors: [


### PR DESCRIPTION
## Add breathing pulse animation to the empty-state orb accent

The Today blank state shows a static dim orb accent behind the title, which makes the most-seen first-run screen feel inert. Add a subtle, continuous breathing animation (scale + opacity) to the orbAccent so the empty Today canvas feels alive and gently draws the eye toward the title and CTA, matching the warm 'ambient' design language already used elsewhere.

### Acceptance
Build DayPage scheme succeeds. Launch in iPhone 17 simulator on the first-run Today blank state: the orb accent behind the title gently pulses (scales ~0.92→1.12 and fades ~0.7→1.0) on a smooth ~2.4s loop that never stops. Title/CTA entrance animation still plays once on appear. With Settings > Accessibility > Reduce Motion enabled, the orb holds a steady static state and does not pulse. No layout shift of the title text.