### PR TITLE
auto: Animate the next-to-fill segment in CompileProgressDock to signal compile-unlock momentum

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -153,6 +153,10 @@ struct CompileProgressDock: View {
     @State private var previousMemoCount: Int = 0
     /// When true, the third segment plays a one-shot scale+glow pulse.
     @State private var thirdSegmentPulsing: Bool = false
+    /// When true, the next-to-fill segment breathes to signal forward momentum.
+    @State private var nextSegmentBreathing: Bool = false
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         VStack(spacing: 6) {
@@ -160,13 +164,23 @@ struct CompileProgressDock: View {
                 ForEach(0..<3, id: \.self) { index in
                     let isFilled = index < memoCount
                     let isPulsingSegment = (index == 2) && thirdSegmentPulsing
+                    // The leftmost unfilled segment index, clamped to [0, 2].
+                    let nextIndex = min(memoCount, 2)
+                    let isBreathingSegment = index == nextIndex && memoCount < 3
                     // Glass base always present; amber fill draws on from leading edge.
                     ZStack(alignment: .leading) {
                         Capsule(style: .continuous)
                             .fill(DSColor.glassStd)
                         Capsule(style: .continuous)
                             .fill(DSColor.accentAmber)
-                            .scaleEffect(x: isFilled ? 1 : 0, y: 1, anchor: .leading)
+                            .opacity(isBreathingSegment ? (nextSegmentBreathing ? 0.55 : 0.2) : 1)
+                            .animation(
+                                isBreathingSegment && !reduceMotion
+                                    ? .easeInOut(duration: 1.4).repeatForever(autoreverses: true)
+                                    : nil,
+                                value: nextSegmentBreathing
+                            )
+                            .scaleEffect(x: isFilled ? 1 : (isBreathingSegment ? 1 : 0), y: 1, anchor: .leading)
                             .animation(
                                 Motion.respectReduceMotion(
                                     .spring(response: 0.45, dampingFraction: 0.7)
@@ -204,9 +218,13 @@ struct CompileProgressDock: View {
         .accessibilityValue("\(memoCount) of 3")
         .onAppear {
             previousMemoCount = memoCount
+            if !reduceMotion && memoCount < 3 {
+                nextSegmentBreathing = true
+            }
         }
         .onChange(of: memoCount) { newCount in
             if previousMemoCount < 3 && newCount == 3 {
+                nextSegmentBreathing = false
                 Haptics.success()
                 UIAccessibility.post(notification: .announcement, argument: L10n.Empty.compileDockUnlocked)
                 thirdSegmentPulsing = true


### PR DESCRIPTION
## Animate the next-to-fill segment in CompileProgressDock to signal compile-unlock momentum

The 3-segment compile progress dock fills statically as memos accumulate, but gives no forward cue about what the user needs to do next. Add a gentle, reduce-motion-aware opacity 'breathing' pulse to the first *unfilled* segment so users glance-read that they're partway to unlocking AI compilation (3 memos), reinforcing the existing 2→3 unlock celebration already wired in.

### Acceptance
Build the DayPage scheme for iPhone 17 with no errors. With 0–2 memos today, the leftmost empty progress segment shows a subtle pulsing amber hint; filled segments are unaffected. At exactly 3 memos the hint stops and the existing third-segment unlock pulse + success haptic still fire once. With Reduce Motion enabled, no breathing animation runs (segment renders static). Existing accessibilityValue '\(memoCount) of 3' is unchanged.