### PR TITLE
auto: Group EmptyStateView into a single VoiceOver element with combined label and CTA action

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -35,12 +35,22 @@ struct EmptyStateView: View {
             }
         }
         .padding(.horizontal, 32)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(combinedAccessibilityLabel)
+        .modifier(CTAAccessibilityModifier(ctaLabel: ctaLabel, ctaAction: ctaAction))
         .onAppear {
             appeared = true
             if !reduceMotion {
                 breathing = true
             }
         }
+    }
+
+    private var combinedAccessibilityLabel: Text {
+        if let subtitle {
+            return Text(title) + Text(", \(subtitle)")
+        }
+        return Text(title)
     }
 
     // MARK: - Private
@@ -84,6 +94,7 @@ struct EmptyStateView: View {
                 value: breathing
             )
             .allowsHitTesting(false)
+            .accessibilityHidden(true)
     }
 
     private func ctaButton(label: String, action: @escaping () -> Void) -> some View {
@@ -102,6 +113,27 @@ struct EmptyStateView: View {
                 .clipShape(Capsule())
         }
         .buttonStyle(PressableScaleStyle(reduceMotion: reduceMotion))
+    }
+}
+
+// MARK: - CTAAccessibilityModifier
+
+private struct CTAAccessibilityModifier: ViewModifier {
+    let ctaLabel: String?
+    let ctaAction: (() -> Void)?
+
+    func body(content: Content) -> some View {
+        if let label = ctaLabel, let action = ctaAction {
+            content
+                .accessibilityAddTraits(.isButton)
+                .accessibilityHint(label)
+                .accessibilityAction {
+                    Haptics.tapConfirm()
+                    action()
+                }
+        } else {
+            content
+        }
     }
 }
 


### PR DESCRIPTION
## Group EmptyStateView into a single VoiceOver element with combined label and CTA action

Closes #456

EmptyStateView (used on Today, Archive day/month, Graph, and mic-denied states) currently exposes its serif title, subtitle, decorative orb, and CTA button as separate, fragmented VoiceOver elements, and the animated orbAccent glow is not hidden from assistive tech. This change combines the text into one accessibility element with a clear label (title + subtitle), hides the decorative orb, and surfaces the CTA as a named accessibility action so VoiceOver users hear one coherent announcement instead of disjointed fragments.

### Acceptance
Build the DayPage scheme with `xcodebuild -scheme DayPage build` (success). Launch in iPhone 17 Simulator, enable the Accessibility Inspector / VoiceOver, and focus an empty state (e.g. Today blank or Archive empty month): VoiceOver announces one element reading title + subtitle, the CTA is available as a single activatable action that fires the original action with a tapConfirm haptic, and the decorative orb glow is not focusable. Existing SwiftUI previews still render unchanged.