### PR TITLE
auto: Day Orb: fix double-haptic bug + add count 'pop' on new signal

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -16,6 +16,7 @@ struct DayOrbView: View {
     @State private var pulse: Bool = false
     @State private var previous: Int = 0
     @State private var isPressed: Bool = false
+    @State private var countPop: CGFloat = 1.0
 
     var body: some View {
         ZStack {
@@ -46,9 +47,14 @@ struct DayOrbView: View {
             if new > previous {
                 Haptics.success()
                 pulse = true
-                Haptics.success()
-                withAnimation(.easeOut(duration: 0.6)) { }
+                withAnimation(.spring(response: 0.25, dampingFraction: 0.5)) {
+                    countPop = 1.18
+                }
                 Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                    withAnimation(.spring(response: 0.25, dampingFraction: 0.6)) {
+                        countPop = 1.0
+                    }
                     try? await Task.sleep(nanoseconds: 650_000_000)
                     pulse = false
                 }
@@ -188,6 +194,7 @@ struct DayOrbView: View {
                 .foregroundColor(DSColor.amberDeep)
                 .contentTransition(.numericText())
                 .animation(.snappy, value: signalCount)
+                .scaleEffect(countPop)
 
             Text(readoutLabel)
                 .font(DSFonts.jetBrainsMono(size: 9, weight: .medium))


### PR DESCRIPTION
## Day Orb: fix double-haptic bug + add count 'pop' on new signal

The Day Orb fires Haptics.success() twice per signal increment and runs a dead empty withAnimation closure (DayOrbView.swift:48-50). This fixes the duplicate haptic and dead code, and adds a visible scale 'pop' to the count digit when a signal lands so the increment reads as a satisfying reward rather than a silent text swap.

### Acceptance
Tapping submit on a new memo increments the orb count exactly once and fires a single success haptic (no double-buzz). The count digit visibly scales up ~18% and springs back when the number changes. Builds clean with `xcodebuild -scheme DayPage build`; orb previews still render at 0/12/5 signals.