### PR TITLE
auto: Add press-down scale & haptic feedback to the primary Compile button

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -77,6 +77,7 @@ struct CompileFooterButton: View {
             // Main compile button
             Button(action: {
                 guard !isCompiling else { return }
+                Haptics.tapConfirm()
                 onTap()
             }) {
                 HStack(spacing: 8) {
@@ -112,7 +113,7 @@ struct CompileFooterButton: View {
                 )
                 .surfaceElevatedShadow()
             }
-            .buttonStyle(.plain)
+            .buttonStyle(CompilePressStyle(isDisabled: isCompiling))
             .disabled(isCompiling)
             .scaleEffect(didAppearPulse ? 1.06 : 1.0)
             .animation(
@@ -162,6 +163,24 @@ struct CompileFooterButton: View {
         case .formatting:  return "写入 Daily Page…"
         case .done:        return "准备编译 \(memoCount) 条 memo"
         }
+    }
+}
+
+// MARK: - CompilePressStyle
+
+private struct CompilePressStyle: ButtonStyle {
+    let isDisabled: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func makeBody(configuration: Configuration) -> some View {
+        let pressed = configuration.isPressed && !isDisabled
+        configuration.label
+            .scaleEffect((!reduceMotion && pressed) ? 0.96 : 1)
+            .opacity(pressed ? 0.92 : 1)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7),
+                value: configuration.isPressed
+            )
     }
 }
 


### PR DESCRIPTION
## Add press-down scale & haptic feedback to the primary Compile button

The app's most important CTA — the 'compile today' button in CompileFooterButton — uses .buttonStyle(.plain) with no press-down response, while every other primary CTA (EmptyStateView) gives tactile scale feedback via PressableScaleStyle. This adds a reduce-motion-aware press-scale and a confirm haptic on tap so the primary action feels responsive and consistent with the rest of the app.

### Acceptance
Build the DayPage scheme (xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'). In the iPhone 17 simulator with >=3 memos, pressing the '编译今日 · N 条' button visibly scales it down ~4% and fires a confirm haptic; releasing springs it back. With Reduce Motion enabled the scale is suppressed (no animation) but the action still works. The button shows no press response while compiling (disabled), and the existing appear-pulse and shadow behavior is unchanged.