### PR TITLE
fix: address Claude Code review findings from PR #441 and #443

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -30,6 +30,11 @@ struct GraphView: View {
     // Filter state
     @State private var showFilters: Bool = false
 
+    // Empty state animation + ClearFiltersPressStyle (do not remove this @Environment:
+    // both `emptyState` and `clearFiltersButton` read `reduceMotion`; deleting it
+    // breaks the build — see incident around PR #466).
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var pulse: Bool = false
     private let nodeRadius: CGFloat = 16
     private let maxSimSteps = 200
 

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -709,7 +709,16 @@ struct VoiceMemoPlayerRow: View {
             retryCount = UserDefaults.standard.integer(forKey: retryKey)
         }
         .onChange(of: transcript) { newValue in
-            if newValue != nil { isRetranscribing = false }
+            // When transcription succeeds, also clear the persisted retry counter
+            // so future failures start over from attempt #1. Previously this
+            // handler only reset `isRetranscribing`, which left retryCount frozen
+            // at 3 and the card permanently stuck at "Transcription unavailable"
+            // even when transcription had actually succeeded.
+            if newValue != nil {
+                isRetranscribing = false
+                retryCount = 0
+                UserDefaults.standard.removeObject(forKey: retryKey)
+            }
         }
         .onDisappear { stopPlayback() }
     }

--- a/DayPageTests/EntitySlugDedupTests.swift
+++ b/DayPageTests/EntitySlugDedupTests.swift
@@ -1,71 +1,82 @@
-import XCTest
+import Testing
+import Foundation
 @testable import DayPage
 
 /// US-025: Entity slug dedup + fuzzy matching.
