### PR TITLE
auto: Pull-to-refresh on the Today timeline

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -397,6 +397,9 @@ struct TodayView: View {
                         .allowsHitTesting(false),
                         alignment: .bottom
                     )
+                    .refreshable {
+                        await viewModel.refresh()
+                    }
                     .coordinateSpace(name: "todayScroll")
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
 

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -416,6 +416,20 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         }
     }
 
+    // MARK: - Refresh (pull-to-refresh)
+
+    /// Called by SwiftUI's `.refreshable` modifier. Triggers a full reload and
+    /// waits until `loadState` returns to `.ready` before returning, so the
+    /// system spinner stays visible for the true duration of the reload.
+    func refresh() async {
+        load()
+        let deadline = Date().addingTimeInterval(3)
+        while loadState == .loading && Date() < deadline {
+            try? await Task.sleep(nanoseconds: 50_000_000)
+        }
+        Haptics.soft()
+    }
+
     // MARK: - Load Memos
 
     /// Loads today's memos from the raw storage file and checks compiled status.

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -418,15 +418,9 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
 
     // MARK: - Refresh (pull-to-refresh)
 
-    /// Called by SwiftUI's `.refreshable` modifier. Triggers a full reload and
-    /// waits until `loadState` returns to `.ready` before returning, so the
-    /// system spinner stays visible for the true duration of the reload.
     func refresh() async {
         load()
-        let deadline = Date().addingTimeInterval(3)
-        while loadState == .loading && Date() < deadline {
-            try? await Task.sleep(nanoseconds: 50_000_000)
-        }
+        await loadTask?.value
         Haptics.soft()
     }
 


### PR DESCRIPTION
## Pull-to-refresh on the Today timeline

The Today timeline ScrollView currently reloads only on appear, scenePhase changes, and voice-queue updates — there is no user-initiated refresh, which is the iOS-standard gesture users instinctively reach for (e.g. to surface a passively-detected location draft or re-check compile state). Add SwiftUI's native `.refreshable` to the timeline ScrollView, wiring it to a new async `TodayViewModel.refresh()` that reloads memos plus passive location drafts and awaits `loadState` settling back to `.ready` so the spinner reflects real completion.

### Acceptance
Building the DayPage scheme succeeds. In the iPhone 17 simulator, pulling down on the Today timeline shows the native refresh spinner, which persists until memos finish reloading and then dismisses; a passively-detected location draft created while the view is open appears after a pull-to-refresh. Reduce Motion users see the standard system spinner with no custom animation. Existing scroll, swipe-to-reveal on memo cards, and the sidebar edge-swipe continue to work unchanged.