### PR TITLE
auto: Celebrate the compile unlock — haptic + glow when the 3rd memo crosses the threshold

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -22,10 +22,8 @@ struct CompileFooterButton: View {
     /// 用户点击重试时触发（US-020）。
     var onRetry: (() -> Void)? = nil
 
-    /// Controls the one-shot scale + amber glow pulse on first reveal.
+    /// Controls the one-shot scale pulse on first reveal (visual only).
     @State private var didAppearPulse = false
-    /// Guards the unlock effect so it only fires on the genuine first reveal.
-    @State private var hasPlayedUnlock = false
 
     var body: some View {
         Group {
@@ -121,9 +119,7 @@ struct CompileFooterButton: View {
             )
             .padding(.bottom, 6)
             .onAppear {
-                guard !isCompiling, errorMessage == nil, !hasPlayedUnlock else { return }
-                hasPlayedUnlock = true
-                Haptics.success()
+                guard !isCompiling, errorMessage == nil else { return }
                 didAppearPulse = true
                 Task {
                     try? await Task.sleep(nanoseconds: 450_000_000)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -74,6 +74,12 @@ struct TodayView: View {
     /// Hint offset for the one-time swipe-left nudge on the Daily Page card.
     @State private var dailyPageHintOffset: CGFloat = 0
 
+    /// Session-only: true once the 3-memo unlock celebration has fired this session.
+    /// Resets to false when memo count drops back below 3 so delete+readd re-fires it.
+    @State private var didCelebrateUnlock: Bool = false
+    /// Drives the one-shot amber glow pulse on the compile button at unlock.
+    @State private var unlockGlow: Bool = false
+
     private var isInSelectionMode: Bool { selectedMemoIds != nil }
 
     /// Live drag offset for the daily page card (negative = pulled left).
@@ -425,6 +431,11 @@ struct TodayView: View {
                                         onTap: { viewModel.compile() },
                                         onRetry: { viewModel.compile() }
                                     )
+                                    .shadow(
+                                        color: DSColor.accentAmber.opacity(unlockGlow ? 0.5 : 0),
+                                        radius: unlockGlow ? 18 : 0
+                                    )
+                                    .animation(.easeOut(duration: 0.6), value: unlockGlow)
                                     Spacer()
                                 }
                                 .padding(.bottom, 4)
@@ -432,6 +443,21 @@ struct TodayView: View {
                         }
                     }
                     .animation(Motion.spring, value: viewModel.memos.count)
+                    .onChange(of: viewModel.memos.count) { count in
+                        if count >= 3 && !viewModel.isDailyPageCompiled && !didCelebrateUnlock {
+                            didCelebrateUnlock = true
+                            Haptics.success()
+                            if !reduceMotion {
+                                unlockGlow = true
+                                Task {
+                                    try? await Task.sleep(nanoseconds: 600_000_000)
+                                    unlockGlow = false
+                                }
+                            }
+                        } else if count < 3 {
+                            didCelebrateUnlock = false
+                        }
+                    }
                     // MARK: Input Bar — single canonical surface (V4).
                     // V1/V2/V3 were removed in the Capture v2 cleanup; the
                     // variant switch was a feature-flag carcass keeping four


### PR DESCRIPTION
## Celebrate the compile unlock — haptic + glow when the 3rd memo crosses the threshold

When a user logs their 3rd memo, the CompileProgressDock swaps to the CompileFooterButton with only a spring animation — a quietly significant moment (the AI Daily Page is now unlockable) passes with no acknowledgment. Add a one-shot success haptic and a brief amber glow pulse on the compile button the first time the memo count crosses from <3 to ≥3 in a session, turning an invisible state change into a small reward that teaches the core loop.

### Acceptance
Build the DayPage scheme on iPhone 17. Add 2 memos (button area shows the progress dock, no celebration). Add a 3rd memo: a success haptic fires once and the compile button briefly pulses an amber glow before settling. Adding a 4th memo produces no further celebration. Deleting back to 2 then re-adding a 3rd re-fires the celebration once. With Reduce Motion enabled, the haptic still fires but no glow animation plays. Existing dock→button spring transition is unchanged.