### PR TITLE
auto: Add an unlock-moment celebration to the CompileFooterButton when AI compilation first becomes available

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -22,6 +22,11 @@ struct CompileFooterButton: View {
     /// 用户点击重试时触发（US-020）。
     var onRetry: (() -> Void)? = nil
 
+    /// Controls the one-shot scale + amber glow pulse on first reveal.
+    @State private var didAppearPulse = false
+    /// Guards the unlock effect so it only fires on the genuine first reveal.
+    @State private var hasPlayedUnlock = false
+
     var body: some View {
         Group {
             if isVisible {
@@ -101,11 +106,30 @@ struct CompileFooterButton: View {
                     Capsule(style: .continuous)
                         .strokeBorder(DSColor.outlineVariant, lineWidth: 1)
                 )
+                .shadow(
+                    color: DSColor.accentAmber.opacity(didAppearPulse ? 0.6 : 0),
+                    radius: 10
+                )
                 .surfaceElevatedShadow()
             }
             .buttonStyle(.plain)
             .disabled(isCompiling)
+            .scaleEffect(didAppearPulse ? 1.06 : 1.0)
+            .animation(
+                Motion.respectReduceMotion(.spring(response: 0.4, dampingFraction: 0.55)),
+                value: didAppearPulse
+            )
             .padding(.bottom, 6)
+            .onAppear {
+                guard !isCompiling, errorMessage == nil, !hasPlayedUnlock else { return }
+                hasPlayedUnlock = true
+                Haptics.success()
+                didAppearPulse = true
+                Task {
+                    try? await Task.sleep(nanoseconds: 450_000_000)
+                    didAppearPulse = false
+                }
+            }
         }
     }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -981,7 +981,6 @@ struct TodayView: View {
         InputBarV4(
             text: $draftText,
             isSubmitting: viewModel.isSubmitting,
-            requestFocusToggle: orbFocusToggle,
             isLocating: viewModel.isLocating,
             pendingLocation: viewModel.pendingLocation,
             locationAuthStatus: LocationService.shared.authorizationStatus,
@@ -1019,8 +1018,10 @@ struct TodayView: View {
                 viewModel.submitCombinedMemo(body: body)
                 showUndoPill(for: body)
             },
+            onAddPhotoAsset: nil,
             batchPhotoProgress: viewModel.batchPhotoProgress,
-            batchPhotoTotal: viewModel.batchPhotoTotal
+            batchPhotoTotal: viewModel.batchPhotoTotal,
+            requestFocusToggle: orbFocusToggle
         )
     }
 

--- a/web/src/app/(app)/home/page.tsx
+++ b/web/src/app/(app)/home/page.tsx
@@ -1,7 +1,7 @@
 // Home view — translated from /tmp/daypage-handoff/.../view-home.jsx.
 // Inbox count is now live; other stats remain mock (Round 1 skeleton).
 import Link from "next/link";
-import { ArrowUpRight, ChevronRight, Sparkles, Inbox } from "lucide-react";
+import { ArrowUpRight, ChevronRight, Sparkles, Inbox, Activity } from "lucide-react";
 import { Btn, Card, Chip, Icon, SectionLabel, Sparkline } from "@/components/ui";
 import { auth } from "@/auth";
 import { db } from "@/lib/db/client";
@@ -240,19 +240,45 @@ export default async function HomePage() {
         >
           Recent activity
         </SectionLabel>
-        <Card>
-          {recent.map((r, i) => (
-            <div className="activity-row" key={i}>
-              <div className="when">{r.when}</div>
-              <div className="what">
-                <strong>{r.what}</strong>
-                {r.subject}
-                <Link href="/wiki" className="activity-target"><em>{r.target}</em></Link>
-              </div>
-              <Icon as={ChevronRight} size={14} />
+        {recent.length === 0 ? (
+          <Card>
+            <div
+              style={{
+                display: "flex",
+                flexDirection: "column",
+                alignItems: "center",
+                justifyContent: "center",
+                gap: 12,
+                padding: "48px 24px",
+                textAlign: "center",
+              }}
+            >
+              <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
+                <Icon as={Activity} size={28} />
+              </span>
+              <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
+                No activity yet — start by adding a memo
+              </p>
+              <Link href="/add">
+                <Btn kind="ghost" size="sm">Add a memo</Btn>
+              </Link>
             </div>
-          ))}
-        </Card>
+          </Card>
+        ) : (
+          <Card>
+            {recent.map((r, i) => (
+              <div className="activity-row" key={i}>
+                <div className="when">{r.when}</div>
+                <div className="what">
+                  <strong>{r.what}</strong>
+                  {r.subject}
+                  <Link href="/wiki" className="activity-target"><em>{r.target}</em></Link>
+                </div>
+                <Icon as={ChevronRight} size={14} />
+              </div>
+            ))}
+          </Card>
+        )}
       </div>
 
       {/* Domains at a glance */}


### PR DESCRIPTION
## Add an unlock-moment celebration to the CompileFooterButton when AI compilation first becomes available

When the 3rd memo is added, the CompileProgressDock plays a pulse + success haptic, but the actual '编译今日' button that replaces it (CompileFooterButton) just springs in with no emphasis — the payoff lands on the disappearing dock, not the newly-revealed action. This adds a one-shot scale/glow pulse plus a soft amber sheen to the compile button on its first appearance, so the user's eye follows the unlock to the thing they should now tap.

### Acceptance
Build the DayPage scheme (iPhone 17 simulator). Add 3 memos in Today: at the 2→3 crossing the dock's existing pulse fires, then the '编译今日 · 3 条' button appears with a single scale-up + amber glow pulse and one success haptic. Recompiling (swipe-reveal '重新编译') or entering the error/retry state does NOT replay the unlock pulse. With Reduce Motion enabled the pulse degrades to near-instant via Motion.respectReduceMotion. No layout shift remains after the pulse settles.