### PR TITLE
auto: Animate the today cell in the Archive calendar with a gentle breathing ring

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -423,6 +423,8 @@ struct ArchiveView: View {
     @State private var showShareSheet: Bool = false
     @State private var shareItems: [Any] = []
     @State private var monthNavDirection: Edge = .leading
+    @State private var todayPulse: Bool = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     /// Issue #302: monthly summary → share-card sheet.
     @State private var sharePayload: SharePayload? = nil
@@ -512,6 +514,8 @@ struct ArchiveView: View {
                 viewModel.loadMonth()
                 Task { await preScanVault() }
                 consumePendingArchiveDate()
+                guard !reduceMotion else { return }
+                withAnimation(Motion.breathing) { todayPulse = true }
             }
             .onChange(of: nav.pendingArchiveDate) { _ in
                 consumePendingArchiveDate()
@@ -778,6 +782,14 @@ struct ArchiveView: View {
                                 .stroke(isToday ? DSColor.amberAccent : DSColor.glassRim,
                                         lineWidth: isToday ? 1.5 : 0.5)
                         )
+
+                    if isToday && !reduceMotion {
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(DSColor.amberAccent, lineWidth: 1.5)
+                            .opacity(todayPulse ? 1.0 : 0.4)
+                            .shadow(color: DSColor.amberAccent.opacity(todayPulse ? 0.6 : 0.2), radius: todayPulse ? 6 : 2)
+                            .allowsHitTesting(false)
+                    }
 
                     Text(String(format: "%02d", day))
                         .monoLabelStyle(size: 9)


### PR DESCRIPTION
## Animate the "today" cell in the Archive calendar with a gentle breathing ring

The current day in the Archive calendar grid is marked only by a static 1.5pt amber border, which is easy to lose in a dense heatmap of 28-31 cells. Add a subtle, slowly-breathing amber glow ring around the today cell so it stays alive and instantly locatable — matching the app's established motion language (the Day Orb's breathing/invite pulse). Respects Reduce Motion by falling back to the existing static border.

### Acceptance
Build the DayPage scheme and launch on iPhone 17 Simulator. On the Archive tab, the current day's cell shows a gentle, continuously-breathing amber ring/glow that draws the eye, while all other cells and the heatmap colors are visually unchanged. Enabling Settings > Accessibility > Reduce Motion stops the animation and the today cell falls back to the existing static 1.5pt amber border. Tapping the cell still navigates to that day (haptic + handleDateTap) with no regression.