### PR TITLE
auto: Pull-to-refresh on the Today timeline

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -373,6 +373,9 @@ struct TodayView: View {
                         }
                         .padding(.top, 12)
                     }
+                    .refreshable {
+                        await viewModel.refresh()
+                    }
                     // US-010: Vignette gradient at the bottom edge fades timeline
                     // content behind the composer dock, so cards appear to recede
                     // rather than abruptly stopping at the input bar boundary.

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -524,6 +524,17 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         }
     }
 
+    // MARK: - Pull-to-Refresh
+
+    /// Called by SwiftUI's .refreshable modifier. Fires a haptic, kicks off
+    /// load(), then suspends until the detached disk-load Task completes so
+    /// the system spinner stays visible for the actual I/O duration.
+    func refresh() async {
+        Haptics.soft()
+        load()
+        await loadTask?.value
+    }
+
     // MARK: - On This Day
 
     func dismissOnThisDay() {


### PR DESCRIPTION
## Pull-to-refresh on the Today timeline

The Today timeline reloads only implicitly (onAppear, scene-phase changes, voice-queue completion) — there is no `.refreshable` anywhere in the codebase, so a user who suspects stale data (e.g. a background compilation just finished, or a passive location draft arrived) has no standard gesture to force a reload. Add the canonical iOS pull-to-refresh to the Today ScrollView, wired to an async reload that ties the system spinner to the actual disk-load duration.

### Acceptance
Builds clean via `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'`. In the Simulator: pulling down on the Today timeline shows the system refresh spinner; the spinner persists until the disk reload completes (verify by adding several memos, force-quitting, relaunching, then pulling — reloaded memos appear and the spinner dismisses only after they render). Pull-to-refresh also surfaces a newly-arrived passive location draft card without backgrounding the app. Existing onAppear/scene-phase reload behavior is unchanged; no regression in scroll, swipe-to-delete, or multi-select gestures on the timeline.