### PR TITLE
auto: Fix the dead count-bump animation on the Day Orb when a signal lands

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -18,6 +18,8 @@ struct DayOrbView: View {
     @State private var isPressed: Bool = false
     @State private var countPop: CGFloat = 1.0
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         ZStack {
             halo
@@ -47,6 +49,7 @@ struct DayOrbView: View {
             if new > previous {
                 Haptics.success()
                 pulse = true
+                if !reduceMotion { countPop = 1.18 }
                 Task { @MainActor in
                     try? await Task.sleep(nanoseconds: 250_000_000)
                     withAnimation(.spring(response: 0.25, dampingFraction: 0.6)) {


### PR DESCRIPTION
## Fix the dead count-bump animation on the Day Orb when a signal lands

When a new memo is added, DayOrbView is supposed to 'pop' the signal-count number (a tactile scale bump) alongside the pulse halo, but the animation is dead code: countPop is initialized to 1.0 and the increment handler only ever animates it back to 1.0, so the number never visibly bumps. This fix makes the count number actually spring up and settle, restoring the intended micro-celebration when a signal lands.

### Acceptance
Build the DayPage scheme for iPhone 17 and run in Simulator. Add a memo so signalCount increments: the large count number visibly scales up (~1.18x) and springs back to rest in tandem with the amber pulse halo, accompanied by the existing success haptic. Enable Reduce Motion in Simulator settings and confirm the number does not scale (no bump) while the count still updates via the numericText transition. Verify no regression to the breathing scale or press-to-tap scale.