### PR TITLE
auto: Live countdown on the Undo-send pill

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -1,3 +1,4 @@
+import Combine
 import SwiftUI
 
 // MARK: - UndoPillView (US-009)
@@ -14,8 +15,11 @@ struct UndoPillView: View {
 
     @State private var countdownProgress: CGFloat = 1.0
     @State private var isUrgent: Bool = false
+    @State private var secondsRemaining: Int = 5
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
 
     // Work item for the haptic — cancelled on disappear so stale
     // firings don't happen after the pill is removed from the hierarchy.
@@ -44,7 +48,7 @@ struct UndoPillView: View {
                         .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: isUrgent)
                         .accessibilityHidden(true)
                 }
-                Text(label)
+                Text("Undo · \(secondsRemaining)s")
                     .font(.custom("Inter-Medium", size: 13))
             }
             .foregroundColor(DSColor.inkPrimary)
@@ -62,10 +66,12 @@ struct UndoPillView: View {
             .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel(label)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Undo send, \(secondsRemaining) seconds remaining")
         .accessibilityHint("Restores the note you just submitted back to the input field")
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(.updatesFrequently)
+        .accessibilityIdentifier("undo-send-pill")
         .onAppear {
             if reduceMotion {
                 countdownProgress = 0
@@ -88,6 +94,11 @@ struct UndoPillView: View {
         .onDisappear {
             hapticWorkItem.item?.cancel()
             hapticWorkItem.item = nil
+        }
+        .onReceive(timer) { _ in
+            if secondsRemaining > 1 {
+                secondsRemaining -= 1
+            }
         }
     }
 

--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -1,4 +1,3 @@
-import Combine
 import SwiftUI
 
 // MARK: - UndoPillView (US-009)
@@ -19,11 +18,10 @@ struct UndoPillView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    private let timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
-
     // Work item for the haptic — cancelled on disappear so stale
     // firings don't happen after the pill is removed from the hierarchy.
     private let hapticWorkItem = HapticWorkItemHolder()
+
 
     var body: some View {
         Button {
@@ -95,9 +93,10 @@ struct UndoPillView: View {
             hapticWorkItem.item?.cancel()
             hapticWorkItem.item = nil
         }
-        .onReceive(timer) { _ in
-            if secondsRemaining > 1 {
-                secondsRemaining -= 1
+        .task {
+            for tick in stride(from: 4, through: 0, by: -1) {
+                try? await Task.sleep(for: .seconds(1))
+                secondsRemaining = tick
             }
         }
     }


### PR DESCRIPTION
## Live countdown on the Undo-send pill

The post-submit Undo pill animates a 5-second ring but its label is a static "Undo send", so users can't tell how much of the undo window remains. Add a live seconds countdown synced to the ring (e.g. "Undo · 4s") that ticks down 5→1 and matches the existing amber progress arc, plus a VoiceOver-friendly label and accessibility identifier for UI tests. Self-contained to one file with no model or schema changes.

### Acceptance
Build the DayPage scheme for iPhone 17 succeeds. After submitting a memo, the pill appears reading "Undo · 5s" and visibly ticks 5→4→3→2→1 in step with the shrinking amber ring, disappearing at ~5s. Tapping it still restores the draft text. With VoiceOver on, the pill is announced as a button with the remaining-seconds label, and `undo-send-pill` is queryable via accessibility identifier.