### PR TITLE
auto: Add success/failure feedback to Markdown export in Today header

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -898,11 +898,21 @@ struct TodayView: View {
                     df.locale = Locale(identifier: "en_US_POSIX")
                     df.timeZone = AppSettings.currentTimeZone()
                     let dateString = df.string(from: Date())
-                    if let url = try? MarkdownExportService.writeExportFile(
-                        content: content, dateString: dateString
-                    ) {
+                    do {
+                        let url = try MarkdownExportService.writeExportFile(
+                            content: content, dateString: dateString
+                        )
                         exportFileURL = url
                         showExportSheet = true
+                        Haptics.tapConfirm()
+                    } catch {
+                        Haptics.warn()
+                        bannerCenter.show(AppBannerModel(
+                            kind: .error,
+                            title: NSLocalizedString("export.error.title", comment: ""),
+                            autoDismiss: true
+                        ))
+                        DayPageLogger.shared.error("TodayView: export failed: \(error)")
                     }
                 } label: {
                     Image(systemName: "square.and.arrow.up")

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -169,6 +169,7 @@
 /* Markdown Export — US-019 */
 "export.action.title"  = "Export as Markdown";
 "export.action.label"  = "Export";
+"export.error.title"   = "Export failed, please try again";
 
 /* Voice attachment retry — US-016 */
 "voice.retry.button"           = "Retry transcription";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -197,6 +197,7 @@
 /* Markdown Export — US-019 */
 "export.action.title"  = "导出为 Markdown";
 "export.action.label"  = "导出";
+"export.error.title"   = "导出失败，请重试";
 
 /* Voice attachment retry — US-016 */
 "voice.retry.button"           = "重试转写";


### PR DESCRIPTION
## Add success/failure feedback to Markdown export in Today header

The Today header's export button writes a Markdown file via `try? MarkdownExportService.writeExportFile(...)` and only opens the share sheet on the silent-optional success path. When the write fails the button does nothing — the user taps Export and gets zero feedback. This adds a haptic confirmation on success and an error banner on failure, reusing the existing BannerCenter and Haptics infrastructure already wired into TodayView.

### Acceptance
Build the DayPage scheme with `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build`. In Simulator with ≥1 memo: tapping the header export button gives a confirmation haptic and opens the share sheet (unchanged happy path). Simulating a write failure (e.g. via a forced throw during testing) shows the red error banner and a warning haptic instead of silently doing nothing. No regression to the existing share-sheet flow.