### PR TITLE
auto: Make Graph knowledge-graph nodes navigable with VoiceOver

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -203,6 +203,33 @@ struct GraphView: View {
         }
     }
 
+    // MARK: - Accessibility Helpers
+
+    private func localizedEntityTypeName(_ entityType: String) -> String {
+        switch entityType {
+        case "places":  return "地点"
+        case "people":  return "人物"
+        default:        return "主题"
+        }
+    }
+
+    private func openNode(_ node: GraphNode) {
+        Haptics.tapConfirm()
+        selectedNode = node
+        tapPulseNodeID = node.id
+        tapPulseProgress = 0
+        tapPulseGeneration += 1
+        let gen = tapPulseGeneration
+        withAnimation(.easeOut(duration: 0.35)) {
+            tapPulseProgress = 1
+        }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            if tapPulseGeneration == gen { tapPulseNodeID = nil }
+        }
+        showEntityPage = true
+    }
+
     // MARK: - Graph Canvas
 
     private var graphCanvas: some View {
@@ -240,6 +267,7 @@ struct GraphView: View {
                     }
                 }
                 .frame(width: size.width, height: size.height)
+                .accessibilityHidden(true)
                 .onAppear { simulationSize = size }
                 .onChange(of: size) { simulationSize = $0 }
 
@@ -269,27 +297,13 @@ struct GraphView: View {
                         .frame(width: r * 2, height: r * 2)
                         .contentShape(Circle())
                         .position(x: x, y: y)
-                        .onTapGesture {
-                            Haptics.tapConfirm()
-                            selectedNode = node
-                            tapPulseNodeID = node.id
-                            tapPulseProgress = 0
-                            tapPulseGeneration += 1
-                            let gen = tapPulseGeneration
-                            withAnimation(.easeOut(duration: 0.35)) {
-                                tapPulseProgress = 1
-                            }
-                            Task { @MainActor in
-                                try? await Task.sleep(nanoseconds: 400_000_000)
-                                if tapPulseGeneration == gen { tapPulseNodeID = nil }
-                            }
-                            showEntityPage = true
-                        }
-                        .accessibilityElement(children: .ignore)
-                        .accessibilityAddTraits(.isButton)
+                        .onTapGesture { openNode(node) }
+                        .accessibilityElement()
                         .accessibilityLabel(node.name)
-                        .accessibilityValue(typeLabel(node.entityType))
-                        .accessibilityHint("Opens this entity's page")
+                        .accessibilityValue(localizedEntityTypeName(node.entityType))
+                        .accessibilityHint("打开实体页面")
+                        .accessibilityAddTraits(.isButton)
+                        .accessibilityAction { openNode(node) }
                 }
 
                 // Tap pulse ring — reads live position from the model so it tracks


### PR DESCRIPTION
## Make Graph knowledge-graph nodes navigable with VoiceOver

The Graph tab renders all nodes and labels inside a SwiftUI Canvas, which is opaque to VoiceOver — and the invisible per-node tap targets carry no accessibility metadata, so a screen-reader user finds nothing to select on the entire screen. This adds an accessibility element per filtered node (label = entity name, value = entity type, hint = 'Opens the entity page', and an .accessibilityAction that triggers the same node-open path as a tap), continuing the recent accessibility push (#411 Day Orb, #410 search clear).

### Acceptance
Build the DayPage scheme for iPhone 17 succeeds. With VoiceOver on in the Simulator, swiping through the Graph tab moves focus node-by-node; each node announces its name, entity type, and the 'opens entity page' hint, and a VoiceOver double-tap (or the rotor action) opens that node's EntityPageView — identical to a sighted tap. The decorative Canvas and drawn labels are not separately focusable (no duplicate announcements). Sighted tap behavior, zoom/pan, and the tap-pulse ring are unchanged.