### PR TITLE
auto: Fix the dead count-bump animation on the Day Orb when a signal lands

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -57,11 +57,17 @@ struct DayOrbView: View {
             if new > previous {
                 Haptics.success()
                 pulse = true
-                if !reduceMotion { countPop = 1.18 }
+                if !reduceMotion {
+                    withAnimation(.spring(response: 0.18, dampingFraction: 0.5)) {
+                        countPop = 1.25
+                    }
+                }
                 Task { @MainActor in
-                    try? await Task.sleep(nanoseconds: 250_000_000)
-                    withAnimation(.spring(response: 0.25, dampingFraction: 0.6)) {
-                        countPop = 1.0
+                    if !reduceMotion {
+                        try? await Task.sleep(nanoseconds: 180_000_000)
+                        withAnimation(.spring(response: 0.3, dampingFraction: 0.6)) {
+                            countPop = 1.0
+                        }
                     }
                     try? await Task.sleep(nanoseconds: 650_000_000)
                     pulse = false


### PR DESCRIPTION
## Fix the dead count-bump animation on the Day Orb when a signal lands

When a new memo is captured, DayOrbView fires a haptic and an expanding amber pulse halo, but the central signal-count number is supposed to also 'pop' (scale up then settle). The countPop state is initialized to 1.0 and the onChange handler only ever re-assigns it to 1.0 — a no-op — so the number never actually bumps. This wires the pop correctly: snap countPop up to ~1.25 the instant the count increments, then spring it back to 1.0, gating on Reduce Motion.

### Acceptance
Build the DayPage scheme for iPhone 17. In the Simulator on the Today tab with the orb hero visible (zero memos so the 140pt orb shows), submit a new memo: the central number visibly scales up and springs back exactly once as it transitions to the new count, in sync with the amber pulse halo and success haptic. Submitting again repeats the pop. With Reduce Motion enabled (Settings > Accessibility), the number changes without scaling but the haptic still fires. No change to the orb's resting size, breathing animation, or press-scale gesture.