### PR TITLE
auto: Add staggered entrance fade to EmptyStateView subtitle

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -23,6 +23,9 @@ struct EmptyStateView: View {
                     .foregroundColor(DSColor.inkMuted)
                     .multilineTextAlignment(.center)
                     .padding(.horizontal, 8)
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : 6)
+                    .animation(Motion.rise.delay(0.06), value: appeared)
             }
             if let label = ctaLabel, let action = ctaAction {
                 ctaButton(label: label, action: action)


### PR DESCRIPTION
## Add staggered entrance fade to EmptyStateView subtitle

EmptyStateView animates its title (Motion.rise) and CTA button (Motion.rise delayed 0.12s) on appear, but the subtitle between them snaps in instantly with no transition — breaking the intended top-to-bottom reveal cadence. Adding a delayed fade+rise to the subtitle completes the stagger so every empty state (Today blank, Archive day/month, Graph empty/no-matches, mic-denied — 7 variants) reveals as one cohesive sequence.

### Acceptance
Build the DayPage scheme succeeds. Launch in iPhone 17 simulator with a fresh/empty Today tab (no memos, not onboarded → todayBlank state): on appear the title fades up first, the subtitle follows ~60ms later, then the CTA button last — a smooth top-to-bottom cascade with no element snapping in instantly. Verify the same cascade on an empty Archive day. With Reduce Motion enabled in simulator Settings, all elements still appear correctly (no animation, fully visible). No layout shift or clipping of the subtitle text.