### PR TITLE
auto: Match Daily Page card swipe to the canonical SwipeableMemoCard feel: rubber-band resistance + snap-open haptic

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -38,7 +38,7 @@ struct TodayView: View {
     /// Whether the daily page card is swiped open to reveal the recompile action.
     @State private var dailyPageRevealed: Bool = false
     /// Arming flag: true after the drag crosses -44pt; prevents repeat haptics mid-drag.
-    @State private var dailyPageDidArm: Bool = false
+    @GestureState private var dailyPageDidArm: Bool = false
 
     /// Session-only flag: true once the "restored unsent draft" banner has been shown this session.
     @State private var draftRestoredBannerShown: Bool = false
@@ -876,9 +876,12 @@ struct TodayView: View {
                         } else {
                             state = revealEdge + (dx - revealEdge) * 0.25
                         }
-                        // Fire arming haptic once when crossing the -44pt open threshold.
-                        if dx < -44 && !dailyPageDidArm {
-                            dailyPageDidArm = true
+                    }
+                    .updating($dailyPageDidArm) { value, state, _ in
+                        let dx = value.translation.width
+                        // Arm once when crossing -44pt; @GestureState auto-resets on gesture end.
+                        if dx < -44 && !state {
+                            state = true
                             Haptics.soft()
                         }
                     }
@@ -886,7 +889,6 @@ struct TodayView: View {
                         withAnimation(Motion.spring) {
                             dailyPageRevealed = value.translation.width < -44
                         }
-                        dailyPageDidArm = false
                     }
             )
         }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -37,6 +37,8 @@ struct TodayView: View {
 
     /// Whether the daily page card is swiped open to reveal the recompile action.
     @State private var dailyPageRevealed: Bool = false
+    /// Arming flag: true after the drag crosses -44pt; prevents repeat haptics mid-drag.
+    @State private var dailyPageDidArm: Bool = false
 
     /// Session-only flag: true once the "restored unsent draft" banner has been shown this session.
     @State private var draftRestoredBannerShown: Bool = false
@@ -865,14 +867,26 @@ struct TodayView: View {
             .highPriorityGesture(
                 DragGesture(minimumDistance: 10)
                     .updating($dailyPageDrag) { value, state, _ in
-                        if value.translation.width < 0 {
-                            state = value.translation.width
+                        let dx = value.translation.width
+                        guard dx < 0 else { return }
+                        // 1:1 tracking up to -80pt, then rubber-band resistance (0.25x).
+                        let revealEdge: CGFloat = -80
+                        if dx >= revealEdge {
+                            state = dx
+                        } else {
+                            state = revealEdge + (dx - revealEdge) * 0.25
+                        }
+                        // Fire arming haptic once when crossing the -44pt open threshold.
+                        if dx < -44 && !dailyPageDidArm {
+                            dailyPageDidArm = true
+                            Haptics.soft()
                         }
                     }
                     .onEnded { value in
                         withAnimation(Motion.spring) {
                             dailyPageRevealed = value.translation.width < -44
                         }
+                        dailyPageDidArm = false
                     }
             )
         }


### PR DESCRIPTION
## Match Daily Page card swipe to the canonical SwipeableMemoCard feel: rubber-band resistance + snap-open haptic

The Daily Page entry card's left-swipe-to-reveal-recompile gesture in TodayView tracks the finger 1:1 with no resistance and fires no haptic when it snaps open — unlike SwipeableMemoCard, which the card's own comment says it 'mirrors'. This adds rubber-band resistance past the -80pt reveal point and a soft haptic at the moment the card crosses the open threshold, so the two swipe surfaces feel like one consistent interaction.

### Acceptance
Build DayPage scheme (iPhone 17) clean. In Simulator with a compiled Daily Page card present: slowly dragging the card left feels 1:1 until ~44pt, gives a single soft haptic as it arms open, then visibly resists (rubber-bands) if dragged further rather than tracking the finger off-screen; releasing past -44pt snaps to the -80pt revealed state showing the amber 重新编译 button, releasing before snaps closed. Tapping the revealed card closes it (existing behavior unchanged). The interaction is indistinguishable in feel from swiping a memo card open. Reduce-Motion users still get the snap with no regression.