### PR TITLE
auto: Dismiss the keyboard when scrolling Search results

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -502,6 +502,7 @@ struct SearchView: View {
             }
             .padding(.bottom, 24)
         }
+        .scrollDismissesKeyboard(.interactively)
     }
 
     private func sectionHeader(title: String, trailing: AnyView) -> some View {
@@ -633,6 +634,7 @@ struct SearchView: View {
             .padding(.top, 80)
             .padding(.bottom, 24)
         }
+        .scrollDismissesKeyboard(.interactively)
         .transition(.opacity)
         .dsAnimation(Motion.fade, value: vm.results.isEmpty)
     }
@@ -685,6 +687,7 @@ struct SearchView: View {
             }
             .padding(.bottom, 24)
         }
+        .scrollDismissesKeyboard(.interactively)
     }
 
     private func resultRow(_ result: SearchResult) -> some View {


### PR DESCRIPTION
## Dismiss the keyboard when scrolling Search results

On the Archive search screen the soft keyboard stays raised while the user scrolls through grouped results and both empty states, covering the lower half of the matches and forcing a manual '取消' tap to reclaim screen space. Add `.scrollDismissesKeyboard(.interactively)` to the three ScrollViews so dragging the result list (or either empty state) interactively retracts the keyboard, matching standard iOS search behavior.

### Acceptance
Build the DayPage scheme and launch on the iPhone 17 simulator. Open Archive → Search, type a query so grouped results appear with the keyboard up. Dragging the results list downward interactively retracts the keyboard following the finger; reversing the drag cancels the dismissal. Repeat with a no-match query (empty result state) and with an empty query showing recent searches/frequent entities — scrolling each dismisses the keyboard. Tapping a result still navigates to the day. Existing tests pass.