### PR TITLE
auto: Swipe-to-delete on recent search rows in SearchView

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -519,33 +519,13 @@ struct SearchView: View {
 
     @ViewBuilder
     private func recentSearchRow(_ q: String) -> some View {
-        HStack {
-            Image(systemName: "clock")
-                .font(.system(size: 12))
-                .foregroundColor(DSColor.outline)
-
-            Button(action: {
-                Haptics.tapConfirm()
-                vm.query = q
-                runSearch(keyword: q)
-            }) {
-                Text(q)
-                    .font(.custom("Inter-Regular", size: 14))
-                    .foregroundColor(DSColor.onSurface)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
-            .buttonStyle(.plain)
-
-            Button(action: { vm.removeRecentSearch(q) }) {
-                Image(systemName: "xmark")
-                    .font(.system(size: 11))
-                    .foregroundColor(DSColor.outline)
-            }
-            .buttonStyle(.plain)
-        }
-        .padding(.horizontal, 20)
-        .padding(.vertical, 10)
-        .background(DSColor.background)
+        SwipeableRecentRow(query: q, onSelect: { query in
+            Haptics.tapConfirm()
+            vm.query = query
+            runSearch(keyword: query)
+        }, onDelete: {
+            vm.removeRecentSearch(q)
+        })
         Divider()
             .padding(.leading, 52)
             .background(DSColor.outlineVariant.opacity(0.5))
@@ -809,6 +789,112 @@ struct SearchView: View {
         case .location: return "LOCATION"
         case .date:     return "DATE"
         }
+    }
+}
+
+// MARK: - SwipeableRecentRow
+
+private struct SwipeableRecentRow: View {
+
+    let query: String
+    let onSelect: (String) -> Void
+    let onDelete: () -> Void
+
+    private let revealWidth: CGFloat = 64
+    private let snapThreshold: CGFloat = 32
+
+    @State private var revealed: Bool = false
+    @GestureState private var drag: CGFloat = 0
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var currentOffset: CGFloat {
+        let base: CGFloat = revealed ? -revealWidth : 0
+        let live = min(0, drag)
+        let combined = base + live
+        if combined < -revealWidth {
+            return -revealWidth + (combined + revealWidth) * 0.25
+        }
+        return combined
+    }
+
+    private var snapAnimation: Animation {
+        reduceMotion ? .linear(duration: 0.001) : Motion.spring
+    }
+
+    var body: some View {
+        ZStack(alignment: .trailing) {
+            // Delete action surface — revealed on left swipe
+            Button(action: {
+                withAnimation(snapAnimation) { revealed = false }
+                Haptics.warn()
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { onDelete() }
+            }) {
+                Image(systemName: "trash")
+                    .font(.system(size: 16, weight: .medium))
+                    .foregroundColor(.white)
+                    .frame(width: revealWidth, maxHeight: .infinity)
+                    .background(DSColor.error)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("删除该搜索记录")
+
+            // Row content
+            HStack {
+                Image(systemName: "clock")
+                    .font(.system(size: 12))
+                    .foregroundColor(DSColor.outline)
+
+                Button(action: {
+                    if revealed {
+                        withAnimation(snapAnimation) { revealed = false }
+                    } else {
+                        onSelect(query)
+                    }
+                }) {
+                    Text(query)
+                        .font(.custom("Inter-Regular", size: 14))
+                        .foregroundColor(DSColor.onSurface)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .buttonStyle(.plain)
+
+                Button(action: { onDelete() }) {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 11))
+                        .foregroundColor(DSColor.outline)
+                        .frame(width: 44, height: 44)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("删除该搜索记录")
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+            .background(DSColor.background)
+            .offset(x: currentOffset)
+            .highPriorityGesture(
+                DragGesture(minimumDistance: 10)
+                    .updating($drag) { value, state, _ in
+                        let tx = value.translation.width
+                        if tx < 0 { state = tx }
+                    }
+                    .onEnded { value in
+                        let tx = value.translation.width
+                        if revealed {
+                            withAnimation(snapAnimation) {
+                                revealed = (tx > -snapThreshold)
+                            }
+                        } else {
+                            withAnimation(snapAnimation) {
+                                revealed = (tx < -snapThreshold)
+                            }
+                        }
+                    }
+            )
+        }
+        .clipped()
     }
 }
 

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -716,7 +716,7 @@ struct VoiceMemoPlayerRow: View {
                     var tx = Transaction()
                     tx.disablesAnimations = true
                     withTransaction(tx) {
-                        playbackProgress = p.currentTime / p.duration
+                        playbackProgress = p.duration > 0 ? p.currentTime / p.duration : 0
                     }
                 }
             }
@@ -726,8 +726,35 @@ struct VoiceMemoPlayerRow: View {
     private func seek(to fraction: Double) {
         let clampedFraction = max(0, min(1, fraction))
         if player == nil {
-            // No active player — start playback first, then seek into it.
-            startPlayback()
+            // No active player — prepare, seek, then play so the audio engine
+            // starts at the tapped position instead of briefly playing from 0.
+            // If setup fails, clear isScrubbing so the gesture doesn't stall.
+            guard FileManager.default.fileExists(atPath: fileURL.path) else {
+                fileError = true; isScrubbing = false; return
+            }
+            do {
+                try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default)
+                try AVAudioSession.sharedInstance().setActive(true)
+                let p = try AVAudioPlayer(contentsOf: fileURL)
+                p.prepareToPlay()
+                p.currentTime = clampedFraction * p.duration
+                p.play()
+                player = p
+                isPlaying = true
+                playbackProgress = clampedFraction
+                progressTimer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [self] _ in
+                    Task { @MainActor in
+                        guard let p = player, p.isPlaying else { stopPlayback(); return }
+                        guard !isScrubbing else { return }
+                        var tx = Transaction()
+                        tx.disablesAnimations = true
+                        withTransaction(tx) {
+                            playbackProgress = p.duration > 0 ? p.currentTime / p.duration : 0
+                        }
+                    }
+                }
+            } catch { fileError = true; isScrubbing = false }
+            return
         }
         guard let p = player else { return }
         p.currentTime = clampedFraction * p.duration


### PR DESCRIPTION
## Swipe-to-delete on recent search rows in SearchView

Recent-search rows in SearchView currently expose only a tiny 11pt ✕ button with no enclosing 44pt tap target and no swipe affordance — inconsistent with the app's swipe-first interaction language (SwipeableMemoCard, swipeable daily-page card, swipe-to-dismiss undo pill). Add a left-swipe-to-reveal delete action on each recent search row, mirroring the existing SwipeableMemoCard pattern, and fix the bare ✕ button's tap target to 44pt for accessibility.

### Acceptance
Build succeeds on iPhone 17 sim. In Archive → Search with ≥1 recent search: swiping a recent-search row left reveals a red trash button; tapping it removes that row with a spring animation and a warning haptic, and the row disappears immediately. Tapping the row body (not swiped) still fills the query and runs the search. The fallback ✕ button now has a 44pt hit area and a VoiceOver label. Swiping does not trigger navigation or search. Reduce Motion users still get a functional (non-springy) reveal.