### PR TITLE
auto: Polish search results: consolidated VoiceOver labels + staggered entrance animation

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -146,6 +146,9 @@ struct SearchView: View {
     @State private var filters: SearchFilters = SearchFilters.empty
     @State private var showFilters: Bool = false
     @State private var cancellable: AnyCancellable? = nil
+    @State private var appearedIDs: Set<UUID> = []
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var onSelect: (String) -> Void
 
@@ -201,6 +204,7 @@ struct SearchView: View {
         let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
         let wasEmpty = vm.results.isEmpty
         let hits = SearchService.search(keyword: trimmed, filters: filters)
+        appearedIDs = []
         vm.results = hits
         vm.hasSearched = !trimmed.isEmpty || filters.isActive
         if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
@@ -646,9 +650,18 @@ struct SearchView: View {
                 ForEach(groups, id: \.section) { group in
                     Section {
                         ForEach(group.results) { result in
+                            let appeared = appearedIDs.contains(result.id)
                             resultRow(result)
                                 .padding(.horizontal, 20)
                                 .padding(.bottom, 8)
+                                .opacity(appeared ? 1 : 0)
+                                .offset(y: appeared || reduceMotion ? 0 : 10)
+                                .onAppear {
+                                    guard !appearedIDs.contains(result.id) else { return }
+                                    withAnimation(reduceMotion ? .linear(duration: 0.001) : Motion.rise) {
+                                        appearedIDs.insert(result.id)
+                                    }
+                                }
                         }
                     } header: {
                         HStack {
@@ -671,7 +684,10 @@ struct SearchView: View {
     }
 
     private func resultRow(_ result: SearchResult) -> some View {
-        Button(action: {
+        let status = result.isDailyPageCompiled ? "VERIFIED" : "METADATA"
+        let snippet = String(result.snippet.prefix(80))
+        let a11yLabel = "\(formatDate(result.dateString)), \(matchLabel(for: result.matchKind)) match, \(status), \(snippet)"
+        return Button(action: {
             Haptics.tapConfirm()
             vm.recordSearch(vm.query)
             onSelect(result.dateString)
@@ -721,6 +737,9 @@ struct SearchView: View {
             }
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(a11yLabel)
+        .accessibilityHint("双击打开当天页面")
     }
 
     // MARK: - Keyword highlight via AttributedString


### PR DESCRIPTION
## Polish search results: consolidated VoiceOver labels + staggered entrance animation

Search result rows in SearchView render their date, status badge, snippet, and match metadata as separate VoiceOver fragments and appear with no transition. This change wraps each row into a single accessibility element with a clear spoken summary (date, match kind, daily-page status, snippet) and adds a subtle staggered fade/slide-in so results feel like they arrive when a query resolves, matching the timeline's existing entrance motion.

### Acceptance
Build the DayPage scheme cleanly (xcodebuild -scheme DayPage build). In the iPhone 17 simulator, run a search that returns results and confirm rows fade/slide in rather than snapping. With VoiceOver enabled, swiping to a result announces a single label like 'MARCH 3, 2026, memo match, verified, <snippet>' and the hint, instead of reading date/badge/snippet/type as separate elements. With Reduce Motion on, rows appear instantly with no offset. No regression to tap-to-open or keyword highlighting.