### PR TITLE
auto: Add haptic feedback and a results landing pulse to Search

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -189,9 +189,11 @@ struct SearchView: View {
 
     private func runSearch(keyword: String) {
         let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+        let wasEmpty = vm.results.isEmpty
         let hits = SearchService.search(keyword: trimmed, filters: filters)
         vm.results = hits
         vm.hasSearched = !trimmed.isEmpty || filters.isActive
+        if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
     }
 
     // MARK: - Search Bar
@@ -234,6 +236,7 @@ struct SearchView: View {
             .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
 
             Button(action: {
+                Haptics.soft()
                 isInputFocused = false
                 showFilters.toggle()
             }) {
@@ -371,6 +374,7 @@ struct SearchView: View {
                 HStack {
                     Spacer()
                     Button(action: {
+                        Haptics.light()
                         filters = .empty
                         runSearch(keyword: vm.query)
                     }) {
@@ -390,6 +394,7 @@ struct SearchView: View {
     private func typeChip(_ type: Memo.MemoType) -> some View {
         let isSelected = filters.types.contains(type)
         return Button(action: {
+            Haptics.soft()
             if isSelected {
                 filters.types.remove(type)
             } else {
@@ -438,7 +443,10 @@ struct SearchView: View {
 
                 if !recent.isEmpty {
                     sectionHeader(title: "最近搜索", trailing: AnyView(
-                        Button(action: { vm.clearRecentSearches() }) {
+                        Button(action: {
+                            Haptics.light()
+                            vm.clearRecentSearches()
+                        }) {
                             Text("清除")
                                 .monoLabelStyle(size: 10)
                                 .foregroundColor(DSColor.primary)
@@ -506,6 +514,7 @@ struct SearchView: View {
                 .foregroundColor(DSColor.outline)
 
             Button(action: {
+                Haptics.tapConfirm()
                 vm.query = q
                 runSearch(keyword: q)
             }) {
@@ -533,6 +542,7 @@ struct SearchView: View {
 
     private func entityChip(_ entity: String) -> some View {
         Button(action: {
+            Haptics.tapConfirm()
             vm.query = entity
             runSearch(keyword: entity)
         }) {
@@ -624,6 +634,7 @@ struct SearchView: View {
 
     private func resultRow(_ result: SearchResult) -> some View {
         Button(action: {
+            Haptics.tapConfirm()
             vm.recordSearch(vm.query)
             onSelect(result.dateString)
         }) {


### PR DESCRIPTION
## Add haptic feedback and a results landing pulse to Search

SearchView is the only major interactive surface in the app with zero haptic feedback — recent-search taps, entity chips, filter toggles, and result selection all fire silently, breaking the tactile consistency the rest of DayPage establishes via the shared Haptics API. This adds light/soft haptics to those touch points plus a single subtle selection pulse the moment a debounced search transitions from zero to non-zero results, so the user feels the search resolve.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator with no warnings. Open Archive → Search: tapping a recent search, an entity chip, or a result row produces a light haptic; toggling the filter panel or a type chip produces a soft haptic; typing a query that yields results fires exactly one soft pulse on the first frame results appear (not on every keystroke), and no pulse fires when results stay empty. No change to search logic, grouping, or result ordering.