### PR TITLE
auto: Fix competing breathing animations on the Today hero Day Orb

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -73,7 +73,6 @@ struct TodayView: View {
     @State private var exportFileURL: URL? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var orbBreathing: Bool = false
 
     /// Hint offset for the one-time swipe-left nudge on the Daily Page card.
     @State private var dailyPageHintOffset: CGFloat = 0
@@ -691,23 +690,9 @@ struct TodayView: View {
                 Haptics.tapConfirm()
                 orbFocusToggle.toggle()
             }
-            .scaleEffect(reduceMotion ? 1.0 : (orbBreathing ? 1.03 : 0.985))
-            .shadow(
-                color: DSColor.accentAmber.opacity(orbBreathing ? 0.28 : 0.12),
-                radius: orbBreathing ? 22 : 12
-            )
-            .animation(
-                reduceMotion ? nil : .easeInOut(duration: 3.0).repeatForever(autoreverses: true),
-                value: orbBreathing
-            )
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
-        .onAppear {
-            if !reduceMotion {
-                orbBreathing = true
-            }
-        }
     }
 
     /// Issue #309 W2: top action bar shown while in multi-select mode.


### PR DESCRIPTION
## Fix competing breathing animations on the Today hero Day Orb

The orbHero in TodayView wraps DayOrbView in an external breathing scaleEffect (3.0s, ×0.985–1.03) and an extra amber pulsing shadow, but DayOrbView already owns an internal breathing animation (4.0s, ×1.0–1.035) plus a two-layer drop shadow. The two scale animations run at different periods and amplitudes, producing a visible beating/jitter, and the duplicate shadow muddies the orb's edge. Removing the redundant wrapper lets the purpose-built component own its motion and shadow.

### Acceptance
Build the DayPage scheme cleanly. Launch on iPhone 17 simulator with zero memos so the orbHero is visible: the orb breathes at a single steady rhythm with no double-beat/jitter and a single clean amber halo (no doubled shadow). Tapping the orb still fires the confirm haptic and focuses the composer. With Reduce Motion enabled, the orb is static. No remaining references to orbBreathing in TodayView.