### PR TITLE
auto: Fix UndoPillView ignoring its localized label param (send vs. delete, zh-Hans)

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -48,7 +48,7 @@ struct UndoPillView: View {
                         .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: isUrgent)
                         .accessibilityHidden(true)
                 }
-                Text("Undo · \(secondsRemaining)s")
+                Text("\(label) · \(secondsRemaining)s")
                     .font(.custom("Inter-Medium", size: 13))
             }
             .foregroundColor(DSColor.inkPrimary)
@@ -83,8 +83,8 @@ struct UndoPillView: View {
                 }
         )
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Undo send, \(secondsRemaining) seconds remaining")
-        .accessibilityHint("Restores the note you just submitted back to the input field")
+        .accessibilityLabel("\(label), \(secondsRemaining) seconds remaining")
+        .accessibilityHint("Restores the previous state")
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(.updatesFrequently)
         .accessibilityIdentifier("undo-send-pill")


### PR DESCRIPTION
## Fix UndoPillView ignoring its localized label param (send vs. delete, zh-Hans)

UndoPillView accepts a localized `label` parameter that distinguishes the send-undo ("撤销发送"/"Undo send") from the delete-undo ("已删除 · 撤销"/"Deleted · Undo"), but the body hardcodes the English string "Undo · \(secondsRemaining)s" and a hardcoded "Undo send" VoiceOver label — so the param is silently dropped. Every pill reads identically in English regardless of action, fully breaking Chinese localization and the send/delete distinction. This wires the existing `label` through to the visible Text and the accessibility label, with the countdown appended.

### Acceptance
Build the DayPage scheme (xcodebuild -scheme DayPage build) succeeds. In Simulator (iPhone 17) with system language English: submit a memo → pill reads 'Undo send · 5s'; delete a memo → pill reads 'Deleted · Undo · 5s'. With system language 简体中文: submit → '撤销发送 · 5s'; delete → '已删除 · 撤销 · 5s'. VoiceOver announces the matching localized label (not a hardcoded 'Undo send') for both actions. Existing countdown ring, urgency color shift, haptic, and swipe-to-dismiss behavior are unchanged.