### PR TITLE
auto: Add a contextual time-of-day hint to the compile button so it nudges evening reflection

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -126,6 +126,27 @@ struct CompileFooterButton: View {
                     didAppearPulse = false
                 }
             }
+
+            // Time-of-day hint — only when idle and no error
+            if !isCompiling && errorMessage == nil {
+                Text(timeHint)
+                    .font(DSType.mono10)
+                    .foregroundColor(DSColor.inkSubtle)
+                    .tracking(0.5)
+                    .opacity(0.8)
+                    .transition(.opacity)
+            }
+        }
+    }
+
+    /// Contextual nudge based on time of day.
+    private var timeHint: String {
+        let hour = Calendar.current.component(.hour, from: Date())
+        switch hour {
+        case 5..<12:  return "今天才刚开始"
+        case 12..<18: return "记录还在继续"
+        case 18..<23: return "夜深了，回顾今天吧"
+        default:      return "为今天画上句号"
         }
     }
 

--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -24,6 +24,8 @@ struct CompileFooterButton: View {
 
     /// Controls the one-shot scale pulse on first reveal (visual only).
     @State private var didAppearPulse = false
+    /// Cached hour component, refreshed every minute so the hint stays current across hour boundaries.
+    @State private var currentHour: Int = Calendar.current.component(.hour, from: Date())
 
     var body: some View {
         Group {
@@ -137,15 +139,17 @@ struct CompileFooterButton: View {
                     .transition(.opacity)
             }
         }
+        .onReceive(Timer.publish(every: 60, on: .main, in: .common).autoconnect()) { _ in
+            currentHour = Calendar.current.component(.hour, from: Date())
+        }
     }
 
     /// Contextual nudge based on time of day.
     private var timeHint: String {
-        let hour = Calendar.current.component(.hour, from: Date())
-        switch hour {
+        switch currentHour {
         case 5..<12:  return "今天才刚开始"
         case 12..<18: return "记录还在继续"
-        case 18..<23: return "夜深了，回顾今天吧"
+        case 18..<24: return "夜深了，回顾今天吧"
         default:      return "为今天画上句号"
         }
     }


### PR DESCRIPTION
## Add a contextual time-of-day hint to the compile button so it nudges evening reflection

Closes #452

The compile button currently shows a static label '编译今日 · N 条' regardless of time. Add a subtle, time-aware secondary line (e.g. '夜深了，回顾今天' in the evening, '记录还在继续' midday) below the button so the prime compile action feels alive and gently encourages end-of-day reflection — the core DayPage ritual. This is a purely additive, visible UX touch with no model or storage changes.

### Acceptance
Build the DayPage scheme succeeds. In Simulator (iPhone 17) with ≥3 memos and no compiled daily page, the compile button shows the '编译今日 · N 条' label with a smaller contextual hint line beneath it that matches the current time bucket. The hint never appears while compiling or when an error banner is shown. VoiceOver still reads the compile button as a single button. No regressions to the existing appear-pulse animation.