### PR TITLE
auto: Pull-to-refresh on the Today timeline

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -382,6 +382,9 @@ struct TodayView: View {
                         }
                         .padding(.top, 12)
                     }
+                    .refreshable {
+                        await viewModel.refresh()
+                    }
                     // US-010: Vignette gradient at the bottom edge fades timeline
                     // content behind the composer dock, so cards appear to recede
                     // rather than abruptly stopping at the input bar boundary.

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -418,6 +418,14 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
 
     // MARK: - Load Memos
 
+    /// Async entry point for pull-to-refresh: kicks off load() and suspends until
+    /// the underlying loadTask finishes, so the system refresh spinner persists for
+    /// exactly as long as the reload takes.
+    func refresh() async {
+        load()
+        await loadTask?.value
+    }
+
     /// Loads today's memos from the raw storage file and checks compiled status.
     /// Signature is intentionally synchronous so call sites (TodayView.onAppear) need
     /// no changes. Disk I/O is offloaded to a background task to avoid blocking the


### PR DESCRIPTION
## Pull-to-refresh on the Today timeline

The Today timeline only reloads on appear, scenePhase changes, and voice-queue changes — there is no manual refresh gesture, so when background compilation finishes or transcripts land while the app is foregrounded, users must background/foreground the app to see updates. Add SwiftUI's native .refreshable to the timeline ScrollView so a downward pull reloads memos, passive-location drafts, and the compiled daily page, with the system's built-in spinner and haptic.

### Acceptance
Build the DayPage scheme for iPhone 17 and launch in Simulator. On the Today tab with at least one memo, pulling the timeline down reveals the native refresh spinner; releasing triggers viewModel.refresh(), the spinner persists until the reload completes, then dismisses. Memos, pending location drafts, and the compiled daily-page card all reflect the latest vault state after the pull (verify by adding a memo to the vault .md file externally, then pulling to refresh). No regression to existing scroll, swipe-to-reveal on cards, or the bottom vignette gradient. Existing DayPageTests still pass.