### PR TITLE
auto: Expose the Daily Page 重新编译 (Recompile) action to VoiceOver

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -876,6 +876,15 @@ struct TodayView: View {
                     }
             )
         }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Daily page")
+        .accessibilityValue(viewModel.dailyPageSummary ?? "")
+        .accessibilityHint("Double tap to open the daily page")
+        .accessibilityAction { showDailyPage = true }
+        .accessibilityAction(named: Text(NSLocalizedString("today.action.recompile", comment: ""))) {
+            dailyPageRevealed = false
+            viewModel.compile()
+        }
     }
 
     // MARK: - Day Orb Hero


### PR DESCRIPTION
## Expose the Daily Page "重新编译" (Recompile) action to VoiceOver

The compiled Daily Page card on Today only reveals its "重新编译" (Recompile) action via a left-swipe drag gesture, which VoiceOver users cannot perform — leaving them with no way to redo a poor AI compilation. This adds a Custom Action and a tap-to-open Daily Page accessibility affordance, following the exact pattern just shipped for the Day Orb (#411) and already present in SwipeableMemoCard.

### Acceptance
Build the DayPage scheme on iPhone 17 with no warnings. With VoiceOver on and a compiled daily page present: (1) the daily page card is reachable as a single focusable element announcing its summary; (2) a single-finger double-tap opens DailyPageView; (3) the VoiceOver rotor's Actions menu lists a "重新编译" action that triggers `viewModel.compile()` and closes any revealed swipe panel. Sighted left-swipe-to-recompile behavior is unchanged. Reduce Motion users are unaffected since no new animation is added.