### PR TITLE
auto: Add undo-on-delete for memos (5s restore pill)

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -285,7 +285,12 @@ struct TodayView: View {
                                     TimelineRow(
                                         memo: memo,
                                         isLast: idx == viewModel.memos.count - 1,
-                                        onDelete: { viewModel.deleteMemo(memo) },
+                                        onDelete: {
+                                            // Clear submit undo pill so the two never stack
+                                            undoText = nil
+                                            undoTask?.cancel()
+                                            viewModel.deleteMemo(memo)
+                                        },
                                         onPin: {
                                             if memo.pinnedAt != nil {
                                                 viewModel.unpinMemo(memo)
@@ -431,6 +436,17 @@ struct TodayView: View {
                     }
                 }
                 .animation(Motion.rise, value: undoText != nil)
+                // Undo pill shown for 5s after memo delete
+                .overlay(alignment: .bottom) {
+                    if viewModel.lastDeletedMemo != nil {
+                        UndoPillView(label: "已删除 · 撤销") {
+                            viewModel.undoDelete()
+                        }
+                        .padding(.bottom, 96)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+                .animation(Motion.rise, value: viewModel.lastDeletedMemo != nil)
                 // Submit error toast — scoped animation lives on the overlay
                 // container so only the toast itself animates, not the whole
                 // ZStack tree. (#217)
@@ -1002,6 +1018,8 @@ struct TodayView: View {
     // US-009: Show undo pill for 5 seconds after submitting a memo.
     private func showUndoPill(for text: String) {
         guard !text.isEmpty else { return }
+        // Clear delete undo pill so the two never stack
+        viewModel.lastDeletedMemo = nil
         undoTask?.cancel()
         undoText = text
         undoTask = Task {

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -178,6 +178,9 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         return .pureEmpty
     }
 
+    /// The most recently deleted memo; non-nil while the undo pill is visible.
+    @Published var lastDeletedMemo: Memo? = nil
+
     // MARK: Private
 
     private var date: Date
@@ -197,6 +200,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
     private var submitMemoTask: Task<Void, Never>?
     private var locationTask: Task<Void, Never>?
     private var compilationTask: Task<Void, Never>?
+    private var deleteUndoTask: Task<Void, Never>?
     private var cancellables = Set<AnyCancellable>()
 
     // MARK: Init
@@ -217,6 +221,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         submitMemoTask?.cancel()
         locationTask?.cancel()
         compilationTask?.cancel()
+        deleteUndoTask?.cancel()
     }
 
     private func observeCompilationFailure() {
@@ -294,11 +299,46 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
     func deleteMemo(_ memo: Memo) {
         let previous = memos
         let remaining = memos.filter { $0.id != memo.id }
-        // Optimistic UI update
         withAnimation(Motion.rise) {
             memos = remaining
         }
         persistMemos(remaining, capturedDate: date, previous: previous, failureMessagePrefix: "删除失败")
+
+        // Start 5-second undo window
+        deleteUndoTask?.cancel()
+        lastDeletedMemo = memo
+        deleteUndoTask = Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 5_000_000_000)
+            guard !Task.isCancelled else { return }
+            lastDeletedMemo = nil
+        }
+    }
+
+    /// Restores the last deleted memo to its original sort position and rewrites the file.
+    func undoDelete() {
+        guard let memo = lastDeletedMemo else { return }
+        deleteUndoTask?.cancel()
+        deleteUndoTask = nil
+        lastDeletedMemo = nil
+
+        var restored = memos
+        // Re-insert using the same sort order as the load path:
+        // pinned memos float to top (by pinnedAt desc), then by created desc.
+        if memo.pinnedAt != nil {
+            let insertIdx = restored.firstIndex(where: { $0.pinnedAt == nil }) ?? restored.endIndex
+            restored.insert(memo, at: insertIdx)
+        } else {
+            let insertIdx = restored.firstIndex(where: { m in
+                m.pinnedAt == nil && m.created < memo.created
+            }) ?? restored.endIndex
+            restored.insert(memo, at: insertIdx)
+        }
+        let previous = memos
+        withAnimation(Motion.rise) {
+            memos = restored
+        }
+        Haptics.soft()
+        persistMemos(restored, capturedDate: date, previous: previous, failureMessagePrefix: "撤销失败")
     }
 
     /// Replaces the body text of an existing memo and writes through to disk.

--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 /// Pill shown for 5 seconds after a memo is submitted.
 /// Tapping it restores the submitted text to the draft.
 struct UndoPillView: View {
+    var label: String = "Undo send"
     let onUndo: () -> Void
 
     @State private var countdownProgress: CGFloat = 1.0
@@ -21,7 +22,7 @@ struct UndoPillView: View {
                         .rotationEffect(.degrees(-90))
                         .frame(width: 22, height: 22)
                 }
-                Text("Undo send")
+                Text(label)
                     .font(.custom("Inter-Medium", size: 13))
             }
             .foregroundColor(DSColor.inkPrimary)


### PR DESCRIPTION
## Add undo-on-delete for memos (5s restore pill)

Deleting a memo on the Today timeline is currently irreversible — once the swipe-to-reveal Delete is tapped, the memo is rewritten out of the day's .md file with no recovery path. This adds a 5-second 'memo deleted · 撤销' pill (reusing the existing UndoPillView pattern already used for submit) that restores the exact deleted memo to its original position, protecting against accidental destructive taps.

### Acceptance
Swipe a memo left, tap Delete: the card animates out AND a pill '已删除 · 撤销' appears at the bottom for ~5s. Tapping 撤销 restores the memo to its original timeline position and rewrites the day's .md file to include it again (verify YAML front-matter intact under vault/raw/). Letting the pill auto-dismiss leaves the memo permanently deleted. The submit undo pill and delete undo pill never appear stacked. Build succeeds via `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'` and existing DayPageTests pass.