### PR TITLE
auto: Add press feedback to Archive calendar day cells

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -538,6 +538,7 @@ struct ArchiveView: View {
     /// 每个日历单元格均可点击（US-006）。DayDetailView 自身处理
     /// `.empty` / `.error` / `.rawOnly` / `.compiled` 等状态 — 参见 US-002。
     private func handleDateTap(dateStr: String) {
+        Haptics.tapConfirm()
         selectedDateString = dateStr
         showDayDetail = true
     }
@@ -789,6 +790,7 @@ struct ArchiveView: View {
                     }
                 }
                 .aspectRatio(1, contentMode: .fit)
+                .pressableCard()
             }
             .buttonStyle(.plain)
             .frame(maxWidth: .infinity)

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -538,7 +538,6 @@ struct ArchiveView: View {
     /// 每个日历单元格均可点击（US-006）。DayDetailView 自身处理
     /// `.empty` / `.error` / `.rawOnly` / `.compiled` 等状态 — 参见 US-002。
     private func handleDateTap(dateStr: String) {
-        Haptics.tapConfirm()
         selectedDateString = dateStr
         showDayDetail = true
     }


### PR DESCRIPTION
## Add press feedback to Archive calendar day cells

Tapping a day cell in the Archive calendar grid navigates to DayDetailView but gives zero feedback — no haptic, no press animation — unlike the Archive list rows (which use .pressableCard()), the month-swipe gesture (Haptics.soft()), and every other tappable surface in the app. This makes the calendar's primary navigation action feel dead and unresponsive. Add a light haptic on tap plus a subtle scale-down press state so calendar navigation matches the rest of the app's tactile language.

### Acceptance
Build the DayPage scheme for iPhone 17. Launch in Simulator, open Archive (calendar mode): tapping any day cell produces a light haptic and a brief scale-down press animation before DayDetailView presents, visually consistent with tapping an Archive list row. Empty/no-data cells (still tappable) get the same feedback. Today's cell retains its amber border and the rawOnly dot is unaffected. With Reduce Motion on, the scale animation is suppressed but the haptic still fires. No regression to month swipe or cell density colors.