### PR TITLE
auto: Make the Day Orb activatable by VoiceOver

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -21,6 +21,12 @@ struct DayOrbView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    private var accessibilityLabelText: String {
+        if signalCount == 0 { return "Day orb, no signals yet" }
+        let word = signalCount == 1 ? "signal" : "signals"
+        return "Day orb, \(signalCount) \(word) today"
+    }
+
     var body: some View {
         ZStack {
             if signalCount == 0 { inviteHalo }
@@ -67,6 +73,11 @@ struct DayOrbView: View {
         // Drop shadow: two-layer stack matching the glass card recipe
         .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 4, x: 0, y: 2)
         .shadow(color: Color(hex: "2D1E0A").opacity(0.14), radius: 28, x: 0, y: 12)
+        .accessibilityElement(children: .ignore)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(accessibilityLabelText)
+        .accessibilityHint("Activates to start writing today's note")
+        .accessibilityAction { onTap?() }
         .onAppear {
             withAnimation(
                 .easeInOut(duration: 4).repeatForever(autoreverses: true)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -907,8 +907,6 @@ struct TodayView: View {
                 reduceMotion ? nil : .easeInOut(duration: 3.0).repeatForever(autoreverses: true),
                 value: orbBreathing
             )
-            .accessibilityLabel("Today's orb, \(viewModel.signalCount) signals")
-            .accessibilityHint("Tap to start writing today's first note")
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)


### PR DESCRIPTION
## Make the Day Orb activatable by VoiceOver

The Day Orb is a primary tappable element (tap focuses the composer; it's the only CTA in the zero-memo empty state via 'TAP TO BEGIN'), but its tap is implemented with a custom DragGesture(minimumDistance: 0). VoiceOver does not expose custom drag gestures as activatable actions, so VoiceOver users land on the orb but cannot trigger it. Add the .isButton trait and an .accessibilityAction(.default) that invokes onTap, plus a self-contained accessibility label/value so the orb reads correctly even when used outside orbHero (e.g. EmptyStateView's orb accent contexts).

### Acceptance
Build the DayPage scheme succeeds. With VoiceOver on in the iPhone 17 simulator: navigating to the orb announces it as a button with the signal-count label and hint; performing the default VoiceOver activation (double-tap) focuses the composer input (orbFocusToggle fires), matching the sighted tap behavior. Sighted tap/press-scale behavior via the existing DragGesture is unchanged. No duplicate/competing accessibility labels on the orb.