### PR TITLE
auto: Animate the ambient background — slow-drifting warm blobs behind every screen

### DIFF
--- a/DayPage/DesignSystem/GlassSurface.swift
+++ b/DayPage/DesignSystem/GlassSurface.swift
@@ -2,48 +2,52 @@ import SwiftUI
 
 // MARK: - Ambient Background
 //
-// Default: pure cream base (DSColor.bgWarm / #FAF7F2) — clean paper feel.
-// Amber blobs are available for debug inspection via UserDefaults key
-// "debug.ambientBlobs" (default false).
+// Warm cream base (DSColor.bgWarm / #FAF7F2) with four slow-drifting amber
+// blobs that breathe beneath glass surfaces. Honors Reduce Motion by keeping
+// blobs at their base offsets (no animation). Drift cycle: ~16s, autoreverses.
 
 struct AmbientBackground: View {
-    @AppStorage("debug.ambientBlobs") private var showBlobs: Bool = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var drift = false
 
     var body: some View {
         ZStack {
             DSColor.bgWarm.ignoresSafeArea()
 
-            if showBlobs {
-                // Top-left peach highlight
-                Circle()
-                    .fill(Color(hex: "E8974D").opacity(0.55))
-                    .frame(width: 360, height: 360)
-                    .blur(radius: 80)
-                    .offset(x: -60, y: -100)
+            // Top-left peach highlight — drifts down-right
+            Circle()
+                .fill(Color(hex: "E8974D").opacity(0.55))
+                .frame(width: 360, height: 360)
+                .blur(radius: 80)
+                .offset(x: drift ? -42 : -60, y: drift ? -72 : -100)
 
-                // Top-right warm yellow
-                Circle()
-                    .fill(Color(hex: "FFCE8C").opacity(0.55))
-                    .frame(width: 320, height: 320)
-                    .blur(radius: 80)
-                    .offset(x: 140, y: -50)
+            // Top-right warm yellow — drifts left-down
+            Circle()
+                .fill(Color(hex: "FFCE8C").opacity(0.55))
+                .frame(width: 320, height: 320)
+                .blur(radius: 80)
+                .offset(x: drift ? 118 : 140, y: drift ? -28 : -50)
 
-                // Center-left deep amber
-                Circle()
-                    .fill(Color(hex: "A8541B").opacity(0.32))
-                    .frame(width: 420, height: 420)
-                    .blur(radius: 80)
-                    .offset(x: -20, y: 200)
+            // Center-left deep amber — drifts right-up
+            Circle()
+                .fill(Color(hex: "A8541B").opacity(0.32))
+                .frame(width: 420, height: 420)
+                .blur(radius: 80)
+                .offset(x: drift ? 4 : -20, y: drift ? 222 : 200)
 
-                // Bottom-right warm rust
-                Circle()
-                    .fill(Color(hex: "D98D54").opacity(0.40))
-                    .frame(width: 300, height: 300)
-                    .blur(radius: 80)
-                    .offset(x: 100, y: 300)
-            }
+            // Bottom-right warm rust — drifts left-up
+            Circle()
+                .fill(Color(hex: "D98D54").opacity(0.40))
+                .frame(width: 300, height: 300)
+                .blur(radius: 80)
+                .offset(x: drift ? 76 : 100, y: drift ? 324 : 300)
         }
+        .animation(
+            reduceMotion ? nil : .easeInOut(duration: 16).repeatForever(autoreverses: true),
+            value: drift
+        )
         .allowsHitTesting(false)
+        .onAppear { drift = true }
     }
 }
 


### PR DESCRIPTION
## Animate the ambient background — slow-drifting warm blobs behind every screen

AmbientBackground is the shared warm canvas behind Today, Archive, Graph, and all empty states, but in production it renders as a flat DSColor.bgWarm — the four gradient blobs that give the canvas depth are gated behind a default-off debug flag (debug.ambientBlobs) and are completely static. Promote the blobs to production and give them a slow, continuous drift so the warm canvas subtly breathes beneath the glass surfaces, matching the orb's existing breathing language. Honors Reduce Motion by falling back to static blobs.

### Acceptance
Build the DayPage scheme for iPhone 17 and launch in Simulator. On Today (empty and with memos), Archive, and Graph the warm background now shows soft amber/peach blobs that slowly drift over ~16s and loop seamlessly, with glass cards visibly refracting against them. Enabling Settings > Accessibility > Reduce Motion shows the blobs static (no drift) with no layout shift. No regression to scroll, gestures, or the existing debug.ambientBlobs behavior is removed cleanly (flag no longer referenced).