### PR TITLE
auto: Add an unlock moment when the 3rd memo unlocks AI compilation

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -128,14 +128,33 @@ struct CompileFooterButton: View {
 struct CompileProgressDock: View {
     let memoCount: Int
 
+    /// Tracks the memoCount from the previous render so we can detect the
+    /// exact 2→3 crossing and fire the unlock celebration only once.
+    @State private var previousMemoCount: Int = 0
+    /// When true, the third segment plays a one-shot scale+glow pulse.
+    @State private var thirdSegmentPulsing: Bool = false
+
     var body: some View {
         VStack(spacing: 6) {
             HStack(spacing: 5) {
                 ForEach(0..<3, id: \.self) { index in
+                    let isFilled = index < memoCount
+                    let isPulsingSegment = (index == 2) && thirdSegmentPulsing
                     Capsule(style: .continuous)
-                        .fill(index < memoCount ? DSColor.accentAmber : DSColor.glassStd)
+                        .fill(isFilled ? DSColor.accentAmber : DSColor.glassStd)
                         .frame(width: 28, height: 4)
+                        .shadow(
+                            color: isPulsingSegment ? DSColor.accentAmber.opacity(0.75) : .clear,
+                            radius: isPulsingSegment ? 6 : 0
+                        )
+                        .scaleEffect(isPulsingSegment ? 1.35 : 1.0)
                         .dsAnimation(Motion.spring, value: memoCount)
+                        .animation(
+                            Motion.respectReduceMotion(
+                                .spring(response: 0.4, dampingFraction: 0.6)
+                            ),
+                            value: thirdSegmentPulsing
+                        )
                 }
             }
 
@@ -151,6 +170,20 @@ struct CompileProgressDock: View {
         .frame(maxWidth: .infinity)
         .accessibilityIdentifier("compile-dock-hint")
         .accessibilityValue("\(memoCount) of 3")
+        .onAppear {
+            previousMemoCount = memoCount
+        }
+        .onChange(of: memoCount) { newCount in
+            if previousMemoCount < 3 && newCount == 3 {
+                Haptics.success()
+                thirdSegmentPulsing = true
+                Task {
+                    try? await Task.sleep(nanoseconds: 400_000_000)
+                    thirdSegmentPulsing = false
+                }
+            }
+            previousMemoCount = newCount
+        }
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -394,27 +394,38 @@ struct TodayView: View {
                     // the input bar — it belongs to the composer dock, not to
                     // the timeline. When ≥ 3 memos: show the compile button.
                     // Hidden entirely once today's page is compiled.
-                    if !viewModel.isDailyPageCompiled && !viewModel.memos.isEmpty {
-                        if viewModel.memos.count < 3 {
-                            CompileProgressDock(memoCount: viewModel.memos.count)
-                                .padding(.vertical, 6)
-                        } else {
-                            HStack {
-                                Spacer()
-                                CompileFooterButton(
-                                    memoCount: viewModel.memos.count,
-                                    isCompiling: viewModel.isCompiling,
-                                    isVisible: true,
-                                    stage: compilationService.stage,
-                                    errorMessage: viewModel.submitError,
-                                    onTap: { viewModel.compile() },
-                                    onRetry: { viewModel.compile() }
-                                )
-                                Spacer()
+                    // Motion.spring on memoCount drives the dock→button swap so
+                    // the unlock moment transitions with a spring rather than cutting.
+                    Group {
+                        if !viewModel.isDailyPageCompiled && !viewModel.memos.isEmpty {
+                            if viewModel.memos.count < 3 {
+                                CompileProgressDock(memoCount: viewModel.memos.count)
+                                    .padding(.vertical, 6)
+                                    .transition(
+                                        .asymmetric(
+                                            insertion: .opacity,
+                                            removal: .opacity.combined(with: .scale(scale: 0.9))
+                                        )
+                                    )
+                            } else {
+                                HStack {
+                                    Spacer()
+                                    CompileFooterButton(
+                                        memoCount: viewModel.memos.count,
+                                        isCompiling: viewModel.isCompiling,
+                                        isVisible: true,
+                                        stage: compilationService.stage,
+                                        errorMessage: viewModel.submitError,
+                                        onTap: { viewModel.compile() },
+                                        onRetry: { viewModel.compile() }
+                                    )
+                                    Spacer()
+                                }
+                                .padding(.bottom, 4)
                             }
-                            .padding(.bottom, 4)
                         }
                     }
+                    .animation(Motion.spring, value: viewModel.memos.count)
 
                     // MARK: Input Bar — single canonical surface (V4).
                     // V1/V2/V3 were removed in the Capture v2 cleanup; the


### PR DESCRIPTION
## Add an "unlock" moment when the 3rd memo unlocks AI compilation

When a user logs their 3rd memo, the CompileProgressDock (3 filling segments) abruptly swaps to the compile button with no feedback, missing the most rewarding micro-moment in the capture flow. Add a celebratory cue: the final segment fills with a brief amber pulse/glow plus a success haptic, and the dock→button transition becomes a smooth spring rather than an instant swap, signaling 'AI compilation is now unlocked.'

### Acceptance
Building the DayPage scheme succeeds and existing tests pass. In the iPhone 17 simulator: with 2 memos the dock shows 2 filled segments; adding a 3rd memo plays a success haptic, pulses/glows the third segment amber, then the dock springs out and the '编译今日 · 3 条' button springs in (no instant swap). Adding a 4th+ memo does not re-pulse. With reduce-motion enabled the pulse degrades gracefully (no scale jump). No regression to the <3 'N / 3 memos' hint text or the ≥3 compile button behavior.