### PR TITLE
auto: Add 'Clear filters' CTA to Graph's no-matches empty state

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -189,10 +189,12 @@ extension EmptyStateView {
     }
 
     /// Graph — nodes exist but current search/filter matches nothing.
-    static func graphNoMatches() -> EmptyStateView {
+    static func graphNoMatches(ctaAction: @escaping () -> Void) -> EmptyStateView {
         EmptyStateView(
             title: L10n.Empty.graphNoMatchesTitle,
             subtitle: L10n.Empty.graphNoMatchesSubtitle,
+            ctaLabel: "清除筛选",
+            ctaAction: ctaAction,
             showOrbAccent: false
         )
     }
@@ -271,6 +273,6 @@ extension EmptyStateView {
 #Preview("Graph No Matches") {
     ZStack {
         AmbientBackground()
-        EmptyStateView.graphNoMatches()
+        EmptyStateView.graphNoMatches { }
     }
 }

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -200,8 +200,39 @@ struct GraphView: View {
                 nav.navigate(to: .today)
             }
         } else {
-            EmptyStateView.graphNoMatches()
+            EmptyStateView.graphNoMatches {
+                Haptics.tapConfirm()
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    viewModel.searchQuery = ""
+                    viewModel.filterStartDate = nil
+                    viewModel.filterEndDate = nil
+                }
+            }
         }
+    }
+
+    private var clearFiltersButton: some View {
+        Button {
+            Haptics.tapConfirm()
+            withAnimation(.easeInOut(duration: 0.15)) {
+                viewModel.searchQuery = ""
+                viewModel.filterStartDate = nil
+                viewModel.filterEndDate = nil
+            }
+        } label: {
+            Text("清除筛选")
+                .font(DSType.sectionLabel)
+                .textCase(.uppercase)
+                .tracking(1.5)
+                .foregroundColor(Color.white)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 12)
+                .background(DSColor.amberDeep)
+                .clipShape(Capsule())
+        }
+        .buttonStyle(ClearFiltersPressStyle(reduceMotion: reduceMotion))
+        .accessibilityLabel("清除筛选")
+        .accessibilityAddTraits(.isButton)
     }
 
     // MARK: - Accessibility Helpers
@@ -431,5 +462,21 @@ struct GraphView: View {
     private func stopSimulation() {
         simulationTimer?.invalidate()
         simulationTimer = nil
+    }
+}
+
+// MARK: - ClearFiltersPressStyle
+
+private struct ClearFiltersPressStyle: ButtonStyle {
+    let reduceMotion: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect((!reduceMotion && configuration.isPressed) ? 0.96 : 1)
+            .opacity(configuration.isPressed ? 0.92 : 1)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7),
+                value: configuration.isPressed
+            )
     }
 }


### PR DESCRIPTION
## Add 'Clear filters' CTA to Graph's no-matches empty state

When a Graph search or date filter matches no nodes, the app shows a dead-end empty state ('无匹配节点') with no actionable way out — the user must manually find and clear the search field. This adds a one-tap 'Clear filters' CTA to that empty state (matching the existing amber capsule button pattern) and routes it back through GraphViewModel to reset search text and date filter, turning a dead end into a recoverable state.

### Acceptance
Build DayPage scheme succeeds. In Simulator (iPhone 17): open Graph with at least one compiled entity, type a search query that matches nothing → the empty state now shows a '清除筛选' amber capsule button; tapping it clears the search/date filter and the node graph reappears. Reduce Motion users see the static button (no scale). VoiceOver reads the button as a tappable control.