### PR TITLE
auto: Haptic + tap-pulse feedback on Graph node selection

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -21,6 +21,10 @@ struct GraphView: View {
     @State private var selectedNode: GraphNode? = nil
     @State private var showEntityPage: Bool = false
 
+    // Tap pulse state
+    @State private var tapPulseNode: GraphNode? = nil
+    @State private var tapPulseScale: CGFloat = 0.6
+
     // Filter state
     @State private var showFilters: Bool = false
 
@@ -250,9 +254,31 @@ struct GraphView: View {
                         .contentShape(Circle())
                         .position(x: x, y: y)
                         .onTapGesture {
+                            Haptics.tapConfirm()
                             selectedNode = node
+                            tapPulseNode = node
+                            tapPulseScale = 0.6
+                            withAnimation(.easeOut(duration: 0.35)) {
+                                tapPulseScale = 1.6
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                                tapPulseNode = nil
+                            }
                             showEntityPage = true
                         }
+                }
+
+                // Tap pulse ring
+                if let pulseNode = tapPulseNode {
+                    let px = pulseNode.position.x * scale + offset.width + size.width / 2
+                    let py = pulseNode.position.y * scale + offset.height + size.height / 2
+                    let diameter = nodeRadius * scale * 2 * tapPulseScale
+                    Circle()
+                        .strokeBorder(pulseNode.color, lineWidth: 2)
+                        .frame(width: diameter, height: diameter)
+                        .opacity(Double(1.6 - tapPulseScale))
+                        .position(x: px, y: py)
+                        .allowsHitTesting(false)
                 }
             }
             .gesture(


### PR DESCRIPTION
## Haptic + tap-pulse feedback on Graph node selection

Tapping a node in the knowledge Graph navigates to its EntityPage with zero tactile or visual confirmation, unlike Today's orb (Haptics.tapConfirm) and the recently-shipped Search landing pulse (#384). This adds a confirm haptic and a brief expanding-ring pulse drawn at the tapped node so the selection registers before the EntityPage sheet rises.

### Acceptance
Build the DayPage scheme for iPhone 17 sim. With a compiled vault that yields graph nodes, tapping a node produces a light confirm haptic, a visible amber/colored ring pulse expanding once from the tapped node, and then the existing EntityPage sheet. Tapping empty canvas still pans without firing the pulse. No regression to zoom/pan gestures or to the empty/loading states. Total change under ~40 lines, single file.