### PR TITLE
auto: Upgrade the Graph empty state to the polished shared EmptyStateView with an actionable CTA

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -181,6 +181,26 @@ extension EmptyStateView {
         )
     }
 
+    /// Graph — no knowledge graph compiled yet.
+    static func graphEmpty(ctaAction: @escaping () -> Void) -> EmptyStateView {
+        EmptyStateView(
+            title: "尚无知识图谱",
+            subtitle: "编译日记后，实体节点将在此出现",
+            ctaLabel: "去记录",
+            ctaAction: ctaAction,
+            showOrbAccent: true
+        )
+    }
+
+    /// Graph — nodes exist but current search/filter matches nothing.
+    static func graphNoMatches() -> EmptyStateView {
+        EmptyStateView(
+            title: "无匹配节点",
+            subtitle: "调整搜索或筛选条件以查看节点",
+            showOrbAccent: false
+        )
+    }
+
     /// Mic permission denied — recording unavailable.
     static func micPermissionDenied(ctaAction: @escaping () -> Void) -> EmptyStateView {
         EmptyStateView(
@@ -231,5 +251,19 @@ extension EmptyStateView {
     ZStack {
         AmbientBackground()
         EmptyStateView.micPermissionDenied { }
+    }
+}
+
+#Preview("Graph Empty") {
+    ZStack {
+        AmbientBackground()
+        EmptyStateView.graphEmpty { }
+    }
+}
+
+#Preview("Graph No Matches") {
+    ZStack {
+        AmbientBackground()
+        EmptyStateView.graphNoMatches()
     }
 }

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -5,6 +5,7 @@ import SwiftUI
 struct GraphView: View {
 
     @StateObject private var viewModel = GraphViewModel()
+    @EnvironmentObject private var nav: AppNavigationModel
 
     // Zoom & pan state
     @State private var scale: CGFloat = 1.0
@@ -191,19 +192,14 @@ struct GraphView: View {
 
     // MARK: - Empty State
 
+    @ViewBuilder
     private var emptyState: some View {
-        VStack(spacing: DSSpacing.md) {
-            Image(systemName: "point.3.connected.trianglepath.dotted")
-                .font(.system(size: 48, weight: .thin))
-                .foregroundColor(DSColor.inkFaint)
-            Text(viewModel.nodes.isEmpty ? "尚无知识图谱" : "无匹配节点")
-                .font(DSType.h2)
-                .foregroundColor(DSColor.inkMuted)
-            Text(viewModel.nodes.isEmpty ? "编译日记后，实体节点将在此出现" : "调整搜索或筛选条件以查看节点")
-                .bodySMStyle()
-                .foregroundColor(DSColor.inkMuted)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, DSSpacing.xl4)
+        if viewModel.nodes.isEmpty {
+            EmptyStateView.graphEmpty {
+                nav.navigate(to: .today)
+            }
+        } else {
+            EmptyStateView.graphNoMatches()
         }
     }
 


### PR DESCRIPTION
## Upgrade the Graph empty state to the polished shared EmptyStateView with an actionable CTA

The Graph tab's 'no knowledge graph yet' state is a hand-rolled flat VStack that, unlike every other empty state in the app, lacks the breathing orb accent, fade-in animation, and any call-to-action — it's a dead end that tells users to 'compile their diary' but gives them no way to get there. Replace it with the shared EmptyStateView component (consistent with Today/Archive), and for the genuinely-empty case add a CTA button that routes the user back to the Today tab to start capturing. Keep the 'no matching nodes' (filtered) case as a lightweight inline state since a CTA there would be wrong.

### Acceptance
Build the DayPage scheme cleanly for iPhone 17. Launch in Simulator with an empty vault and open the Graph tab: the empty state now shows the serif title with the breathing amber orb accent and a '去记录' capsule button; tapping it (with haptic) switches to the Today tab. With nodes present, apply a search/filter that matches nothing: the 'no matching nodes' state appears with NO CTA button. Both states fade in on appear. Reduce Motion disables the breathing/scale animation. No regressions to graph rendering, zoom/pan, or node tap navigation.