### PR TITLE
auto: Make the Day Orb tap functional with a press-down animation instead of a dead TODO

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -10,10 +10,12 @@ struct DayOrbView: View {
     let signalCount: Int
     var size: CGFloat = 140
     var haloOpacity: CGFloat = 0.15
+    var onTap: (() -> Void)? = nil
 
     @State private var breatheScale: CGFloat = 1.0
     @State private var pulse: Bool = false
     @State private var previous: Int = 0
+    @State private var isPressed: Bool = false
 
     var body: some View {
         ZStack {
@@ -22,7 +24,23 @@ struct DayOrbView: View {
             orb
         }
         .frame(width: size + 32, height: size + 32)
-        .scaleEffect(breatheScale)
+        .scaleEffect(isPressed ? breatheScale * 0.94 : breatheScale)
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in
+                    if !isPressed {
+                        withAnimation(.spring(response: 0.2, dampingFraction: 0.6)) {
+                            isPressed = true
+                        }
+                    }
+                }
+                .onEnded { _ in
+                    withAnimation(.spring(response: 0.35, dampingFraction: 0.55)) {
+                        isPressed = false
+                    }
+                    onTap?()
+                }
+        )
         .onChange(of: signalCount) { new in
             if new > previous {
                 pulse = true

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -55,6 +55,9 @@ struct InputBarV4: View {
     // US-012: batch photo progress bar
     var batchPhotoProgress: Double = 0
     var batchPhotoTotal: Int = 0
+    /// Toggle this bool (flip its value) from the parent to programmatically
+    /// open the composer and focus the text field.
+    var requestFocusToggle: Bool = false
 
     // MARK: Private State
 
@@ -311,6 +314,10 @@ struct InputBarV4: View {
             if newCount > 0 {
                 Haptics.medium()
             }
+        }
+        .onChange(of: requestFocusToggle) { _ in
+            transition(to: .expanding)
+            isFocused = true
         }
     }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -65,6 +65,9 @@ struct TodayView: View {
     // across launches; selection is always an immediate action.
     @State private var selectedMemoIds: Set<UUID>? = nil
 
+    /// Toggled each time the Day Orb is tapped to focus the composer input.
+    @State private var orbFocusToggle: Bool = false
+
     private var isInSelectionMode: Bool { selectedMemoIds != nil }
 
     /// Live drag offset for the daily page card (negative = pulled left).
@@ -866,15 +869,12 @@ struct TodayView: View {
                 .textCase(.uppercase)
                 .tracking(1.0)
 
-            Button {
+            DayOrbView(signalCount: viewModel.signalCount, size: 140) {
                 Haptics.tapConfirm()
-                // TODO: open Day Drawer (follow-up story)
-            } label: {
-                DayOrbView(signalCount: viewModel.signalCount, size: 140)
+                orbFocusToggle.toggle()
             }
-            .buttonStyle(.plain)
             .accessibilityLabel("Today's orb, \(viewModel.signalCount) signals")
-            .accessibilityHint("Tap to open today's day drawer")
+            .accessibilityHint("Tap to start writing today's first note")
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
@@ -963,6 +963,7 @@ struct TodayView: View {
         InputBarV4(
             text: $draftText,
             isSubmitting: viewModel.isSubmitting,
+            requestFocusToggle: orbFocusToggle,
             isLocating: viewModel.isLocating,
             pendingLocation: viewModel.pendingLocation,
             locationAuthStatus: LocationService.shared.authorizationStatus,


### PR DESCRIPTION
## Make the Day Orb tap functional with a press-down animation instead of a dead TODO

On the empty Today screen the 140pt Day Orb is the dominant interactive element, but its tap action is a dead  that fires a haptic and does nothing — and its accessibility hint promises a 'day drawer' that doesn't exist, misleading VoiceOver users. This replaces the no-op with a tactile press-down scale animation and a meaningful action (focusing the composer so the user can immediately start capturing), and corrects the misleading accessibility hint.

### Acceptance
Tapping the Day Orb on an empty Today screen produces a visible spring press-down/bounce animation and focuses the composer input (keyboard appears) instead of doing nothing; VoiceOver reads the corrected hint; the  comment is gone; project builds clean with  and existing tests pass.