### PR TITLE
auto: Add double-tap-to-reset zoom/pan gesture to the knowledge Graph canvas

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -310,6 +310,11 @@ struct GraphView: View {
 
                 if isTransformed { recenterButton }
             }
+            .onTapGesture(count: 2) {
+                guard isTransformed else { return }
+                Haptics.tapConfirm()
+                resetTransform()
+            }
             .gesture(
                 SimultaneousGesture(
                     MagnificationGesture()
@@ -343,13 +348,17 @@ struct GraphView: View {
         .padding(DSSpacing.lg)
     }
 
+    private func resetTransform() {
+        withAnimation(Motion.spring) {
+            scale = 1.0; lastScale = 1.0
+            offset = .zero; lastOffset = .zero
+        }
+    }
+
     private var recenterButton: some View {
         Button {
             Haptics.tapConfirm()
-            withAnimation(Motion.spring) {
-                scale = 1.0; lastScale = 1.0
-                offset = .zero; lastOffset = .zero
-            }
+            resetTransform()
         } label: {
             Image(systemName: "scope")
                 .font(.system(size: 20, weight: .regular))


### PR DESCRIPTION
## Add double-tap-to-reset zoom/pan gesture to the knowledge Graph canvas

The Graph canvas (GraphView) supports pinch-zoom and drag-pan but offers no double-tap-to-reset, a near-universal gesture on zoomable surfaces (Maps, Photos). Today the only way to recover from a zoomed/panned-into-a-corner state is the small 'scope' recenter button, which only appears once transformed and is easy to miss. A double-tap anywhere on the canvas should spring the scale and offset back to identity, reusing the exact reset logic the recenter button already runs.

### Acceptance
Build the DayPage scheme for iPhone 17 and run in Simulator. Open the Graph tab with ≥2 entity nodes. Pinch to zoom in and/or drag to pan — the 'scope' recenter button appears. Double-tap on empty canvas space: the graph springs back to scale 1.0 / offset zero with a confirm haptic, and the recenter button fades out. Verify a single tap on a node still opens its EntityPage (double-tap does not hijack node taps), and that double-tapping while already centered does nothing (no haptic, no animation). No regression to pinch-zoom, pan, or the force-directed layout.