### PR TITLE
fix: correct requestFocusToggle parameter order in InputBarV4 call

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -981,7 +981,6 @@ struct TodayView: View {
         InputBarV4(
             text: $draftText,
             isSubmitting: viewModel.isSubmitting,
-            requestFocusToggle: orbFocusToggle,
             isLocating: viewModel.isLocating,
             pendingLocation: viewModel.pendingLocation,
             locationAuthStatus: LocationService.shared.authorizationStatus,
@@ -1020,7 +1019,8 @@ struct TodayView: View {
                 showUndoPill(for: body)
             },
             batchPhotoProgress: viewModel.batchPhotoProgress,
-            batchPhotoTotal: viewModel.batchPhotoTotal
+            batchPhotoTotal: viewModel.batchPhotoTotal,
+            requestFocusToggle: orbFocusToggle
         )
     }
 


### PR DESCRIPTION
## Summary
- Moves `requestFocusToggle` from position 3 to the end of the `InputBarV4(...)` initializer in `TodayView.swift`, matching the struct's memberwise declaration order
- Fixes the CI build failure introduced in #381: `error: incorrect argument labels in call`

## Test plan
- [ ] CI Xcode Build passes
- [ ] `requestFocusToggle: orbFocusToggle` is now the last argument, matching `InputBarV4`'s struct declaration

Fixes #381 regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)