### PR TITLE
auto: Announce search result counts to VoiceOver in SearchView

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -213,6 +213,18 @@ struct SearchView: View {
         vm.hasSearched = !trimmed.isEmpty || filters.isActive
         if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
         if hits.isEmpty { didBuzzEmpty = false }
+        if vm.hasSearched {
+            announceResultCount(hits.count, query: trimmed, filtersActive: filters.isActive)
+        }
+    }
+
+    private func announceResultCount(_ count: Int, query: String, filtersActive: Bool) {
+        guard UIAccessibility.isVoiceOverRunning else { return }
+        guard !query.isEmpty || filtersActive else { return }
+        let message = count == 0 ? "未找到匹配结果" : "找到 \(count) 条结果"
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+            UIAccessibility.post(notification: .announcement, argument: message)
+        }
     }
 
     // MARK: - Search Bar


### PR DESCRIPTION
## Announce search result counts to VoiceOver in SearchView

SearchView debounces queries and shows a visible "N 条结果" header, but VoiceOver users get no spoken feedback when the result set changes — an accessibility gap (only CompileFooterButton posts announcements today). Post a UIAccessibility announcement on each search completion (e.g. "找到 12 条结果" / "未找到匹配结果") so non-sighted users know the search landed and how many hits there are.

### Acceptance
With VoiceOver on (iPhone 17 sim, Settings → Accessibility), typing a query that returns hits speaks "找到 N 条结果" after the 200ms debounce; a query with no matches speaks "未找到匹配结果"; clearing the query speaks nothing. With VoiceOver off, behavior is unchanged (no announcements, no extra work). DayPage scheme builds clean and existing tests pass.