### PR TITLE
auto: Actionable empty-result state in Search — recover instead of dead-ending

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -194,6 +194,7 @@ struct SearchView: View {
         vm.results = hits
         vm.hasSearched = !trimmed.isEmpty || filters.isActive
         if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
+        if hits.isEmpty && vm.hasSearched && !trimmed.isEmpty { Haptics.warningNotification() }
     }
 
     // MARK: - Search Bar
@@ -560,26 +561,70 @@ struct SearchView: View {
     // MARK: - Empty result state
 
     private var emptyResultState: some View {
-        VStack(spacing: 12) {
-            Image(systemName: "tray")
-                .font(.system(size: 32, weight: .regular))
-                .foregroundColor(DSColor.outlineVariant)
-            if vm.query.isEmpty && filters.isActive {
-                Text("当前筛选条件下无匹配结果")
-                    .bodySMStyle()
-                    .foregroundColor(DSColor.onSurfaceVariant)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
-            } else {
-                Text("未找到「\(vm.query)」的匹配结果")
-                    .bodySMStyle()
-                    .foregroundColor(DSColor.onSurfaceVariant)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 40)
+        ScrollView {
+            VStack(spacing: 20) {
+                VStack(spacing: 12) {
+                    Image(systemName: "tray")
+                        .font(.system(size: 32, weight: .regular))
+                        .foregroundColor(DSColor.outlineVariant)
+                    if vm.query.isEmpty && filters.isActive {
+                        Text("当前筛选条件下无匹配结果")
+                            .bodySMStyle()
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 40)
+                    } else {
+                        Text("未找到「\(vm.query)」的匹配结果")
+                            .bodySMStyle()
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .multilineTextAlignment(.center)
+                            .padding(.horizontal, 40)
+                    }
+                }
+
+                if filters.isActive {
+                    Button(action: {
+                        Haptics.tapConfirm()
+                        filters = .empty
+                        runSearch(keyword: vm.query)
+                    }) {
+                        Text("清除筛选并重试")
+                            .monoLabelStyle(size: 12)
+                            .foregroundColor(DSColor.primary)
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 10)
+                            .overlay(Rectangle().stroke(DSColor.primary, lineWidth: 1))
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                let recentSuggestions = Array(vm.recentSearches.filter { $0 != vm.query }.prefix(4))
+                if !recentSuggestions.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("换个关键词试试")
+                            .monoLabelStyle(size: 10)
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 20)
+
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(recentSuggestions, id: \.self) { q in
+                                    entityChip(q)
+                                }
+                            }
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
             }
+            .frame(maxWidth: .infinity)
+            .padding(.top, 80)
+            .padding(.bottom, 24)
         }
-        .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .padding(.top, 80)
+        .transition(.opacity)
+        .dsAnimation(Motion.fade, value: vm.results.isEmpty)
     }
 
     // MARK: - Grouped result list

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -21,9 +21,10 @@ struct GraphView: View {
     @State private var selectedNode: GraphNode? = nil
     @State private var showEntityPage: Bool = false
 
-    // Tap pulse state
-    @State private var tapPulseNode: GraphNode? = nil
-    @State private var tapPulseScale: CGFloat = 0.6
+    // Tap pulse state — ID-based so the ring tracks the live simulation position
+    @State private var tapPulseNodeID: String? = nil
+    @State private var tapPulseProgress: CGFloat = 0   // 0 → 1 drives both scale and opacity
+    @State private var tapPulseGeneration: Int = 0     // cancels stale clear tasks on rapid taps
 
     // Filter state
     @State private var showFilters: Bool = false
@@ -256,27 +257,33 @@ struct GraphView: View {
                         .onTapGesture {
                             Haptics.tapConfirm()
                             selectedNode = node
-                            tapPulseNode = node
-                            tapPulseScale = 0.6
+                            tapPulseNodeID = node.id
+                            tapPulseProgress = 0
+                            tapPulseGeneration += 1
+                            let gen = tapPulseGeneration
                             withAnimation(.easeOut(duration: 0.35)) {
-                                tapPulseScale = 1.6
+                                tapPulseProgress = 1
                             }
-                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
-                                tapPulseNode = nil
+                            Task { @MainActor in
+                                try? await Task.sleep(nanoseconds: 400_000_000)
+                                if tapPulseGeneration == gen { tapPulseNodeID = nil }
                             }
                             showEntityPage = true
                         }
                 }
 
-                // Tap pulse ring
-                if let pulseNode = tapPulseNode {
+                // Tap pulse ring — reads live position from the model so it tracks
+                // the node even while the force-directed simulation is still running.
+                if let id = tapPulseNodeID,
+                   let pulseNode = viewModel.nodes.first(where: { $0.id == id }) {
                     let px = pulseNode.position.x * scale + offset.width + size.width / 2
                     let py = pulseNode.position.y * scale + offset.height + size.height / 2
-                    let diameter = nodeRadius * scale * 2 * tapPulseScale
+                    let ringScale = 1.0 + tapPulseProgress   // 1.0 → 2.0
+                    let diameter = nodeRadius * scale * 2 * ringScale
                     Circle()
                         .strokeBorder(pulseNode.color, lineWidth: 2)
                         .frame(width: diameter, height: diameter)
-                        .opacity(Double(1.6 - tapPulseScale))
+                        .opacity(Double(1 - tapPulseProgress))
                         .position(x: px, y: py)
                         .allowsHitTesting(false)
                 }


### PR DESCRIPTION
## Actionable empty-result state in Search — recover instead of dead-ending

When a search returns no matches, SearchView currently shows a static "no results" message with no recovery path, even though the cause is often an active filter that's too narrow. This adds context-aware recovery actions to the empty-result state: a one-tap "clear filters & retry" button when filters are active, and recent-search chips as fallback suggestions, with a subtle fade-in and a warning haptic so the dead-end becomes a helpful pivot point.

### Acceptance
Build the DayPage scheme cleanly. In Simulator (iPhone 17): open Archive → Search. (1) Apply a date filter that yields zero results → the empty state shows a tappable "清除筛选并重试" button; tapping it clears filters, re-runs the search, and results reappear. (2) Perform a successful search, then type a gibberish query with no matches and prior recent searches present → recent-search chips appear under "换个关键词试试"; tapping a chip repopulates the query and shows its results. (3) The empty-result state fades in rather than hard-cutting, and is suppressed to an instant change when Reduce Motion is enabled. (4) A warning haptic fires once on entering the no-results state. No regressions to the existing empty-query (recent + entities) state or the grouped result list.