### PR TITLE
auto: Make knowledge Graph nodes navigable with VoiceOver

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -247,7 +247,7 @@ struct GraphView: View {
                 .onAppear { simulationSize = size }
                 .onChange(of: size) { simulationSize = $0 }
 
-                // Node labels (filtered only)
+                // Node labels (filtered only) — hidden from VoiceOver; the tap target below announces the name
                 ForEach(viewModel.filteredNodes) { node in
                     let x = node.position.x * scale + offset.width + size.width / 2
                     let y = node.position.y * scale + offset.height + size.height / 2
@@ -260,6 +260,7 @@ struct GraphView: View {
                         .lineLimit(1)
                         .fixedSize()
                         .position(x: x, y: y + nodeRadius * scale + 10 * scale)
+                        .accessibilityHidden(true)
                 }
 
                 // Invisible tap targets for each filtered node
@@ -288,6 +289,11 @@ struct GraphView: View {
                             }
                             showEntityPage = true
                         }
+                        .accessibilityElement(children: .ignore)
+                        .accessibilityAddTraits(.isButton)
+                        .accessibilityLabel(node.name)
+                        .accessibilityValue(typeLabel(node.entityType))
+                        .accessibilityHint("Opens this entity's page")
                 }
 
                 // Tap pulse ring — reads live position from the model so it tracks
@@ -371,6 +377,17 @@ struct GraphView: View {
             Text(label)
                 .font(DSFonts.jetBrainsMono(size: 10))
                 .foregroundColor(DSColor.inkPrimary)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func typeLabel(_ entityType: String) -> String {
+        switch entityType {
+        case "places":  return "地点"
+        case "people":  return "人物"
+        case "themes":  return "主题"
+        default:        return entityType
         }
     }
 


### PR DESCRIPTION
## Make knowledge Graph nodes navigable with VoiceOver

The Graph tab's entity nodes are drawn with SwiftUI Canvas and made tappable via invisible clear Circles — neither is exposed to VoiceOver, so the entire knowledge graph (the tab's core content) is unreachable for VoiceOver users. This adds proper accessibility labels, values, traits, and a localized type description to each node tap target so VoiceOver users can swipe through nodes, hear each entity's name and category, and double-tap to open its Entity Page.

### Acceptance
Build the DayPage scheme for iPhone 17 succeeds. Launch in Simulator with VoiceOver (Accessibility Inspector or Settings) on the Graph tab with ≥2 compiled entities: swiping right moves focus node-to-node, each announces "<name>, <地点/人物/主题>, button" with the hint, and double-tapping a focused node opens its EntityPageView. Visual node labels are not double-announced. No regression to existing pan/zoom/tap-to-open behavior for sighted users.