### PR TITLE
auto: Breathing pulse + accessibility on the empty-state Day Orb hero

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -68,6 +68,9 @@ struct TodayView: View {
     /// Toggled each time the Day Orb is tapped to focus the composer input.
     @State private var orbFocusToggle: Bool = false
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var orbBreathing: Bool = false
+
     private var isInSelectionMode: Bool { selectedMemoIds != nil }
 
     /// Live drag offset for the daily page card (negative = pulled left).
@@ -890,11 +893,25 @@ struct TodayView: View {
                 Haptics.tapConfirm()
                 orbFocusToggle.toggle()
             }
+            .scaleEffect(reduceMotion ? 1.0 : (orbBreathing ? 1.03 : 0.985))
+            .shadow(
+                color: DSColor.accentAmber.opacity(orbBreathing ? 0.28 : 0.12),
+                radius: orbBreathing ? 22 : 12
+            )
+            .animation(
+                reduceMotion ? nil : .easeInOut(duration: 3.0).repeatForever(autoreverses: true),
+                value: orbBreathing
+            )
             .accessibilityLabel("Today's orb, \(viewModel.signalCount) signals")
             .accessibilityHint("Tap to start writing today's first note")
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
+        .onAppear {
+            if !reduceMotion {
+                orbBreathing = true
+            }
+        }
     }
 
     /// Issue #309 W2: top action bar shown while in multi-select mode.


### PR DESCRIPTION
## Breathing pulse + accessibility on the empty-state Day Orb hero

On a zero-signal Today screen, the 140pt Day Orb is the emotional focal point but sits visually static, giving no live cue that it's the tap-to-write affordance. Add a subtle, reduce-motion-respecting breathing scale/glow loop to the orb hero (matching the ambient pulse already used in EmptyStateView.orbAccent) so the empty state feels alive and invites the first capture.

### Acceptance
Build the DayPage scheme cleanly. On iPhone 17 simulator with no memos today, the orb hero gently breathes (scale ~0.985→1.03 over ~3s, soft amber glow swelling) without affecting layout or the date/kicker text. The pulse never appears once a memo exists (orbHero is unmounted). With Reduce Motion enabled, the orb is fully static. Tapping the orb still focuses the composer and fires the existing haptic.