### PR TITLE
auto: Add haptics, selection animation & accessibility to Archive month-summary filter chips

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -915,7 +915,10 @@ struct ArchiveView: View {
                 } else {
                     VStack(spacing: 6) {
                         ForEach(filtered, id: \.dateString) { stats in
-                            Button(action: { handleDateTap(dateStr: stats.dateString) }) {
+                            Button(action: {
+                                Haptics.tapConfirm()
+                                handleDateTap(dateStr: stats.dateString)
+                            }) {
                                 HStack {
                                     Text(formatArchiveDate(stats.dateString))
                                         .monoLabelStyle(size: 11)
@@ -937,6 +940,8 @@ struct ArchiveView: View {
                                 .liquidGlassCard(cornerRadius: 10)
                             }
                             .buttonStyle(.plain)
+                            .accessibilityLabel(formatArchiveDate(stats.dateString))
+                            .accessibilityHint("Opens this day's entry")
                         }
                     }
                 }
@@ -980,15 +985,21 @@ struct ArchiveView: View {
 
     private func filterChip(_ filter: MonthlySummaryFilter) -> some View {
         let isSelected = summaryFilter == filter
-        return Button(action: { summaryFilter = filter }) {
+        return Button(action: {
+            Haptics.soft()
+            withAnimation(Motion.spring) { summaryFilter = filter }
+        }) {
             Text(filter.rawValue)
                 .monoLabelStyle(size: 10)
                 .foregroundColor(isSelected ? Color.white : DSColor.inkSubtle)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
                 .background(isSelected ? DSColor.amberDeep : DSColor.glassLo, in: Capsule())
+                .animation(Motion.spring, value: isSelected)
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(filter.rawValue)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 
     private func exportMarkdown() {


### PR DESCRIPTION
## Add haptics, selection animation & accessibility to Archive month-summary filter chips

The Archive monthly-summary filter chips and filtered date-list rows tap silently with no haptic feedback, no spring on selection, and no accessibility labels — inconsistent with the rest of the app, where Today's interactions are heavily haptic-instrumented (Haptics.soft/tapConfirm) and labeled. This adds a light selection haptic and an eased selection transition to the chips, a soft tap haptic to the filtered date rows, and VoiceOver labels/traits so the filter is announced as a selectable control.

### Acceptance
Build DayPage scheme succeeds on iPhone 17 simulator. Tapping a filter chip in the Archive monthly summary plays a light haptic and the amber fill animates in with a spring instead of snapping; tapping a filtered date row plays a confirm haptic before navigating. VoiceOver announces each chip with its label and a selected/unselected state, and each date row reads its formatted date with the 'Opens this day's entry' hint. No regression to existing chip filtering or date navigation behavior.