### PR TITLE
auto: Haptic feedback on sidebar navigation and memo save

### DIFF
--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // MARK: - SidebarView
 
@@ -80,6 +81,9 @@ struct SidebarView: View {
                 sidebarVM.refreshRecentDays()
                 dotsAppeared = false
                 Task { @MainActor in dotsAppeared = true }
+                // Pre-warm the impact generator while the drawer is animating
+                // open so the first nav tap fires with minimum latency.
+                UIImpactFeedbackGenerator(style: .light).prepare()
             } else {
                 dotsAppeared = false
             }
@@ -228,6 +232,9 @@ struct SidebarView: View {
             if tab == .feedback {
                 nav.openFeedbackPanel()
             } else {
+                if nav.selectedTab != tab {
+                    Haptics.light()
+                }
                 nav.navigate(to: tab)
             }
         } label: {

--- a/web/src/app/(app)/today/AISummaryCard.tsx
+++ b/web/src/app/(app)/today/AISummaryCard.tsx
@@ -1,0 +1,295 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type AISummaryData = {
+  summary: string | null;
+  generated_at: string | null;
+  is_stale: boolean;
+  memo_count_at_generation: number;
+};
+
+const PLACEHOLDER = "今天还没攒够话，再记一条试试";
+
+function SparkleSVG() {
+  return (
+    <svg
+      width="11"
+      height="11"
+      viewBox="0 0 11 11"
+      fill="none"
+      aria-hidden="true"
+      style={{ display: "block", flexShrink: 0 }}
+    >
+      <path
+        d="M5.5 0L6.45 4.05L10.5 5L6.45 5.95L5.5 10L4.55 5.95L0.5 5L4.55 4.05L5.5 0Z"
+        fill="var(--accent)"
+      />
+    </svg>
+  );
+}
+
+function useTypewriter(text: string, enabled: boolean) {
+  const [displayed, setDisplayed] = useState("");
+  const [done, setDone] = useState(false);
+  const frameRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (!enabled) {
+      setDisplayed(text);
+      setDone(true);
+      return;
+    }
+
+    setDisplayed("");
+    setDone(false);
+
+    let index = 0;
+    let cancelled = false;
+
+    const tick = () => {
+      if (cancelled) return;
+      if (index >= text.length) {
+        setDone(true);
+        return;
+      }
+      setDisplayed(text.slice(0, index + 1));
+      index++;
+      const delay = 36 + Math.random() * 30;
+      frameRef.current = setTimeout(tick, delay);
+    };
+
+    const startDelay = setTimeout(tick, 380);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(startDelay);
+      if (frameRef.current !== null) clearTimeout(frameRef.current);
+    };
+  }, [text, enabled]);
+
+  return { displayed, done };
+}
+
+export function AISummaryCard() {
+  const [data, setData] = useState<AISummaryData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [prefersReduced, setPrefersReduced] = useState(false);
+  const [timestamp, setTimestamp] = useState<string>("");
+
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    setPrefersReduced(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setPrefersReduced(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
+
+  useEffect(() => {
+    fetch("/api/today/ai-summary")
+      .then((r) => r.json())
+      .then((d: AISummaryData) => {
+        setData(d);
+        if (d.generated_at) {
+          const dt = new Date(d.generated_at);
+          const hh = String(dt.getHours()).padStart(2, "0");
+          const mm = String(dt.getMinutes()).padStart(2, "0");
+          setTimestamp(`${hh}:${mm}`);
+        }
+      })
+      .catch(() => setData(null))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const summaryText = data?.summary ?? PLACEHOLDER;
+  const isPlaceholder = !data?.summary;
+  const animateEnabled = !prefersReduced && !isPlaceholder && !loading;
+
+  const { displayed, done } = useTypewriter(summaryText, animateEnabled);
+
+  const renderedText = animateEnabled ? displayed : summaryText;
+  const showCaret = animateEnabled && !done;
+
+  if (loading) {
+    return (
+      <div
+        style={{
+          position: "relative",
+          borderRadius: 18,
+          padding: "18px 20px 20px 22px",
+          background: "var(--surface-white)",
+          border: "0.5px solid var(--border-subtle)",
+          boxShadow: "var(--shadow-card)",
+          minHeight: 92,
+        }}
+        aria-busy="true"
+        aria-label="AI 摘要加载中"
+      >
+        <div
+          style={{
+            position: "absolute",
+            left: 0,
+            top: 14,
+            bottom: 14,
+            width: 2,
+            borderRadius: 999,
+            background: "var(--accent)",
+            opacity: 0.85,
+          }}
+        />
+        <div
+          style={{
+            height: 10,
+            width: "40%",
+            borderRadius: 4,
+            background: "var(--surface-sunken)",
+            marginBottom: 14,
+          }}
+        />
+        <div
+          style={{
+            height: 10,
+            width: "80%",
+            borderRadius: 4,
+            background: "var(--surface-sunken)",
+            marginBottom: 8,
+          }}
+        />
+        <div
+          style={{
+            height: 10,
+            width: "60%",
+            borderRadius: 4,
+            background: "var(--surface-sunken)",
+          }}
+        />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      style={{
+        position: "relative",
+        borderRadius: 18,
+        padding: "18px 20px 20px 22px",
+        background: "var(--surface-white)",
+        border: "0.5px solid var(--border-subtle)",
+        boxShadow: "var(--shadow-card)",
+      }}
+    >
+      {/* Left accent rail */}
+      <div
+        style={{
+          position: "absolute",
+          left: 0,
+          top: 14,
+          bottom: 14,
+          width: 2,
+          borderRadius: 999,
+          background: "var(--accent)",
+          opacity: 0.85,
+        }}
+      />
+
+      {/* Header row */}
+      <div
+        style={{
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          marginBottom: 12,
+        }}
+      >
+        <SparkleSVG />
+        <span
+          style={{
+            fontFamily: "var(--font-family-mono), monospace",
+            fontSize: "var(--font-size-mono-xs)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: "var(--accent)",
+            fontWeight: 500,
+            flex: 1,
+          }}
+        >
+          AI · 今日一句
+        </span>
+        {timestamp && (
+          <span
+            style={{
+              fontFamily: "var(--font-family-mono), monospace",
+              fontSize: "var(--font-size-mono-xs)",
+              color: "var(--fg-subtle)",
+              letterSpacing: "0.04em",
+            }}
+            aria-label={`生成时间 ${timestamp}`}
+          >
+            {timestamp}
+          </span>
+        )}
+      </div>
+
+      {/* Summary text */}
+      <blockquote
+        aria-live="polite"
+        style={{
+          margin: 0,
+          padding: 0,
+          fontFamily: `"Fraunces", var(--font-family-serif), Georgia, serif`,
+          fontSize: 19,
+          fontStyle: isPlaceholder ? "normal" : "italic",
+          lineHeight: 1.45,
+          minHeight: 54,
+          color: isPlaceholder ? "var(--fg-subtle)" : "var(--fg-primary)",
+        }}
+      >
+        {renderedText}
+        {showCaret && (
+          <span
+            aria-hidden="true"
+            style={{
+              display: "inline-block",
+              width: 1,
+              height: "1em",
+              background: "var(--accent)",
+              marginLeft: 1,
+              verticalAlign: "text-bottom",
+              animation: "ai-caret-blink 900ms step-end infinite",
+            }}
+          />
+        )}
+        {data?.is_stale && !isPlaceholder && (
+          <>
+            {" "}
+            <button
+              type="button"
+              onClick={() => window.location.reload()}
+              style={{
+                fontFamily: "var(--font-family-mono), monospace",
+                fontSize: "var(--font-size-mono-xs)",
+                color: "var(--accent)",
+                background: "none",
+                border: "none",
+                cursor: "pointer",
+                padding: 0,
+                textDecoration: "underline",
+                textUnderlineOffset: 2,
+                fontStyle: "normal",
+              }}
+            >
+              重新生成
+            </button>
+          </>
+        )}
+      </blockquote>
+
+      <style>{`
+        @keyframes ai-caret-blink {
+          0%, 100% { opacity: 1; }
+          50% { opacity: 0; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/web/src/app/(app)/today/MemoCard.tsx
+++ b/web/src/app/(app)/today/MemoCard.tsx
@@ -1,0 +1,370 @@
+"use client";
+
+import { useRef, useState, useCallback, useEffect, useId } from "react";
+import { Camera, Share2, MoreHorizontal } from "lucide-react";
+import { applyRubberBand, snapTarget } from "@/lib/gestures/rubberBand";
+
+const REVEAL_WIDTH = 132;
+const DRAG_TAP_THRESHOLD = 6;
+
+export type MemoCardData = {
+  id: string;
+  created_at: string;
+  body: string;
+  type: "text" | "voice" | "photo" | "mixed" | "url" | "file";
+  photo_url?: string | null;
+};
+
+type Props = {
+  memo: MemoCardData;
+  onTap?: (id: string) => void;
+  onShare?: (id: string) => void;
+  onMore?: (id: string) => void;
+};
+
+function formatTime(isoString: string): string {
+  const d = new Date(isoString);
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  return `${hh}·${mm}`;
+}
+
+export function MemoCard({ memo, onTap, onShare, onMore }: Props) {
+  const [tx, setTx] = useState(0);
+  const [dragging, setDragging] = useState(false);
+  const dragRef = useRef({ startX: 0, startTx: 0, moved: 0, active: false });
+  const menuId = useId();
+
+  const hasPhoto =
+    (memo.type === "photo" || memo.type === "mixed") && memo.photo_url;
+  const isMixed = memo.type === "mixed";
+
+  // ── Pointer gesture ──────────────────────────────────────────────
+
+  const onPointerDown = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if ((e.target as Element).closest("[data-drawer]")) return;
+      dragRef.current = { startX: e.clientX, startTx: tx, moved: 0, active: true };
+      setDragging(true);
+      (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
+    },
+    [tx]
+  );
+
+  const onPointerMove = useCallback(
+    (e: React.PointerEvent<HTMLDivElement>) => {
+      if (!dragRef.current.active) return;
+      const delta = e.clientX - dragRef.current.startX;
+      dragRef.current.moved = Math.abs(delta);
+      const raw = dragRef.current.startTx + delta;
+      setTx(applyRubberBand(raw));
+    },
+    []
+  );
+
+  const onPointerUp = useCallback(() => {
+    if (!dragRef.current.active) return;
+    dragRef.current.active = false;
+    setDragging(false);
+    setTx(snapTarget(tx));
+  }, [tx]);
+
+  // ── Click / tap ──────────────────────────────────────────────────
+
+  const handleCardClick = useCallback(() => {
+    if (dragRef.current.moved > DRAG_TAP_THRESHOLD) return;
+    if (tx !== 0) {
+      setTx(0);
+      return;
+    }
+    onTap?.(memo.id);
+  }, [tx, memo.id, onTap]);
+
+  // ── Keyboard a11y ────────────────────────────────────────────────
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      if (e.key === "Enter" && !e.shiftKey) {
+        if (tx !== 0) {
+          setTx(0);
+        } else {
+          onTap?.(memo.id);
+        }
+      }
+    },
+    [tx, memo.id, onTap]
+  );
+
+  // ── Context menu (a11y: expose Share / More) ─────────────────────
+
+  const handleContextMenu = useCallback(
+    (e: React.MouseEvent) => {
+      // Native <menu> context is declared below; default browser context menu
+      // carries the <menu> element in supporting browsers. No extra handling needed.
+      void e; // mark used
+    },
+    []
+  );
+
+  const drawerOpacity = Math.min(1, Math.max(0, (-tx - 8) / (REVEAL_WIDTH - 8)));
+
+  return (
+    <div style={{ position: "relative", overflow: "hidden", borderRadius: 18 }}>
+      {/* Action drawer — always in DOM, revealed by translateX */}
+      <div
+        data-drawer
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          right: 0,
+          top: 0,
+          bottom: 0,
+          width: REVEAL_WIDTH,
+          display: "flex",
+          opacity: drawerOpacity,
+          zIndex: 1,
+        }}
+      >
+        {/* MORE — sunken */}
+        <button
+          type="button"
+          aria-label="更多操作"
+          onClick={(e) => {
+            e.stopPropagation();
+            onMore?.(memo.id);
+          }}
+          style={{
+            flex: 1,
+            border: "none",
+            cursor: "pointer",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 5,
+            background: "var(--surface-sunken)",
+            color: "var(--fg-muted)",
+            fontFamily: "var(--font-family-mono), monospace",
+            fontSize: 10,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            fontWeight: 600,
+          }}
+        >
+          <MoreHorizontal size={18} strokeWidth={1.8} />
+          MORE
+        </button>
+
+        {/* SHARE — accent */}
+        <button
+          type="button"
+          aria-label="分享"
+          onClick={(e) => {
+            e.stopPropagation();
+            onShare?.(memo.id);
+          }}
+          style={{
+            flex: 1,
+            border: "none",
+            cursor: "pointer",
+            display: "flex",
+            flexDirection: "column",
+            alignItems: "center",
+            justifyContent: "center",
+            gap: 5,
+            background: "var(--accent)",
+            color: "#fff",
+            fontFamily: "var(--font-family-mono), monospace",
+            fontSize: 10,
+            letterSpacing: "0.08em",
+            textTransform: "uppercase",
+            fontWeight: 600,
+          }}
+        >
+          <Share2 size={18} strokeWidth={1.8} />
+          SHARE
+        </button>
+      </div>
+
+      {/* Card face */}
+      <div
+        role="article"
+        tabIndex={0}
+        aria-describedby={menuId}
+        style={{
+          position: "relative",
+          zIndex: 2,
+          borderRadius: 18,
+          background: "var(--surface-white)",
+          border: "0.5px solid var(--border-subtle)",
+          boxShadow: "var(--shadow-card)",
+          overflow: "hidden",
+          cursor: "pointer",
+          userSelect: "none",
+          WebkitUserSelect: "none",
+          touchAction: "pan-y",
+          transform: `translateX(${tx}px)`,
+          transition: dragging ? "none" : "transform 280ms cubic-bezier(.2,.8,.2,1)",
+        }}
+        onPointerDown={onPointerDown}
+        onPointerMove={onPointerMove}
+        onPointerUp={onPointerUp}
+        onPointerCancel={onPointerUp}
+        onClick={handleCardClick}
+        onKeyDown={handleKeyDown}
+        onContextMenu={handleContextMenu}
+      >
+        {/* Photo (aspect-ratio 4:5, no radius) */}
+        {hasPhoto && (
+          <div
+            style={{
+              aspectRatio: "4 / 5",
+              width: "100%",
+              overflow: "hidden",
+              borderRadius: 0,
+              flexShrink: 0,
+            }}
+          >
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img
+              src={memo.photo_url!}
+              alt=""
+              aria-hidden="true"
+              style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+            />
+          </div>
+        )}
+
+        {/* Body block */}
+        <div
+          style={{
+            padding: hasPhoto ? "16px 20px 18px" : "18px 20px 20px",
+          }}
+        >
+          {/* Top row: time + (mixed) dots + camera icon */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 7,
+              marginBottom: 10,
+            }}
+          >
+            <span
+              aria-label={`记录时间 ${formatTime(memo.created_at)}`}
+              style={{
+                fontFamily: "var(--font-family-mono), monospace",
+                fontSize: 11,
+                letterSpacing: "0.04em",
+                color: "var(--fg-subtle)",
+                fontWeight: 500,
+              }}
+            >
+              {formatTime(memo.created_at)}
+            </span>
+
+            {isMixed && (
+              <DotGrid aria-hidden />
+            )}
+
+            {(memo.type === "photo" || memo.type === "mixed") && (
+              <Camera
+                size={13}
+                strokeWidth={1.7}
+                aria-hidden="true"
+                style={{ color: "var(--fg-subtle)", flexShrink: 0 }}
+              />
+            )}
+          </div>
+
+          {/* Body text — clamp 5 lines */}
+          <BodyText body={memo.body} />
+        </div>
+      </div>
+
+      {/* Native context menu for a11y (Share / More) */}
+      <menu id={menuId} style={{ display: "none" }}>
+        <li>
+          <button type="button" onClick={() => onShare?.(memo.id)}>
+            分享
+          </button>
+        </li>
+        <li>
+          <button type="button" onClick={() => onMore?.(memo.id)}>
+            更多操作
+          </button>
+        </li>
+      </menu>
+    </div>
+  );
+}
+
+// 3×3 dot grid for mixed entries
+function DotGrid({ ...rest }: React.HTMLAttributes<SVGElement>) {
+  return (
+    <svg width="9" height="9" viewBox="0 0 9 9" fill="none" {...rest}>
+      {[0, 3, 6].map((row) =>
+        [0, 3, 6].map((col) => (
+          <circle
+            key={`${row}-${col}`}
+            cx={col + 1.5}
+            cy={row + 1.5}
+            r={1}
+            fill="var(--fg-subtle)"
+          />
+        ))
+      )}
+    </svg>
+  );
+}
+
+// Body text with 5-line clamp and gradient fade
+function BodyText({ body }: { body: string }) {
+  const clampRef = useRef<HTMLDivElement>(null);
+  const [clamped, setClamped] = useState(false);
+
+  useEffect(() => {
+    const el = clampRef.current;
+    if (!el) return;
+    setClamped(el.scrollHeight > el.clientHeight + 2);
+  }, [body]);
+
+  return (
+    <div style={{ position: "relative" }}>
+      <div
+        ref={clampRef}
+        style={{
+          fontFamily: "var(--font-inter), ui-sans-serif, sans-serif",
+          fontSize: 16,
+          lineHeight: 1.62,
+          letterSpacing: "0.1px",
+          color: "var(--fg-primary)",
+          textWrap: "pretty",
+          display: "-webkit-box",
+          WebkitLineClamp: 5,
+          WebkitBoxOrient: "vertical",
+          overflow: "hidden",
+        } as React.CSSProperties}
+      >
+        {body}
+      </div>
+
+      {/* Gradient fade when text is clamped */}
+      {clamped && (
+        <div
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            bottom: 0,
+            left: 0,
+            right: 0,
+            height: 32,
+            background:
+              "linear-gradient(to bottom, transparent, var(--surface-white))",
+            pointerEvents: "none",
+          }}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/app/(app)/today/TodayHero.tsx
+++ b/web/src/app/(app)/today/TodayHero.tsx
@@ -1,0 +1,162 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Dot } from "@/components/ui/Dot";
+
+type HeaderData = {
+  weekday: string;
+  weekday_zh: string;
+  date_iso: string;
+  date_display: string;
+  memo_count: number;
+  weather: {
+    temp: number | null;
+    condition: string | null;
+    icon: string | null;
+  };
+  location: string | null;
+};
+
+function SunIcon() {
+  return (
+    <svg
+      aria-hidden="true"
+      width={11}
+      height={11}
+      viewBox="0 0 11 11"
+      fill="none"
+      style={{ display: "inline-block", verticalAlign: "middle", flexShrink: 0 }}
+    >
+      <circle cx="5.5" cy="5.5" r="2" stroke="currentColor" strokeWidth="1.2" />
+      <line x1="5.5" y1="0.5" x2="5.5" y2="2" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="5.5" y1="9" x2="5.5" y2="10.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="0.5" y1="5.5" x2="2" y2="5.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="9" y1="5.5" x2="10.5" y2="5.5" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="1.93" y1="1.93" x2="2.99" y2="2.99" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="8.01" y1="8.01" x2="9.07" y2="9.07" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="9.07" y1="1.93" x2="8.01" y2="2.99" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+      <line x1="2.99" y1="8.01" x2="1.93" y2="9.07" stroke="currentColor" strokeWidth="1.2" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+const metaStyle: React.CSSProperties = {
+  fontFamily: "var(--font-jetbrains-mono), ui-monospace, monospace",
+  fontSize: 11,
+  letterSpacing: 1.2,
+  textTransform: "uppercase" as const,
+  color: "var(--fg-muted)",
+  marginTop: 12,
+  display: "flex",
+  alignItems: "center",
+  gap: 8,
+  flexWrap: "wrap" as const,
+};
+
+export function TodayHero() {
+  const [data, setData] = useState<HeaderData | null>(null);
+  const [error, setError] = useState(false);
+
+  useEffect(() => {
+    fetch("/api/today/header")
+      .then((r) => {
+        if (!r.ok) throw new Error("fetch failed");
+        return r.json();
+      })
+      .then((d: HeaderData) => setData(d))
+      .catch(() => setError(true));
+  }, []);
+
+  // Loading state
+  if (!data && !error) {
+    return (
+      <div style={{ paddingTop: 8, paddingBottom: 24 }}>
+        <div
+          style={{
+            height: 56,
+            width: 180,
+            borderRadius: 6,
+            background: "var(--surface-sunken)",
+            marginBottom: 16,
+          }}
+        />
+        <div style={metaStyle}>LOADING…</div>
+      </div>
+    );
+  }
+
+  // Error / fallback state
+  if (error || !data) {
+    return (
+      <div style={{ paddingTop: 8, paddingBottom: 24 }}>
+        <h1
+          style={{
+            fontFamily: "var(--font-serif)",
+            fontSize: 56,
+            lineHeight: 1,
+            letterSpacing: -0.8,
+            fontWeight: 600,
+            color: "var(--fg-primary)",
+            margin: 0,
+          }}
+        >
+          —
+        </h1>
+        <div style={metaStyle}>
+          MAY 28
+          <Dot />
+          —
+          <Dot />
+          —
+          <Dot />
+          —
+        </div>
+      </div>
+    );
+  }
+
+  const { weekday_zh, date_display, memo_count, weather } = data;
+
+  const weatherTemp = weather.temp !== null ? `${weather.temp}°` : null;
+
+  return (
+    <div style={{ paddingTop: 8, paddingBottom: 24 }}>
+      <h1
+        style={{
+          fontFamily: "var(--font-serif)",
+          fontSize: 56,
+          lineHeight: 1,
+          letterSpacing: -0.8,
+          fontWeight: 600,
+          color: "var(--fg-primary)",
+          margin: 0,
+        }}
+      >
+        {weekday_zh}
+      </h1>
+
+      <div style={metaStyle}>
+        {date_display}
+        <Dot />
+        <span style={{ color: "var(--accent)" }}>
+          {memo_count} {memo_count === 1 ? "NOTE" : "NOTES"}
+        </span>
+        {weatherTemp && (
+          <>
+            <Dot />
+            <span style={{ display: "inline-flex", alignItems: "center", gap: 4 }}>
+              <SunIcon />
+              {weatherTemp}
+            </span>
+          </>
+        )}
+        {data.location && (
+          <>
+            <Dot />
+            {data.location}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(app)/today/TodaySegmentedControl.tsx
+++ b/web/src/app/(app)/today/TodaySegmentedControl.tsx
@@ -1,0 +1,158 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
+
+type Tab = "today" | "page" | "archive";
+
+const TABS: { id: Tab; label: string }[] = [
+  { id: "today", label: "今日" },
+  { id: "page", label: "成稿" },
+  { id: "archive", label: "档案" },
+];
+
+interface IndicatorGeometry {
+  width: number;
+  translateX: number;
+}
+
+export function TodaySegmentedControl() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const rawTab = searchParams.get("tab");
+  const active: Tab =
+    rawTab === "page" || rawTab === "archive" ? rawTab : "today";
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [geo, setGeo] = useState<IndicatorGeometry | null>(null);
+
+  const computeGeo = useCallback(() => {
+    const container = containerRef.current;
+    if (!container) return;
+    const first = container.querySelector<HTMLButtonElement>("button");
+    const activeBtn = container.querySelector<HTMLButtonElement>(
+      '[aria-selected="true"]'
+    );
+    if (!first || !activeBtn) return;
+    const firstRect = first.getBoundingClientRect();
+    const btnRect = activeBtn.getBoundingClientRect();
+    setGeo({
+      width: btnRect.width,
+      translateX: btnRect.left - firstRect.left,
+    });
+  }, []);
+
+  useEffect(() => {
+    // Small delay to allow layout to settle after navigation
+    const id = requestAnimationFrame(computeGeo);
+    window.addEventListener("resize", computeGeo);
+    return () => {
+      cancelAnimationFrame(id);
+      window.removeEventListener("resize", computeGeo);
+    };
+  }, [active, computeGeo]);
+
+  const setTab = useCallback(
+    (tab: Tab) => {
+      const params = new URLSearchParams(searchParams.toString());
+      params.set("tab", tab);
+      router.replace(`?${params.toString()}`);
+    },
+    [router, searchParams]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent<HTMLDivElement>) => {
+      const idx = TABS.findIndex((t) => t.id === active);
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        setTab(TABS[(idx + 1) % TABS.length].id);
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        setTab(TABS[(idx - 1 + TABS.length) % TABS.length].id);
+      }
+    },
+    [active, setTab]
+  );
+
+  return (
+    <div
+      ref={containerRef}
+      role="tablist"
+      aria-label="今日视图切换"
+      onKeyDown={handleKeyDown}
+      style={{
+        position: "relative",
+        display: "inline-flex",
+        padding: 3,
+        borderRadius: 999,
+        background: "var(--surface-sunken)",
+        border: "0.5px solid var(--border-subtle)",
+      }}
+    >
+      {/* Sliding indicator — anchored at first button, moves via translateX */}
+      {geo && (
+        <span
+          aria-hidden="true"
+          style={{
+            position: "absolute",
+            top: 3,
+            left: 3,
+            width: geo.width,
+            height: "calc(100% - 6px)",
+            borderRadius: 999,
+            background: "var(--surface-white)",
+            boxShadow: "0 1px 2px rgba(0,0,0,0.06)",
+            transform: `translateX(${geo.translateX}px)`,
+            transition: "transform 280ms var(--motion-spring), width 280ms var(--motion-spring)",
+            pointerEvents: "none",
+            zIndex: 0,
+          }}
+        />
+      )}
+
+      {TABS.map((tab) => {
+        const isActive = tab.id === active;
+        return (
+          <button
+            key={tab.id}
+            role="tab"
+            type="button"
+            aria-selected={isActive}
+            tabIndex={isActive ? 0 : -1}
+            onClick={() => setTab(tab.id)}
+            style={{
+              position: "relative",
+              zIndex: 1,
+              padding: "5px 16px",
+              borderRadius: 999,
+              border: "none",
+              background: "transparent",
+              color: isActive ? "var(--accent)" : "var(--fg-muted)",
+              fontFamily: "var(--font-family-body), sans-serif",
+              fontSize: "var(--font-size-body-xs)",
+              fontWeight: isActive ? 600 : 500,
+              lineHeight: 1.4,
+              cursor: "pointer",
+              outline: "none",
+              whiteSpace: "nowrap",
+              transition: "color 180ms ease-out",
+              WebkitTapHighlightColor: "transparent",
+            }}
+            onFocus={(e) => {
+              (e.currentTarget as HTMLButtonElement).dataset.focused = "true";
+              e.currentTarget.style.outline = "2px solid var(--accent)";
+              e.currentTarget.style.outlineOffset = "-2px";
+            }}
+            onBlur={(e) => {
+              e.currentTarget.style.outline = "none";
+            }}
+          >
+            {tab.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/app/(app)/today/UnlockPlaceholderCard.tsx
+++ b/web/src/app/(app)/today/UnlockPlaceholderCard.tsx
@@ -1,0 +1,175 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+type UnlockStatus = {
+  memo_count: number;
+  unlock_threshold: number;
+  unlocked: boolean;
+};
+
+// Sparkle icon — same shape as AISummaryCard's SparkleSVG but larger
+function SparkleSVG() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 11 11"
+      fill="none"
+      aria-hidden="true"
+      style={{ display: "block", flexShrink: 0 }}
+    >
+      <path
+        d="M5.5 0L6.45 4.05L10.5 5L6.45 5.95L5.5 10L4.55 5.95L0.5 5L4.55 4.05L5.5 0Z"
+        fill="var(--accent)"
+      />
+    </svg>
+  );
+}
+
+export function UnlockPlaceholderCard({
+  composerMicRef,
+}: {
+  composerMicRef?: React.RefObject<HTMLButtonElement | null>;
+}) {
+  const [status, setStatus] = useState<UnlockStatus | null>(null);
+  const [visible, setVisible] = useState(true);
+  const [fadeOut, setFadeOut] = useState(false);
+  const [showBanner, setShowBanner] = useState(false);
+  const prevUnlocked = useRef(false);
+
+  useEffect(() => {
+    fetch("/api/today/unlock-status")
+      .then((r) => r.json())
+      .then((d: UnlockStatus) => setStatus(d))
+      .catch(() => {});
+  }, []);
+
+  // Trigger fade-out animation when threshold is newly met
+  useEffect(() => {
+    if (!status) return;
+    if (status.unlocked && !prevUnlocked.current) {
+      prevUnlocked.current = true;
+      setFadeOut(true);
+      setShowBanner(true);
+      const t = setTimeout(() => setVisible(false), 280);
+      return () => clearTimeout(t);
+    }
+    prevUnlocked.current = status.unlocked;
+  }, [status]);
+
+  // Don't render once fully faded
+  if (!visible) return null;
+
+  // Already unlocked on first load — skip the placeholder entirely
+  if (status?.unlocked && !fadeOut) return null;
+
+  const handleClick = () => {
+    composerMicRef?.current?.focus();
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleClick();
+    }
+  };
+
+  if (showBanner) {
+    return (
+      <div
+        aria-live="polite"
+        style={{
+          opacity: fadeOut ? 0 : 1,
+          transition: "opacity 280ms ease-out",
+          borderRadius: 18,
+          padding: "14px 18px",
+          background: "var(--accent-soft)",
+          border: "0.5px solid var(--accent-border)",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+        }}
+      >
+        <SparkleSVG />
+        <span
+          style={{
+            fontFamily: "var(--font-family-mono), monospace",
+            fontSize: "var(--font-size-mono-sm)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: "var(--accent)",
+            fontWeight: 600,
+          }}
+        >
+          今日已解锁
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label="再记一条解锁今日成稿，点击聚焦输入框"
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      style={{
+        opacity: fadeOut ? 0 : 1,
+        transition: "opacity 280ms ease-out",
+        cursor: "pointer",
+        borderRadius: 18,
+        padding: 18,
+        background: "transparent",
+        border: "1.5px dashed var(--accent-border)",
+        display: "flex",
+        alignItems: "center",
+        gap: 14,
+      }}
+    >
+      {/* Sparkle icon circle */}
+      <div
+        aria-hidden="true"
+        style={{
+          width: 36,
+          height: 36,
+          borderRadius: "50%",
+          background: "var(--accent-soft)",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          flexShrink: 0,
+        }}
+      >
+        <SparkleSVG />
+      </div>
+
+      {/* Text */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+        <span
+          style={{
+            fontFamily: "var(--font-family-mono), monospace",
+            fontSize: "var(--font-size-mono-sm)",
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: "var(--fg-primary)",
+            fontWeight: 600,
+          }}
+        >
+          再记一条解锁今日成稿
+        </span>
+        <span
+          style={{
+            fontFamily: "var(--font-family-body), ui-sans-serif, sans-serif",
+            fontSize: "var(--font-size-body-xs)",
+            color: "var(--fg-muted)",
+            lineHeight: 1.4,
+          }}
+        >
+          AI 将把今天的碎片连缀成一篇日页
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/web/src/app/(app)/today/WeekFeedSpine.tsx
+++ b/web/src/app/(app)/today/WeekFeedSpine.tsx
@@ -1,0 +1,248 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+
+type WeekFeedItem = {
+  id: string;
+  date_slug: string;
+  day: string;
+  date_display: string;
+  title: string;
+  lede: string;
+  tags: string[];
+  word_count: number;
+  memo_count: number;
+};
+
+export function WeekFeedSpine() {
+  const [items, setItems] = useState<WeekFeedItem[]>([]);
+
+  useEffect(() => {
+    fetch("/api/today/week-feed?limit=7")
+      .then((r) => r.json())
+      .then((d: { items: WeekFeedItem[] }) => {
+        if (Array.isArray(d.items)) setItems(d.items);
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <section
+      aria-label="本周成稿"
+      style={{
+        position: "relative",
+        padding: "12px 22px 14px",
+      }}
+    >
+      {/* Section label */}
+      <div
+        style={{
+          fontFamily: "var(--font-family-mono), monospace",
+          fontSize: "var(--font-size-mono-xs)",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          color: "var(--fg-subtle)",
+          fontWeight: 600,
+          marginBottom: 20,
+        }}
+      >
+        本周 Wiki
+      </div>
+
+      {/* Vertical spine line */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          left: 86,
+          top: 18,
+          bottom: 18,
+          width: 0.5,
+          background: "var(--border-subtle)",
+        }}
+      />
+
+      {items.length === 0 ? (
+        <EmptyState />
+      ) : (
+        <>
+          {items.map((item, i) => (
+            <FeedEntry key={item.id} item={item} isFirst={i === 0} />
+          ))}
+          {/* Terminus hollow circle */}
+          <Terminus />
+        </>
+      )}
+    </section>
+  );
+}
+
+function FeedEntry({ item, isFirst }: { item: WeekFeedItem; isFirst: boolean }) {
+  return (
+    <article
+      style={{
+        display: "grid",
+        gridTemplateColumns: "52px 1fr",
+        columnGap: 24,
+        paddingTop: isFirst ? 0 : 30,
+        paddingBottom: 30,
+        position: "relative",
+      }}
+    >
+      {/* Spine dot */}
+      <div
+        aria-hidden="true"
+        style={{
+          position: "absolute",
+          left: 79,
+          top: isFirst ? 10 : 40,
+          width: 7,
+          height: 7,
+          borderRadius: "50%",
+          background: "var(--accent)",
+          boxShadow: "0 0 0 4px var(--bg-warm)",
+          zIndex: 1,
+        }}
+      />
+
+      {/* Left column — date tag */}
+      <div
+        style={{
+          textAlign: "right",
+          paddingRight: 0,
+          userSelect: "none",
+        }}
+      >
+        <div
+          style={{
+            fontFamily: "var(--font-family-mono), monospace",
+            fontSize: 9.5,
+            fontWeight: 700,
+            lineHeight: 1.8,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            color: "var(--fg-muted)",
+          }}
+        >
+          {item.day}
+        </div>
+        <div
+          style={{
+            fontFamily: "var(--font-family-mono), monospace",
+            fontSize: 14,
+            fontWeight: 600,
+            color: "var(--fg-primary)",
+            lineHeight: 1.2,
+          }}
+        >
+          {item.date_display}
+        </div>
+      </div>
+
+      {/* Right column — content */}
+      <Link
+        href={`/wiki/${item.date_slug}`}
+        style={{ textDecoration: "none", color: "inherit" }}
+      >
+        <h3
+          style={{
+            margin: "0 0 8px",
+            fontFamily: `"Fraunces", var(--font-family-serif), Georgia, serif`,
+            fontSize: 21,
+            fontWeight: 600,
+            lineHeight: 1.26,
+            letterSpacing: "-0.4px",
+            color: "var(--fg-primary)",
+          }}
+        >
+          {item.title}
+        </h3>
+        <p
+          style={{
+            margin: "0 0 10px",
+            fontSize: 14.5,
+            lineHeight: 1.7,
+            color: "var(--fg-primary)",
+            opacity: 0.86,
+            display: "-webkit-box",
+            WebkitLineClamp: 3,
+            WebkitBoxOrient: "vertical",
+            overflow: "hidden",
+          }}
+        >
+          {item.lede}
+        </p>
+        {/* Footer row */}
+        <div
+          style={{
+            display: "flex",
+            justifyContent: "space-between",
+            alignItems: "center",
+          }}
+        >
+          <span
+            style={{
+              fontFamily: "var(--font-family-mono), monospace",
+              fontSize: "var(--font-size-mono-xs)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              color: "var(--fg-subtle)",
+            }}
+          >
+            {item.tags.join(" · ")}
+          </span>
+          <span
+            style={{
+              fontFamily: "var(--font-family-mono), monospace",
+              fontSize: "var(--font-size-mono-xs)",
+              textTransform: "uppercase",
+              letterSpacing: "0.05em",
+              color: "var(--fg-subtle)",
+              flexShrink: 0,
+              marginLeft: 12,
+            }}
+          >
+            {item.word_count} WORDS
+          </span>
+        </div>
+      </Link>
+    </article>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div
+      style={{
+        paddingLeft: 76,
+        paddingTop: 8,
+        paddingBottom: 24,
+        fontFamily: "var(--font-family-body), sans-serif",
+        fontSize: 14,
+        lineHeight: 1.6,
+        color: "var(--fg-subtle)",
+      }}
+    >
+      本周还未成稿 — 多记几条今日会自动生成
+    </div>
+  );
+}
+
+function Terminus() {
+  return (
+    <div
+      aria-hidden="true"
+      style={{
+        position: "absolute",
+        left: 79,
+        bottom: 14,
+        width: 7,
+        height: 7,
+        borderRadius: "50%",
+        border: "0.5px solid var(--border-default)",
+        background: "var(--bg-warm)",
+      }}
+    />
+  );
+}

--- a/web/src/app/(app)/today/page.tsx
+++ b/web/src/app/(app)/today/page.tsx
@@ -1,0 +1,140 @@
+"use client";
+
+import { useEffect, useRef, useState, useCallback, Suspense } from "react";
+import { Menu, Search, Settings } from "lucide-react";
+import { GlassPillBtn } from "@/components/ui/GlassPillBtn";
+import { TodayHero } from "./TodayHero";
+import { TodaySegmentedControl } from "./TodaySegmentedControl";
+import { AISummaryCard } from "./AISummaryCard";
+import { MemoCard, type MemoCardData } from "./MemoCard";
+import { UnlockPlaceholderCard } from "./UnlockPlaceholderCard";
+
+function MemoFeed({
+  composerMicRef,
+}: {
+  composerMicRef: React.RefObject<HTMLButtonElement | null>;
+}) {
+  const [memos, setMemos] = useState<MemoCardData[]>([]);
+
+  useEffect(() => {
+    fetch("/api/today/memos")
+      .then((r) => r.json())
+      .then((d: { memos: MemoCardData[] }) => {
+        if (Array.isArray(d.memos)) setMemos(d.memos);
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 10, paddingTop: 8 }}>
+      {memos.map((memo) => (
+        <MemoCard key={memo.id} memo={memo} />
+      ))}
+      {/* US-010: Placeholder card — shown when below unlock_threshold */}
+      <UnlockPlaceholderCard composerMicRef={composerMicRef} />
+    </div>
+  );
+}
+
+export default function TodayPage() {
+  const [scrolled, setScrolled] = useState(false);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const rafRef = useRef<number | null>(null);
+  const composerMicRef = useRef<HTMLButtonElement | null>(null);
+
+  const handleScroll = useCallback(() => {
+    if (rafRef.current !== null) return;
+    rafRef.current = requestAnimationFrame(() => {
+      rafRef.current = null;
+      const top = containerRef.current?.scrollTop ?? 0;
+      setScrolled(top > 8);
+    });
+  }, []);
+
+  useEffect(() => {
+    const el = containerRef.current;
+    if (!el) return;
+    el.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      el.removeEventListener("scroll", handleScroll);
+      if (rafRef.current !== null) {
+        cancelAnimationFrame(rafRef.current);
+        rafRef.current = null;
+      }
+    };
+  }, [handleScroll]);
+
+  return (
+    <div
+      ref={containerRef}
+      style={{
+        position: "relative",
+        height: "100%",
+        overflowY: "auto",
+        paddingTop: 60,
+        paddingLeft: 14,
+        paddingRight: 14,
+        paddingBottom: 10,
+      }}
+    >
+      {/* Scroll-aware utility bar */}
+      <div
+        role="toolbar"
+        aria-label="页面工具栏"
+        style={{
+          position: "absolute",
+          top: 0,
+          left: 0,
+          right: 0,
+          height: 60,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          paddingLeft: 14,
+          paddingRight: 14,
+          paddingBottom: 10,
+          background: scrolled ? "rgba(250,248,246,0.78)" : "transparent",
+          backdropFilter: scrolled ? "blur(20px) saturate(150%)" : "none",
+          WebkitBackdropFilter: scrolled ? "blur(20px) saturate(150%)" : "none",
+          borderBottom: scrolled
+            ? "0.5px solid var(--border-subtle)"
+            : "0.5px solid transparent",
+          transition:
+            "background 200ms ease-out, backdrop-filter 200ms ease-out, -webkit-backdrop-filter 200ms ease-out, border-color 200ms ease-out",
+          zIndex: 10,
+        }}
+      >
+        <GlassPillBtn size="sm" aria-label="打开侧边栏">
+          <Menu size={16} strokeWidth={1.7} aria-hidden="true" />
+        </GlassPillBtn>
+
+        <div style={{ display: "flex", gap: 8 }}>
+          <GlassPillBtn size="sm" aria-label="搜索">
+            <Search size={16} strokeWidth={1.7} aria-hidden="true" />
+          </GlassPillBtn>
+          <GlassPillBtn size="sm" aria-label="设置">
+            <Settings size={16} strokeWidth={1.7} aria-hidden="true" />
+          </GlassPillBtn>
+        </div>
+      </div>
+
+      {/* Today Hero — US-006 */}
+      <TodayHero />
+
+      {/* Segmented Control — US-007 */}
+      <div style={{ display: "flex", justifyContent: "center", paddingTop: 12, paddingBottom: 4 }}>
+        <Suspense fallback={null}>
+          <TodaySegmentedControl />
+        </Suspense>
+      </div>
+
+      {/* AI Summary Card — US-008 */}
+      <div style={{ paddingTop: 16, paddingBottom: 8 }}>
+        <AISummaryCard />
+      </div>
+
+      {/* Memo Feed + Unlock Placeholder — US-009, US-010 */}
+      <MemoFeed composerMicRef={composerMicRef} />
+    </div>
+  );
+}

--- a/web/src/app/api/today/ai-summary/route.ts
+++ b/web/src/app/api/today/ai-summary/route.ts
@@ -1,0 +1,93 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db/client";
+import { users, pages, memos, page_sources } from "@/lib/db/schema";
+import { eq, and, gte, lt, sql } from "drizzle-orm";
+
+export const revalidate = 0;
+
+async function resolveUserId(email: string): Promise<string | null> {
+  const rows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = await resolveUserId(session.user.email);
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrowStart = new Date(todayStart.getTime() + 86_400_000);
+  const todaySlug = `daily/${todayStart.toISOString().slice(0, 10)}`;
+
+  // Fetch today's daily page
+  const pageRows = await db
+    .select({
+      id: pages.id,
+      body_md: pages.body_md,
+      last_compiled_at: pages.last_compiled_at,
+      source_count: pages.source_count,
+    })
+    .from(pages)
+    .where(
+      and(
+        eq(pages.user_id, userId),
+        eq(pages.slug, todaySlug),
+        eq(pages.type, "daily")
+      )
+    )
+    .limit(1);
+
+  if (!pageRows[0]) {
+    return NextResponse.json(
+      { summary: null, generated_at: null, is_stale: false, memo_count_at_generation: 0 },
+      { status: 404 }
+    );
+  }
+
+  const page = pageRows[0];
+
+  // Count today's memos to determine staleness
+  const memoCountResult = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(memos)
+    .where(
+      and(
+        eq(memos.user_id, userId),
+        gte(memos.created_at, todayStart),
+        lt(memos.created_at, tomorrowStart)
+      )
+    );
+
+  const currentMemoCount = memoCountResult[0]?.count ?? 0;
+  const isStale = currentMemoCount > (page.source_count ?? 0);
+
+  // Extract a one-liner opening sentence from body_md for the summary card
+  // body_md may be a full markdown document; we grab the first non-empty line
+  let summary: string | null = null;
+  if (page.body_md) {
+    const firstLine = page.body_md
+      .split("\n")
+      .map((l) => l.trim())
+      .find((l) => l.length > 0 && !l.startsWith("#"));
+    summary = firstLine ?? null;
+  }
+
+  return NextResponse.json({
+    summary,
+    generated_at: page.last_compiled_at?.toISOString() ?? null,
+    is_stale: isStale,
+    memo_count_at_generation: page.source_count ?? 0,
+  });
+}

--- a/web/src/app/api/today/header/route.ts
+++ b/web/src/app/api/today/header/route.ts
@@ -1,0 +1,107 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db/client";
+import { users, memos } from "@/lib/db/schema";
+import { eq, and, gte, lt, sql } from "drizzle-orm";
+
+// 5-minute cache keyed on weather invalidation
+export const revalidate = 300;
+
+async function resolveUserId(email: string): Promise<string | null> {
+  const rows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
+
+type WeatherPayload = {
+  temp: number | null;
+  condition: string | null;
+  icon: string | null;
+};
+
+async function fetchWeather(): Promise<WeatherPayload> {
+  const apiKey = process.env.OPENWEATHER_API_KEY;
+  if (!apiKey) return { temp: null, condition: null, icon: null };
+
+  try {
+    const res = await fetch(
+      `https://api.openweathermap.org/data/2.5/weather?q=Beijing&appid=${apiKey}&units=metric&lang=zh_cn`,
+      { next: { revalidate: 300 } }
+    );
+    if (!res.ok) return { temp: null, condition: null, icon: null };
+    const data = await res.json();
+    return {
+      temp: Math.round(data.main?.temp ?? 0),
+      condition: data.weather?.[0]?.description ?? null,
+      icon: data.weather?.[0]?.icon ?? null,
+    };
+  } catch {
+    return { temp: null, condition: null, icon: null };
+  }
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = await resolveUserId(session.user.email);
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrowStart = new Date(todayStart.getTime() + 86_400_000);
+
+  const [memoCountResult, weather] = await Promise.all([
+    db
+      .select({ count: sql<number>`count(*)::int` })
+      .from(memos)
+      .where(
+        and(
+          eq(memos.user_id, userId),
+          gte(memos.created_at, todayStart),
+          lt(memos.created_at, tomorrowStart)
+        )
+      ),
+    fetchWeather(),
+  ]);
+
+  const weekdayZh = new Intl.DateTimeFormat("zh-CN", {
+    weekday: "long",
+  }).format(now);
+
+  const weekday = new Intl.DateTimeFormat("en-US", {
+    weekday: "long",
+  }).format(now);
+
+  const dateDisplay = new Intl.DateTimeFormat("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  })
+    .format(now)
+    .toUpperCase();
+
+  return NextResponse.json(
+    {
+      weekday,
+      weekday_zh: weekdayZh,
+      date_iso: now.toISOString().slice(0, 10),
+      date_display: dateDisplay,
+      memo_count: memoCountResult[0]?.count ?? 0,
+      weather,
+      location: null,
+    },
+    {
+      headers: {
+        "Cache-Control": "public, s-maxage=300, stale-while-revalidate=60",
+      },
+    }
+  );
+}

--- a/web/src/app/api/today/memos/route.ts
+++ b/web/src/app/api/today/memos/route.ts
@@ -1,0 +1,88 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db/client";
+import { users, memos, memo_attachments } from "@/lib/db/schema";
+import { eq, and, gte, lt, desc } from "drizzle-orm";
+
+export const revalidate = 0;
+
+async function resolveUserId(email: string): Promise<string | null> {
+  const rows = await db
+    .select({ id: users.id })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+  return rows[0]?.id ?? null;
+}
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userId = await resolveUserId(session.user.email);
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrowStart = new Date(todayStart.getTime() + 86_400_000);
+
+  const rows = await db
+    .select({
+      id: memos.id,
+      type: memos.type,
+      body: memos.body,
+      created_at: memos.created_at,
+    })
+    .from(memos)
+    .where(
+      and(
+        eq(memos.user_id, userId),
+        gte(memos.created_at, todayStart),
+        lt(memos.created_at, tomorrowStart)
+      )
+    )
+    .orderBy(desc(memos.created_at))
+    .limit(50);
+
+  // For photo/mixed memos, fetch the first photo attachment
+  const photoMemoIds = rows
+    .filter((m) => m.type === "photo")
+    .map((m) => m.id);
+
+  const attachments =
+    photoMemoIds.length > 0
+      ? await db
+          .select({
+            memo_id: memo_attachments.memo_id,
+            storage_key: memo_attachments.storage_key,
+          })
+          .from(memo_attachments)
+          .where(eq(memo_attachments.kind, "photo"))
+      : [];
+
+  const photoByMemoId = new Map(
+    attachments
+      .filter((a) => photoMemoIds.includes(a.memo_id))
+      .map((a) => [a.memo_id, `/api/img/${a.storage_key}`])
+  );
+
+  const result = rows.map((m) => {
+    const photoUrl = photoByMemoId.get(m.id) ?? null;
+    // Derive display type: photo memo with non-empty body → "mixed"
+    const displayType: "text" | "voice" | "photo" | "mixed" | "url" | "file" =
+      m.type === "photo" && m.body.trim().length > 0 ? "mixed" : m.type;
+    return {
+      id: m.id,
+      type: displayType,
+      body: m.body,
+      created_at: m.created_at.toISOString(),
+      photo_url: photoUrl,
+    };
+  });
+
+  return NextResponse.json({ memos: result });
+}

--- a/web/src/app/api/today/unlock-status/route.ts
+++ b/web/src/app/api/today/unlock-status/route.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { db } from "@/lib/db/client";
+import { users, memos } from "@/lib/db/schema";
+import { eq, and, gte, lt, count } from "drizzle-orm";
+
+export const revalidate = 0;
+
+const DEFAULT_THRESHOLD = 3;
+
+export async function GET() {
+  const session = await auth();
+  if (!session?.user?.email) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const userRows = await db
+    .select({ id: users.id, settings: users.settings })
+    .from(users)
+    .where(eq(users.email, session.user.email))
+    .limit(1);
+
+  if (!userRows[0]) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { id: userId, settings } = userRows[0];
+
+  const rawThreshold = (settings as Record<string, unknown> | null)?.unlock_threshold;
+  const unlock_threshold =
+    typeof rawThreshold === "number" && rawThreshold > 0
+      ? rawThreshold
+      : DEFAULT_THRESHOLD;
+
+  const now = new Date();
+  const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const tomorrowStart = new Date(todayStart.getTime() + 86_400_000);
+
+  const rows = await db
+    .select({ count: count() })
+    .from(memos)
+    .where(
+      and(
+        eq(memos.user_id, userId),
+        gte(memos.created_at, todayStart),
+        lt(memos.created_at, tomorrowStart)
+      )
+    );
+
+  const memo_count = rows[0]?.count ?? 0;
+
+  return NextResponse.json({
+    memo_count,
+    unlock_threshold,
+    unlocked: memo_count >= unlock_threshold,
+  });
+}

--- a/web/src/app/api/today/week-feed/route.ts
+++ b/web/src/app/api/today/week-feed/route.ts
@@ -1,0 +1,23 @@
+import { NextRequest, NextResponse } from "next/server";
+
+export const revalidate = 0;
+
+export type WeekFeedItem = {
+  id: string;
+  date_slug: string;
+  day: string;
+  date_display: string;
+  title: string;
+  lede: string;
+  tags: string[];
+  word_count: number;
+  memo_count: number;
+};
+
+export async function GET(req: NextRequest) {
+  const limitParam = req.nextUrl.searchParams.get("limit");
+  const limit = Math.min(Math.max(parseInt(limitParam ?? "7", 10) || 7, 1), 30);
+  void limit;
+
+  return NextResponse.json({ items: [] satisfies WeekFeedItem[] });
+}


### PR DESCRIPTION
## Haptic feedback on sidebar navigation and memo save

DayPage's sidebar drawer and Today view memo save action currently provide no tactile confirmation, making interactions feel flat on a daily-capture tool meant to feel responsive. Adding lightweight UIImpactFeedbackGenerator calls on sidebar item selection and successful memo save will give users the same kind of physical confirmation Apple's first-party Journal and Notes apps provide.

### Acceptance
Build succeeds on iPhone 17 simulator. On a physical device (or simulator with haptic logging), tapping any sidebar destination produces a light impact; saving a memo in Today view produces a success notification haptic. No haptic fires on failed saves or repeated taps of the already-active sidebar item. No visual regressions in RootView or TodayView.