### PR TITLE
auto: Staggered left-to-right entrance animation for the sidebar's 7-day activity dots

### DIFF
--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -6,10 +6,12 @@ struct SidebarView: View {
 
     @EnvironmentObject private var nav: AppNavigationModel
     @EnvironmentObject private var authService: AuthService
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     @StateObject private var sidebarVM = SidebarViewModel()
     @State private var showSettings = false
     @State private var showAccountSheet = false
+    @State private var dotsAppeared = false
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -74,7 +76,13 @@ struct SidebarView: View {
         .onChange(of: nav.isSidebarOpen) { isOpen in
             // Refresh the recent-day list every time the drawer opens so the
             // user sees the latest activity without having to relaunch.
-            if isOpen { sidebarVM.refreshRecentDays() }
+            if isOpen {
+                sidebarVM.refreshRecentDays()
+                dotsAppeared = false
+                Task { @MainActor in dotsAppeared = true }
+            } else {
+                dotsAppeared = false
+            }
         }
         .sheet(isPresented: $showSettings) {
             SettingsView()
@@ -129,10 +137,12 @@ struct SidebarView: View {
         let days = last7DayPairs()
         let todayStr = Self.isoFormatter.string(from: Date())
         return HStack(spacing: 5) {
-            ForEach(days, id: \.dateString) { pair in
+            ForEach(Array(days.enumerated()), id: \.element.dateString) { index, pair in
                 let isToday = pair.dateString == todayStr
                 let count = pair.count
                 let label = Self.dotAccessibilityLabel(for: pair.dateString, count: count)
+                let restingOpacity = count > 0 ? min(0.4 + Double(count) * 0.15, 1.0) : 0.25
+                let delay = reduceMotion ? 0.0 : Double(index) * 0.05
                 Button {
                     Haptics.soft()
                     nav.openArchive(at: pair.dateString)
@@ -140,13 +150,18 @@ struct SidebarView: View {
                     Circle()
                         .fill(count > 0 ? DSColor.amberAccent : DSColor.inkFaint)
                         .frame(width: 8, height: 8)
-                        .opacity(count > 0 ? min(0.4 + Double(count) * 0.15, 1.0) : 0.25)
+                        .opacity(dotsAppeared ? restingOpacity : 0)
+                        .scaleEffect(dotsAppeared ? 1 : 0.6)
                         .overlay {
                             if isToday {
                                 Circle()
                                     .strokeBorder(DSColor.amberRim, lineWidth: 1)
                             }
                         }
+                        .animation(
+                            reduceMotion ? .linear(duration: 0.001) : Motion.spring.delay(delay),
+                            value: dotsAppeared
+                        )
                         .dsAnimation(Motion.spring, value: count)
                 }
                 .frame(width: 28, height: 28)


### PR DESCRIPTION
## Staggered left-to-right entrance animation for the sidebar's 7-day activity dots

The 7-day activity-dot strip in the sidebar brand header currently snaps in fully formed when the drawer opens. Animate the dots so they fade-and-pop in sequentially left-to-right (oldest → today) each time the sidebar opens, reinforcing the 'days accumulating toward today' metaphor that the adjacent streak chip already celebrates. Respects Reduce Motion by skipping the stagger.

### Acceptance
Build the DayPage scheme for iPhone 17 and run in Simulator. Opening the sidebar shows the 7 activity dots animating in sequentially from the leftmost (6-days-ago) dot to today's outlined dot over ~0.4s; closing and reopening replays the cascade. Filled (amber) dots retain their count-based opacity at rest, empty dots stay faint. With Reduce Motion enabled (Settings > Accessibility), all dots appear at once with no stagger. Tapping any dot still fires soft haptic + navigates to that day in Archive. No layout shift or jitter in the brand header, and existing tests still pass.