### PR TITLE
auto: Animate CompileProgressDock segment fills left-to-right + announce unlock to VoiceOver

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -164,21 +164,33 @@ struct CompileProgressDock: View {
                 ForEach(0..<3, id: \.self) { index in
                     let isFilled = index < memoCount
                     let isPulsingSegment = (index == 2) && thirdSegmentPulsing
-                    Capsule(style: .continuous)
-                        .fill(isFilled ? DSColor.accentAmber : DSColor.glassStd)
-                        .frame(width: 28, height: 4)
-                        .shadow(
-                            color: isPulsingSegment ? DSColor.accentAmber.opacity(0.75) : .clear,
-                            radius: isPulsingSegment ? 6 : 0
-                        )
-                        .scaleEffect(isPulsingSegment ? 1.35 : 1.0)
-                        .dsAnimation(Motion.spring, value: memoCount)
-                        .animation(
-                            Motion.respectReduceMotion(
-                                .spring(response: 0.4, dampingFraction: 0.6)
-                            ),
-                            value: thirdSegmentPulsing
-                        )
+                    // Glass base always present; amber fill draws on from leading edge.
+                    ZStack(alignment: .leading) {
+                        Capsule(style: .continuous)
+                            .fill(DSColor.glassStd)
+                        Capsule(style: .continuous)
+                            .fill(DSColor.accentAmber)
+                            .scaleEffect(x: isFilled ? 1 : 0, y: 1, anchor: .leading)
+                            .animation(
+                                Motion.respectReduceMotion(
+                                    .spring(response: 0.45, dampingFraction: 0.7)
+                                )
+                                .delay(Double(index) * 0.04),
+                                value: memoCount
+                            )
+                    }
+                    .frame(width: 28, height: 4)
+                    .shadow(
+                        color: isPulsingSegment ? DSColor.accentAmber.opacity(0.75) : .clear,
+                        radius: isPulsingSegment ? 6 : 0
+                    )
+                    .scaleEffect(isPulsingSegment ? 1.35 : 1.0)
+                    .animation(
+                        Motion.respectReduceMotion(
+                            .spring(response: 0.4, dampingFraction: 0.6)
+                        ),
+                        value: thirdSegmentPulsing
+                    )
                 }
             }
 
@@ -200,6 +212,7 @@ struct CompileProgressDock: View {
         .onChange(of: memoCount) { newCount in
             if previousMemoCount < 3 && newCount == 3 {
                 Haptics.success()
+                UIAccessibility.post(notification: .announcement, argument: L10n.Empty.compileDockUnlocked)
                 thirdSegmentPulsing = true
                 Task {
                     try? await Task.sleep(nanoseconds: 400_000_000)

--- a/DayPage/Resources/L10n.swift
+++ b/DayPage/Resources/L10n.swift
@@ -24,6 +24,9 @@ enum L10n {
             String(format: NSLocalizedString("compile.dock.locked", comment: ""), current, remaining)
         }
 
+        /// VoiceOver announcement spoken once when the 3rd memo unlocks compilation.
+        static let compileDockUnlocked = NSLocalizedString("compile.dock.unlocked", comment: "")
+
         // Archive Day Empty
         static let archiveDayTitle    = LocalizedStringKey("empty.archive_day.title")
         static let archiveDaySubtitle = NSLocalizedString("empty.archive_day.subtitle", comment: "")

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -16,6 +16,9 @@
 /* Compile-locked dock hint (shown above the input bar) */
 "compile.dock.locked" = "%1$d / 3 memos · %2$d more to unlock";
 
+/* VoiceOver announcement when 3rd memo unlocks compilation */
+"compile.dock.unlocked" = "Daily compilation unlocked";
+
 /* InputBarV4 — press-to-talk hint states */
 "input.hint.idle"            = "Hold to record · Release to transcribe";
 "input.hint.pre_recording"   = "Hold a moment longer";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -16,6 +16,9 @@
 /* Compile-locked dock hint (shown above the input bar) */
 "compile.dock.locked" = "%1$d / 3 条备忘 · 再写 %2$d 条解锁每日编译";
 
+/* VoiceOver announcement when 3rd memo unlocks compilation */
+"compile.dock.unlocked" = "已解锁今日编译";
+
 /* InputBarV4 — press-to-talk hint states */
 "input.hint.idle"            = "按住录音 · 松手转文字";
 "input.hint.pre_recording"   = "再按住一下";


### PR DESCRIPTION
## Animate CompileProgressDock segment fills left-to-right + announce unlock to VoiceOver

When a memo is added, the three progress-dock capsules above the input bar currently snap from glass to amber via a generic spring with no directional reading and no accessibility feedback. Add a left-anchored horizontal scale 'draw-on' fill so each newly-unlocked segment visibly fills in the reading direction, and post a UIAccessibility announcement at the 2→3 unlock crossing so VoiceOver users learn compilation just unlocked (the moment is currently haptic-only and silent to screen readers).

### Acceptance
Build the DayPage scheme clean on iPhone 17. Adding memos 1→2→3 shows each dock segment filling left-to-right (visible directional growth, not a cross-fade); the 3rd memo still fires the success haptic and unlock pulse. With Reduce Motion enabled, segments fill instantly with no animation and no errors. With VoiceOver on, reaching the 3rd memo speaks the unlock announcement once (not on every reload). The locked hint text and accessibilityValue ('N of 3') still update correctly at each count.