### PR TITLE
auto: Live match-count pill in Graph search field

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -30,6 +30,8 @@ struct GraphView: View {
     // Filter state
     @State private var showFilters: Bool = false
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     private let nodeRadius: CGFloat = 16
     private let maxSimSteps = 200
 
@@ -74,6 +76,11 @@ struct GraphView: View {
                     )
                     .clipShape(RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous))
 
+                    // Match count pill — visible when filter is active and nodes matched
+                    if hasActiveFilter && !viewModel.filteredNodes.isEmpty {
+                        matchCountPill
+                    }
+
                     // Filter toggle — amber when active
                     Button {
                         withAnimation(.easeInOut) { showFilters.toggle() }
@@ -86,6 +93,8 @@ struct GraphView: View {
                     }
                     .accessibilityLabel(showFilters ? "Hide filters" : "Show filters")
                 }
+                .animation(Motion.fade, value: hasActiveFilter)
+                .animation(Motion.fade, value: viewModel.filteredNodes.count)
                 .padding(.horizontal, DSSpacing.lg)
                 .padding(.vertical, DSSpacing.sm)
 
@@ -187,6 +196,22 @@ struct GraphView: View {
 
     private var hasActiveFilter: Bool {
         viewModel.filterStartDate != nil || viewModel.filterEndDate != nil || !viewModel.searchQuery.isEmpty
+    }
+
+    private var matchCountPill: some View {
+        let count = viewModel.filteredNodes.count
+        return Text("\(count) 个节点")
+            .font(DSType.mono10)
+            .foregroundColor(DSColor.amberAccent)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(DSColor.amberAccent.opacity(0.12))
+            .background(.ultraThinMaterial, in: Capsule())
+            .overlay(Capsule().strokeBorder(DSColor.amberAccent.opacity(0.3), lineWidth: 0.5))
+            .clipShape(Capsule())
+            .transition(.opacity)
+            .animation(Motion.fade, value: count)
+            .accessibilityLabel("\(count) 个节点匹配")
     }
 
     private var isTransformed: Bool { scale != 1.0 || offset != .zero }


### PR DESCRIPTION
## Live match-count pill in Graph search field

When searching or filtering the knowledge graph, the canvas re-lays out silently with no indication of how many nodes matched — the user must visually scan the graph or hit the empty state to know. Add a compact mono-styled count pill (e.g. "7 个节点") inside the search bar that appears whenever a search query or date filter is active, giving immediate quantitative feedback as the user types.

### Acceptance
Build the DayPage scheme and launch on iPhone 17 simulator. Open Graph with ≥2 entities. Typing a query that matches some nodes shows a pill with the correct live count that updates per keystroke; clearing the query hides the pill; a query matching zero nodes shows the existing 'no matches' empty state (no pill); VoiceOver reads the match count. No layout shift or clipping in the header at default and accessibility text sizes.