### PR TITLE
auto: Recenter button for the knowledge Graph — recover from a zoomed/panned-away view

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -171,6 +171,8 @@ struct GraphView: View {
         viewModel.filterStartDate != nil || viewModel.filterEndDate != nil || !viewModel.searchQuery.isEmpty
     }
 
+    private var isTransformed: Bool { scale != 1.0 || offset != .zero }
+
     // MARK: - Empty State
 
     private var emptyState: some View {
@@ -287,6 +289,8 @@ struct GraphView: View {
                         .position(x: px, y: py)
                         .allowsHitTesting(false)
                 }
+
+                if isTransformed { recenterButton }
             }
             .gesture(
                 SimultaneousGesture(
@@ -319,6 +323,28 @@ struct GraphView: View {
         .fixedSize()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         .padding(DSSpacing.lg)
+    }
+
+    private var recenterButton: some View {
+        Button {
+            Haptics.tapConfirm()
+            withAnimation(Motion.spring) {
+                scale = 1.0; lastScale = 1.0
+                offset = .zero; lastOffset = .zero
+            }
+        } label: {
+            Image(systemName: "scope")
+                .font(.system(size: 20, weight: .regular))
+                .foregroundColor(DSColor.inkPrimary)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        .padding(DSSpacing.lg)
+        .accessibilityLabel("Recenter graph")
+        .transition(.opacity.combined(with: .scale))
+        .animation(Motion.spring, value: isTransformed)
     }
 
     private func legendRow(color: Color, label: String) -> some View {


### PR DESCRIPTION
## Recenter button for the knowledge Graph — recover from a zoomed/panned-away view

GraphView supports pinch-zoom and drag-pan but provides no way to return to the default 1.0 scale / centered offset — a user who zooms in or pans the graph off-screen has no recovery path except switching tabs and back (which re-runs load()). Add a floating glass recenter button (bottom-trailing, mirroring the existing bottom-leading legend) that animates scale and offset back to default, plus a confirm haptic. Show it only while the view is actually transformed, matching the Archive haptic-feedback polish just shipped (#401).

### Acceptance
Build of the DayPage scheme succeeds and existing tests pass. In Simulator (iPhone 17), open Graph with >=1 node: recenter button is hidden at default zoom/offset. After a pinch-zoom or pan, the button fades in at bottom-trailing; tapping it springs scale back to 1.0 and offset back to .zero, fires a light haptic, and the button fades out. The bottom-leading legend and node-tap navigation/zoom/pan gestures are unaffected.