### PR TITLE
auto: Live result-count badge in the Search bar

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -248,6 +248,23 @@ struct SearchView: View {
                     }
                     .buttonStyle(.plain)
                 }
+
+                if vm.hasSearched && !vm.query.isEmpty {
+                    Text("\(vm.results.count)")
+                        .monoLabelStyle(size: 10)
+                        .foregroundColor(vm.results.isEmpty ? DSColor.onSurfaceVariant : DSColor.amberAccent)
+                        .contentTransition(.numericText())
+                        .animation(reduceMotion ? nil : Motion.fade, value: vm.results.count)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(
+                            Capsule()
+                                .fill(DSColor.surfaceContainer)
+                                .overlay(Capsule().stroke(DSColor.outlineVariant, lineWidth: 0.5))
+                        )
+                        .accessibilityLabel("\(vm.results.count) 条结果")
+                        .accessibilityHidden(false)
+                }
             }
             .padding(.horizontal, 12)
             .frame(height: 36)


### PR DESCRIPTION
## Live result-count badge in the Search bar

While typing in Archive → Search, hit feedback only appears once the grouped result list renders below the fold. Add a compact animated mono-label badge (e.g. "7") inside the search bar's trailing edge that updates live with the 200ms-debounced results, giving instant glanceable feedback before scrolling — turning amber when there are hits, muted at zero.

### Acceptance
Build the DayPage scheme (xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'). In the Simulator open Archive → Search and type a query: a count badge appears inside the search bar, updates within ~200ms of each keystroke, animates the number change, shows amber for ≥1 hits and muted gray at 0, and disappears when the field is cleared. VoiceOver reads "N 条结果". With Reduce Motion enabled the number updates without animation. Existing search, filters, highlight, and grouped-list behavior are unchanged.