### PR TITLE
auto: Group EmptyStateView as a single VoiceOver element with a coherent label

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -16,17 +16,20 @@ struct EmptyStateView: View {
 
     var body: some View {
         VStack(spacing: 20) {
-            titleSection
-            if let subtitle {
-                Text(subtitle)
-                    .font(DSType.bodyMD)
-                    .foregroundColor(DSColor.inkMuted)
-                    .multilineTextAlignment(.center)
-                    .padding(.horizontal, 8)
-                    .opacity(appeared ? 1 : 0)
-                    .offset(y: appeared ? 0 : 6)
-                    .animation(Motion.rise.delay(0.06), value: appeared)
+            VStack(spacing: 20) {
+                titleSection
+                if let subtitle {
+                    Text(subtitle)
+                        .font(DSType.bodyMD)
+                        .foregroundColor(DSColor.inkMuted)
+                        .multilineTextAlignment(.center)
+                        .padding(.horizontal, 8)
+                        .opacity(appeared ? 1 : 0)
+                        .offset(y: appeared ? 0 : 6)
+                        .animation(Motion.rise.delay(0.06), value: appeared)
+                }
             }
+            .accessibilityElement(children: .combine)
             if let label = ctaLabel, let action = ctaAction {
                 ctaButton(label: label, action: action)
                     .opacity(appeared ? 1 : 0)
@@ -84,6 +87,7 @@ struct EmptyStateView: View {
                 value: breathing
             )
             .allowsHitTesting(false)
+            .accessibilityHidden(true)
     }
 
     private func ctaButton(label: String, action: @escaping () -> Void) -> some View {


### PR DESCRIPTION
## Group EmptyStateView as a single VoiceOver element with a coherent label

EmptyStateView (used in 7+ places across Today, Archive, and Graph) currently exposes its serif title, subtitle, and decorative orb accent as separate, fragmented accessibility elements — VoiceOver reads them as disconnected swipes and may even focus the purely-decorative orb Circle. This change combines the title+subtitle into one accessibility element with a clear label, hides the decorative orb from VoiceOver, and ensures the CTA button stays a distinct, separately-focusable control.

### Acceptance
Build the DayPage scheme succeeds. With VoiceOver on (iPhone 17 simulator, Today tab with zero memos / Archive empty day), swiping right moves focus from the combined title+subtitle element directly to the CTA button — the orb glow is skipped and the title/subtitle are announced together as a single phrase rather than as separate fragments. All 7 #Preview variants still render visually identically.