### PR TITLE
auto: Add a clear (×) button to the Graph search field

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -63,6 +63,7 @@ struct GraphView: View {
                             .transition(.opacity)
                         }
                     }
+                    .animation(Motion.fade, value: viewModel.searchQuery.isEmpty)
                     .padding(.horizontal, DSSpacing.md)
                     .padding(.vertical, 7)
                     .background(DSColor.glassLo)


### PR DESCRIPTION
## Add a clear (×) button to the Graph search field

The Graph search field (GraphView.swift) dims non-matching nodes as you type but offers no way to clear the query except manually backspacing every character. Add an inline clear button that appears only when the field is non-empty, tapping it resets the query (and re-shows all nodes) with a light haptic — matching the tactile-polish pattern of recent commits (#404, #405, #406).

### Acceptance
Build the DayPage scheme (iPhone 17 simulator) with no errors. In Graph, typing a query shows the × button inside the search capsule; tapping it clears the text, re-shows/undims all nodes, and fires a light haptic. The button is hidden when the field is empty and animates in/out. VoiceOver reads 'Clear search'. No layout shift in the capsule when the button toggles.