### PR TITLE
auto: Add VoiceOver recompile action to the Daily Page card

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -861,6 +861,14 @@ struct TodayView: View {
                     }
                 }
             )
+            .accessibilityElement(children: .combine)
+            .accessibilityHint(NSLocalizedString("today.accessibility.dailypage.hint", comment: ""))
+            .accessibilityAction(named: Text(NSLocalizedString("today.action.recompile", comment: ""))) {
+                viewModel.compile()
+                withAnimation(Motion.spring) {
+                    dailyPageRevealed = false
+                }
+            }
             .offset(x: (dailyPageRevealed ? -80 : 0) + dailyPageDrag)
             .highPriorityGesture(
                 DragGesture(minimumDistance: 10)

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -51,6 +51,9 @@
 /* DailyPage swipe action */
 "today.action.recompile"     = "Recompile";
 
+/* DailyPage card accessibility hint */
+"today.accessibility.dailypage.hint" = "Opens today's compiled page. Use the Actions menu to recompile.";
+
 /* Archive Day Empty */
 "empty.archive_day.title" = "No page for this day.";
 "empty.archive_day.subtitle" = "This day hasn't been compiled yet. Head to Today to add memos first.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -51,6 +51,9 @@
 /* DailyPage swipe action */
 "today.action.recompile"     = "重新编译";
 
+/* DailyPage card accessibility hint */
+"today.accessibility.dailypage.hint" = "打开今日编译页。通过操作菜单可重新编译。";
+
 /* Archive Day Empty */
 "empty.archive_day.title" = "这一天还没有日记页。";
 "empty.archive_day.subtitle" = "这天尚未编译。先去「今天」添加备忘吧。";


### PR DESCRIPTION
## Add VoiceOver recompile action to the Daily Page card

The Daily Page card on Today reveals a '重新编译' (recompile) button only via a left-swipe drag gesture, which is invisible and unreachable for VoiceOver users — they can open the page but can never re-trigger AI compilation. Add an `.accessibilityAction(named:)` so the recompile action surfaces in the VoiceOver rotor's Actions menu, matching the accessibility pattern recently established for the Day Orb (#411) and Graph nodes (#413).

### Acceptance
Build the DayPage scheme on the iPhone 17 simulator. With VoiceOver on, focus the compiled Daily Page card: the rotor Actions menu lists a 'recompile' action that, when activated, triggers AI compilation (verify viewModel.compile() runs) without requiring any swipe. The standard activation (double-tap) still opens the Daily Page. No regression to the visual left-swipe-to-reveal behavior for sighted users; existing tests still pass.