### PR TITLE
feat(web): Add real-time character count to the Add memo textarea

### DIFF
--- a/web/src/app/(app)/add/UnifiedInput.tsx
+++ b/web/src/app/(app)/add/UnifiedInput.tsx
@@ -331,12 +331,29 @@ export function UnifiedInput() {
         placeholder={textareaPlaceholder}
         rows={3}
       />
-      {/* Keyboard shortcut hint */}
+      {/* Character / word counter */}
       <div
         className="ds-mono-11"
-        style={{ color: "var(--fg-subtle)", marginTop: "0.25rem", userSelect: "none" }}
+        style={{
+          color: "var(--fg-subtle)",
+          marginTop: "0.25rem",
+          userSelect: "none",
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          minHeight: "1.25em",
+        }}
       >
-        {isMac ? "⌘ + Enter to submit" : "Ctrl + Enter to submit"}
+        <span>{isMac ? "⌘ + Enter to submit" : "Ctrl + Enter to submit"}</span>
+        <span
+          aria-live="polite"
+          style={{
+            opacity: body.length > 0 ? 1 : 0,
+            transition: "opacity 0.2s ease",
+          }}
+        >
+          {body.trim().split(/\s+/).filter(Boolean).length} words &middot; {body.length} chars
+        </span>
       </div>
 
       {/* Attachment preview row */}


### PR DESCRIPTION
## Add real-time character count to the Add memo textarea

Users have no sense of how much they've written or how close they are to the AI compilation sweet-spot (~2k–5k tokens). A live word/character counter sets expectations and encourages richer memos.

### Changes
- `web/src/app/(app)/add/UnifiedInput.tsx`: Add a live character+word counter below the textarea that appears once the user starts typing (>0 chars). Show format '42 words · 218 chars' in a small muted caption. The counter should fade in with a CSS transition and disappear when the field is empty, keeping the UI uncluttered.

### Verification
Open /add, type text in the memo box, confirm a small '… words · … chars' counter appears beneath the textarea and updates on every keystroke. Verify it is absent when the field is empty and does not shift layout when it appears.