### PR TITLE
auto: Make the Graph legend tap-to-filter by entity type

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -190,7 +190,10 @@ struct GraphView: View {
     }
 
     private var hasActiveFilter: Bool {
-        viewModel.filterStartDate != nil || viewModel.filterEndDate != nil || !viewModel.searchQuery.isEmpty
+        viewModel.filterStartDate != nil
+            || viewModel.filterEndDate != nil
+            || !viewModel.searchQuery.isEmpty
+            || viewModel.enabledTypes.count < 3
     }
 
     private var isTransformed: Bool { scale != 1.0 || offset != .zero }
@@ -400,9 +403,9 @@ struct GraphView: View {
 
     private var legend: some View {
         VStack(alignment: .leading, spacing: 6) {
-            legendRow(color: DSColor.amberDeep, label: "地点")
-            legendRow(color: DSColor.inkMuted, label: "人物")
-            legendRow(color: DSColor.amberAccent, label: "主题")
+            legendRow(color: DSColor.amberDeep,   label: "地点", type: "places")
+            legendRow(color: DSColor.inkMuted,    label: "人物", type: "people")
+            legendRow(color: DSColor.amberAccent, label: "主题", type: "themes")
         }
         .padding(DSSpacing.md)
         .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
@@ -437,15 +440,34 @@ struct GraphView: View {
         .animation(Motion.spring, value: isTransformed)
     }
 
-    private func legendRow(color: Color, label: String) -> some View {
-        HStack(spacing: 6) {
-            Circle()
-                .fill(color)
-                .frame(width: 10, height: 10)
-            Text(label)
-                .font(DSFonts.jetBrainsMono(size: 10))
-                .foregroundColor(DSColor.inkPrimary)
+    private func legendRow(color: Color, label: String, type: String) -> some View {
+        let enabled = viewModel.enabledTypes.contains(type)
+        return Button {
+            Haptics.soft()
+            withAnimation(Motion.fade) {
+                viewModel.toggleType(type)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                if enabled {
+                    Circle()
+                        .fill(color)
+                        .frame(width: 10, height: 10)
+                } else {
+                    Circle()
+                        .strokeBorder(color, lineWidth: 1.5)
+                        .frame(width: 10, height: 10)
+                }
+                Text(label)
+                    .font(DSFonts.jetBrainsMono(size: 10))
+                    .foregroundColor(DSColor.inkPrimary)
+            }
+            .opacity(enabled ? 1.0 : 0.35)
         }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+        .accessibilityValue(enabled ? "启用" : "已隐藏")
+        .accessibilityAddTraits(.isButton)
     }
 
     // MARK: - Helpers

--- a/DayPage/Features/Graph/GraphViewModel.swift
+++ b/DayPage/Features/Graph/GraphViewModel.swift
@@ -51,8 +51,19 @@ final class GraphViewModel: ObservableObject {
     @Published var searchQuery: String = ""
     @Published var filterStartDate: Date? = nil
     @Published var filterEndDate: Date? = nil
+    @Published var enabledTypes: Set<String> = ["places", "people", "themes"]
 
-    /// Nodes after applying search and date filters.
+    /// Flips the type's membership. Re-enables all when the last one would be removed.
+    func toggleType(_ type: String) {
+        if enabledTypes.contains(type) {
+            let next = enabledTypes.subtracting([type])
+            enabledTypes = next.isEmpty ? ["places", "people", "themes"] : next
+        } else {
+            enabledTypes.insert(type)
+        }
+    }
+
+    /// Nodes after applying search, date, and entity-type filters.
     var filteredNodes: [GraphNode] {
         nodes.filter { node in
             let matchesSearch = searchQuery.isEmpty
@@ -70,7 +81,7 @@ final class GraphViewModel: ObservableObject {
                 }
                 return true
             }()
-            return matchesSearch && matchesDate
+            return matchesSearch && matchesDate && enabledTypes.contains(node.entityType)
         }
     }
 


### PR DESCRIPTION
## Make the Graph legend tap-to-filter by entity type

The knowledge-graph legend (地点/人物/主题) is currently a static color key that does nothing when tapped. This adds tap-to-toggle filtering so users can isolate one or more entity types — tapping '地点' fades out everyone but places, with the active rows showing a filled state and a haptic on toggle. It reuses the existing filteredNodes pipeline so search and date filters compose cleanly.

### Acceptance
Build the DayPage scheme on iPhone 17 succeeds. With a compiled vault, the Graph legend renders three tappable rows; tapping '人物' fades all people nodes (and their now-dangling edges) to the dimmed alpha while places/themes stay full opacity, and the legend row visibly switches to a hollow circle at reduced opacity. Tapping it again restores. Tapping all three off auto-re-enables all. The filter icon turns amber while any type is hidden. VoiceOver announces each row as a button with its enabled/hidden state, and reduceMotion users see the change without animation.