### PR TITLE
auto: Fix dead shimmer in MemoListSkeleton — loading placeholder is actually static

### DIFF
--- a/DayPage/Components/MemoListSkeleton.swift
+++ b/DayPage/Components/MemoListSkeleton.swift
@@ -21,36 +21,73 @@ private struct SkeletonCard: View {
     let lineCount: Int
     let wide: Bool
 
-    @State private var shimmerPhase: CGFloat = 0
+    @State private var shimmerOffset: CGFloat = -1
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulseOpacity: Double = 0.5
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            // Timestamp pill
-            RoundedRectangle(cornerRadius: 3)
-                .fill(shimmerColor)
-                .frame(width: 80, height: 8)
-
-            // Body lines
-            ForEach(0..<lineCount, id: \.self) { idx in
-                RoundedRectangle(cornerRadius: 3)
-                    .fill(shimmerColor)
-                    .frame(maxWidth: lineWidth(for: idx), alignment: .leading)
-                    .frame(height: 10)
-            }
+        GeometryReader { geo in
+            let cardWidth = geo.size.width
+            cardContent(cardWidth: cardWidth)
         }
-        .padding(16)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(DSColor.glassStd)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
-        )
-        .clipShape(RoundedRectangle(cornerRadius: 12))
-        .onAppear { startShimmer() }
+        .frame(height: cardHeight)
     }
 
-    private var shimmerColor: Color {
-        DSColor.inkFaint
+    private var cardHeight: CGFloat {
+        // Timestamp pill (8) + lineCount * line (10) + spacing ((lineCount) * 6) + padding (32)
+        CGFloat(8 + lineCount * 10 + lineCount * 6 + 32)
+    }
+
+    @ViewBuilder
+    private func cardContent(cardWidth: CGFloat) -> some View {
+        ZStack(alignment: .leading) {
+            // Base card shape with placeholder bars
+            VStack(alignment: .leading, spacing: 6) {
+                RoundedRectangle(cornerRadius: 3)
+                    .fill(DSColor.inkFaint)
+                    .frame(width: 80, height: 8)
+
+                ForEach(0..<lineCount, id: \.self) { idx in
+                    RoundedRectangle(cornerRadius: 3)
+                        .fill(DSColor.inkFaint)
+                        .frame(maxWidth: lineWidth(for: idx), alignment: .leading)
+                        .frame(height: 10)
+                }
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(DSColor.glassStd)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: 12))
+
+            // Shimmer highlight overlay
+            if reduceMotion {
+                // Gentle opacity pulse instead of horizontal motion
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(DSColor.bgWarm.opacity(0.25 * pulseOpacity))
+                    .allowsHitTesting(false)
+                    .onAppear { startPulse() }
+            } else {
+                // Sweeping linear gradient
+                LinearGradient(
+                    stops: [
+                        .init(color: .clear, location: 0),
+                        .init(color: DSColor.bgWarm.opacity(0.6), location: 0.5),
+                        .init(color: .clear, location: 1),
+                    ],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+                .frame(width: cardWidth)
+                .offset(x: shimmerOffset * cardWidth)
+                .clipShape(RoundedRectangle(cornerRadius: 12))
+                .allowsHitTesting(false)
+                .onAppear { startSweep(cardWidth: cardWidth) }
+            }
+        }
     }
 
     private func lineWidth(for index: Int) -> CGFloat {
@@ -60,12 +97,29 @@ private struct SkeletonCard: View {
         return widths[index % widths.count]
     }
 
-    private func startShimmer() {
+    private func startSweep(cardWidth: CGFloat) {
+        shimmerOffset = -1
+        withAnimation(
+            Animation.easeInOut(duration: 1.2)
+                .repeatForever(autoreverses: false)
+        ) {
+            shimmerOffset = 1
+        }
+    }
+
+    private func startPulse() {
         withAnimation(
             Animation.easeInOut(duration: 1.2)
                 .repeatForever(autoreverses: true)
         ) {
-            shimmerPhase = 1
+            pulseOpacity = 1.0
         }
     }
+}
+
+// MARK: - Preview
+
+#Preview {
+    MemoListSkeleton()
+        .padding()
 }


### PR DESCRIPTION
## Fix dead shimmer in MemoListSkeleton — loading placeholder is actually static

The MemoListSkeleton's SkeletonCard animates a @State value but never binds it to any visual property — returns a constant, so the loading placeholder sits completely motionless despite the doc comment claiming it 'uses a shimmer animation to signal activity.' This replaces the unused phase with a real moving gradient highlight that sweeps across each placeholder bar, making the initial-load state read as live rather than frozen.

### Acceptance
Build the DayPage scheme for iPhone 17 simulator with no errors/warnings. Launch the app and trigger the initial Today load (cold start or pull to reload): the three skeleton cards now show a visible highlight sweeping horizontally across the placeholder bars at a steady ~1.2s cadence, rather than rendering as a flat static block. With Settings → Accessibility → Reduce Motion enabled, the sweep is suppressed and replaced by a static or gently-pulsing placeholder (no continuous horizontal motion). No layout shift occurs when real memo cards replace the skeleton. No other screens change.

Closes #364