-final class EntitySlugDedupTests: XCTestCase {
+///
+/// Serialized because tests mutate global `VaultInitializer.testOverrideURL`
+/// and exercise `EntityPageService.shared` (singleton).
+@Suite("EntitySlugDedupTests", .serialized)
+struct EntitySlugDedupTests {
 
-    private var tempDir: URL!
+    private let tempDir: URL
     private let fm = FileManager.default
     private var service: EntityPageService { EntityPageService.shared }
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    init() throws {
         tempDir = fm.temporaryDirectory
             .appendingPathComponent("EntitySlugTests-\(UUID().uuidString)", isDirectory: true)
         try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
         VaultInitializer.testOverrideURL = tempDir
     }
 
-    override func tearDownWithError() throws {
+    private func cleanup() {
         VaultInitializer.testOverrideURL = nil
         try? fm.removeItem(at: tempDir)
-        tempDir = nil
-        try super.tearDownWithError()
     }
 
     // MARK: - sanitizeSlug
 
-    func testSanitizeSlug_lowercasesAndHyphenates() {
-        XCTAssertEqual(EntityPageService.sanitizeSlug("Coffee Shop"), "coffee-shop")
+    @Test func sanitizeSlug_lowercasesAndHyphenates() {
+        defer { cleanup() }
+        #expect(EntityPageService.sanitizeSlug("Coffee Shop") == "coffee-shop")
     }
 
-    func testSanitizeSlug_stripsCamelCase() {
-        XCTAssertEqual(EntityPageService.sanitizeSlug("CoffeeShop"), "coffeeshop")
+    @Test func sanitizeSlug_stripsCamelCase() {
+        defer { cleanup() }
+        #expect(EntityPageService.sanitizeSlug("CoffeeShop") == "coffeeshop")
     }
 
-    func testSanitizeSlug_trimsLeadingTrailingWhitespace() {
-        XCTAssertEqual(EntityPageService.sanitizeSlug("  Bangkok  "), "bangkok")
+    @Test func sanitizeSlug_trimsLeadingTrailingWhitespace() {
+        defer { cleanup() }
+        #expect(EntityPageService.sanitizeSlug("  Bangkok  ") == "bangkok")
     }
 
-    func testSanitizeSlug_collapsesMultipleSpaces() {
-        XCTAssertEqual(EntityPageService.sanitizeSlug("Joma  Coffee"), "joma-coffee")
+    @Test func sanitizeSlug_collapsesMultipleSpaces() {
+        defer { cleanup() }
+        #expect(EntityPageService.sanitizeSlug("Joma  Coffee") == "joma-coffee")
     }
 
     // MARK: - isFuzzyMatch: hyphen-stripped equality
 
-    func testFuzzyMatch_hyphenStripped_coffeeShopVariants() {
+    @Test func fuzzyMatch_hyphenStripped_coffeeShopVariants() {
+        defer { cleanup() }
         // "coffee-shop" and "coffeeshop" differ only by a hyphen
-        XCTAssertTrue(service.isFuzzyMatch("coffee-shop", "coffeeshop"))
-        XCTAssertTrue(service.isFuzzyMatch("coffeeshop", "coffee-shop"))
+        #expect(service.isFuzzyMatch("coffee-shop", "coffeeshop"))
+        #expect(service.isFuzzyMatch("coffeeshop", "coffee-shop"))
     }
 
-    func testFuzzyMatch_hyphenStripped_multiHyphen() {
-        XCTAssertTrue(service.isFuzzyMatch("new-york-city", "newyorkcity"))
+    @Test func fuzzyMatch_hyphenStripped_multiHyphen() {
+        defer { cleanup() }
+        #expect(service.isFuzzyMatch("new-york-city", "newyorkcity"))
     }
 
-    func testFuzzyMatch_editDistance_smallDiff() {
+    @Test func fuzzyMatch_editDistance_smallDiff() {
+        defer { cleanup() }
         // "joma-coffe" vs "joma-coffee" — edit distance 1
-        XCTAssertTrue(service.isFuzzyMatch("joma-coffe", "joma-coffee"))
+        #expect(service.isFuzzyMatch("joma-coffe", "joma-coffee"))
     }
 
-    func testFuzzyMatch_sharedPrefix() {
+    @Test func fuzzyMatch_sharedPrefix() {
+        defer { cleanup() }
         // share 6-char prefix "bangko"
-        XCTAssertTrue(service.isFuzzyMatch("bangkokx", "bangkoky"))
+        #expect(service.isFuzzyMatch("bangkokx", "bangkoky"))
     }
 
-    func testFuzzyMatch_dissimilarSlugs_returnsFalse() {
-        XCTAssertFalse(service.isFuzzyMatch("alice", "bangkok"))
-        XCTAssertFalse(service.isFuzzyMatch("coffee-shop", "tea-house"))
+    @Test func fuzzyMatch_dissimilarSlugs_returnsFalse() {
+        defer { cleanup() }
+        #expect(!service.isFuzzyMatch("alice", "bangkok"))
+        #expect(!service.isFuzzyMatch("coffee-shop", "tea-house"))
     }
 
     // MARK: - resolveSlug: dedup via apply()
@@ -96,7 +107,8 @@ final class EntitySlugDedupTests: XCTestCase {
     }
 
     /// "coffee shop" (with space) should map to existing "coffee-shop" slug.
-    func testApply_dedupsSpacedVariant() throws {
+    @Test func apply_dedupsSpacedVariant() throws {
+        defer { cleanup() }
         try seedEntity(type: "places", slug: "coffee-shop")
 
         let instruction = EntityUpdateInstruction(
@@ -113,11 +125,13 @@ final class EntitySlugDedupTests: XCTestCase {
         let dir = tempDir.appendingPathComponent("wiki/places")
         let files = try fm.contentsOfDirectory(atPath: dir.path)
             .filter { $0.hasSuffix(".md") }
-        XCTAssertEqual(files, ["coffee-shop.md"], "Dedup should reuse existing coffee-shop.md, not create a new file")
+        #expect(files == ["coffee-shop.md"],
+                "Dedup should reuse existing coffee-shop.md, not create a new file")
     }
 
     /// "CoffeeShop" (camelCase) → sanitize → "coffeeshop" → fuzzy matches existing "coffee-shop".
-    func testApply_dedupsCamelCaseVariant() throws {
+    @Test func apply_dedupsCamelCaseVariant() throws {
+        defer { cleanup() }
         try seedEntity(type: "places", slug: "coffee-shop")
 
         let instruction = EntityUpdateInstruction(
@@ -133,13 +147,14 @@ final class EntitySlugDedupTests: XCTestCase {
         let dir = tempDir.appendingPathComponent("wiki/places")
         let files = try fm.contentsOfDirectory(atPath: dir.path)
             .filter { $0.hasSuffix(".md") }
-        XCTAssertEqual(files, ["coffee-shop.md"],
-                       "CoffeeShop should fuzzy-merge into existing coffee-shop.md")
+        #expect(files == ["coffee-shop.md"],
+                "CoffeeShop should fuzzy-merge into existing coffee-shop.md")
     }
 
     /// Two distinct slugs must NOT be merged.
-    func testApply_distinctEntitiesCreatedSeparately() throws {
-        try makeWikiDir(type: "places")
+    @Test func apply_distinctEntitiesCreatedSeparately() throws {
+        defer { cleanup() }
+        _ = try makeWikiDir(type: "places")
 
         let i1 = EntityUpdateInstruction(
             entityType: "places",
@@ -162,7 +177,7 @@ final class EntitySlugDedupTests: XCTestCase {
         let files = try fm.contentsOfDirectory(atPath: dir.path)
             .filter { $0.hasSuffix(".md") }
             .sorted()
-        XCTAssertEqual(files, ["alice.md", "bangkok.md"],
-                       "Distinct entities must not be merged")
+        #expect(files == ["alice.md", "bangkok.md"],
+                "Distinct entities must not be merged")
     }
 }

--- a/DayPageTests/PhotoServiceBackgroundTests.swift
+++ b/DayPageTests/PhotoServiceBackgroundTests.swift
@@ -1,30 +1,34 @@
-import XCTest
+import Testing
+import Foundation
+import UIKit
 @testable import DayPage
 
 /// US-018: HEIC batch photo conversion must not block the main thread.
-final class PhotoServiceBackgroundTests: XCTestCase {
+///
+/// Serialized because the test mutates global `VaultInitializer.testOverrideURL`.
+@Suite("PhotoServiceBackgroundTests", .serialized)
+struct PhotoServiceBackgroundTests {
 
-    private var tempDir: URL!
+    private let tempDir: URL
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    init() throws {
         tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("PhotoServiceTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
         VaultInitializer.testOverrideURL = tempDir
     }
 
-    override func tearDownWithError() throws {
+    private func cleanup() {
         VaultInitializer.testOverrideURL = nil
         try? FileManager.default.removeItem(at: tempDir)
-        tempDir = nil
-        try super.tearDownWithError()
     }
 
     /// Verifies that `processImageDataAsync` returns without blocking the main thread.
     /// We supply a minimal 1×1 JPEG so the codec path executes, then assert the
     /// result arrives and the main thread was never used for the CPU-heavy work.
-    func testProcessImageDataAsync_runsOffMainThread() async {
+    @Test func processImageDataAsync_runsOffMainThread() async {
+        defer { cleanup() }
+
         // Create a minimal 1×1 solid JPEG in memory.
         let jpegData = makeMinimalJPEG()
 
@@ -37,8 +41,8 @@ final class PhotoServiceBackgroundTests: XCTestCase {
             backgroundThreadConfirmed = !Thread.isMainThread
         }.value
 
-        XCTAssertTrue(backgroundThreadConfirmed,
-                      "HEIC/JPEG conversion must run on a non-main thread")
+        #expect(backgroundThreadConfirmed,
+                "HEIC/JPEG conversion must run on a non-main thread")
 
         // Also confirm the async API itself completes without hanging.
         let service = await PhotoService.shared

--- a/DayPageTests/TodayViewModelTests.swift
+++ b/DayPageTests/TodayViewModelTests.swift
@@ -1,4 +1,5 @@
-import XCTest
+import Testing
+import Foundation
 @testable import DayPage
 
 /// US-020: Unit tests for TodayViewModel core paths: addMemo, deleteMemo, toggleFavorite (pin/unpin).
@@ -6,14 +7,17 @@ import XCTest
 /// TodayViewModel reads/writes via RawStorage which uses VaultInitializer.testOverrideURL.
 /// Tests run synchronously by directly mutating `memos` and calling the view model methods,
 /// bypassing the async submission path that requires live services (Location, Weather).
+///
+/// Serialized + @MainActor because TodayViewModel is @MainActor-isolated and tests
+/// share the global `VaultInitializer.testOverrideURL`.
 @MainActor
-final class TodayViewModelTests: XCTestCase {
+@Suite("TodayViewModelTests", .serialized)
+struct TodayViewModelTests {
 
-    private var tempDir: URL!
-    private var vm: TodayViewModel!
+    private let tempDir: URL
+    private let vm: TodayViewModel
 
-    override func setUp() async throws {
-        try await super.setUp()
+    init() throws {
         tempDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("TodayVMTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
@@ -21,27 +25,27 @@ final class TodayViewModelTests: XCTestCase {
         vm = TodayViewModel(date: Date())
     }
 
-    override func tearDown() async throws {
+    private func cleanup() {
         VaultInitializer.testOverrideURL = nil
         try? FileManager.default.removeItem(at: tempDir)
-        vm = nil
-        try await super.tearDown()
     }
 
     // MARK: - addMemo (via RawStorage.append + in-memory insert)
 
-    func testAddMemo_insertsIntoMemosArray() throws {
+    @Test func addMemo_insertsIntoMemosArray() throws {
+        defer { cleanup() }
         let memo = makeMemo(body: "test memo body")
         try RawStorage.append(memo)
         // Simulate the in-memory update that submitCombinedMemo performs
         vm.memos.insert(memo, at: 0)
 
-        XCTAssertEqual(vm.memos.count, 1)
-        XCTAssertEqual(vm.memos.first?.id, memo.id)
-        XCTAssertEqual(vm.memos.first?.body, "test memo body")
+        #expect(vm.memos.count == 1)
+        #expect(vm.memos.first?.id == memo.id)
+        #expect(vm.memos.first?.body == "test memo body")
     }
 
-    func testAddMemo_multipleMemosOrderedNewestFirst() throws {
+    @Test func addMemo_multipleMemosOrderedNewestFirst() throws {
+        defer { cleanup() }
         let older = makeMemo(body: "older", created: Date(timeIntervalSinceNow: -120))
         let newer = makeMemo(body: "newer", created: Date(timeIntervalSinceNow: -60))
         try RawStorage.append(older)
@@ -50,13 +54,14 @@ final class TodayViewModelTests: XCTestCase {
         // Simulate load sort (newest first)
         vm.memos = [newer, older]
 
-        XCTAssertEqual(vm.memos.first?.body, "newer")
-        XCTAssertEqual(vm.memos.last?.body, "older")
+        #expect(vm.memos.first?.body == "newer")
+        #expect(vm.memos.last?.body == "older")
     }
 
     // MARK: - deleteMemo
 
-    func testDeleteMemo_removesMemoFromMemosArray() throws {
+    @Test func deleteMemo_removesMemoFromMemosArray() throws {
+        defer { cleanup() }
         let m1 = makeMemo(body: "keep me")
         let m2 = makeMemo(body: "delete me")
         try RawStorage.append(m1)
@@ -65,46 +70,50 @@ final class TodayViewModelTests: XCTestCase {
 
         vm.deleteMemo(m2)
 
-        XCTAssertEqual(vm.memos.count, 1)
-        XCTAssertEqual(vm.memos.first?.id, m1.id)
+        #expect(vm.memos.count == 1)
+        #expect(vm.memos.first?.id == m1.id)
     }
 
-    func testDeleteMemo_setsLastDeletedMemo() throws {
+    @Test func deleteMemo_setsLastDeletedMemo() throws {
+        defer { cleanup() }
         let memo = makeMemo(body: "will be deleted")
         vm.memos = [memo]
 
         vm.deleteMemo(memo)
 
-        XCTAssertEqual(vm.lastDeletedMemo?.id, memo.id)
+        #expect(vm.lastDeletedMemo?.id == memo.id)
     }
 
-    func testUndoDelete_restoresMemo() throws {
+    @Test func undoDelete_restoresMemo() throws {
+        defer { cleanup() }
         let memo = makeMemo(body: "restore me")
         vm.memos = [memo]
 
         vm.deleteMemo(memo)
-        XCTAssertEqual(vm.memos.count, 0)
+        #expect(vm.memos.count == 0)
 
         vm.undoDelete()
-        XCTAssertEqual(vm.memos.count, 1)
-        XCTAssertEqual(vm.memos.first?.id, memo.id)
-        XCTAssertNil(vm.lastDeletedMemo)
+        #expect(vm.memos.count == 1)
+        #expect(vm.memos.first?.id == memo.id)
+        #expect(vm.lastDeletedMemo == nil)
     }
 
     // MARK: - toggleFavorite (pin / unpin)
 
-    func testPinMemo_setsPinnedAtAndMovesToTop() throws {
+    @Test func pinMemo_setsPinnedAtAndMovesToTop() throws {
+        defer { cleanup() }
         let m1 = makeMemo(body: "first", created: Date(timeIntervalSinceNow: -60))
         let m2 = makeMemo(body: "second", created: Date())
         vm.memos = [m2, m1] // newest first
 
         vm.pinMemo(m1)
 
-        XCTAssertNotNil(vm.memos.first?.pinnedAt, "Pinned memo must have pinnedAt set")
-        XCTAssertEqual(vm.memos.first?.id, m1.id, "Pinned memo must move to top")
+        #expect(vm.memos.first?.pinnedAt != nil, "Pinned memo must have pinnedAt set")
+        #expect(vm.memos.first?.id == m1.id, "Pinned memo must move to top")
     }
 
-    func testUnpinMemo_clearsPinnedAtAndResortsByCreated() throws {
+    @Test func unpinMemo_clearsPinnedAtAndResortsByCreated() throws {
+        defer { cleanup() }
         var pinned = makeMemo(body: "pinned", created: Date(timeIntervalSinceNow: -60))
         pinned.pinnedAt = Date()
         let normal = makeMemo(body: "normal", created: Date())
@@ -112,27 +121,29 @@ final class TodayViewModelTests: XCTestCase {
 
         vm.unpinMemo(pinned)
 
-        XCTAssertNil(vm.memos.first(where: { $0.id == pinned.id })?.pinnedAt,
-                     "Unpinned memo must have nil pinnedAt")
+        #expect(vm.memos.first(where: { $0.id == pinned.id })?.pinnedAt == nil,
+                "Unpinned memo must have nil pinnedAt")
         // After unpin, normal (newer) should be first
-        XCTAssertEqual(vm.memos.first?.id, normal.id)
+        #expect(vm.memos.first?.id == normal.id)
     }
 
-    func testPinMemo_onlyOneMemoInList() throws {
+    @Test func pinMemo_onlyOneMemoInList() throws {
+        defer { cleanup() }
         let memo = makeMemo(body: "solo")
         vm.memos = [memo]
 
         vm.pinMemo(memo)
 
-        XCTAssertEqual(vm.memos.count, 1)
-        XCTAssertNotNil(vm.memos.first?.pinnedAt)
+        #expect(vm.memos.count == 1)
+        #expect(vm.memos.first?.pinnedAt != nil)
     }
 
     // MARK: - signalCount
 
-    func testSignalCount_matchesMemoCount() {
+    @Test func signalCount_matchesMemoCount() {
+        defer { cleanup() }
         vm.memos = [makeMemo(body: "a"), makeMemo(body: "b"), makeMemo(body: "c")]
-        XCTAssertEqual(vm.signalCount, 3)
+        #expect(vm.signalCount == 3)
     }
 
     // MARK: - Helpers

--- a/DayPageTests/TrashTTLTests.swift
+++ b/DayPageTests/TrashTTLTests.swift
@@ -1,28 +1,36 @@
-import XCTest
+import Testing
+import Foundation
 @testable import DayPage
 
 /// US-023: Trash TTL — files older than 7 days are deleted; recent files survive.
-final class TrashTTLTests: XCTestCase {
+///
+/// Serialized because all tests in this suite mutate the global
+/// `VaultInitializer.testOverrideURL` — running them in parallel would let
+/// one test's vault leak into another.
+@Suite("TrashTTLTests", .serialized)
+struct TrashTTLTests {
 
-    private var tempDir: URL!
+    private let tempDir: URL
     private let fm = FileManager.default
 
-    override func setUpWithError() throws {
-        try super.setUpWithError()
+    init() throws {
         tempDir = fm.temporaryDirectory
             .appendingPathComponent("TrashTTLTests-\(UUID().uuidString)", isDirectory: true)
         try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
         VaultInitializer.testOverrideURL = tempDir
     }
 
-    override func tearDownWithError() throws {
+    // Swift Testing has no per-test tearDown; the suite is value-typed, so each
+    // test gets a fresh init(). We still need to reset the global after the
+    // test finishes — see the `defer` in each @Test below.
+    private func cleanup() {
         VaultInitializer.testOverrideURL = nil
         try? fm.removeItem(at: tempDir)
-        tempDir = nil
-        try super.tearDownWithError()
     }
 
-    func testPruneTrash_deletesOldFiles() throws {
+    @Test func pruneTrash_deletesOldFiles() throws {
+        defer { cleanup() }
+
         let trashDir = tempDir
             .appendingPathComponent("wiki/daily/.trash", isDirectory: true)
         try fm.createDirectory(at: trashDir, withIntermediateDirectories: true)
@@ -38,15 +46,17 @@ final class TrashTTLTests: XCTestCase {
             ofItemAtPath: staleFile.path
         )
 
-        XCTAssertTrue(fm.fileExists(atPath: staleFile.path), "Stale file must exist before pruning")
+        #expect(fm.fileExists(atPath: staleFile.path), "Stale file must exist before pruning")
 
         RawStorage.pruneTrashOlderThan(days: 7)
 
-        XCTAssertFalse(fm.fileExists(atPath: staleFile.path),
-                       "Stale file (8 days old) must be deleted by pruneTrashOlderThan(days: 7)")
+        #expect(!fm.fileExists(atPath: staleFile.path),
+                "Stale file (8 days old) must be deleted by pruneTrashOlderThan(days: 7)")
     }
 
-    func testPruneTrash_preservesRecentFiles() throws {
+    @Test func pruneTrash_preservesRecentFiles() throws {
+        defer { cleanup() }
+
         let trashDir = tempDir
             .appendingPathComponent("wiki/daily/.trash", isDirectory: true)
         try fm.createDirectory(at: trashDir, withIntermediateDirectories: true)
@@ -63,12 +73,16 @@ final class TrashTTLTests: XCTestCase {
 
         RawStorage.pruneTrashOlderThan(days: 7)
 
-        XCTAssertTrue(fm.fileExists(atPath: freshFile.path),
-                      "Recent file (3 days old) must NOT be deleted by pruneTrashOlderThan(days: 7)")
+        #expect(fm.fileExists(atPath: freshFile.path),
+                "Recent file (3 days old) must NOT be deleted by pruneTrashOlderThan(days: 7)")
     }
 
-    func testPruneTrash_missingDirectoryIsNoop() {
-        // Vault has no .trash dir at all — must not crash.
-        XCTAssertNoThrow(RawStorage.pruneTrashOlderThan(days: 7))
+    @Test func pruneTrash_missingDirectoryIsNoop() {
+        defer { cleanup() }
+        // Vault has no .trash dir at all — must not crash. #expect(throws:) does
+        // the same job as XCTAssertNoThrow.
+        #expect(throws: Never.self) {
+            RawStorage.pruneTrashOlderThan(days: 7)
+        }
     }
 }

--- a/packages/mcp-server/src/db.ts
+++ b/packages/mcp-server/src/db.ts
@@ -1,6 +1,18 @@
 /**
  * DB client for MCP server — reuses web's schema, reads DATABASE_URL from env.
  * The MCP server is run as a separate process, so it gets its own connection pool.
+ *
+ * KNOWN ISSUE (tracked from PR #443 review, ARCH-11):
+ * The MCP server SHOULD authenticate with a Personal Access Token and call the
+ * DayPage REST API instead of opening a direct Postgres connection here. Direct
+ * DB access widens the attack surface: any compromise of the MCP server process
+ * exposes the entire database, including api_keys.key_hash and ingest_sources
+ * secrets. Migrating to HTTP+PAT requires:
+ *   1. Adding REST endpoints for the read paths used by tools/{search,crud}.ts
+ *      (pages by slug, recent memos, page_links neighbours, annotations).
+ *   2. Reusing POST /api/ingest (PAT, scope `write`) for add_memo.
+ *   3. Removing db.ts and auth.ts's direct query.
+ * Deferred to a separate PR because it touches every tool's data layer.
  */
 
 import postgres from "postgres";

--- a/packages/mcp-server/src/index.ts
+++ b/packages/mcp-server/src/index.ts
@@ -12,8 +12,6 @@ import { handleRequest } from "./server.js";
 
 const rl = createInterface({ input: process.stdin, terminal: false });
 
-const chunks: string[] = [];
-
 rl.on("line", (line) => {
   const trimmed = line.trim();
   if (trimmed === "") return;
@@ -55,5 +53,3 @@ rl.on("close", () => {
 // Keep alive — MCP servers run as persistent processes
 process.on("SIGTERM", () => process.exit(0));
 process.on("SIGINT", () => process.exit(0));
-
-void chunks; // suppress unused warning

--- a/packages/mcp-server/src/tools/index.ts
+++ b/packages/mcp-server/src/tools/index.ts
@@ -1,13 +1,9 @@
-import type { McpToolDefinition, McpToolResult } from "../types.js";
+import type { McpToolResult, ToolHandler } from "../types.js";
 import searchTool from "./search.js";
 import { getPageTool, addMemoTool, listRecentTool, graphNeighborsTool } from "./crud.js";
 
-export interface ToolHandler {
-  name: string;
-  description: string;
-  inputSchema: McpToolDefinition["inputSchema"];
-  handler: (args: Record<string, unknown>) => Promise<McpToolResult>;
-}
+// Re-export so existing callers using `from "./tools/index.js"` keep working.
+export type { ToolHandler } from "../types.js";
 
 export const ALL_TOOLS: ToolHandler[] = [
   searchTool,

--- a/packages/mcp-server/src/types.ts
+++ b/packages/mcp-server/src/types.ts
@@ -26,3 +26,13 @@ export interface McpToolResult {
   content: Array<{ type: "text"; text: string }>;
   isError?: boolean;
 }
+
+// A concrete tool implementation. Lives in types.ts (not tools/index.ts) so that
+// tool modules can import it from the shared types barrel without creating a
+// circular dependency with tools/index.ts.
+export interface ToolHandler {
+  name: string;
+  description: string;
+  inputSchema: McpToolDefinition["inputSchema"];
+  handler: (args: Record<string, unknown>) => Promise<McpToolResult>;
+}

--- a/web/scripts/ios-bulk-sync.sh
+++ b/web/scripts/ios-bulk-sync.sh
@@ -73,9 +73,12 @@ for i in $(seq 0 $((TOTAL - 1))); do
   BODY=$(echo "$MEMO" | jq -r '.body // ""')
   IKEY=$(echo "$MEMO" | jq -r '.idempotency_key // ""')
 
-  # Auto-derive idempotency_key from body hash if not provided
+  # Auto-derive idempotency_key from body hash if not provided.
+  # Use python3 for portability — md5sum is GNU coreutils and absent on macOS.
+  # (matches the approach used in claude-code-hook.sh)
   if [[ -z "$IKEY" ]]; then
-    IKEY="ios_bulk_sync:$(echo "$BODY" | md5sum | cut -d' ' -f1):$i"
+    HASH=$(printf '%s' "$BODY" | python3 -c 'import sys,hashlib; sys.stdout.write(hashlib.md5(sys.stdin.buffer.read()).hexdigest())')
+    IKEY="ios_bulk_sync:${HASH}:$i"
   fi
 
   PAYLOAD=$(jq -n \

--- a/web/src/app/(app)/memos/[id]/page.tsx
+++ b/web/src/app/(app)/memos/[id]/page.tsx
@@ -1,10 +1,22 @@
 import { auth } from "@/auth";
 import { db } from "@/lib/db/client";
 import { memos, users, page_sources, pages, annotations } from "@/lib/db/schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, inArray } from "drizzle-orm";
 import { notFound } from "next/navigation";
 import Link from "next/link";
 import { MemoActions } from "./MemoActions";
+
+// Defense in depth: even though /api/ingest now rejects non-http(s) source_url,
+// pre-existing rows could contain `javascript:` URIs. Guard the href render.
+function safeHref(url: string | null | undefined): string | null {
+  if (!url) return null;
+  try {
+    const u = new URL(url);
+    return u.protocol === "http:" || u.protocol === "https:" ? url : null;
+  } catch {
+    return null;
+  }
+}
 
 type Props = { params: Promise<{ id: string }> };
 
@@ -42,18 +54,35 @@ export default async function MemoDetailPage({ params }: Props) {
   const memo = memoRows[0];
   if (!memo) notFound();
 
-  const [linkedPages, memoAnnotations] = await Promise.all([
-    db
-      .select({ page_id: page_sources.page_id, page_title: pages.title, page_slug: pages.slug, page_type: pages.type })
-      .from(page_sources)
-      .innerJoin(pages, eq(page_sources.page_id, pages.id))
-      .where(eq(page_sources.memo_id, id)),
-    db
-      .select()
-      .from(annotations)
-      .where(and(eq(annotations.user_id, userId)))
-      .limit(20),
-  ]);
+  // Annotations attach to pages (via page_id), not memos. To scope them to
+  // this memo, first find the pages it sourced, then load annotations on
+  // those pages only. Previously the query filtered solely by user_id and
+  // would surface unrelated annotations from any other page the user owned.
+  const linkedPages = await db
+    .select({
+      page_id: page_sources.page_id,
+      page_title: pages.title,
+      page_slug: pages.slug,
+      page_type: pages.type,
+    })
+    .from(page_sources)
+    .innerJoin(pages, eq(page_sources.page_id, pages.id))
+    .where(eq(page_sources.memo_id, id));
+
+  const linkedPageIds = linkedPages.map((p) => p.page_id);
+  const memoAnnotations =
+    linkedPageIds.length > 0
+      ? await db
+          .select()
+          .from(annotations)
+          .where(
+            and(
+              eq(annotations.user_id, userId),
+              inArray(annotations.page_id, linkedPageIds)
+            )
+          )
+          .limit(20)
+      : [];
 
   const statusColor: Record<string, string> = {
     pending: "var(--fg-subtle)",
@@ -103,14 +132,23 @@ export default async function MemoDetailPage({ params }: Props) {
 
       {/* Metadata */}
       <div style={{ display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(200px, 1fr))", gap: 12, marginBottom: 24 }}>
-        {memo.source_url && (
-          <div style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 8, padding: "10px 14px" }}>
-            <div style={{ fontSize: "0.7rem", color: "var(--fg-subtle)", textTransform: "uppercase", fontWeight: 600, marginBottom: 4 }}>Source URL</div>
-            <a href={memo.source_url} target="_blank" rel="noopener noreferrer" style={{ fontSize: "0.8125rem", color: "var(--accent)", wordBreak: "break-all" }}>
-              {memo.source_url}
-            </a>
-          </div>
-        )}
+        {memo.source_url && (() => {
+          const safe = safeHref(memo.source_url);
+          return (
+            <div style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 8, padding: "10px 14px" }}>
+              <div style={{ fontSize: "0.7rem", color: "var(--fg-subtle)", textTransform: "uppercase", fontWeight: 600, marginBottom: 4 }}>Source URL</div>
+              {safe ? (
+                <a href={safe} target="_blank" rel="noopener noreferrer" style={{ fontSize: "0.8125rem", color: "var(--accent)", wordBreak: "break-all" }}>
+                  {memo.source_url}
+                </a>
+              ) : (
+                <span style={{ fontSize: "0.8125rem", color: "var(--fg-subtle)", wordBreak: "break-all" }} title="Blocked: non-http(s) URL">
+                  {memo.source_url}
+                </span>
+              )}
+            </div>
+          );
+        })()}
         {memo.device && (
           <div style={{ background: "var(--surface)", border: "1px solid var(--border)", borderRadius: 8, padding: "10px 14px" }}>
             <div style={{ fontSize: "0.7rem", color: "var(--fg-subtle)", textTransform: "uppercase", fontWeight: 600, marginBottom: 4 }}>Device</div>

--- a/web/src/app/api/compile/route.ts
+++ b/web/src/app/api/compile/route.ts
@@ -5,7 +5,7 @@ import { users, memos, pages } from "@/lib/db/schema";
 import { eq, and, gte, lt, inArray, sql } from "drizzle-orm";
 import { z } from "zod";
 import { sendEvent } from "@/lib/inngest/client";
-import { authenticateApiKey } from "@/lib/api-auth";
+import { authenticateApiKey, hasScope } from "@/lib/api-auth";
 
 // NOTE: iOS BackgroundCompilationService.swift is deprecated in favour of this endpoint.
 // The iOS client should call POST /api/compile instead of running its own BGAppRefreshTask
@@ -13,6 +13,10 @@ import { authenticateApiKey } from "@/lib/api-auth";
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+function forbidden(message: string) {
+  return NextResponse.json({ error: message }, { status: 403 });
 }
 
 function badRequest(message: string) {
@@ -43,6 +47,10 @@ export async function POST(req: NextRequest) {
 
   const apiAuth = await authenticateApiKey(req);
   if (apiAuth) {
+    // /api/compile mutates memos.compile_status — require the "write" scope.
+    if (!hasScope(apiAuth, "write")) {
+      return forbidden("API key lacks 'write' scope");
+    }
     userId = apiAuth.userId;
   } else {
     const session = await auth();

--- a/web/src/app/api/ingest-sources/[id]/route.ts
+++ b/web/src/app/api/ingest-sources/[id]/route.ts
@@ -4,6 +4,7 @@ import { db } from "@/lib/db/client";
 import { users, ingest_sources } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { z } from "zod";
+import { encryptConfig, redactConfigForClient } from "@/lib/secret-crypto";
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -52,7 +53,7 @@ export async function GET(
     .limit(1);
 
   if (!rows[0]) return notFound();
-  return NextResponse.json(rows[0]);
+  return NextResponse.json({ ...rows[0], config: redactConfigForClient(rows[0].config) });
 }
 
 // PATCH /api/ingest-sources/[id]
@@ -81,14 +82,20 @@ export async function PATCH(
     return badRequest("No fields to update");
   }
 
+  // Encrypt config on update too — never let secrets land in the table as plaintext.
+  const dbUpdates: typeof updates = { ...updates };
+  if (updates.config !== undefined) {
+    dbUpdates.config = encryptConfig(updates.config);
+  }
+
   const rows = await db
     .update(ingest_sources)
-    .set(updates)
+    .set(dbUpdates)
     .where(and(eq(ingest_sources.id, id), eq(ingest_sources.user_id, userId)))
     .returning();
 
   if (!rows[0]) return notFound();
-  return NextResponse.json(rows[0]);
+  return NextResponse.json({ ...rows[0], config: redactConfigForClient(rows[0].config) });
 }
 
 // DELETE /api/ingest-sources/[id]

--- a/web/src/app/api/ingest-sources/route.ts
+++ b/web/src/app/api/ingest-sources/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { db } from "@/lib/db/client";
 import { users, ingest_sources } from "@/lib/db/schema";
-import { eq, and, desc } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 import { z } from "zod";
+import { encryptConfig, redactConfigForClient } from "@/lib/secret-crypto";
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -43,7 +44,10 @@ export async function GET(_req: NextRequest) {
     .where(eq(ingest_sources.user_id, userId))
     .orderBy(desc(ingest_sources.created_at));
 
-  return NextResponse.json(rows);
+  // Strip the encrypted envelope; the client never needs the ciphertext.
+  return NextResponse.json(
+    rows.map((r) => ({ ...r, config: redactConfigForClient(r.config) }))
+  );
 }
 
 // POST /api/ingest-sources — create a new ingest source
@@ -69,10 +73,15 @@ export async function POST(req: NextRequest) {
       user_id: userId,
       name: input.name,
       source_type: input.source_type,
-      config: input.config,
+      // Encrypt the entire config blob — it may carry bot tokens, webhook
+      // secrets, feed URLs with private API keys, etc.
+      config: encryptConfig(input.config),
       enabled: input.enabled,
     })
     .returning();
 
-  return NextResponse.json(source, { status: 201 });
+  return NextResponse.json(
+    { ...source, config: redactConfigForClient(source.config) },
+    { status: 201 }
+  );
 }

--- a/web/src/app/api/ingest/email/route.ts
+++ b/web/src/app/api/ingest/email/route.ts
@@ -2,11 +2,15 @@ import { NextRequest, NextResponse } from "next/server";
 import { db } from "@/lib/db/client";
 import { memos, activities } from "@/lib/db/schema";
 import { z } from "zod";
-import { authenticateApiKey } from "@/lib/api-auth";
+import { authenticateApiKey, hasScope } from "@/lib/api-auth";
 import { sendEvent } from "@/lib/inngest/client";
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+function forbidden(message: string) {
+  return NextResponse.json({ error: message }, { status: 403 });
 }
 
 function badRequest(message: string) {
@@ -33,6 +37,10 @@ const EmailIngestSchema = z.object({
 export async function POST(req: NextRequest) {
   const apiAuth = await authenticateApiKey(req);
   if (!apiAuth) return unauthorized();
+  // Email ingest is write-only — require the "write" scope.
+  if (!hasScope(apiAuth, "write")) {
+    return forbidden("API key lacks 'write' scope");
+  }
 
   const userId = apiAuth.userId;
 

--- a/web/src/app/api/ingest/route.ts
+++ b/web/src/app/api/ingest/route.ts
@@ -4,15 +4,31 @@ import { db } from "@/lib/db/client";
 import { users, memos, inbox_items, activities } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { z } from "zod";
-import { authenticateApiKey } from "@/lib/api-auth";
+import { authenticateApiKey, hasScope } from "@/lib/api-auth";
 import { sendEvent } from "@/lib/inngest/client";
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 }
 
+function forbidden(message: string) {
+  return NextResponse.json({ error: message }, { status: 403 });
+}
+
 function badRequest(message: string) {
   return NextResponse.json({ error: message }, { status: 400 });
+}
+
+// z.string().url() accepts javascript:/data: URIs, which become stored XSS when
+// rendered as <a href>. Only allow http(s) for user-supplied source URLs.
+function sanitizeSourceUrl(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  try {
+    const u = new URL(value);
+    return u.protocol === "http:" || u.protocol === "https:" ? value : null;
+  } catch {
+    return null;
+  }
 }
 
 async function resolveUserId(email: string): Promise<string | null> {
@@ -53,6 +69,10 @@ export async function POST(req: NextRequest) {
 
   const apiAuth = await authenticateApiKey(req);
   if (apiAuth) {
+    // /api/ingest only performs writes — require the "write" scope.
+    if (!hasScope(apiAuth, "write")) {
+      return forbidden("API key lacks 'write' scope");
+    }
     userId = apiAuth.userId;
   } else {
     const session = await auth();
@@ -82,7 +102,7 @@ export async function POST(req: NextRequest) {
         type: "text",
         body: memoBody,
         origin: "api",
-        source_url: typeof payload.source_url === "string" ? payload.source_url : null,
+        source_url: sanitizeSourceUrl(payload.source_url),
         device: source,
       })
       .returning();

--- a/web/src/app/api/ingest/telegram/webhook/route.ts
+++ b/web/src/app/api/ingest/telegram/webhook/route.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db/client";
 import { memos, activities, ingest_sources } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { sendEvent } from "@/lib/inngest/client";
+import { decryptConfig } from "@/lib/secret-crypto";
 
 // Telegram Update object (partial — only fields we use)
 interface TelegramMessage {
@@ -27,14 +28,19 @@ async function logActivity(userId: string, verb: string, subject: string, target
 
 // POST /api/ingest/telegram/webhook
 export async function POST(req: NextRequest) {
-  // Verify secret token sent by Telegram
+  // Verify secret token sent by Telegram. Fail closed: if the server is not
+  // configured with a secret, reject all requests rather than accepting any
+  // unauthenticated POST (which would let anyone who knows a chat_id inject memos).
   const secretToken = process.env.TELEGRAM_WEBHOOK_SECRET;
-  if (secretToken) {
-    const provided = req.headers.get("X-Telegram-Bot-Api-Secret-Token");
-    if (provided !== secretToken) {
-      // Return 200 to avoid Telegram retrying; just ignore
-      return NextResponse.json({ ok: true });
-    }
+  if (!secretToken) {
+    return NextResponse.json(
+      { error: "Webhook not configured" },
+      { status: 503 }
+    );
+  }
+  const provided = req.headers.get("X-Telegram-Bot-Api-Secret-Token");
+  if (provided !== secretToken) {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }
 
   let update: TelegramUpdate;
@@ -56,7 +62,9 @@ export async function POST(req: NextRequest) {
     .where(and(eq(ingest_sources.source_type, "telegram"), eq(ingest_sources.enabled, true)));
 
   const matchingSource = sources.find((s) => {
-    const cfg = s.config as Record<string, unknown>;
+    // config may be encrypted (envelope) or legacy plaintext — decryptConfig
+    // handles both transparently.
+    const cfg = decryptConfig(s.config);
     return String(cfg.chat_id) === chatId;
   });
 

--- a/web/src/app/api/upload/route.ts
+++ b/web/src/app/api/upload/route.ts
@@ -7,6 +7,10 @@ import { writeFile, mkdir } from "fs/promises";
 import { join, extname } from "path";
 import { randomUUID } from "crypto";
 
+// fs/promises is Node-only; force the Node.js runtime so Next.js does not
+// attempt to compile this handler for the Edge runtime (would fail on `fs`).
+export const runtime = "nodejs";
+
 const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
 
 const ALLOWED_MIME_PREFIXES = [

--- a/web/src/lib/api-auth.ts
+++ b/web/src/lib/api-auth.ts
@@ -44,3 +44,8 @@ export async function authenticateApiKey(
 
   return { userId: key.user_id, scopes };
 }
+
+// A key with "admin" implicitly grants every scope.
+export function hasScope(auth: ApiAuthResult, scope: string): boolean {
+  return auth.scopes.includes("admin") || auth.scopes.includes(scope);
+}

--- a/web/src/lib/auth-ratelimit.ts
+++ b/web/src/lib/auth-ratelimit.ts
@@ -1,0 +1,100 @@
+// Rate limiter for /api/auth — separate from the per-user mutation limiter in
+// ratelimit.ts. Keyed by client IP. Uses the Upstash Redis REST API directly
+// when configured (works in any Next.js runtime); falls back to an in-memory
+// sliding window for local dev.
+//
+// The previous in-memory-only implementation lived in middleware.ts and was
+// a no-op in production because Next.js Middleware runs in the Edge runtime
+// where module state is not shared across requests.
+
+const AUTH_LIMIT = 10;
+const AUTH_WINDOW_SEC = 60;
+
+// ── In-memory fallback (dev only) ────────────────────────────────────────────
+
+interface MemWindow {
+  count: number;
+  reset: number; // epoch ms
+}
+const memStore = new Map<string, MemWindow>();
+
+function inMemoryCheck(key: string): {
+  success: boolean;
+  remaining: number;
+  reset: number;
+} {
+  const now = Date.now();
+  const windowMs = AUTH_WINDOW_SEC * 1000;
+  const existing = memStore.get(key);
+  if (!existing || now > existing.reset) {
+    const reset = now + windowMs;
+    memStore.set(key, { count: 1, reset });
+    return { success: true, remaining: AUTH_LIMIT - 1, reset };
+  }
+  if (existing.count >= AUTH_LIMIT) {
+    return { success: false, remaining: 0, reset: existing.reset };
+  }
+  existing.count += 1;
+  return {
+    success: true,
+    remaining: AUTH_LIMIT - existing.count,
+    reset: existing.reset,
+  };
+}
+
+// ── Upstash REST ─────────────────────────────────────────────────────────────
+
+interface UpstashPipelineResult {
+  result: number | string | null;
+}
+
+async function upstashCheck(
+  url: string,
+  token: string,
+  key: string
+): Promise<{ success: boolean; remaining: number; reset: number } | null> {
+  // INCR the counter, set TTL only on the first hit (NX), then read the
+  // remaining TTL. One round-trip via the REST pipeline endpoint.
+  const body = JSON.stringify([
+    ["INCR", `daypage:auth:${key}`],
+    ["EXPIRE", `daypage:auth:${key}`, String(AUTH_WINDOW_SEC), "NX"],
+    ["PTTL", `daypage:auth:${key}`],
+  ]);
+  try {
+    const res = await fetch(`${url}/pipeline`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${token}`,
+        "Content-Type": "application/json",
+      },
+      body,
+    });
+    if (!res.ok) return null;
+    const parsed = (await res.json()) as UpstashPipelineResult[];
+    const count = Number(parsed[0]?.result ?? 0);
+    const ttlMs = Number(parsed[2]?.result ?? AUTH_WINDOW_SEC * 1000);
+    const now = Date.now();
+    const reset = now + (ttlMs > 0 ? ttlMs : AUTH_WINDOW_SEC * 1000);
+    if (count > AUTH_LIMIT) {
+      return { success: false, remaining: 0, reset };
+    }
+    return { success: true, remaining: Math.max(0, AUTH_LIMIT - count), reset };
+  } catch {
+    return null;
+  }
+}
+
+export async function checkAuthRateLimit(
+  ip: string
+): Promise<{ success: boolean; remaining: number; reset: number; limit: number }> {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+  if (url && token) {
+    const r = await upstashCheck(url, token, ip);
+    if (r) return { ...r, limit: AUTH_LIMIT };
+  }
+  return { ...inMemoryCheck(ip), limit: AUTH_LIMIT };
+}
+
+export const AUTH_RATE_LIMIT = AUTH_LIMIT;
+export const AUTH_RATE_WINDOW_SEC = AUTH_WINDOW_SEC;

--- a/web/src/lib/inngest/functions/fetch-rss.ts
+++ b/web/src/lib/inngest/functions/fetch-rss.ts
@@ -3,6 +3,7 @@ import { db } from "@/lib/db/client";
 import { ingest_sources, memos } from "@/lib/db/schema";
 import { eq, and } from "drizzle-orm";
 import { sendEvent } from "@/lib/inngest/client";
+import { decryptConfig } from "@/lib/secret-crypto";
 
 // Lightweight RSS/Atom item parser — no external XML library required.
 // Extracts <item> or <entry> blocks, then pulls title, link, and description.
@@ -96,7 +97,9 @@ export const fetchRss = inngest.createFunction(
     let totalCreated = 0;
 
     for (const source of sources) {
-      const config = source.config as Record<string, unknown>;
+      // config may be encrypted (envelope) or legacy plaintext — decryptConfig
+      // handles both transparently.
+      const config = decryptConfig(source.config);
       const feedUrl = typeof config.url === "string" ? config.url : null;
       if (!feedUrl) continue;
 

--- a/web/src/lib/secret-crypto.ts
+++ b/web/src/lib/secret-crypto.ts
@@ -1,0 +1,90 @@
+// Symmetric encryption for ingest_sources.config (and similar secret-bearing
+// jsonb fields). AES-256-GCM with a key derived from INGEST_CONFIG_SECRET.
+//
+// Storage shape on disk (jsonb): { "_encrypted": "enc:v1:<base64(iv|tag|ct)>" }
+// — keeps the column type as jsonb while making it obvious the row is opaque.
+// Plaintext rows that pre-date this change are still readable: decryptConfig
+// returns them unchanged when the envelope marker is absent.
+
+import { createCipheriv, createDecipheriv, randomBytes, createHash } from "crypto";
+
+const ALGO = "aes-256-gcm";
+const IV_LEN = 12;
+const TAG_LEN = 16;
+const PREFIX = "enc:v1:";
+const ENVELOPE_KEY = "_encrypted";
+
+function getKey(): Buffer {
+  const raw = process.env.INGEST_CONFIG_SECRET;
+  if (!raw) {
+    throw new Error(
+      "INGEST_CONFIG_SECRET is not set — required to encrypt/decrypt ingest_sources.config"
+    );
+  }
+  // Accept any length; hash to 32 bytes so misconfigured short secrets still
+  // produce a usable key. Operators SHOULD provide a strong random secret.
+  return createHash("sha256").update(raw).digest();
+}
+
+function encryptString(plaintext: string): string {
+  const key = getKey();
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, "utf8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return PREFIX + Buffer.concat([iv, tag, ct]).toString("base64");
+}
+
+function decryptString(token: string): string {
+  if (!token.startsWith(PREFIX)) {
+    throw new Error("Not an encrypted envelope");
+  }
+  const buf = Buffer.from(token.slice(PREFIX.length), "base64");
+  if (buf.length <= IV_LEN + TAG_LEN) {
+    throw new Error("Ciphertext too short");
+  }
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+  const ct = buf.subarray(IV_LEN + TAG_LEN);
+  const key = getKey();
+  const decipher = createDecipheriv(ALGO, key, iv);
+  decipher.setAuthTag(tag);
+  const pt = Buffer.concat([decipher.update(ct), decipher.final()]);
+  return pt.toString("utf8");
+}
+
+export type ConfigObject = Record<string, unknown>;
+
+export function encryptConfig(config: ConfigObject): ConfigObject {
+  const json = JSON.stringify(config ?? {});
+  return { [ENVELOPE_KEY]: encryptString(json) };
+}
+
+export function decryptConfig(raw: unknown): ConfigObject {
+  if (!raw || typeof raw !== "object") return {};
+  const obj = raw as Record<string, unknown>;
+  const envelope = obj[ENVELOPE_KEY];
+  if (typeof envelope === "string" && envelope.startsWith(PREFIX)) {
+    try {
+      return JSON.parse(decryptString(envelope)) as ConfigObject;
+    } catch {
+      // Corrupted ciphertext — surface as empty rather than leaking
+      // partial data; logging is the caller's responsibility.
+      return {};
+    }
+  }
+  // Legacy plaintext row, or env not set when stored — return as-is.
+  return obj;
+}
+
+// Redact the encrypted envelope before returning a source row to the client.
+// Callers should use this whenever they expose a row over the API.
+export function redactConfigForClient(raw: unknown): ConfigObject {
+  if (!raw || typeof raw !== "object") return {};
+  const obj = raw as Record<string, unknown>;
+  if (typeof obj[ENVELOPE_KEY] === "string") {
+    // Don't ship the ciphertext; tell the client this row has stored secrets.
+    return { _encrypted: true };
+  }
+  return obj;
+}

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,29 +1,13 @@
 import { NextRequest, NextResponse } from "next/server";
+import { checkAuthRateLimit } from "@/lib/auth-ratelimit";
 
-// ── In-memory auth rate limiter (no Redis dependency in Edge middleware) ───────
-
-interface RateWindow {
-  count: number;
-  reset: number;
-}
-
-const authRateStore = new Map<string, RateWindow>();
-const AUTH_LIMIT = 10;
-const AUTH_WINDOW_MS = 60_000;
-
-function checkAuthRateLimit(ip: string): boolean {
-  const now = Date.now();
-  const existing = authRateStore.get(ip);
-
-  if (!existing || now > existing.reset) {
-    authRateStore.set(ip, { count: 1, reset: now + AUTH_WINDOW_MS });
-    return true;
-  }
-
-  if (existing.count >= AUTH_LIMIT) return false;
-  existing.count += 1;
-  return true;
-}
+// NOTE: Next.js Middleware runs in the Edge runtime by default. Module-level
+// state (Map, counters, etc.) is NOT shared across requests there — a cold
+// start resets it. The previous implementation kept the counter in a
+// module-level Map and was a no-op in production. The auth rate limiter has
+// been moved to lib/auth-ratelimit.ts, which uses Upstash Redis via the REST
+// API (works in any runtime) and only falls back to in-memory in local dev
+// when UPSTASH_REDIS_REST_* env vars are unset.
 
 function getClientIp(req: NextRequest): string {
   return (
@@ -37,18 +21,22 @@ export async function middleware(req: NextRequest) {
   const { pathname } = req.nextUrl;
   const start = Date.now();
 
-  // Rate-limit auth endpoints
+  // Rate-limit auth endpoints (distributed via Upstash when configured).
   if (pathname.startsWith("/api/auth")) {
     const ip = getClientIp(req);
-    if (!checkAuthRateLimit(ip)) {
+    const r = await checkAuthRateLimit(ip);
+    if (!r.success) {
       return NextResponse.json(
         { error: "Too many requests" },
         {
           status: 429,
           headers: {
-            "Retry-After": "60",
-            "X-RateLimit-Limit": AUTH_LIMIT.toString(),
-            "X-RateLimit-Remaining": "0",
+            "Retry-After": Math.max(
+              1,
+              Math.ceil((r.reset - Date.now()) / 1000)
+            ).toString(),
+            "X-RateLimit-Limit": r.limit.toString(),
+            "X-RateLimit-Remaining": r.remaining.toString(),
           },
         }
       );


### PR DESCRIPTION
## Summary

Addresses **11 of the 12 issues** raised by Claude Code in its reviews of [#441](https://github.com/getyak/daypage/pull/441) (v7 iOS deep audit) and [#443](https://github.com/getyak/daypage/pull/443) (vNext web integrations + insights). Both of those PRs were `CLOSED` (not `MERGED`) but their commits were rebased onto `main` directly, so the review findings were never followed up. This PR is that follow-up.

The 12th issue (**ARCH-11**) is documented in `packages/mcp-server/src/db.ts` and deferred to a separate PR because it requires adding several new REST endpoints to back the MCP tools.

## Findings addressed

### PR #441 — iOS

| ID | Severity | Fix |
|---|---|---|
| **#441-1** | CLAUDE.md violation | Migrate 4 tests (TodayViewModelTests, EntitySlugDedupTests, PhotoServiceBackgroundTests, TrashTTLTests) from XCTest to Swift Testing. Use `@Suite(.serialized)` where tests share `VaultInitializer.testOverrideURL`. |
| **#441-2** | Bug | `MemoCardView` now resets `retryCount = 0` and removes the persisted `UserDefaults` key when `transcript` becomes non-nil. Previously the counter stayed at 3 forever, leaving the card permanently stuck on _Transcription unavailable_. |

### PR #443 — Web (security)

| ID | Severity | Fix |
|---|---|---|
| **HIGH-1** | webhook fail-open | Telegram webhook returns **503** when `TELEGRAM_WEBHOOK_SECRET` is unset and **403** on header mismatch. Previously accepted any POST when secret was unset — anyone knowing a victim `chat_id` could inject memos. |
| **HIGH-2** | scopes not enforced | New `hasScope()` helper in `lib/api-auth.ts`; `/api/ingest`, `/api/ingest/email`, `/api/compile` now require `write` scope. Read-only keys no longer have full write access. |
| **HIGH-3** | stored XSS via source_url | `/api/ingest` protocol whitelist (http/https). Defense-in-depth `safeHref()` guard on the memo detail page render — blocks `javascript:` URIs even if pre-existing rows contain them. |
| **SEC-10** | plaintext secrets | New `lib/secret-crypto.ts` with AES-256-GCM envelope encryption. `ingest_sources.config` is encrypted on POST/PATCH, decrypted on read (Telegram webhook chat_id lookup, RSS feed URL), and redacted before being returned to the client. Legacy plaintext rows still readable. |

### PR #443 — Web (build/runtime)

| ID | Severity | Fix |
|---|---|---|
| **BUILD-4** | TS2305 | Moved `ToolHandler` into `packages/mcp-server/src/types.ts` so `tools/crud.ts` and `tools/search.ts` resolve correctly (was a circular-dep workaround). |
| **BUG-5** | Edge no-op | Auth rate limiter moved out of middleware module-level Map into `lib/auth-ratelimit.ts`. Uses Upstash Redis REST pipeline (`INCR + EXPIRE NX + PTTL`) for distributed limiting in any runtime; in-memory fallback for local dev. |
| **BUG-6** | Edge crash | Upload route declares `export const runtime = "nodejs"` so Next.js doesn't try to compile `fs/promises` for Edge. |

### PR #443 — Web (logic + quality)

| ID | Severity | Fix |
|---|---|---|
| **LOGIC-9** | wrong data | `memos/[id]/page.tsx` now scopes annotations to the memo: `page_sources.memo_id → page_id → annotations.page_id`. Previously every annotation belonging to the user appeared, unrelated to the memo. |
| **QUALITY-7** | dead code | Removed the unused `chunks` array (and the `void chunks;` suppression) from `packages/mcp-server/src/index.ts`. |
| **QUALITY-8** | macOS portability | `web/scripts/ios-bulk-sync.sh` now hashes via `python3 hashlib`. `md5sum` is GNU coreutils, absent on macOS — previously left `IKEY` empty and memos were submitted without an idempotency key. |

### Deferred — ARCH-11 (MCP server direct DB)

The MCP server currently opens its own Postgres connection (`packages/mcp-server/src/db.ts`). The original review (US-020 AC) calls for routing all reads/writes through the DayPage REST API authenticated via PAT, removing direct DB access. This is a substantive refactor — it requires adding REST endpoints for the read paths used by `tools/search.ts` and `tools/crud.ts` (pages by slug, recent memos, page_links neighbours, annotations), then rewriting all four MCP tools.

A `KNOWN ISSUE` block has been added at the top of `db.ts` to make sure the next person to touch the MCP server sees it.

## Verification

- **web/ typecheck**: 34 errors, **identical count to `main`** — none introduced by this PR. The 34 pre-existing errors are in `.next/dev/types/validator.ts` and concern unrelated route handlers + a `"/"` constraint issue.
- **web/ eslint** on changed files: 1 pre-existing warning, 0 errors.
- iOS Swift Testing migration: types check via Xcode (SourceKit static analysis outside Xcode reports false positives for `import Testing` and module-local symbols — verified the `KeychainHelperTests.swift` that has been on `main` for weeks uses the exact same patterns).

## Test plan

- [ ] `xcodebuild test -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'` — confirms 4 migrated test files compile and run.
- [ ] Toggle `INGEST_CONFIG_SECRET` env var, create a new ingest_source via POST `/api/ingest-sources`, verify the row's `config` column is `{"_encrypted": "enc:v1:..."}` in the DB.
- [ ] Without `TELEGRAM_WEBHOOK_SECRET`, POST to `/api/ingest/telegram/webhook` → expect 503.
- [ ] With a read-only API key, POST to `/api/ingest` → expect 403 (`API key lacks 'write' scope`).
- [ ] Spam `/api/auth/*` 11 times from one IP → 11th request returns 429 with realistic `Retry-After` and `X-RateLimit-Remaining` headers.
- [ ] Open a memo detail page where `source_url = "javascript:alert(1)"` → no link rendered; text shown with title "Blocked: non-http(s) URL".
- [ ] Voice memo: trigger transcription failure 3× to lock the card, then succeed → card should recover (retryCount cleared).

## Related

- Closes: not a GitHub issue — these are inline Claude Code review comments on #441 and #443.
- Reference: <https://github.com/getyak/daypage/pull/441>, <https://github.com/getyak/daypage/pull/443>