### PR TITLE
auto: Add recovery actions to SearchView's empty-result state

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -172,6 +172,8 @@ struct SearchView: View {
                     }
 
                     contentArea
+                        .animation(.easeInOut(duration: 0.2), value: vm.hasSearched)
+                        .animation(.easeInOut(duration: 0.2), value: vm.results.isEmpty)
                 }
             }
             .navigationBarHidden(true)
@@ -210,7 +212,7 @@ struct SearchView: View {
         vm.results = hits
         vm.hasSearched = !trimmed.isEmpty || filters.isActive
         if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
-        if hits.isEmpty && vm.hasSearched && !trimmed.isEmpty { Haptics.warningNotification() }
+        if hits.isEmpty { didBuzzEmpty = false }
     }
 
     // MARK: - Search Bar
@@ -570,6 +572,12 @@ struct SearchView: View {
                             .foregroundColor(DSColor.onSurfaceVariant)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 40)
+                    } else if !vm.query.isEmpty && filters.isActive {
+                        Text("「\(vm.query)」在当前筛选条件下无匹配结果")
+                            .bodySMStyle()
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 40)
                     } else {
                         Text("未找到「\(vm.query)」的匹配结果")
                             .bodySMStyle()
@@ -581,25 +589,27 @@ struct SearchView: View {
 
                 if filters.isActive {
                     Button(action: {
-                        Haptics.tapConfirm()
+                        Haptics.light()
                         filters = .empty
                         runSearch(keyword: vm.query)
                     }) {
-                        Text("清除筛选并重试")
-                            .monoLabelStyle(size: 12)
+                        Text("清除筛选条件")
+                            .monoLabelStyle(size: 11)
                             .foregroundColor(DSColor.primary)
-                            .padding(.horizontal, 20)
-                            .padding(.vertical, 10)
-                            .overlay(Rectangle().stroke(DSColor.primary, lineWidth: 1))
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 6)
+                            .background(Capsule().stroke(DSColor.primary, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
                 } else if !vm.query.isEmpty {
                     Button(action: {
                         Haptics.light()
+                        cancellable?.cancel()
                         vm.query = ""
                         vm.results = []
                         vm.hasSearched = false
                         didBuzzEmpty = false
+                        setupDebounce()
                     }) {
                         Text("清除搜索")
                             .monoLabelStyle(size: 11)
@@ -644,7 +654,7 @@ struct SearchView: View {
         .onAppear {
             if !didBuzzEmpty {
                 didBuzzEmpty = true
-                Haptics.warn()
+                if !reduceMotion { Haptics.warn() }
             }
         }
     }

--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -147,6 +147,7 @@ struct SearchView: View {
     @State private var showFilters: Bool = false
     @State private var cancellable: AnyCancellable? = nil
     @State private var appearedIDs: Set<UUID> = []
+    @State private var didBuzzEmpty: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -205,6 +206,7 @@ struct SearchView: View {
         let wasEmpty = vm.results.isEmpty
         let hits = SearchService.search(keyword: trimmed, filters: filters)
         appearedIDs = []
+        didBuzzEmpty = false
         vm.results = hits
         vm.hasSearched = !trimmed.isEmpty || filters.isActive
         if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
@@ -591,6 +593,22 @@ struct SearchView: View {
                             .overlay(Rectangle().stroke(DSColor.primary, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
+                } else if !vm.query.isEmpty {
+                    Button(action: {
+                        Haptics.light()
+                        vm.query = ""
+                        vm.results = []
+                        vm.hasSearched = false
+                        didBuzzEmpty = false
+                    }) {
+                        Text("清除搜索")
+                            .monoLabelStyle(size: 11)
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 6)
+                            .background(Capsule().stroke(DSColor.outlineVariant, lineWidth: 1))
+                    }
+                    .buttonStyle(.plain)
                 }
 
                 let recentSuggestions = Array(vm.recentSearches.filter { $0 != vm.query }.prefix(4))
@@ -619,8 +637,16 @@ struct SearchView: View {
             .padding(.bottom, 24)
         }
         .scrollDismissesKeyboard(.interactively)
+        .scaleEffect(didBuzzEmpty ? 1.0 : (reduceMotion ? 1.0 : 0.88))
+        .animation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7), value: didBuzzEmpty)
         .transition(.opacity)
         .dsAnimation(Motion.fade, value: vm.results.isEmpty)
+        .onAppear {
+            if !didBuzzEmpty {
+                didBuzzEmpty = true
+                Haptics.warn()
+            }
+        }
     }
 
     // MARK: - Grouped result list


### PR DESCRIPTION
## Add recovery actions to SearchView's empty-result state

When a search yields no matches, SearchView shows a static 'no results' message with no escape hatch — if active filters caused the empty result, the user must hunt back to the filter panel to clear them. Add a contextual 'clear filters' button (when filters are active) and a subtle entrance animation + haptic so the dead-end becomes an actionable, polished moment.

### Acceptance
Build the DayPage scheme (iPhone 17 sim). Open Search, type a keyword that matches nothing → tray state animates in, a single warn haptic fires once. Apply a date/type filter that excludes all results → a '清除筛选条件' button appears; tapping it empties filters and re-runs search, restoring results. With ReduceMotion on, the scale-in is skipped. No regressions to the populated result list or empty-query (recent/entities) state.