### PR TITLE
auto: Tactile press feedback on Archive calendar day cells

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -764,6 +764,7 @@ struct ArchiveView: View {
             let dotColor: Color = isToday ? Color.white : DSColor.amberAccent
 
             Button(action: {
+                Haptics.tapConfirm()
                 handleDateTap(dateStr: dateStr)
             }) {
                 ZStack(alignment: .topLeading) {
@@ -790,7 +791,7 @@ struct ArchiveView: View {
                 }
                 .aspectRatio(1, contentMode: .fit)
             }
-            .buttonStyle(.plain)
+            .buttonStyle(CalendarCellButtonStyle())
             .frame(maxWidth: .infinity)
             .accessibilityLabel(accessibilityLabel(dateStr: dateStr, state: data))
         } else {
@@ -1279,5 +1280,16 @@ private extension Array {
         stride(from: 0, to: count, by: size).map {
             Array(self[$0 ..< Swift.min($0 + size, count)])
         }
+    }
+}
+
+// MARK: - CalendarCellButtonStyle
+
+private struct CalendarCellButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.93 : 1.0)
+            .opacity(configuration.isPressed ? 0.82 : 1.0)
+            .dsAnimation(Motion.spring, value: configuration.isPressed)
     }
 }


### PR DESCRIPTION
## Tactile press feedback on Archive calendar day cells

Tapping a day in the Archive calendar heatmap currently fires navigation with no haptic or visual press response — the cell is a bare Button(.plain), out of step with the Day Orb, Graph nodes, Search results, and sidebar dots that all got haptic + press-scale feedback in recent commits (#379, #383, #384, #396). This adds a light haptic on tap plus a subtle scale-down press animation so each day cell confirms the touch before DayDetailView presents.

### Acceptance
Build the DayPage scheme for iPhone 17 and launch in Simulator. In Archive → calendar mode, pressing any day cell visibly scales it down (~0.93) and dips slightly while the finger is held, springs back on release, and emits a light haptic on a physical device; DayDetailView still presents on tap. Empty trailing/leading blank cells remain non-interactive and silent. VoiceOver still reads the existing per-cell label (e.g. "2026-05-26，已编译 Daily Page"). No regression to swipe-to-change-month or the heatmap fill colors.