### PR TITLE
auto: Add a clear (✕) button to the Graph search field

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -45,6 +45,22 @@ struct GraphView: View {
                         TextField("搜索节点...", text: $viewModel.searchQuery)
                             .font(DSFonts.jetBrainsMono(size: 12))
                             .foregroundColor(DSColor.inkPrimary)
+                        if !viewModel.searchQuery.isEmpty {
+                            Button {
+                                Haptics.soft()
+                                withAnimation(.easeInOut(duration: 0.15)) {
+                                    viewModel.searchQuery = ""
+                                }
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .font(.system(size: 14))
+                                    .foregroundColor(DSColor.inkSubtle)
+                                    .frame(width: 28, height: 28)
+                                    .contentShape(Rectangle())
+                            }
+                            .accessibilityLabel("Clear search")
+                            .transition(.opacity)
+                        }
                     }
                     .padding(.horizontal, DSSpacing.md)
                     .padding(.vertical, 7)


### PR DESCRIPTION
## Add a clear (✕) button to the Graph search field

The Graph view's search capsule has no way to clear the query except manual backspacing — unlike standard iOS search fields. Add a tappable clear button that appears only while the field has text, wiping the query (and thus restoring all nodes) in one tap with a soft haptic.

### Acceptance
Build the DayPage scheme for iPhone 17. In the Graph tab: typing into the search field reveals an ✕ button at the trailing edge of the capsule; tapping it clears the text, dismisses the button, fires a soft haptic, and the dimmed/filtered nodes return to full opacity. The capsule height does not change between empty and filled states. VoiceOver reads the button as 'Clear search'.