### PR TITLE
auto: Undo pill: warning color-shift + final-second haptic as the 5s window closes

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -450,7 +450,7 @@ struct TodayView: View {
                 // Undo pill shown for 5s after memo delete
                 .overlay(alignment: .bottom) {
                     if viewModel.lastDeletedMemo != nil {
-                        UndoPillView(label: "已删除 · 撤销") {
+                        UndoPillView(label: NSLocalizedString("undo_pill.label.delete", comment: "Undo delete pill label")) {
                             viewModel.undoDelete()
                         }
                         .padding(.bottom, 96)

--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -2,14 +2,24 @@ import SwiftUI
 
 // MARK: - UndoPillView (US-009)
 
-/// Pill shown for 5 seconds after a memo is submitted.
-/// Tapping it restores the submitted text to the draft.
+/// Pill shown for 5 seconds after a memo is submitted or deleted.
+/// Tapping it restores the submitted text / memo to its previous state.
+///
+/// Escalating urgency cues over the final ~1.5s:
+///  - Ring stroke transitions from amber → error red and thickens (1.5 → 2 pt)
+///  - A single soft haptic fires at the 4s mark (1s remaining)
 struct UndoPillView: View {
-    var label: String = "Undo send"
+    var label: String = NSLocalizedString("undo_pill.label.send", comment: "Undo send pill label")
     let onUndo: () -> Void
 
     @State private var countdownProgress: CGFloat = 1.0
+    @State private var isUrgent: Bool = false
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    // Work item for the haptic — cancelled on disappear so stale
+    // firings don't happen after the pill is removed from the hierarchy.
+    private let hapticWorkItem = HapticWorkItemHolder()
 
     var body: some View {
         Button {
@@ -22,9 +32,16 @@ struct UndoPillView: View {
                         .font(.system(size: 13, weight: .semibold))
                     Circle()
                         .trim(from: 0, to: countdownProgress)
-                        .stroke(DSColor.accentAmber, style: StrokeStyle(lineWidth: 1.5, lineCap: .round))
+                        .stroke(
+                            ringColor,
+                            style: StrokeStyle(
+                                lineWidth: isUrgent ? 2 : 1.5,
+                                lineCap: .round
+                            )
+                        )
                         .rotationEffect(.degrees(-90))
                         .frame(width: 22, height: 22)
+                        .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: isUrgent)
                         .accessibilityHidden(true)
                 }
                 Text(label)
@@ -45,9 +62,10 @@ struct UndoPillView: View {
             .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
         }
         .buttonStyle(.plain)
-        .accessibilityLabel("Undo send")
+        .accessibilityLabel(label)
         .accessibilityHint("Restores the note you just submitted back to the input field")
         .accessibilityAddTraits(.isButton)
+        .accessibilityAddTraits(.updatesFrequently)
         .onAppear {
             if reduceMotion {
                 countdownProgress = 0
@@ -56,6 +74,33 @@ struct UndoPillView: View {
                     countdownProgress = 0
                 }
             }
+            // Flip to urgent state at 3.5s (1.5s before dismissal)
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) {
+                isUrgent = true
+            }
+            // Fire a single soft haptic at 4s (1s remaining)
+            let workItem = DispatchWorkItem {
+                HapticFeedback.light()
+            }
+            hapticWorkItem.item = workItem
+            DispatchQueue.main.asyncAfter(deadline: .now() + 4, execute: workItem)
+        }
+        .onDisappear {
+            hapticWorkItem.item?.cancel()
+            hapticWorkItem.item = nil
         }
     }
+
+    private var ringColor: Color {
+        guard !reduceMotion else { return DSColor.accentAmber }
+        return isUrgent ? DSColor.error : DSColor.accentAmber
+    }
+}
+
+// MARK: - HapticWorkItemHolder
+
+/// Reference-type box so the work item can be shared between onAppear and
+/// onDisappear closures without capturing a mutating struct.
+private final class HapticWorkItemHolder {
+    var item: DispatchWorkItem?
 }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -41,6 +41,10 @@
 "input.dock.record"          = "Record";
 "input.dock.text"            = "Text";
 
+/* UndoPillView — US-009 */
+"undo_pill.label.send"       = "Undo send";
+"undo_pill.label.delete"     = "Deleted · Undo";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "Recompile";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -41,6 +41,10 @@
 "input.dock.record"          = "录音";
 "input.dock.text"            = "文字";
 
+/* UndoPillView — US-009 */
+"undo_pill.label.send"       = "撤销发送";
+"undo_pill.label.delete"     = "已删除 · 撤销";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "重新编译";
 


### PR DESCRIPTION
## Undo pill: warning color-shift + final-second haptic as the 5s window closes

The submit/delete undo pill shows a 5-second countdown ring but gives no escalating cue that the window is about to expire — the ring just silently empties. Add a color transition (amber → warning red) over the final ~1.5s and a single soft haptic tick at the 1-second mark, so users feel and see the undo opportunity slipping away before it vanishes.

### Acceptance
Submit a memo (or delete one) on iPhone 17 simulator: the undo pill appears with the amber countdown ring; over the final ~1.5 seconds the ring shifts to a warning red tint and thickens; a single soft haptic fires ~1s before it disappears; tapping still restores the text/memo; the pill auto-dismisses at 5s as before; build passes xcodebuild -scheme DayPage and no regression to the existing dismissal timing in TodayView/TodayViewModel.