### PR TITLE
auto: Replace jarring system-yellow search highlight with design-system amber

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -756,8 +756,9 @@ struct SearchView: View {
             let attrEnd = attributed.index(attrStart, offsetByCharacters: length)
             let attrRange = attrStart..<attrEnd
 
-            attributed[attrRange].backgroundColor = UIColor.systemYellow
-            attributed[attrRange].foregroundColor = UIColor.black
+            attributed[attrRange].backgroundColor = UIColor(DSColor.amberAccent).withAlphaComponent(0.28)
+            attributed[attrRange].foregroundColor = UIColor(DSColor.onSurface)
+            attributed[attrRange].font = .system(size: 13, weight: .semibold)
 
             searchStart = range.upperBound
         }


### PR DESCRIPTION
## Replace jarring system-yellow search highlight with design-system amber

The search-result keyword highlight in SearchView uses raw `UIColor.systemYellow` background with `UIColor.black` text (SearchView.swift:759-760), a system-default color that clashes with DayPage's warm amber design language and renders harshly in dark mode. Replace it with a soft amber-tinted highlight drawn from DSColor so matched keywords feel native to the journal's aesthetic and remain legible against the surface in both light and dark appearances.

### Acceptance
Build the DayPage scheme (xcodebuild -scheme DayPage build) and launch on the iPhone 17 simulator. Open Archive → Search, type a keyword that appears in an existing memo, and confirm: (1) matched substrings render with a soft amber-tinted background and bold weight rather than bright system yellow + black; (2) highlighted text stays fully legible against the result-card surface; (3) toggling the simulator to Dark Mode keeps the highlight legible with no harsh yellow/black block. No regressions to grouping, snippet truncation (2 lines), or tap-to-open behavior.