### PR TITLE
auto: Cache frequent-entity computation off the main thread in Search empty state

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -22,8 +22,17 @@ final class SearchViewModel: ObservableObject {
         }
     }
 
-    // MARK: Frequent entities — derived from vault memo bodies
-    func topEntities(limit: Int = 5) -> [String] {
+    // MARK: Frequent entities — cached, loaded off the main thread
+    @Published private(set) var topEntities: [String] = []
+
+    func loadTopEntities(limit: Int = 5) {
+        Task.detached(priority: .utility) { [weak self] in
+            let entities = self?.computeTopEntities(limit: limit) ?? []
+            await MainActor.run { self?.topEntities = entities }
+        }
+    }
+
+    private nonisolated func computeTopEntities(limit: Int) -> [String] {
         let rawDir = VaultInitializer.vaultURL.appendingPathComponent("raw")
         let fm = FileManager.default
         guard let files = try? fm.contentsOfDirectory(at: rawDir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]) else { return [] }
@@ -168,6 +177,7 @@ struct SearchView: View {
                     isInputFocused = true
                 }
                 setupDebounce()
+                vm.loadTopEntities()
             }
             .onDisappear {
                 cancellable?.cancel()
@@ -439,7 +449,7 @@ struct SearchView: View {
         ScrollView {
             VStack(alignment: .leading, spacing: 0) {
                 let recent = vm.recentSearches
-                let entities = vm.topEntities(limit: 5)
+                let entities = vm.topEntities
 
                 if !recent.isEmpty {
                     sectionHeader(title: "最近搜索", trailing: AnyView(


### PR DESCRIPTION
## Cache frequent-entity computation off the main thread in Search empty state

The Search empty-query screen calls vm.topEntities() directly inside its SwiftUI body, so every re-render (each keystroke debounce, focus change, or objectWillChange from clearing recent searches) re-enumerates every .md file in the vault, reads each into memory, and runs a regex over it — all synchronously on the main thread during rendering. This produces typing/scroll jank that scales with vault size. The fix computes the top entities once on a background task, caches the result in a @Published property, and refreshes it on appear, removing all file I/O from the render path.

### Acceptance
Opening Search no longer blocks the main thread enumerating the vault during render: the high-frequency-entities chips still appear (populated asynchronously within a frame or two of opening Search), typing in the search field with a large vault no longer drops frames, and the chips remain tappable and seed the query exactly as before. Build succeeds with `xcodebuild -scheme DayPage build` and the app launches in the iPhone 17 simulator with the Search empty state rendering the same recent-searches + frequent-entities layout.