### PR TITLE
auto: Add haptic feedback to Archive calendar — day-cell taps and month-chevron taps

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -538,6 +538,7 @@ struct ArchiveView: View {
     /// 每个日历单元格均可点击（US-006）。DayDetailView 自身处理
     /// `.empty` / `.error` / `.rawOnly` / `.compiled` 等状态 — 参见 US-002。
     private func handleDateTap(dateStr: String) {
+        Haptics.soft()
         selectedDateString = dateStr
         showDayDetail = true
     }
@@ -625,6 +626,7 @@ struct ArchiveView: View {
     private var monthNavigationRow: some View {
         HStack {
             Button(action: {
+                Haptics.soft()
                 monthNavDirection = .leading
                 withAnimation(Motion.spring) { viewModel.goToPreviousMonth() }
             }) {
@@ -654,6 +656,7 @@ struct ArchiveView: View {
             Spacer()
 
             Button(action: {
+                Haptics.soft()
                 monthNavDirection = .trailing
                 withAnimation(Motion.spring) { viewModel.goToNextMonth() }
             }) {


### PR DESCRIPTION
## Add haptic feedback to Archive calendar — day-cell taps and month-chevron taps

The Archive calendar is the one place where tap feedback is inconsistent: swiping to change months fires Haptics.soft() (ArchiveView.swift:475), but tapping a day cell (handleDateTap, line 540) and tapping the prev/next month chevrons (lines 628, 657) emit nothing — even though Today cards, the selection toolbar, and (per recent commit #396) Graph node selection all confirm taps with a haptic. This closes that gap so every selection in the app has the same tactile signature.

### Acceptance
Build the DayPage scheme (xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build) succeeds. Launch in Simulator, open Archive: tapping any calendar day cell produces a soft haptic and opens the day detail; tapping the left/right month chevrons produces a soft haptic and animates the month transition; the existing swipe-to-change-month haptic still fires. No haptic stacking or double-fire when swiping (swipe path unchanged). On a device with Reduce Motion / no haptics support, behavior degrades gracefully (HapticFeedback already no-ops).