### PR TITLE
auto: Make the Graph legend reflect only entity types present in the current view

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -168,7 +168,9 @@ struct GraphView: View {
                     emptyState
                 } else {
                     graphCanvas
-                    legend
+                    if !presentEntityTypes.isEmpty {
+                        legend
+                    }
                 }
             }
         }
@@ -398,17 +400,31 @@ struct GraphView: View {
 
     // MARK: - Legend
 
+    private var presentEntityTypes: [String] {
+        let present = Set(viewModel.filteredNodes.map { $0.entityType })
+        return ["places", "people", "themes"].filter { present.contains($0) }
+    }
+
+    private func legendColor(for entityType: String) -> Color {
+        switch entityType {
+        case "places":  return DSColor.amberArchival
+        case "people":  return DSColor.secondary
+        default:        return DSColor.tertiary
+        }
+    }
+
     private var legend: some View {
         VStack(alignment: .leading, spacing: 6) {
-            legendRow(color: DSColor.amberDeep, label: "地点")
-            legendRow(color: DSColor.inkMuted, label: "人物")
-            legendRow(color: DSColor.amberAccent, label: "主题")
+            ForEach(presentEntityTypes, id: \.self) { entityType in
+                legendRow(color: legendColor(for: entityType), label: typeLabel(entityType))
+            }
         }
         .padding(DSSpacing.md)
         .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
         .fixedSize()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomLeading)
         .padding(DSSpacing.lg)
+        .animation(Motion.fade, value: presentEntityTypes)
     }
 
     private func resetTransform() {


### PR DESCRIPTION
## Make the Graph legend reflect only entity types present in the current view

The knowledge-graph legend statically lists all three entity types (地点/人物/主题) even when the filtered graph contains nodes of only one or two types — showing colors that correspond to nothing on screen. This change derives the legend rows from the entity types actually present in viewModel.filteredNodes, so the legend always matches what the user sees (including after search/date filtering), and hides entirely when no recognized types are present.

### Acceptance
Build the DayPage scheme for iPhone 17 with no warnings. In Simulator: (1) a graph containing only place nodes shows a legend with a single 地点 row; (2) typing a search query that matches only people nodes updates the legend to show only 人物; (3) the legend colors exactly match the rendered node colors; (4) when filteredNodes is empty the existing emptyState shows and no legend appears. Existing zoom/pan/recenter behavior is unchanged.