### PR TITLE
auto: Add pull-to-refresh to the Today timeline

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -401,6 +401,10 @@ struct TodayView: View {
                         alignment: .bottom
                     )
                     .coordinateSpace(name: "todayScroll")
+                    .refreshable {
+                        Haptics.soft()
+                        await viewModel.refresh()
+                    }
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 
                     // MARK: Compile Area


### PR DESCRIPTION
## Add pull-to-refresh to the Today timeline

The Today timeline is a plain ScrollView with no pull-to-refresh; users can only reload memos by switching tabs, backgrounding the app, or waiting on the voice queue. Adding the native `.refreshable` modifier gives the expected iOS pull-down gesture to manually re-sync today's memos (e.g. after an iCloud change lands or a background transcription completes), with the system spinner and haptic for free.

### Acceptance
Build the DayPage scheme for iPhone 17 simulator with no errors. On Today, pulling the timeline down shows the native refresh spinner, triggers viewModel reload, and the spinner dismisses once memos reload. Pull works whether or not memos exist (empty state and populated). Reduce Motion users still get a functional refresh. Existing tab-switch/background reload behavior is unchanged.