### PR TITLE
auto: Day Orb: haptic pulse on new signal + count-aware readout label

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -43,6 +43,7 @@ struct DayOrbView: View {
         )
         .onChange(of: signalCount) { new in
             if new > previous {
+                Haptics.success()
                 pulse = true
                 withAnimation(.easeOut(duration: 0.6)) { }
                 Task { @MainActor in
@@ -169,6 +170,14 @@ struct DayOrbView: View {
 
     // MARK: - Content
 
+    private var readoutLabel: String {
+        switch signalCount {
+        case 0:  return "TAP TO BEGIN"
+        case 1:  return "SIGNAL TODAY"
+        default: return "SIGNALS TODAY"
+        }
+    }
+
     private var orbContent: some View {
         VStack(spacing: 2) {
             Text("\(signalCount)")
@@ -178,11 +187,13 @@ struct DayOrbView: View {
                 .contentTransition(.numericText())
                 .animation(.snappy, value: signalCount)
 
-            Text("SIGNALS TODAY")
+            Text(readoutLabel)
                 .font(DSFonts.jetBrainsMono(size: 9, weight: .medium))
                 .tracking(1.4)
                 .foregroundColor(DSColor.amberDeep)
                 .opacity(0.7)
+                .contentTransition(.opacity)
+                .animation(.easeInOut(duration: 0.25), value: readoutLabel)
         }
     }
 }


### PR DESCRIPTION
## Day Orb: haptic pulse on new signal + count-aware readout label

When a memo lands the Day Orb already fires a one-shot amber pulse, but there is no haptic confirmation and the readout always reads 'SIGNALS TODAY' even at count 1 or 0. Add a success haptic synced to the increment pulse and make the orb label count-aware (a quiet 'TAP TO BEGIN' at zero, singular 'SIGNAL TODAY' at one, 'SIGNALS TODAY' otherwise) so the orb's centerpiece text matches the already-pluralized header kicker.

### Acceptance
Build the DayPage scheme cleanly. Launch on iPhone 17 simulator with zero memos: orb shows '0' and 'TAP TO BEGIN'. Submit one memo: orb pulses, a success haptic fires, count animates to '1', label reads 'SIGNAL TODAY'. Submit a second: label reads 'SIGNALS TODAY'. Reopening the app with existing memos does NOT fire a haptic (no false increment on load). Reduce-motion users still get the haptic; existing previews still render.