### PR TITLE
auto: Add a 3-segment progress indicator to the compile-dock lock hint

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -120,6 +120,40 @@ struct CompileFooterButton: View {
     }
 }
 
+// MARK: - CompileProgressDock
+
+/// Three capsule segments shown above the input bar when memos < 3.
+/// Segments fill amber as memos accumulate, giving glanceable progress
+/// toward unlocking AI compilation.
+struct CompileProgressDock: View {
+    let memoCount: Int
+
+    var body: some View {
+        VStack(spacing: 6) {
+            HStack(spacing: 5) {
+                ForEach(0..<3, id: \.self) { index in
+                    Capsule(style: .continuous)
+                        .fill(index < memoCount ? DSColor.accentAmber : DSColor.glassStd)
+                        .frame(width: 28, height: 4)
+                        .dsAnimation(Motion.spring, value: memoCount)
+                }
+            }
+
+            Text(L10n.Empty.compileDockLocked(
+                current: memoCount,
+                remaining: max(0, 3 - memoCount)
+            ))
+            .font(DSType.mono10)
+            .foregroundColor(DSColor.inkSubtle)
+            .textCase(.uppercase)
+            .tracking(0.8)
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityIdentifier("compile-dock-hint")
+        .accessibilityValue("\(memoCount) of 3")
+    }
+}
+
 // MARK: - ScrollOffsetPreferenceKey
 
 /// 承载底部锚点在 ScrollView 本地坐标空间中的 minY 值。

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -391,17 +391,8 @@ struct TodayView: View {
                     // Hidden entirely once today's page is compiled.
                     if !viewModel.isDailyPageCompiled && !viewModel.memos.isEmpty {
                         if viewModel.memos.count < 3 {
-                            Text(L10n.Empty.compileDockLocked(
-                                current: viewModel.memos.count,
-                                remaining: max(0, 3 - viewModel.memos.count)
-                            ))
-                                .font(DSType.mono10)
-                                .foregroundColor(DSColor.inkSubtle)
-                                .textCase(.uppercase)
-                                .tracking(0.8)
-                                .frame(maxWidth: .infinity)
+                            CompileProgressDock(memoCount: viewModel.memos.count)
                                 .padding(.vertical, 6)
-                                .accessibilityIdentifier("compile-dock-hint")
                         } else {
                             HStack {
                                 Spacer()


### PR DESCRIPTION
## Add a 3-segment progress indicator to the compile-dock lock hint

When fewer than 3 memos exist, TodayView shows a plain mono text ('N / 3 memos · M more to unlock') above the input bar. This replaces it with three small capsule segments that fill amber as memos accumulate, giving glanceable visual feedback on progress toward unlocking AI compilation. The text label is kept beneath the bars for clarity and accessibility.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator. With 1 then 2 memos, the dock shows three capsule segments where the first N fill amber with a spring animation as each memo is added, plus the existing '・more to unlock' text below. At 3 memos the dock is replaced by the CompileFooterButton (unchanged). VoiceOver reads the hint with a value of 'N of 3'. No layout jitter in the timeline.