### PR TITLE
auto: Show a logging streak in the sidebar brand header

### DIFF
--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -97,10 +97,31 @@ struct SidebarView: View {
                 .textCase(.uppercase)
                 .tracking(1.0)
             activityDots
+            if sidebarVM.currentStreak >= 2 {
+                streakChip(streak: sidebarVM.currentStreak)
+                    .dsAnimation(Motion.spring, value: sidebarVM.currentStreak)
+            }
         }
         .padding(.horizontal, 24)
         .padding(.top, 64)
         .padding(.bottom, 24)
+    }
+
+    private func streakChip(streak: Int) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: "flame.fill")
+                .font(.system(size: 10, weight: .medium))
+                .foregroundColor(DSColor.amberAccent)
+            Text("\(streak)-DAY STREAK")
+                .font(DSType.mono10)
+                .foregroundColor(DSColor.amberAccent)
+                .tracking(0.8)
+                .textCase(.uppercase)
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(DSColor.amberSoft, in: Capsule())
+        .accessibilityLabel("Current logging streak: \(streak) days")
     }
 
     /// 7 circles representing memo activity for the last 7 days (today on the right).

--- a/DayPage/App/SidebarViewModel.swift
+++ b/DayPage/App/SidebarViewModel.swift
@@ -27,6 +27,9 @@ final class SidebarViewModel: ObservableObject {
     /// Most recent days (descending) with at least one memo, capped to 7.
     @Published var recentDays: [RecentDay] = []
 
+    /// Consecutive days ending today (or yesterday) with at least one memo.
+    @Published var currentStreak: Int = 0
+
     private var authStateTask: Task<Void, Never>?
 
     func bind(authService: AuthService) {
@@ -50,12 +53,16 @@ final class SidebarViewModel: ObservableObject {
         }
     }
 
-    /// Re-scan `vault/raw/*.md` and publish the most recent 7 days off the
-    /// main actor. Safe to call repeatedly (e.g. whenever the sidebar opens).
+    /// Re-scan `vault/raw/*.md` and publish the most recent 7 days and streak
+    /// off the main actor. Safe to call repeatedly (e.g. whenever the sidebar opens).
     func refreshRecentDays() {
         Task { [weak self] in
-            let days = await Self.scanRecentDays(limit: 7)
-            await MainActor.run { self?.recentDays = days }
+            let wide = await Self.scanRecentDays(limit: 30)
+            let streak = Self.computeStreak(from: wide)
+            await MainActor.run {
+                self?.recentDays = Array(wide.prefix(7))
+                self?.currentStreak = streak
+            }
         }
     }
 
@@ -71,6 +78,41 @@ final class SidebarViewModel: ObservableObject {
     }
 
     // MARK: - Vault Scan
+
+    /// Walk back from today counting consecutive days that have memos.
+    /// Allows the chain to begin at yesterday so the streak isn't broken
+    /// before the user logs their first memo of the day.
+    nonisolated private static func computeStreak(from days: [RecentDay]) -> Int {
+        let cal = Calendar.current
+        let isoFormatter: DateFormatter = {
+            let f = DateFormatter()
+            f.locale = Locale(identifier: "en_US_POSIX")
+            f.dateFormat = "yyyy-MM-dd"
+            f.timeZone = TimeZone.current
+            return f
+        }()
+
+        let today = cal.startOfDay(for: Date())
+        var streak = 0
+        var cursor = today
+
+        // Allow the streak window to start at yesterday if today has no memo yet.
+        let todayStr = isoFormatter.string(from: today)
+        let hasMemoToday = days.contains { $0.dateString == todayStr }
+        if !hasMemoToday {
+            guard let yesterday = cal.date(byAdding: .day, value: -1, to: today) else { return 0 }
+            cursor = yesterday
+        }
+
+        while true {
+            let cursorStr = isoFormatter.string(from: cursor)
+            guard days.contains(where: { $0.dateString == cursorStr }) else { break }
+            streak += 1
+            guard let prev = cal.date(byAdding: .day, value: -1, to: cursor) else { break }
+            cursor = prev
+        }
+        return streak
+    }
 
     /// Reads `vault/raw/YYYY-MM-DD.md`, counts memos per day (memos are
     /// separated by `\n\n---\n\n`), and returns the most recent `limit` days


### PR DESCRIPTION
## Show a logging streak in the sidebar brand header

Add a small streak indicator (e.g. "🔥 5-day streak") beneath the activity dots in the sidebar header. The streak counts consecutive days ending today (or yesterday, so it survives until midnight) that have at least one memo — a core motivational pattern for journaling apps that DayPage currently lacks. All required per-day memo-count data is already scanned into SidebarViewModel.recentDays, so this is a pure derived-display addition with no new storage or schema changes.

### Acceptance
Build the DayPage scheme cleanly. With memos logged on 3+ consecutive days (verified via vault/raw/*.md files in the simulator container), opening the sidebar shows a '3-DAY STREAK' chip with a flame icon below the activity dots, styled with the amber capsule matching the existing Recent count badge. The chip is hidden when the streak is 0 or 1. A gap day (no memos) resets the count; logging today after a gap shows '1' (hidden) then grows. VoiceOver reads 'Current logging streak: 3 days'. No SwiftData/@Model files touched.