### PR TITLE
auto: Swipe-down-to-dismiss on the Undo pill

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -440,6 +440,9 @@ struct TodayView: View {
                             draftText = text
                             undoText = nil
                             undoTask?.cancel()
+                        } onDismiss: {
+                            undoText = nil
+                            undoTask?.cancel()
                         }
                         .padding(.bottom, 96)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
@@ -451,6 +454,8 @@ struct TodayView: View {
                     if viewModel.lastDeletedMemo != nil {
                         UndoPillView(label: NSLocalizedString("undo_pill.label.delete", comment: "Undo delete pill label")) {
                             viewModel.undoDelete()
+                        } onDismiss: {
+                            viewModel.lastDeletedMemo = nil
                         }
                         .padding(.bottom, 96)
                         .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -11,10 +11,12 @@ import SwiftUI
 struct UndoPillView: View {
     var label: String = NSLocalizedString("undo_pill.label.send", comment: "Undo send pill label")
     let onUndo: () -> Void
+    var onDismiss: (() -> Void)? = nil
 
     @State private var countdownProgress: CGFloat = 1.0
     @State private var isUrgent: Bool = false
     @State private var secondsRemaining: Int = 5
+    @GestureState private var dragOffset: CGFloat = 0
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -64,6 +66,22 @@ struct UndoPillView: View {
             .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
         }
         .buttonStyle(.plain)
+        .offset(y: max(0, dragOffset))
+        .opacity(dragOffset > 0 ? Double(1 - dragOffset / 80) : 1)
+        .highPriorityGesture(
+            DragGesture(minimumDistance: 10)
+                .updating($dragOffset) { value, state, _ in
+                    if value.translation.height > 0 {
+                        state = value.translation.height
+                    }
+                }
+                .onEnded { value in
+                    if value.translation.height > 28 {
+                        Haptics.soft()
+                        onDismiss?()
+                    }
+                }
+        )
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Undo send, \(secondsRemaining) seconds remaining")
         .accessibilityHint("Restores the note you just submitted back to the input field")


### PR DESCRIPTION
## Swipe-down-to-dismiss on the Undo pill

The Undo pill (shown for 5s after submit/delete) can currently only be tapped to undo or waited out — there's no way to dismiss it early once the user is sure they don't want to undo. Add a swipe-down gesture that fades the pill out immediately, mirroring the established swipe-to-dismiss interaction already used by `syncBanner` in TodayView. This gives the user a quick, discoverable way to clear the transient pill without affecting the undo timeout logic.

### Acceptance
After submitting or deleting a memo, the Undo pill appears as before; tapping it still undoes. Swiping the pill downward >28pt fades/slides it away with a soft haptic and does NOT perform the undo. The pill still auto-dismisses after 5s if untouched. Build succeeds via `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'` and the behavior is verified in the iPhone 17 simulator.