### PR TITLE
auto: Graph empty state: add actionable CTA to navigate to Today

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -30,10 +30,6 @@ struct GraphView: View {
     // Filter state
     @State private var showFilters: Bool = false
 
-    // Empty state animation
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var pulse: Bool = false
-
     private let nodeRadius: CGFloat = 16
     private let maxSimSteps = 200
 
@@ -199,56 +195,12 @@ struct GraphView: View {
 
     @ViewBuilder
     private var emptyState: some View {
-        VStack(spacing: DSSpacing.md) {
-            ZStack {
-                if !reduceMotion {
-                    // Outer ring — staggered by half a cycle
-                    Circle()
-                        .stroke(DSColor.inkFaint.opacity(pulse ? 0 : 0.5), lineWidth: 1)
-                        .frame(width: 96, height: 96)
-                        .scaleEffect(pulse ? 1.15 : 0.85)
-                        .animation(
-                            .easeInOut(duration: 2.4).repeatForever(autoreverses: false).delay(1.2),
-                            value: pulse
-                        )
-
-                    // Inner ring
-                    Circle()
-                        .stroke(DSColor.inkFaint.opacity(pulse ? 0 : 0.5), lineWidth: 1)
-                        .frame(width: 64, height: 64)
-                        .scaleEffect(pulse ? 1.15 : 0.85)
-                        .animation(
-                            .easeInOut(duration: 2.4).repeatForever(autoreverses: false),
-                            value: pulse
-                        )
-                }
-
-                Image(systemName: "point.3.connected.trianglepath.dotted")
-                    .font(.system(size: 48, weight: .thin))
-                    .foregroundColor(DSColor.inkFaint)
-                    .scaleEffect(reduceMotion ? 1 : (pulse ? 1.04 : 0.96))
-                    .opacity(reduceMotion ? 1 : (pulse ? 1 : 0.75))
-                    .animation(
-                        reduceMotion ? nil : .easeInOut(duration: 2.4).repeatForever(autoreverses: true),
-                        value: pulse
-                    )
+        if viewModel.nodes.isEmpty {
+            EmptyStateView.graphEmpty {
+                nav.navigate(to: .today)
             }
-            .onAppear {
-                guard !reduceMotion else { return }
-                pulse = true
-            }
-            .onDisappear {
-                pulse = false
-            }
-
-            Text(viewModel.nodes.isEmpty ? "尚无知识图谱" : "无匹配节点")
-                .font(DSType.h2)
-                .foregroundColor(DSColor.inkMuted)
-            Text(viewModel.nodes.isEmpty ? "编译日记后，实体节点将在此出现" : "调整搜索或筛选条件以查看节点")
-                .bodySMStyle()
-                .foregroundColor(DSColor.inkMuted)
-                .multilineTextAlignment(.center)
-                .padding(.horizontal, DSSpacing.xl4)
+        } else {
+            EmptyStateView.graphNoMatches()
         }
     }
 


### PR DESCRIPTION
## Graph empty state: add actionable CTA to navigate to Today

The Graph tab's empty state tells the user '编译日记后，实体节点将在此出现' but offers no way to act on it — it's a navigational dead end. An EmptyStateView.graphEmpty(ctaAction:) factory with a '去写点什么' CTA button already exists and is preview-covered, but GraphView never wires it up. This change replaces GraphView's bespoke text-only empty state with the shared, animated EmptyStateView component and routes the CTA to the Today tab via AppNavigationModel.

### Acceptance
Build the DayPage scheme cleanly. In Simulator (iPhone 17), open Graph with zero compiled entities: the empty state shows the '尚无知识图谱' title, subtitle, and a tappable '去写点什么' CTA that switches to the Today tab and focuses input. With entities present but a non-matching search query, the 'no matches' state shows without a CTA. VoiceOver reads the title, subtitle, and CTA as a button. reduceMotion disables looping animations. No dead code or unused @State remains from the old empty state.