### PR TITLE
auto: Replace Archive's bare 本月暂无记录 text with the app's polished EmptyStateView

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -170,6 +170,17 @@ extension EmptyStateView {
         )
     }
 
+    /// Archive — selected month has no entries.
+    static func archiveMonthEmpty(ctaAction: @escaping () -> Void) -> EmptyStateView {
+        EmptyStateView(
+            title: L10n.Empty.archiveMonthEmptyTitle,
+            subtitle: L10n.Empty.archiveMonthEmptySubtitle,
+            ctaLabel: L10n.Empty.archiveMonthEmptyCta,
+            ctaAction: ctaAction,
+            showOrbAccent: true
+        )
+    }
+
     /// Mic permission denied — recording unavailable.
     static func micPermissionDenied(ctaAction: @escaping () -> Void) -> EmptyStateView {
         EmptyStateView(
@@ -206,6 +217,13 @@ extension EmptyStateView {
     ZStack {
         AmbientBackground()
         EmptyStateView.archiveDayEmpty { }
+    }
+}
+
+#Preview("Archive Month Empty") {
+    ZStack {
+        AmbientBackground()
+        EmptyStateView.archiveMonthEmpty { }
     }
 }
 

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -1027,11 +1027,10 @@ struct ArchiveView: View {
     private var listContent: some View {
         LazyVStack(spacing: 8) {
             if viewModel.sortedDays.isEmpty {
-                Text("本月暂无记录")
-                    .bodySMStyle()
-                    .foregroundColor(DSColor.inkSubtle)
-                    .frame(maxWidth: .infinity, alignment: .center)
-                    .padding(.top, 40)
+                EmptyStateView.archiveMonthEmpty {
+                    nav.selectedTab = .today
+                }
+                .padding(.top, 40)
             } else {
                 ForEach(viewModel.sortedDays, id: \.dateString) { stats in
                     archiveListRow(stats: stats)

--- a/DayPage/Resources/L10n.swift
+++ b/DayPage/Resources/L10n.swift
@@ -29,6 +29,11 @@ enum L10n {
         static let archiveDaySubtitle = NSLocalizedString("empty.archive_day.subtitle", comment: "")
         static let archiveDayCta      = NSLocalizedString("empty.archive_day.cta", comment: "")
 
+        // Archive Month Empty
+        static let archiveMonthEmptyTitle    = LocalizedStringKey("empty.archive_month.title")
+        static let archiveMonthEmptySubtitle = NSLocalizedString("empty.archive_month.subtitle", comment: "")
+        static let archiveMonthEmptyCta      = NSLocalizedString("empty.archive_month.cta", comment: "")
+
         // Mic Permission Denied
         static let micDeniedTitle    = LocalizedStringKey("empty.mic_denied.title")
         static let micDeniedSubtitle = NSLocalizedString("empty.mic_denied.subtitle", comment: "")

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -49,6 +49,11 @@
 "empty.archive_day.subtitle" = "This day hasn't been compiled yet. Head to Today to add memos first.";
 "empty.archive_day.cta" = "Go to Today";
 
+/* Archive Month Empty */
+"empty.archive_month.title" = "This month is quiet.";
+"empty.archive_month.subtitle" = "No entries yet — switch to Today to start capturing today's signals.";
+"empty.archive_month.cta" = "Go Capture";
+
 /* Mic Permission Denied */
 "empty.mic_denied.title" = "Microphone access needed.";
 "empty.mic_denied.subtitle" = "Allow microphone access in Settings to record voice memos.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -49,6 +49,11 @@
 "empty.archive_day.subtitle" = "这天尚未编译。先去「今天」添加备忘吧。";
 "empty.archive_day.cta" = "前往今天";
 
+/* Archive Month Empty */
+"empty.archive_month.title" = "这个月还很安静。";
+"empty.archive_month.subtitle" = "还没有记录 — 切回 Today 开始捕捉今天的信号。";
+"empty.archive_month.cta" = "去记录";
+
 /* Mic Permission Denied */
 "empty.mic_denied.title" = "需要麦克风权限。";
 "empty.mic_denied.subtitle" = "请在「设置」中允许访问麦克风，以便录制语音备忘。";


### PR DESCRIPTION
## Replace Archive's bare "本月暂无记录" text with the app's polished EmptyStateView

The Archive month list falls back to a single line of subtle gray text (`Text("本月暂无记录")`) when a month has no entries — the only empty state in the app that doesn't use the designed `EmptyStateView` component (serif title, breathing orb accent, animated CTA). This swaps in a proper `EmptyStateView` with a CTA that jumps to Today so the user can start capturing, matching the visual language used everywhere else.

### Acceptance
Open Archive on a month with zero entries: instead of a thin gray line, the user sees the serif title, supporting subtitle, a softly-breathing amber orb accent, and a 'go capture' CTA capsule that rises in with a spring; tapping it switches to the Today tab. Reduce Motion disables the breathing/rise animations (handled by EmptyStateView). A month with entries still renders the list unchanged. `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` succeeds and existing tests pass.