### PR TITLE
auto: Add a one-time swipe-hint nudge to the compiled Daily Page card

### DIFF
--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -150,6 +150,8 @@ extension AppSettings {
         static let cardDensity        = "cardDensity"
         // Input
         static let usePressToTalk     = "usePressToTalk"
+        // Swipe-hint nudge — shown once when the first compiled Daily Page appears
+        static let dailyPageSwipeHintShown = "today.dailyPageSwipeHintShown"
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -71,6 +71,9 @@ struct TodayView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var orbBreathing: Bool = false
 
+    /// Hint offset for the one-time swipe-left nudge on the Daily Page card.
+    @State private var dailyPageHintOffset: CGFloat = 0
+
     private var isInSelectionMode: Bool { selectedMemoIds != nil }
 
     /// Live drag offset for the daily page card (negative = pulled left).
@@ -869,7 +872,19 @@ struct TodayView: View {
                     dailyPageRevealed = false
                 }
             }
-            .offset(x: (dailyPageRevealed ? -80 : 0) + dailyPageDrag)
+            .offset(x: (dailyPageRevealed ? -80 : 0) + dailyPageDrag + dailyPageHintOffset)
+            .onAppear {
+                guard !UserDefaults.standard.bool(forKey: AppSettings.Keys.dailyPageSwipeHintShown),
+                      !reduceMotion else { return }
+                UserDefaults.standard.set(true, forKey: AppSettings.Keys.dailyPageSwipeHintShown)
+                Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(0.6))
+                    withAnimation(Motion.spring) { dailyPageHintOffset = -24 }
+                    Haptics.soft()
+                    try? await Task.sleep(for: .seconds(0.45))
+                    withAnimation(Motion.spring) { dailyPageHintOffset = 0 }
+                }
+            }
             .highPriorityGesture(
                 DragGesture(minimumDistance: 10)
                     .updating($dailyPageDrag) { value, state, _ in


### PR DESCRIPTION
## Add a one-time swipe-hint nudge to the compiled Daily Page card

The Daily Page card on Today hides its 重新编译 (recompile) action behind a left-swipe gesture, but nothing signals the gesture exists — users have no way to discover it. Add a subtle one-time nudge animation (the card slides left ~24pt revealing a sliver of the amber recompile button, then springs back) the first time a compiled card appears for a user, gated by a UserDefaults flag and disabled under Reduce Motion.

### Acceptance
On first appearance of a compiled Daily Page card, the card briefly slides left ~24pt to reveal a sliver of the amber 重新编译 action then springs back, accompanied by a soft haptic; the nudge plays at most once per install (persisted via UserDefaults) and is fully skipped when Reduce Motion is enabled. The existing swipe-to-reveal, tap-to-open, and recompile actions continue to work unchanged, and the DayPage scheme builds clean on the iPhone 17 simulator.