### PR TITLE
auto: Localize Graph empty-state strings to fix English-locale i18n gap

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -187,8 +187,8 @@ extension EmptyStateView {
     /// Graph — nodes exist but current search/filter matches nothing.
     static func graphNoMatches() -> EmptyStateView {
         EmptyStateView(
-            title: "无匹配节点",
-            subtitle: "调整搜索或筛选条件以查看节点",
+            title: L10n.Empty.graphNoMatchesTitle,
+            subtitle: L10n.Empty.graphNoMatchesSubtitle,
             showOrbAccent: false
         )
     }
@@ -207,9 +207,9 @@ extension EmptyStateView {
     /// Graph tab — no compiled entities exist yet.
     static func graphEmpty(ctaAction: @escaping () -> Void) -> EmptyStateView {
         EmptyStateView(
-            title: "尚无知识图谱",
-            subtitle: "编译日记后，实体节点将在此出现，写点什么开始构建你的知识网络",
-            ctaLabel: "去写点什么",
+            title: L10n.Empty.graphEmptyTitle,
+            subtitle: L10n.Empty.graphEmptySubtitle,
+            ctaLabel: L10n.Empty.graphEmptyCta,
             ctaAction: ctaAction,
             showOrbAccent: true
         )

--- a/DayPage/Resources/L10n.swift
+++ b/DayPage/Resources/L10n.swift
@@ -41,6 +41,15 @@ enum L10n {
         static let micDeniedTitle    = LocalizedStringKey("empty.mic_denied.title")
         static let micDeniedSubtitle = NSLocalizedString("empty.mic_denied.subtitle", comment: "")
         static let micDeniedCta      = NSLocalizedString("empty.mic_denied.cta", comment: "")
+
+        // Graph Empty
+        static let graphEmptyTitle    = LocalizedStringKey("empty.graph.title")
+        static let graphEmptySubtitle = NSLocalizedString("empty.graph.subtitle", comment: "")
+        static let graphEmptyCta      = NSLocalizedString("empty.graph.cta", comment: "")
+
+        // Graph No Matches
+        static let graphNoMatchesTitle    = LocalizedStringKey("empty.graph.no_matches.title")
+        static let graphNoMatchesSubtitle = NSLocalizedString("empty.graph.no_matches.subtitle", comment: "")
     }
 
     enum Error {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -64,6 +64,15 @@
 "empty.archive_month.subtitle" = "No entries yet — switch to Today to start capturing today's signals.";
 "empty.archive_month.cta" = "Go Capture";
 
+/* Graph Empty */
+"empty.graph.title" = "No knowledge graph yet.";
+"empty.graph.subtitle" = "Compiled entries will surface entity nodes here — write something to start building your network.";
+"empty.graph.cta" = "Write something";
+
+/* Graph No Matches */
+"empty.graph.no_matches.title" = "No matching nodes.";
+"empty.graph.no_matches.subtitle" = "Adjust your search or filters to see nodes.";
+
 /* Mic Permission Denied */
 "empty.mic_denied.title" = "Microphone access needed.";
 "empty.mic_denied.subtitle" = "Allow microphone access in Settings to record voice memos.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -64,6 +64,15 @@
 "empty.archive_month.subtitle" = "还没有记录 — 切回 Today 开始捕捉今天的信号。";
 "empty.archive_month.cta" = "去记录";
 
+/* Graph Empty */
+"empty.graph.title" = "尚无知识图谱。";
+"empty.graph.subtitle" = "编译日记后，实体节点将在此出现，写点什么开始构建你的知识网络。";
+"empty.graph.cta" = "去写点什么";
+
+/* Graph No Matches */
+"empty.graph.no_matches.title" = "无匹配节点。";
+"empty.graph.no_matches.subtitle" = "调整搜索或筛选条件以查看节点。";
+
 /* Mic Permission Denied */
 "empty.mic_denied.title" = "需要麦克风权限。";
 "empty.mic_denied.subtitle" = "请在「设置」中允许访问麦克风，以便录制语音备忘。";


### PR DESCRIPTION
## Localize Graph empty-state strings to fix English-locale i18n gap

Two EmptyStateView factory methods — graphEmpty() and graphNoMatches() — use hardcoded Chinese string literals while every other empty state routes through localized L10n.Empty.* keys. On an English device the Graph tab's 'no knowledge graph yet' and 'no matching nodes' states render untranslated Chinese, breaking the bilingual contract the design spec requires (FR-15: '全部中英双文案'). This replaces the literals with new L10n accessors backed by both Localizable.strings tables.

### Acceptance
xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build succeeds; grep of EmptyStateView.swift shows no remaining Chinese string literals in graphEmpty()/graphNoMatches(); both .strings files contain all five new keys; launching the app with the simulator language set to English shows English copy on the empty Graph tab and the no-search-match state, and Chinese copy when set to 简体中文; the #Preview('Graph Empty') and #Preview('Graph No Matches') still render.