### PR TITLE
auto: Swipe-to-navigate months in Archive calendar

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -422,6 +422,7 @@ struct ArchiveView: View {
     @State private var summaryFilter: MonthlySummaryFilter = .all
     @State private var showShareSheet: Bool = false
     @State private var shareItems: [Any] = []
+    @State private var monthNavDirection: Edge = .leading
 
     /// Issue #302: monthly summary → share-card sheet.
     @State private var sharePayload: SharePayload? = nil
@@ -451,6 +452,29 @@ struct ArchiveView: View {
                             if mode == .calendar {
                                 calendarGrid
                                     .padding(.horizontal, 12)
+                                    .id("\(viewModel.currentYear)-\(viewModel.currentMonth)")
+                                    .transition(
+                                        .asymmetric(
+                                            insertion: .move(edge: monthNavDirection).combined(with: .opacity),
+                                            removal: .move(edge: monthNavDirection == .trailing ? .leading : .trailing).combined(with: .opacity)
+                                        )
+                                    )
+                                    .gesture(
+                                        DragGesture(minimumDistance: 30)
+                                            .onEnded { value in
+                                                let w = value.translation.width
+                                                let h = value.translation.height
+                                                guard abs(w) > abs(h) * 1.2, abs(w) > 50 else { return }
+                                                if w < 0 {
+                                                    monthNavDirection = .trailing
+                                                    withAnimation(Motion.spring) { viewModel.goToNextMonth() }
+                                                } else {
+                                                    monthNavDirection = .leading
+                                                    withAnimation(Motion.spring) { viewModel.goToPreviousMonth() }
+                                                }
+                                                Haptics.soft()
+                                            }
+                                    )
 
                                 legendRow
                                     .padding(.horizontal, 12)
@@ -600,7 +624,10 @@ struct ArchiveView: View {
 
     private var monthNavigationRow: some View {
         HStack {
-            Button(action: { viewModel.goToPreviousMonth() }) {
+            Button(action: {
+                monthNavDirection = .leading
+                withAnimation(Motion.spring) { viewModel.goToPreviousMonth() }
+            }) {
                 Image(systemName: "chevron.left")
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(DSColor.inkMuted)
@@ -626,7 +653,10 @@ struct ArchiveView: View {
 
             Spacer()
 
-            Button(action: { viewModel.goToNextMonth() }) {
+            Button(action: {
+                monthNavDirection = .trailing
+                withAnimation(Motion.spring) { viewModel.goToNextMonth() }
+            }) {
                 Image(systemName: "chevron.right")
                     .font(.system(size: 14, weight: .semibold))
                     .foregroundColor(DSColor.inkMuted)


### PR DESCRIPTION
## Swipe-to-navigate months in Archive calendar

The Archive calendar only switches months via two small chevron buttons — there's no horizontal swipe, which is the expected iOS calendar gesture and the dominant interaction pattern elsewhere in the app (Today's cards, sidebar edge-swipe). Add a horizontal drag gesture on the calendar grid so users can swipe left for the next month and right for the previous, paired with a directional slide+fade transition and a soft haptic to match the app's existing motion language.

### Acceptance
Build the DayPage scheme cleanly (xcodebuild -scheme DayPage build). In the iPhone 17 simulator, open Archive in calendar mode: swiping the calendar grid left advances to the next month with a left-sliding transition, swiping right returns to the previous month with a right-sliding transition, and each successful change fires a soft haptic. Vertical scroll of the Archive page still works (swipe gesture does not hijack vertical drags). Chevron buttons still navigate and animate in the matching direction. List mode is unaffected.