### PR TITLE
auto: Live time + signal-aware glow on the empty-state Day Orb hero

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -687,14 +687,15 @@ struct TodayView: View {
                 .textCase(.uppercase)
                 .tracking(1.0)
 
+            let glowBoost = min(Double(viewModel.signalCount), 5) * 0.04
             DayOrbView(signalCount: viewModel.signalCount, size: 140) {
                 Haptics.tapConfirm()
                 orbFocusToggle.toggle()
             }
             .scaleEffect(reduceMotion ? 1.0 : (orbBreathing ? 1.03 : 0.985))
             .shadow(
-                color: DSColor.accentAmber.opacity(orbBreathing ? 0.28 : 0.12),
-                radius: orbBreathing ? 22 : 12
+                color: DSColor.accentAmber.opacity(orbBreathing ? 0.28 + glowBoost : 0.12 + glowBoost),
+                radius: orbBreathing ? 22 + glowBoost * 40 : 12
             )
             .animation(
                 reduceMotion ? nil : .easeInOut(duration: 3.0).repeatForever(autoreverses: true),
@@ -781,7 +782,9 @@ struct TodayView: View {
         f.timeZone = TimeZone.current
         let count = viewModel.signalCount
         let plural = count == 1 ? "SIGNAL" : "SIGNALS"
-        return "\(f.string(from: date).uppercased()) · \(count) \(plural)"
+        let dateStr = f.string(from: date).uppercased()
+        let timeStr = Self.headerTimeFmt.string(from: date)
+        return "\(dateStr) · \(timeStr) · \(count) \(plural)"
     }
 
     // MARK: - InputBarV4 (variant D: Silent Press-to-Talk)


### PR DESCRIPTION
## Live time + signal-aware glow on the empty-state Day Orb hero

When Today has no memos, the orb hero shows a static 'D MMM · 0 SIGNALS' kicker and a fixed-intensity breathing glow, while the collapsed header (shown once memos exist) carries a live HH:mm clock. This adds a live minute-ticking time to the orb kicker for visual consistency, and scales the orb's amber glow intensity with the live signal count so the hero visibly 'warms up' as the day fills — making the empty screen feel alive and rewarding the first capture.

### Acceptance
Build the DayPage scheme clean (xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'). On a zero-memo Today screen in the iPhone 17 simulator: the orb kicker shows the current HH:mm and advances when the minute rolls over (matching the header clock format). Adding signals (or seeding signalCount) visibly increases the orb's amber glow radius/opacity. With Reduce Motion enabled, the orb does not breathe but the glow still reflects signal count and the time still ticks. No regressions to the existing tap-to-focus haptic or the orb-hide-on-first-memo transition.