### PR TITLE
auto: Celebrate Daily Page compilation completion with a one-shot reveal animation + haptic

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -84,6 +84,12 @@ struct TodayView: View {
     /// Drives the one-shot amber glow pulse on the compile button at unlock.
     @State private var unlockGlow: Bool = false
 
+    /// Session-only: true once the compile-completion celebration has fired for the current daily page.
+    /// Resets to false when isDailyPageCompiled becomes false (recompile/new day) so it re-fires.
+    @State private var didCelebrateCompile: Bool = false
+    /// Drives the one-shot amber glow + scale reveal on the daily page card after compilation.
+    @State private var compileRevealGlow: Bool = false
+
     private var isInSelectionMode: Bool { selectedMemoIds != nil }
 
     /// Live drag offset for the daily page card (negative = pulled left).
@@ -956,6 +962,14 @@ struct TodayView: View {
                 if viewModel.isDailyPageCompiled {
                     swipeableDailyPageCard
                         .padding(.horizontal, 20)
+                        .shadow(
+                            color: DSColor.accentAmber.opacity(compileRevealGlow ? 0.5 : 0),
+                            radius: compileRevealGlow ? 20 : 0
+                        )
+                        .scaleEffect(reduceMotion ? 1 : (compileRevealGlow ? 1.0 : 0.97))
+                        .animation(.easeOut(duration: 0.7), value: compileRevealGlow)
+                        .transition(.scale(scale: 0.95).combined(with: .opacity))
+                        .animation(Motion.spring, value: viewModel.isDailyPageCompiled)
                 }
 
                 if viewModel.loadState == .loading && viewModel.memos.isEmpty {
@@ -1119,6 +1133,21 @@ struct TodayView: View {
                 }
             } else if count < 3 {
                 didCelebrateUnlock = false
+            }
+        }
+        .onChange(of: viewModel.isDailyPageCompiled) { compiled in
+            if compiled && !didCelebrateCompile {
+                didCelebrateCompile = true
+                Haptics.success()
+                if !reduceMotion {
+                    compileRevealGlow = true
+                    Task {
+                        try? await Task.sleep(nanoseconds: 700_000_000)
+                        compileRevealGlow = false
+                    }
+                }
+            } else if !compiled {
+                didCelebrateCompile = false
             }
         }
 


### PR DESCRIPTION
## Celebrate Daily Page compilation completion with a one-shot reveal animation + haptic

When AI compilation finishes and the Daily Page card first appears in TodayView, it currently just pops into the timeline with no acknowledgement of this key pipeline milestone. Add a one-shot success haptic plus a brief amber glow + scale-in reveal on the daily page card (mirroring the existing 3-memo unlock celebration pattern), gated on reduceMotion. This rewards the user at the most meaningful moment in the dump→compile→diary loop.

### Acceptance
Build the DayPage scheme with xcodebuild (iPhone 17 destination) — compiles clean. In Simulator: add 3+ memos and tap Compile; when the Daily Page card appears it scales/fades in with a brief amber glow and a single success haptic fires exactly once. Swipe-to-reveal-recompile still works. Recompiling or crossing into a new day re-arms the celebration (glow fires again, not on every load). With Reduce Motion enabled, no glow/scale animation plays but the haptic still fires and the card appears instantly. No regression to the existing 3-memo unlock glow.