### PR TITLE
auto: Add press-scale animation and haptic feedback to EmptyStateView CTA button

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -84,7 +84,10 @@ struct EmptyStateView: View {
     }
 
     private func ctaButton(label: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
+        Button(action: {
+            Haptics.tapConfirm()
+            action()
+        }) {
             Text(label)
                 .font(DSType.sectionLabel)
                 .textCase(.uppercase)
@@ -95,7 +98,23 @@ struct EmptyStateView: View {
                 .background(DSColor.amberDeep)
                 .clipShape(Capsule())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(PressableScaleStyle(reduceMotion: reduceMotion))
+    }
+}
+
+// MARK: - PressableScaleStyle
+
+private struct PressableScaleStyle: ButtonStyle {
+    let reduceMotion: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect((!reduceMotion && configuration.isPressed) ? 0.96 : 1)
+            .opacity(configuration.isPressed ? 0.92 : 1)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7),
+                value: configuration.isPressed
+            )
     }
 }
 


### PR DESCRIPTION
## Add press-scale animation and haptic feedback to EmptyStateView CTA button

The shared EmptyStateView CTA button (used by the Today blank, Archive empty, and Mic-denied empty states) uses buttonStyle(.plain) with no press-down feedback and fires no haptic — inconsistent with the rest of the app where every tappable surface confirms touch with both a scale and a haptic (DayOrbView, selection toolbar, location draft buttons all do this). Add a reusable pressable button style that scales to ~0.96 on press and fire Haptics.tapConfirm() on tap so the primary empty-state action feels alive and matches the app's tactile language.

### Acceptance
Build the DayPage scheme with `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` and confirm it compiles. Launch in the iPhone 17 simulator: on the Today tab with no memos (fresh onboarded state), the empty-state CTA button visibly scales down ~4% while pressed and springs back on release, and a light haptic fires on tap (verify the Haptics.tapConfirm() call is reached). With Reduce Motion enabled in simulator Settings, the button does not scale but the haptic and action still fire. The same behavior applies to the Archive empty-day CTA and Mic-denied CTA since they share the component. Existing SwiftUI previews still render.