### PR TITLE
auto: Animate + add haptic to the Daily Page Digest/Timeline tab switch

### DIFF
--- a/DayPage/Features/Daily/DailyPageView.swift
+++ b/DayPage/Features/Daily/DailyPageView.swift
@@ -14,6 +14,7 @@ struct DailyPageView: View {
     @StateObject private var memoVM = DailyPageMemoVM()
     @ObservedObject private var compilationService = CompilationService.shared
     @State private var selectedTab: DailyPageTab = .digest
+    @Namespace private var tabPillNS
     @State private var model: DailyPageModel? = nil
     @State private var rawText: String = ""
     @State private var rawMemos: [Memo] = []
@@ -49,11 +50,22 @@ struct DailyPageView: View {
                                 .padding(.horizontal, 20)
                                 .padding(.top, 16)
 
-                            if selectedTab == .digest {
-                                digestContent(model: model)
-                            } else {
-                                timelineContent(model: model)
+                            ZStack {
+                                if selectedTab == .digest {
+                                    digestContent(model: model)
+                                        .transition(.asymmetric(
+                                            insertion: .move(edge: .leading).combined(with: .opacity),
+                                            removal: .move(edge: .trailing).combined(with: .opacity)
+                                        ))
+                                } else {
+                                    timelineContent(model: model)
+                                        .transition(.asymmetric(
+                                            insertion: .move(edge: .trailing).combined(with: .opacity),
+                                            removal: .move(edge: .leading).combined(with: .opacity)
+                                        ))
+                                }
                             }
+                            .dsAnimation(Motion.spring, value: selectedTab)
 
                             footer(model: model)
                                 .padding(.horizontal, 20)
@@ -263,13 +275,25 @@ struct DailyPageView: View {
     private var segmentedControl: some View {
         HStack(spacing: 0) {
             ForEach(DailyPageTab.allCases, id: \.self) { tab in
-                Button(action: { selectedTab = tab }) {
+                Button(action: {
+                    guard selectedTab != tab else { return }
+                    HapticFeedback.soft()
+                    withAnimation(Motion.respectReduceMotion(Motion.spring)) {
+                        selectedTab = tab
+                    }
+                }) {
                     Text(tab.rawValue)
                         .monoLabelStyle(size: 11)
                         .foregroundColor(selectedTab == tab ? DSColor.onPrimary : DSColor.primary)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 10)
-                        .background(selectedTab == tab ? DSColor.primary : Color.clear)
+                        .background {
+                            if selectedTab == tab {
+                                Rectangle()
+                                    .fill(DSColor.primary)
+                                    .matchedGeometryEffect(id: "tabPill", in: tabPillNS)
+                            }
+                        }
                 }
                 .buttonStyle(.plain)
             }


### PR DESCRIPTION
## Animate + add haptic to the Daily Page Digest/Timeline tab switch

The segmented control on DailyPageView — the app's core payoff screen — swaps between the Digest and Timeline tabs with a hard, instant cut and no haptic, which feels jarring next to the spring transitions and tactile feedback the rest of the app invests in (Today orb, compile dock, calendar cells). Wrap the tab change in a spring animation with a matched content crossfade/slide, and fire a light selection haptic on tap so the central toggle on the structured-diary view feels as polished as everything around it.

### Acceptance
Tapping between Digest and Timeline on a compiled Daily Page slides the active-segment highlight and crossfades the content with a spring (no hard cut); a light haptic fires on each switch; re-tapping the already-active tab does nothing (no haptic, no animation). Respects Reduce Motion by falling back to the existing instant swap. Build passes (xcodebuild -scheme DayPage) and the change is confined to DailyPageView.swift under ~40 lines.