### PR TITLE
auto: Tappable graph legend — filter the knowledge graph by entity type

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -185,7 +185,10 @@ struct GraphView: View {
     }
 
     private var hasActiveFilter: Bool {
-        viewModel.filterStartDate != nil || viewModel.filterEndDate != nil || !viewModel.searchQuery.isEmpty
+        viewModel.filterStartDate != nil
+            || viewModel.filterEndDate != nil
+            || !viewModel.searchQuery.isEmpty
+            || !viewModel.activeTypes.isEmpty
     }
 
     private var isTransformed: Bool { scale != 1.0 || offset != .zero }
@@ -336,10 +339,10 @@ struct GraphView: View {
     // MARK: - Legend
 
     private var legend: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            legendRow(color: DSColor.amberDeep, label: "地点")
-            legendRow(color: DSColor.inkMuted, label: "人物")
-            legendRow(color: DSColor.amberAccent, label: "主题")
+        VStack(alignment: .leading, spacing: 2) {
+            legendRow(entityType: "places", color: DSColor.amberDeep, label: "地点")
+            legendRow(entityType: "people", color: DSColor.inkMuted, label: "人物")
+            legendRow(entityType: "themes", color: DSColor.amberAccent, label: "主题")
         }
         .padding(DSSpacing.md)
         .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
@@ -374,15 +377,40 @@ struct GraphView: View {
         .animation(Motion.spring, value: isTransformed)
     }
 
-    private func legendRow(color: Color, label: String) -> some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(color)
-                .frame(width: 10, height: 10)
-            Text(label)
-                .font(DSFonts.jetBrainsMono(size: 10))
-                .foregroundColor(DSColor.inkPrimary)
+    private func legendRow(entityType: String, color: Color, label: String) -> some View {
+        let isActive = viewModel.activeTypes.contains(entityType)
+        let anyActive = !viewModel.activeTypes.isEmpty
+        return Button {
+            Haptics.soft()
+            withAnimation(.easeInOut(duration: 0.18)) {
+                viewModel.toggleType(entityType)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                ZStack {
+                    Circle()
+                        .fill(color)
+                        .frame(width: 10, height: 10)
+                    if isActive {
+                        Circle()
+                            .strokeBorder(DSColor.amberAccent, lineWidth: 2)
+                            .frame(width: 15, height: 15)
+                    }
+                }
+                .frame(width: 16, height: 16)
+                Text(label)
+                    .font(DSFonts.jetBrainsMono(size: 10))
+                    .foregroundColor(isActive ? DSColor.amberDeep : DSColor.inkPrimary)
+                    .fontWeight(isActive ? .bold : .regular)
+            }
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
+            .opacity(anyActive && !isActive ? 0.45 : 1.0)
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityValue(isActive ? "已选中" : "未选中")
     }
 
     // MARK: - Helpers

--- a/DayPage/Features/Graph/GraphViewModel.swift
+++ b/DayPage/Features/Graph/GraphViewModel.swift
@@ -44,8 +44,9 @@ final class GraphViewModel: ObservableObject {
     @Published var searchQuery: String = ""
     @Published var filterStartDate: Date? = nil
     @Published var filterEndDate: Date? = nil
+    @Published var activeTypes: Set<String> = []
 
-    /// Nodes after applying search and date filters.
+    /// Nodes after applying search, date, and type filters.
     var filteredNodes: [GraphNode] {
         nodes.filter { node in
             let matchesSearch = searchQuery.isEmpty
@@ -63,7 +64,16 @@ final class GraphViewModel: ObservableObject {
                 }
                 return true
             }()
-            return matchesSearch && matchesDate
+            let matchesType = activeTypes.isEmpty || activeTypes.contains(node.entityType)
+            return matchesSearch && matchesDate && matchesType
+        }
+    }
+
+    func toggleType(_ type: String) {
+        if activeTypes.contains(type) {
+            activeTypes.remove(type)
+        } else {
+            activeTypes = [type]
         }
     }
 


### PR DESCRIPTION
## Tappable graph legend — filter the knowledge graph by entity type

The Graph view's legend (地点/人物/主题) is currently a static, decorative list with no interaction. Make each legend row a toggle button: tapping a type dims all other-typed nodes (and edges) to the existing 0.2-alpha 'out of filter' treatment, letting nomads isolate just their places, people, or themes. Tapping the active type again clears the filter. This reuses the canvas's existing dim/highlight rendering and the ViewModel's filteredNodes composition, so it's a small, additive change.

### Acceptance
Build the DayPage scheme (iPhone 17) clean. In Simulator on the Graph tab with a compiled vault: (1) tapping '地点' fades people/themes nodes+labels to dim and keeps places fully colored; (2) tapping '地点' again restores all nodes; (3) tapping '人物' after '地点' switches the isolated type; (4) the active legend row shows a clear selected indicator and fires a haptic on tap; (5) the filter toggle's amber 'active' state reflects the legend selection (hasActiveFilter true); (6) VoiceOver announces each legend row as a button with its 选中/未选中 state; (7) search + date filters still compose correctly with the type filter.