### PR TITLE
fix: resolve main CI build failures from dual-agent merge conflicts

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -892,7 +892,8 @@ private struct SwipeableRecentRow: View {
                 Image(systemName: "trash")
                     .font(.system(size: 16, weight: .medium))
                     .foregroundColor(.white)
-                    .frame(width: revealWidth, maxHeight: .infinity)
+                    .frame(width: revealWidth)
+                    .frame(maxHeight: .infinity)
                     .background(DSColor.error)
                     .contentShape(Rectangle())
             }

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -418,14 +418,6 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
 
     // MARK: - Load Memos
 
-    /// Async entry point for pull-to-refresh: kicks off load() and suspends until
-    /// the underlying loadTask finishes, so the system refresh spinner persists for
-    /// exactly as long as the reload takes.
-    func refresh() async {
-        load()
-        await loadTask?.value
-    }
-
     /// Loads today's memos from the raw storage file and checks compiled status.
     /// Signature is intentionally synchronous so call sites (TodayView.onAppear) need
     /// no changes. Disk I/O is offloaded to a background task to avoid blocking the


### PR DESCRIPTION
## Summary

`main` 的 CI (`Xcode Build (no signing)`) 与 `Deploy to TestFlight` 当前处于失败状态，根因是两个并发 dual-agent PR 合并后引入了两处编译错误。本 PR 修复这两处错误，使 main 重新可构建。

- **TodayViewModel**: `func refresh() async` 被重复声明（`invalid redeclaration of 'refresh()'`）。保留带 `Haptics.soft()`、供 `.refreshable` 使用的完整版本，删除较早的重复版本。
- **SearchView**: `.frame(width:maxHeight:)` 不存在该 SwiftUI 重载（`extra argument 'width' in call`）。拆成链式 `.frame(width:)` + `.frame(maxHeight:)`，保持删除按钮固定 64pt 宽、高度撑满的原意。

## Root cause

这两个错误分别来自不同的 dual-agent 分支，各自单独构建时正常，但合并到 main 后产生了重复声明 / API 误用，且合并时未被拦截。

## Test plan

- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' CODE_SIGNING_ALLOWED=NO build` → **BUILD SUCCEEDED**
- [x] 确认 `TodayViewModel` 仅剩一个 `refresh()` 声明
- [x] 调用点 `TodayView.swift` 的 `await viewModel.refresh()` 无需改动（签名不变）
- [ ] CI 全绿后合并