### PR TITLE
feat(today): museum-aesthetic Today screen — hero, AI summary, swipe actions

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -8,11 +8,12 @@
 
 /* Begin PBXBuildFile section */
 		09C6E4728050D69F54949DD1 /* HapticFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FFEA3DDB8DCB528A4189BF /* HapticFeedbackTests.swift */; };
-		KC0000001 /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = KC1000001 /* KeychainHelperTests.swift */; };
 		14188AFE740A834ADF7A41F4 /* DayPageWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B2DFF2B446D2F0AC8DE530A1 /* DayPageWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1530E7C28C23499CFC14C498 /* HapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB12D96218034D3E4555B8AA /* HapticFeedback.swift */; };
 		1719257FE85120ED06CAB183 /* HeroBannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF29E708CBF93A6DD500484C /* HeroBannerView.swift */; };
 		17B5829B738952DA183B1B90 /* DailyPageMetadataEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7E0148C3A6933A903247D /* DailyPageMetadataEditView.swift */; };
+		29C57DABF22715576844485C /* AISummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AF0D6D988BC74555DFB3ED /* AISummaryCard.swift */; };
+		2B194E870578303558D461CD /* CompileUnlockCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE151F5BCB87ACC047C18AD /* CompileUnlockCard.swift */; };
 		326A14114B34412568007B4A /* DayPageWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */; };
 		347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */; };
 		3C0AE791CCB255E33198C9F9 /* UndoPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12641793A8F375B34321E87A /* UndoPillView.swift */; };
@@ -22,6 +23,7 @@
 		60D39385300C46D08D8BF03C /* DraftStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC21412D29A6FB268CE43C58 /* DraftStorage.swift */; };
 		6CE74562753F924A0718DC46 /* DailyPageHeader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57C69070389BADB6984C1A1A /* DailyPageHeader.swift */; };
 		73BECCAED0BDBEFB612B15E4 /* DailyPageParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371058C9DAB9A11AE7EAC835 /* DailyPageParser.swift */; };
+		787E4480A2797607F2DCDE5E /* PillSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EFC77A2EB872EA2279BA2A /* PillSegmentedControl.swift */; };
 		7BB7402C51CCBACF56E7F83A /* DailyPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FF205E680406EC7E4B83DB /* DailyPageModel.swift */; };
 		8C3DEB068D610AAB589EA680 /* TimeZonePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FCD3E2EC4D7257BA7A22BD /* TimeZonePickerView.swift */; };
 		9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B5757B488F583231EC8F6 /* RootView.swift */; };
@@ -36,7 +38,6 @@
 		A10000006 /* Typography.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000006 /* Typography.swift */; };
 		A10000007 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000007 /* Components.swift */; };
 		A10000008 /* Memo.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000008 /* Memo.swift */; };
-		A10000F00 /* FrontmatterParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000F00 /* FrontmatterParser.swift */; };
 		A10000009 /* RawStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000009 /* RawStorage.swift */; };
 		A10000010 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010 /* TodayView.swift */; };
 		A10000011 /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000011 /* ArchiveView.swift */; };
@@ -82,7 +83,6 @@
 		A10000055 /* PressToTalkButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000055 /* PressToTalkButton.swift */; };
 		A10000056 /* VaultLocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000056 /* VaultLocator.swift */; };
 		A10000063 /* SwipeableMemoCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000063 /* SwipeableMemoCard.swift */; };
-		A10000400 /* HorizontalPanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000400 /* HorizontalPanGesture.swift */; };
 		A10000064 /* AttachmentMenuSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000064 /* AttachmentMenuSheet.swift */; };
 		A10000070 /* AuthService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000070 /* AuthService.swift */; };
 		A10000072 /* AuthView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000072 /* AuthView.swift */; };
@@ -94,11 +94,6 @@
 		A10000078 /* VaultMigrationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000078 /* VaultMigrationService.swift */; };
 		A10000079 /* iCloudSyncMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000079 /* iCloudSyncMonitor.swift */; };
 		A10000080 /* AppNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000080 /* AppNavigationModel.swift */; };
-		A10000300 /* DSTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000300 /* DSTokens.swift */; };
-		A10000301 /* DSMotion.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000301 /* DSMotion.swift */; };
-		A10000302 /* DSGlassPill.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000302 /* DSGlassPill.swift */; };
-		A10000303 /* DSSectionLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000303 /* DSSectionLabel.swift */; };
-		A10000304 /* DSDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000304 /* DSDot.swift */; };
 		A10000081 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000081 /* SidebarView.swift */; };
 		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
 		A10000083 /* WeeklyRecapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000083 /* WeeklyRecapService.swift */; };
@@ -117,10 +112,15 @@
 		A10000201 /* SpotlightStripView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000201 /* SpotlightStripView.swift */; };
 		A10000202 /* SmartTemplateRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000202 /* SmartTemplateRow.swift */; };
 		A10000203 /* InlineLensStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000203 /* InlineLensStrip.swift */; };
+		A10000300 /* DSTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000300 /* DSTokens.swift */; };
 		A10000301 /* TimelineService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000301 /* TimelineService.swift */; };
+		A10000302 /* TimelineSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000302 /* TimelineSectionView.swift */; };
+		A10000303 /* DSSectionLabel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000303 /* DSSectionLabel.swift */; };
+		A10000304 /* DSDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000304 /* DSDot.swift */; };
 		A10000350 /* TimelineIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000350 /* TimelineIndex.swift */; };
 		A10000360 /* SentryReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000360 /* SentryReporter.swift */; };
-		A10000302 /* TimelineSectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000302 /* TimelineSectionView.swift */; };
+		A10000400 /* HorizontalPanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000400 /* HorizontalPanGesture.swift */; };
+		A10000F00 /* FrontmatterParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000F00 /* FrontmatterParser.swift */; };
 		A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */; };
 		AF0000001 /* SpaceGrotesk-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000001 /* SpaceGrotesk-Light.ttf */; };
 		AF0000002 /* SpaceGrotesk-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000002 /* SpaceGrotesk-Regular.ttf */; };
@@ -150,6 +150,7 @@
 		DS0000015 /* DSNavRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000015 /* DSNavRow.swift */; };
 		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
 		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
+		E5077A7D97855770914BFB8D /* MarkdownExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8043A3D3371852ACB3D6F3 /* MarkdownExportService.swift */; };
 		EA575F353C6AFD5EA7FF9A6F /* QuickCaptureWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */; };
 		ES0000001 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000001 /* EmptyStateView.swift */; };
 		ES0000002 /* GlassErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000002 /* GlassErrorBanner.swift */; };
@@ -163,6 +164,7 @@
 		FB0000003 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000003 /* FeedbackView.swift */; };
 		FB0000004 /* FeedbackContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000004 /* FeedbackContext.swift */; };
 		FT0000001 /* DayOrbView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT1000001 /* DayOrbView.swift */; };
+		KC0000001 /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = KC1000001 /* KeychainHelperTests.swift */; };
 		LS0000001 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = LS1000001 /* Localizable.strings */; };
 		LS0000002 /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = LS1000004 /* L10n.swift */; };
 		MD0000001 /* MemoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000001 /* MemoDetailView.swift */; };
@@ -174,13 +176,12 @@
 		T10000003 /* VaultMigrationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000003 /* VaultMigrationServiceTests.swift */; };
 		T10000004 /* VaultLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000004 /* VaultLocatorTests.swift */; };
 		T10000005 /* RawStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000005 /* RawStorageTests.swift */; };
-		T10000050 /* TimelineIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000050 /* TimelineIndexTests.swift */; };
 		T10000006 /* ComposerContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000006 /* ComposerContextProviderTests.swift */; };
+		T10000050 /* TimelineIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000050 /* TimelineIndexTests.swift */; };
 		TH0000001 /* ThreadConversationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000001 /* ThreadConversationViewModel.swift */; };
 		TH0000002 /* ThreadConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000002 /* ThreadConversationView.swift */; };
 		TH0000003 /* InlineMicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000003 /* InlineMicButton.swift */; };
 		WS0000001 /* WelcomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = WS1000001 /* WelcomeScreen.swift */; };
-		E5077A7D97855770914BFB8D /* MarkdownExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8043A3D3371852ACB3D6F3 /* MarkdownExportService.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -232,14 +233,16 @@
 		2748059CC689A341C7CAAACC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
 		371058C9DAB9A11AE7EAC835 /* DailyPageParser.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyPageParser.swift; sourceTree = "<group>"; };
+		3DE151F5BCB87ACC047C18AD /* CompileUnlockCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompileUnlockCard.swift; sourceTree = "<group>"; };
 		519B9B12CB68C0E6E2A06292 /* QuickCaptureControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureControl.swift; sourceTree = "<group>"; };
 		57C69070389BADB6984C1A1A /* DailyPageHeader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyPageHeader.swift; sourceTree = "<group>"; };
 		5FD3383348F15CB7B4E82E53 /* DayPageShortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DayPageShortcuts.swift; sourceTree = "<group>"; };
+		61EFC77A2EB872EA2279BA2A /* PillSegmentedControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PillSegmentedControl.swift; sourceTree = "<group>"; };
 		71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DayPageWidgetBundle.swift; sourceTree = "<group>"; };
 		73FCD3E2EC4D7257BA7A22BD /* TimeZonePickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimeZonePickerView.swift; sourceTree = "<group>"; };
 		7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureWidget.swift; sourceTree = "<group>"; };
+		82AF0D6D988BC74555DFB3ED /* AISummaryCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AISummaryCard.swift; sourceTree = "<group>"; };
 		84FFEA3DDB8DCB528A4189BF /* HapticFeedbackTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HapticFeedbackTests.swift; sourceTree = "<group>"; };
-		KC1000001 /* KeychainHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelperTests.swift; sourceTree = "<group>"; };
 		8F07950D8A46BAC7B9CCB1ED /* ShareCardSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareCardSystem.swift; path = ShareCard/ShareCardSystem.swift; sourceTree = "<group>"; };
 		912420086719F3FFFB45FE7A /* InputBarTutorialOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InputBarTutorialOverlay.swift; sourceTree = "<group>"; };
 		986C8E3E042E690BA4CCC12D /* ShareCardSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareCardSystem.swift; path = ShareCard/ShareCardSystem.swift; sourceTree = "<group>"; };
@@ -251,7 +254,6 @@
 		A20000006 /* Typography.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Typography.swift; sourceTree = "<group>"; };
 		A20000007 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
 		A20000008 /* Memo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Memo.swift; sourceTree = "<group>"; };
-		A20000F00 /* FrontmatterParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmatterParser.swift; sourceTree = "<group>"; };
 		A20000009 /* RawStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorage.swift; sourceTree = "<group>"; };
 		A20000010 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		A20000011 /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
@@ -298,7 +300,6 @@
 		A20000055 /* PressToTalkButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PressToTalkButton.swift; sourceTree = "<group>"; };
 		A20000056 /* VaultLocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultLocator.swift; sourceTree = "<group>"; };
 		A20000063 /* SwipeableMemoCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwipeableMemoCard.swift; sourceTree = "<group>"; };
-		A20000400 /* HorizontalPanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalPanGesture.swift; sourceTree = "<group>"; };
 		A20000064 /* AttachmentMenuSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMenuSheet.swift; sourceTree = "<group>"; };
 		A20000070 /* AuthService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthService.swift; sourceTree = "<group>"; };
 		A20000071 /* DayPage.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = DayPage.entitlements; sourceTree = "<group>"; };
@@ -311,11 +312,6 @@
 		A20000078 /* VaultMigrationService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationService.swift; sourceTree = "<group>"; };
 		A20000079 /* iCloudSyncMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudSyncMonitor.swift; sourceTree = "<group>"; };
 		A20000080 /* AppNavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationModel.swift; sourceTree = "<group>"; };
-		A20000300 /* DSTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSTokens.swift; sourceTree = "<group>"; };
-		A20000301 /* DSMotion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSMotion.swift; sourceTree = "<group>"; };
-		A20000302 /* DSGlassPill.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSGlassPill.swift; sourceTree = "<group>"; };
-		A20000303 /* DSSectionLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSSectionLabel.swift; sourceTree = "<group>"; };
-		A20000304 /* DSDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSDot.swift; sourceTree = "<group>"; };
 		A20000081 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		A20000082 /* InputBarV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV4.swift; sourceTree = "<group>"; };
 		A20000083 /* WeeklyRecapService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapService.swift; sourceTree = "<group>"; };
@@ -334,13 +330,19 @@
 		A20000201 /* SpotlightStripView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpotlightStripView.swift; sourceTree = "<group>"; };
 		A20000202 /* SmartTemplateRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartTemplateRow.swift; sourceTree = "<group>"; };
 		A20000203 /* InlineLensStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineLensStrip.swift; sourceTree = "<group>"; };
+		A20000300 /* DSTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSTokens.swift; sourceTree = "<group>"; };
 		A20000301 /* TimelineService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineService.swift; sourceTree = "<group>"; };
+		A20000302 /* TimelineSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineSectionView.swift; sourceTree = "<group>"; };
+		A20000303 /* DSSectionLabel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSSectionLabel.swift; sourceTree = "<group>"; };
+		A20000304 /* DSDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSDot.swift; sourceTree = "<group>"; };
 		A20000350 /* TimelineIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineIndex.swift; sourceTree = "<group>"; };
 		A20000360 /* SentryReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReporter.swift; sourceTree = "<group>"; };
-		A20000302 /* TimelineSectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineSectionView.swift; sourceTree = "<group>"; };
+		A20000400 /* HorizontalPanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalPanGesture.swift; sourceTree = "<group>"; };
+		A20000F00 /* FrontmatterParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontmatterParser.swift; sourceTree = "<group>"; };
 		A30000001 /* DayPage.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPage.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A381FA327A37AE0DD740D61D /* PosterTemplates.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PosterTemplates.swift; path = ShareCard/PosterTemplates.swift; sourceTree = "<group>"; };
 		A4EBD94EB4FD71CC10D478F3 /* DailyPageSummarySection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyPageSummarySection.swift; sourceTree = "<group>"; };
+		AC8043A3D3371852ACB3D6F3 /* MarkdownExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExportService.swift; sourceTree = "<group>"; };
 		AF1000001 /* SpaceGrotesk-Light.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Light.ttf"; sourceTree = "<group>"; };
 		AF1000002 /* SpaceGrotesk-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Regular.ttf"; sourceTree = "<group>"; };
 		AF1000003 /* SpaceGrotesk-Medium.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "SpaceGrotesk-Medium.ttf"; sourceTree = "<group>"; };
@@ -384,6 +386,7 @@
 		FB1000004 /* FeedbackContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackContext.swift; sourceTree = "<group>"; };
 		FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
 		FT1000001 /* DayOrbView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOrbView.swift; sourceTree = "<group>"; };
+		KC1000001 /* KeychainHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelperTests.swift; sourceTree = "<group>"; };
 		LS1000002 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		LS1000003 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		LS1000004 /* L10n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10n.swift; sourceTree = "<group>"; };
@@ -394,14 +397,13 @@
 		T20000003 /* VaultMigrationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationServiceTests.swift; sourceTree = "<group>"; };
 		T20000004 /* VaultLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultLocatorTests.swift; sourceTree = "<group>"; };
 		T20000005 /* RawStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorageTests.swift; sourceTree = "<group>"; };
-		T20000050 /* TimelineIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineIndexTests.swift; sourceTree = "<group>"; };
 		T20000006 /* ComposerContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerContextProviderTests.swift; sourceTree = "<group>"; };
+		T20000050 /* TimelineIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineIndexTests.swift; sourceTree = "<group>"; };
 		T30000001 /* DayPageTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = DayPageTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		TH1000001 /* ThreadConversationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationViewModel.swift; sourceTree = "<group>"; };
 		TH1000002 /* ThreadConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationView.swift; sourceTree = "<group>"; };
 		TH1000003 /* InlineMicButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineMicButton.swift; sourceTree = "<group>"; };
 		WS1000001 /* WelcomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeScreen.swift; sourceTree = "<group>"; };
-		AC8043A3D3371852ACB3D6F3 /* MarkdownExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MarkdownExportService.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -534,8 +536,8 @@
 				A20000081 /* SidebarView.swift */,
 				A20000094 /* SidebarViewModel.swift */,
 				A20000300 /* DSTokens.swift */,
-				A20000301 /* DSMotion.swift */,
-				A20000302 /* DSGlassPill.swift */,
+				A20000301 /* TimelineService.swift */,
+				A20000302 /* TimelineSectionView.swift */,
 				A20000303 /* DSSectionLabel.swift */,
 				A20000304 /* DSDot.swift */,
 				A20000024 /* Info.plist */,
@@ -695,6 +697,8 @@
 				DC21412D29A6FB268CE43C58 /* DraftStorage.swift */,
 				912420086719F3FFFB45FE7A /* InputBarTutorialOverlay.swift */,
 				12641793A8F375B34321E87A /* UndoPillView.swift */,
+				82AF0D6D988BC74555DFB3ED /* AISummaryCard.swift */,
+				3DE151F5BCB87ACC047C18AD /* CompileUnlockCard.swift */,
 			);
 			path = Today;
 			sourceTree = "<group>";
@@ -876,6 +880,7 @@
 				ES1000002 /* GlassErrorBanner.swift */,
 				ES1000003 /* GlassTabBar.swift */,
 				0995108F7E2E8994F114A240 /* MemoListSkeleton.swift */,
+				61EFC77A2EB872EA2279BA2A /* PillSegmentedControl.swift */,
 			);
 			path = Components;
 			sourceTree = "<group>";
@@ -1205,8 +1210,8 @@
 				A10000085 /* iCloudConflictMonitor.swift in Sources */,
 				A10000080 /* AppNavigationModel.swift in Sources */,
 				A10000300 /* DSTokens.swift in Sources */,
-				A10000301 /* DSMotion.swift in Sources */,
-				A10000302 /* DSGlassPill.swift in Sources */,
+				A10000301 /* TimelineService.swift in Sources */,
+				A10000302 /* TimelineSectionView.swift in Sources */,
 				A10000303 /* DSSectionLabel.swift in Sources */,
 				A10000304 /* DSDot.swift in Sources */,
 				A10000081 /* SidebarView.swift in Sources */,
@@ -1262,6 +1267,9 @@
 				C80B52CC8945CDC4EE87DCBB /* PosterTemplates.swift in Sources */,
 				F66780AF157611A4283937FE /* MemoListSkeleton.swift in Sources */,
 				E5077A7D97855770914BFB8D /* MarkdownExportService.swift in Sources */,
+				29C57DABF22715576844485C /* AISummaryCard.swift in Sources */,
+				787E4480A2797607F2DCDE5E /* PillSegmentedControl.swift in Sources */,
+				2B194E870578303558D461CD /* CompileUnlockCard.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage/Components/PillSegmentedControl.swift
+++ b/DayPage/Components/PillSegmentedControl.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+// MARK: - PillSegmentedControl
+//
+// Museum-aesthetic segmented control (Claude Design bundle — app.jsx Segmented).
+// A pill track on a sunken surface; the selected segment lifts onto a white
+// pill with accent text + a whisper of shadow.
+//
+//   ┌─────────────────────────────┐
+//   │ [ 今日 ]   成稿     档案     │   ← selected = white pill, accent text
+//   └─────────────────────────────┘
+//
+// Generic over a Hashable id so callers bind it to their own tab enum.
+
+struct PillSegmentedControl<ID: Hashable>: View {
+    struct Segment: Identifiable {
+        let id: ID
+        let label: String
+    }
+
+    let segments: [Segment]
+    @Binding var selection: ID
+    var onSelect: ((ID) -> Void)? = nil
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Namespace private var pillNamespace
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(segments) { segment in
+                segmentButton(segment)
+            }
+        }
+        .padding(3)
+        .background(
+            Capsule(style: .continuous)
+                .fill(DSColor.surfaceSunken)
+                .overlay(
+                    Capsule(style: .continuous)
+                        .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
+                )
+        )
+        .accessibilityElement(children: .contain)
+    }
+
+    private func segmentButton(_ segment: Segment) -> some View {
+        let isSelected = segment.id == selection
+        return Button {
+            guard !isSelected else { return }
+            Haptics.soft()
+            withAnimation(reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.86)) {
+                selection = segment.id
+            }
+            onSelect?(segment.id)
+        } label: {
+            Text(segment.label)
+                .font(.custom("Inter-Medium", size: 13))
+                .fontWeight(isSelected ? .semibold : .medium)
+                .foregroundColor(isSelected ? DSColor.accentAmber : DSColor.inkMuted)
+                .lineLimit(1)
+                .padding(.vertical, 7)
+                .frame(maxWidth: .infinity)
+                .background {
+                    if isSelected {
+                        Capsule(style: .continuous)
+                            .fill(DSColor.surfaceWhite)
+                            .shadow(color: Color.black.opacity(0.06), radius: 1, x: 0, y: 1)
+                            .matchedGeometryEffect(id: "pill", in: pillNamespace)
+                    }
+                }
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? [.isSelected, .isButton] : .isButton)
+        .accessibilityLabel(segment.label)
+    }
+}

--- a/DayPage/DesignSystem/Surfaces.swift
+++ b/DayPage/DesignSystem/Surfaces.swift
@@ -71,6 +71,30 @@ struct LiquidGlassCard: ViewModifier {
     }
 }
 
+// MARK: - SolidCard
+
+/// Museum-aesthetic content-first card: a plain opaque white surface with a
+/// 0.5 pt hairline and a whisper of shadow. Replaces Liquid Glass on memo
+/// cards so the content (text + photo) reads cleanly against the warm canvas.
+/// Matches the design token: surface-white #FFF, radius 14, hairline border.
+struct SolidCard: ViewModifier {
+    var cornerRadius: CGFloat = 14
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .fill(DSColor.surfaceWhite)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+                    .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
+            )
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+            .shadow(color: Color(hex: "2D1E0A").opacity(0.04), radius: 1, x: 0, y: 1)
+    }
+}
+
 // MARK: - LiquidGlassPill
 
 /// Fully-rounded pill surface (cornerRadius 999, tone .hi).
@@ -110,5 +134,10 @@ extension View {
     /// Expanded-menu panel surface (tone .hi).
     func liquidGlassPanel(cornerRadius: CGFloat = 20) -> some View {
         modifier(LiquidGlassPanel(cornerRadius: cornerRadius))
+    }
+
+    /// Museum-aesthetic content-first white card (surface-white + hairline).
+    func solidCard(cornerRadius: CGFloat = 14) -> some View {
+        modifier(SolidCard(cornerRadius: cornerRadius))
     }
 }

--- a/DayPage/DesignSystem/Typography.swift
+++ b/DayPage/DesignSystem/Typography.swift
@@ -175,6 +175,8 @@ enum DSType {
     static let serifDisplay28: Font = DSFonts.serif(size: 28, weight: .semibold)
     /// Serif display 32pt — sidebar date / large headers.
     static let serifDisplay32: Font = DSFonts.serif(size: 32, weight: .semibold)
+    /// Serif display 56pt — Today hero date title (museum-aesthetic, always-on).
+    static let serifDisplay56: Font = DSFonts.serif(size: 56, weight: .semibold)
 }
 
 // MARK: - View Modifiers

--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -1,0 +1,151 @@
+import SwiftUI
+
+// MARK: - AISummaryCard
+//
+// Museum-aesthetic "AI · 今日一句" card for the Today screen.
+//
+// Design intent (Claude Design bundle — composer.jsx AISummary, restrained variant):
+//   • plain white surface + 0.5pt hairline border, radius 14
+//   • slim 2px accent rail down the left edge
+//   • header: tiny sparkle + mono "AI · 今日一句" + right-aligned timestamp
+//   • body: 19pt serif italic, revealed with a typewriter animation + blinking caret
+//
+// Data: bound to `TodayViewModel.dailyPageSummary` (the compiled daily summary).
+// The caller is expected to only render this when a summary exists.
+
+struct AISummaryCard: View {
+    /// The compiled one-line summary to reveal.
+    let summary: String
+    /// Timestamp shown in the header (defaults to now).
+    var timestamp: Date = Date()
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private static let timeFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = AppSettings.currentTimeZone()
+        return f
+    }()
+
+    var body: some View {
+        ZStack(alignment: .leading) {
+            // Slim accent rail (left edge).
+            RoundedRectangle(cornerRadius: 999, style: .continuous)
+                .fill(DSColor.accentAmber)
+                .opacity(0.85)
+                .frame(width: 2)
+                .padding(.vertical, 14)
+
+            VStack(alignment: .leading, spacing: 8) {
+                header
+                TypewriterText(
+                    fullText: summary,
+                    animated: !reduceMotion
+                )
+                .font(DSType.serifQuote) // 18pt serif italic ≈ design 19pt
+                .foregroundColor(DSColor.inkPrimary)
+                .lineSpacing(4)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+            .padding(.init(top: 18, leading: 22, bottom: 20, trailing: 20))
+        }
+        .background(
+            RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous)
+                .fill(DSColor.surfaceWhite)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous)
+                .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
+        )
+        .shadow(color: Color.black.opacity(0.04), radius: 1, x: 0, y: 1)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("AI 今日一句")
+        .accessibilityValue(summary)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 10, weight: .semibold))
+                .foregroundColor(DSColor.accentAmber)
+            Text("AI · 今日一句")
+                .font(DSType.mono9)
+                .textCase(.uppercase)
+                .tracking(1.6)
+                .foregroundColor(DSColor.accentAmber)
+            Spacer(minLength: 8)
+            HStack(spacing: 5) {
+                Circle()
+                    .fill(DSColor.accentAmber)
+                    .frame(width: 5, height: 5)
+                Text(Self.timeFmt.string(from: timestamp))
+                    .font(DSType.mono9)
+                    .tracking(1.2)
+                    .foregroundColor(DSColor.inkSubtle)
+            }
+        }
+    }
+}
+
+// MARK: - TypewriterText
+//
+// Reveals `fullText` one character at a time with a blinking accent caret while
+// typing. Honors Reduce Motion by showing the full text immediately.
+
+struct TypewriterText: View {
+    let fullText: String
+    var animated: Bool = true
+
+    @State private var shownCount: Int = 0
+    @State private var caretVisible: Bool = true
+    @State private var didStart = false
+
+    private var isTyping: Bool { animated && shownCount < fullText.count }
+
+    var body: some View {
+        // Build the prefix lazily so we don't recompute on every redraw.
+        let shown = String(fullText.prefix(animated ? shownCount : fullText.count))
+        HStack(alignment: .firstTextBaseline, spacing: 1) {
+            Text(shown)
+            if isTyping {
+                Rectangle()
+                    .fill(DSColor.accentAmber)
+                    .frame(width: 2, height: 16)
+                    .opacity(caretVisible ? 1 : 0)
+            }
+        }
+        .onAppear { startIfNeeded() }
+        .onChange(of: fullText) { _ in
+            // New summary → restart the reveal.
+            shownCount = 0
+            didStart = false
+            startIfNeeded()
+        }
+    }
+
+    private func startIfNeeded() {
+        guard animated, !didStart, !fullText.isEmpty else {
+            if !animated { shownCount = fullText.count }
+            return
+        }
+        didStart = true
+        // Blink the caret.
+        withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
+            caretVisible = false
+        }
+        // Kick off the reveal after a short beat (mirrors the design's 380ms lead-in).
+        scheduleNextChar(after: 0.38)
+    }
+
+    private func scheduleNextChar(after delay: Double) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            guard shownCount < fullText.count else { return }
+            shownCount += 1
+            // 36–66ms jitter per char, matching the design's organic cadence.
+            let jitter = Double.random(in: 0.036...0.066)
+            scheduleNextChar(after: jitter)
+        }
+    }
+}

--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -101,6 +101,9 @@ struct TypewriterText: View {
     @State private var shownCount: Int = 0
     @State private var caretVisible: Bool = true
     @State private var didStart = false
+    /// Generation counter that increments each time fullText changes.
+    /// Captured by asyncAfter closures so stale chains bail out.
+    @State private var generation = 0
 
     private var isTyping: Bool { animated && shownCount < fullText.count }
 
@@ -121,6 +124,7 @@ struct TypewriterText: View {
             // New summary → restart the reveal.
             shownCount = 0
             didStart = false
+            generation += 1
             startIfNeeded()
         }
     }
@@ -140,8 +144,9 @@ struct TypewriterText: View {
     }
 
     private func scheduleNextChar(after delay: Double) {
-        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
-            guard shownCount < fullText.count else { return }
+        let gen = generation
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [gen] in
+            guard gen == generation, shownCount < fullText.count else { return }
             shownCount += 1
             // 36–66ms jitter per char, matching the design's organic cadence.
             let jitter = Double.random(in: 0.036...0.066)

--- a/DayPage/Features/Today/CompileUnlockCard.swift
+++ b/DayPage/Features/Today/CompileUnlockCard.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+// MARK: - CompileUnlockCard
+//
+// Museum-aesthetic timeline placeholder card (Claude Design bundle — app.jsx
+// "再记一条解锁今日成稿"). A dashed accent-bordered card that sits inline in the
+// Today timeline, inviting one more memo before AI weaves the day into a page.
+//
+//   ┌╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┐
+//   ┆ (✦)  再记一条解锁今日成稿        ┆
+//   ┆      AI 将把今天的碎片连缀成日页   ┆
+//   └╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┘
+
+struct CompileUnlockCard: View {
+    var body: some View {
+        HStack(spacing: 14) {
+            // Accent-soft sparkle tile.
+            ZStack {
+                Circle()
+                    .fill(DSColor.accentSoft)
+                    .frame(width: 36, height: 36)
+                Image(systemName: "sparkles")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundColor(DSColor.accentAmber)
+            }
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text("再记一条解锁今日成稿")
+                    .font(DSFonts.jetBrainsMono(size: 10))
+                    .tracking(1.2)
+                    .foregroundColor(DSColor.accentAmber)
+                Text("AI 将把今天的碎片连缀成一篇日页。")
+                    .font(.custom("Inter-Regular", size: 13))
+                    .foregroundColor(DSColor.inkMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(18)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(
+                    DSColor.accentBorder,
+                    style: StrokeStyle(lineWidth: 1.5, dash: [6, 5])
+                )
+        )
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("再记一条解锁今日成稿")
+    }
+}

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -28,6 +28,15 @@ struct MemoCardView: View {
     @State private var downloadTask: Task<Void, Never>? = nil
     @State private var sharePayload: SharePayload? = nil
 
+    /// Precise 24h time for the content-first card meta line (rendered as "15·23").
+    private static let cardTimeFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "HH:mm"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = AppSettings.currentTimeZone()
+        return f
+    }()
+
     // MARK: - iCloud helpers
 
     private func attachmentDownloadState(for url: URL) -> AttachmentDownloadState {
@@ -128,8 +137,8 @@ struct MemoCardView: View {
         }
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
-        .liquidGlassCard(cornerRadius: 18)
-        .contentShape(RoundedRectangle(cornerRadius: 18))
+        .solidCard(cornerRadius: 14)
+        .contentShape(RoundedRectangle(cornerRadius: 14))
         .onTapGesture {
             if memo.location?.lat != nil { showLocationSheet = true }
         }
@@ -256,53 +265,34 @@ struct MemoCardView: View {
                     }
             }
 
-            // Bottom meta row: time + type chip + location
+            // Bottom meta row — content-first: only a quiet mono timestamp.
+            // Weather / location / type chip / a resting share button are all
+            // hidden by the museum-aesthetic redesign: location & type live on
+            // the detail page; share is the left-swipe action; power-user
+            // overrides remain in the long-press contextMenu below.
             HStack(spacing: 8) {
-                Text(RelativeTimeFormatter.relative(memo.created))
+                // Single line of metadata: precise 24h time as "15·23".
+                let photoFlag = memo.type == .mixed && memo.attachments.contains { $0.kind == "photo" }
+                Text(Self.cardTimeFmt.string(from: memo.created).replacingOccurrences(of: ":", with: "·"))
                     .font(DSFonts.jetBrainsMono(size: 10))
-                    .tracking(0.6)
-                    .textCase(.uppercase)
+                    .tracking(1.6)
                     .foregroundColor(DSColor.inkSubtle)
 
-                if memo.type != .text {
-                    typeChip
-                }
-
-                if let loc = memo.location?.name, !loc.isEmpty {
-                    HStack(spacing: 3) {
-                        Image(systemName: "mappin")
-                            .font(.system(size: 8, weight: .medium))
-                        Text(loc)
-                            .font(DSFonts.jetBrainsMono(size: 9))
-                            .tracking(0.4)
-                            .textCase(.uppercase)
-                    }
-                    .foregroundColor(DSColor.inkSubtle)
+                // Tiny photo glyph hints a mixed entry without a loud chip.
+                if photoFlag {
+                    Image(systemName: "photo")
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundColor(DSColor.inkSubtle)
                 }
 
                 Spacer(minLength: 4)
-
-                // Primary share entry — issue #309 W1-①.
-                // contextMenu below stays as a power-user override that lets
-                // you force a specific card type or send plain text.
-                Button {
-                    sharePayload = SharePayload.auto(from: memo)
-                } label: {
-                    Image(systemName: "square.and.arrow.up")
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundColor(DSColor.inkSubtle)
-                        .frame(width: 28, height: 28)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("分享这条 memo")
             }
             .padding(.horizontal, 14)
             .padding(.top, 10)
             .padding(.bottom, 14)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
-        .liquidGlassCard(cornerRadius: 18)
+        .solidCard(cornerRadius: 14)
         .contextMenu {
             // Tap the button above for the smart default; long-press here to
             // override the template or send plain text.

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -15,10 +15,10 @@ import SwiftUI
 // overshoot, while keeping the panel surface visually quiet at small offsets.
 private enum SwipePhysics {
 
-    /// Width of the action panel on each side. Matches the iOS Mail / Notes
-    /// trailing action width so the card never reveals more than one action
-    /// at a time and the affordance reads as a single tap target.
-    static let panelWidth: CGFloat = 84
+    /// Width of the action panel on each side. Widened toward the design's
+    /// 132pt reveal (`DSTokens.Gestures.swipeRevealWidth`); 96pt keeps a single
+    /// action reading as one comfortable tap target without over-revealing.
+    static let panelWidth: CGFloat = 96
 
     /// Translation past which a release snaps open (vs. snap back closed).
     /// Apple Notes uses ~40pt; we follow the same ratio to panelWidth so a
@@ -62,9 +62,10 @@ private enum SwipePhysics {
 // progresses, the icon scales up, and the label only resolves once the
 // open threshold is crossed.
 //
-//  - Left swipe → trailing Delete action (two-step: reveal then tap, so a
-//    destructive action always requires explicit confirmation).
-//  - Right swipe → leading Pin/Unpin action.
+//  - Left swipe → trailing SHARE action (accent amber) — the prominent,
+//    content-first action surfaced by the museum-aesthetic redesign.
+//  - Right swipe → leading MORE action (sunken neutral) — opens the fuller
+//    set (pin / delete / …) so secondary chrome stays hidden by default.
 //
 // Gesture model:
 //  - settledOffset is the resting position; dragDelta rides on top 1:1.
@@ -84,6 +85,10 @@ struct SwipeableMemoCard: View {
     let memo: Memo
     var onDelete: (() -> Void)? = nil
     var onPin: (() -> Void)? = nil
+    /// Left-swipe SHARE action (museum-aesthetic primary).
+    var onShare: (() -> Void)? = nil
+    /// Right-swipe MORE action — parent presents the fuller action set.
+    var onMore: (() -> Void)? = nil
     var onRetranscribe: ((Memo, Memo.Attachment) -> Void)? = nil
     /// Issue #309 W2: in multi-select mode, both the NavigationLink tap
     /// and the swipe gesture must be inert — the only valid interaction is
@@ -153,15 +158,15 @@ struct SwipeableMemoCard: View {
             // glass surface rather than an abutting colored rectangle.
             HStack(spacing: 0) {
                 SwipeActionPanel(
-                    kind: .leading(isPinned: memo.pinnedAt != nil),
+                    kind: .more,
                     progress: max(0, revealProgress),
-                    onTap: handlePinTap
+                    onTap: handleMoreTap
                 )
                 Spacer(minLength: 0)
                 SwipeActionPanel(
-                    kind: .trailing,
+                    kind: .share,
                     progress: max(0, -revealProgress),
-                    onTap: handleDeleteTap
+                    onTap: handleShareTap
                 )
             }
 
@@ -212,6 +217,8 @@ struct SwipeableMemoCard: View {
         }
         .clipped()
         .accessibilityLabel(accessibilityMemoLabel)
+        .accessibilityAction(named: "Share") { onShare?() }
+        .accessibilityAction(named: "More") { onMore?() }
         .accessibilityAction(named: "Delete") { onDelete?() }
         .accessibilityAction(named: memo.pinnedAt != nil ? "Unpin" : "Pin") { onPin?() }
         // Entering selection mode mid-swipe (panel revealed) would leave a
@@ -227,16 +234,16 @@ struct SwipeableMemoCard: View {
 
     // MARK: - Action handlers
 
-    private func handlePinTap() {
+    private func handleShareTap() {
         Haptics.tapConfirm()
         snapClose()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { onPin?() }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { onShare?() }
     }
 
-    private func handleDeleteTap() {
-        Haptics.warn()
+    private func handleMoreTap() {
+        Haptics.soft()
         snapClose()
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { onDelete?() }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { onMore?() }
     }
 
     // MARK: - Pan callbacks
@@ -334,8 +341,8 @@ struct SwipeableMemoCard: View {
 private struct SwipeActionPanel: View {
 
     enum Kind {
-        case leading(isPinned: Bool)
-        case trailing
+        case more   // right-swipe (leading) — sunken neutral
+        case share  // left-swipe (trailing) — accent amber
     }
 
     let kind: Kind
@@ -373,20 +380,27 @@ private struct SwipeActionPanel: View {
     private var background: some View {
         // Base tone deepens as the panel is revealed. A single brand color
         // with an opacity ramp reads as a continuous surface waking up,
-        // rather than two distinct fills swapping.
-        baseColor.opacity(0.55 + 0.45 * min(1, progress))
+        // rather than two distinct fills swapping. MORE's sunken neutral
+        // starts more opaque so the pale surface stays legible.
+        let floor: CGFloat = (kindIsMore ? 0.85 : 0.55)
+        return baseColor.opacity(Double(floor + (1 - floor) * min(1, progress)))
+    }
+
+    private var kindIsMore: Bool {
+        if case .more = kind { return true }
+        return false
     }
 
     private var content: some View {
         VStack(spacing: 6) {
             Image(systemName: iconName)
                 .font(.system(size: 17, weight: .semibold))
-                .foregroundColor(.white)
+                .foregroundColor(foreground)
                 .scaleEffect(iconScale)
 
             Text(label)
                 .font(.custom("Inter-Medium", size: 11))
-                .foregroundColor(.white)
+                .foregroundColor(foreground)
                 .opacity(labelOpacity)
         }
     }
@@ -395,22 +409,31 @@ private struct SwipeActionPanel: View {
 
     private var iconName: String {
         switch kind {
-        case .leading(let isPinned): return isPinned ? "pin.slash.fill" : "pin.fill"
-        case .trailing:              return "trash.fill"
+        case .more:  return "ellipsis"
+        case .share: return "square.and.arrow.up"
         }
     }
 
     private var label: String {
         switch kind {
-        case .leading(let isPinned): return isPinned ? "取消置顶" : "置顶"
-        case .trailing:              return "删除"
+        case .more:  return "更多"
+        case .share: return "分享"
         }
     }
 
+    /// MORE rides on a sunken neutral surface (dark ink), SHARE on accent amber
+    /// (white ink) — the design's content-first hierarchy.
     private var baseColor: Color {
         switch kind {
-        case .leading(let isPinned): return isPinned ? DSColor.secondary : DSColor.amberArchival
-        case .trailing:              return DSColor.error
+        case .more:  return DSColor.surfaceSunken
+        case .share: return DSColor.accentAmber
+        }
+    }
+
+    private var foreground: Color {
+        switch kind {
+        case .more:  return DSColor.inkPrimary
+        case .share: return .white
         }
     }
 
@@ -426,8 +449,8 @@ private struct SwipeActionPanel: View {
 
     private var accessibilityLabel: String {
         switch kind {
-        case .leading(let isPinned): return isPinned ? "Unpin memo" : "Pin memo"
-        case .trailing:              return "Delete memo"
+        case .more:  return "More actions"
+        case .share: return "Share memo"
         }
     }
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -680,11 +680,10 @@ struct TodayView: View {
     /// Hero region shown at the top of Today: serif date + mono signal kicker + 200pt Day Orb.
     @ViewBuilder
     private var orbHero: some View {
+        // The 56pt hero title now lives in `sidebarSection` (always-on), so the
+        // empty-state orb block only carries the orb + kicker to avoid a
+        // duplicate weekday title.
         VStack(spacing: 6) {
-            Text(weekdayName(currentTime))
-                .font(DSType.serifDisplay32)
-                .foregroundColor(DSColor.inkPrimary)
-
             Text(orbKicker(currentTime))
                 .font(DSType.mono10)
                 .foregroundColor(DSColor.inkSubtle)
@@ -900,12 +899,14 @@ struct TodayView: View {
             Button {
                 nav.openSidebar()
             } label: {
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: 8) {
+                    // Museum-aesthetic hero title — always-on 56pt serif.
                     Text(weekdayName(currentTime))
-                        .font(DSType.serifDisplay32)
+                        .font(DSType.serifDisplay56)
                         .foregroundColor(DSColor.inkPrimary)
+                        .lineLimit(1)
                         .dynamicTypeSize(.xSmall ... .accessibility2)
-                        .minimumScaleFactor(0.75)
+                        .minimumScaleFactor(0.6)
                     Text(headerSubline(currentTime))
                         .font(DSType.mono10)
                         .foregroundColor(DSColor.inkSubtle)
@@ -1019,6 +1020,16 @@ struct TodayView: View {
             .frame(height: 0)
 
             LazyVStack(spacing: 8) {
+                // Museum-aesthetic "AI · 今日一句" — restrained one-liner pinned
+                // at the very top once the day has a compiled summary.
+                if let summary = viewModel.dailyPageSummary,
+                   !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    AISummaryCard(summary: summary)
+                        .padding(.horizontal, 20)
+                        .padding(.bottom, 4)
+                        .transition(.opacity)
+                }
+
                 if viewModel.isDailyPageCompiled {
                     swipeableDailyPageCard
                         .padding(.horizontal, 20)
@@ -1103,6 +1114,18 @@ struct TodayView: View {
                         .padding(.horizontal, 20)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                     }
+                }
+
+                // Museum-aesthetic inline "unlock today's page" placeholder —
+                // shown once the day has memos but hasn't been compiled and is
+                // still short of the threshold that triggers AI compilation.
+                if !viewModel.memos.isEmpty
+                    && !viewModel.isDailyPageCompiled
+                    && viewModel.memos.count < 3 {
+                    CompileUnlockCard()
+                        .padding(.horizontal, 20)
+                        .padding(.top, 4)
+                        .transition(.opacity)
                 }
 
                 historySupplement
@@ -1300,14 +1323,51 @@ struct TodayView: View {
     private func headerSubline(_ date: Date) -> String {
         let count = viewModel.memos.count
         let dateStr = Self.headerDateFmt.string(from: date)
+
+        // Notes segment (empty-state shows time instead of count).
+        var parts: [String]
         switch count {
         case 0:
-            return "\(dateStr)  ·  \(Self.headerTimeFmt.string(from: date))"
+            parts = [dateStr, Self.headerTimeFmt.string(from: date)]
         case 1:
-            return "\(dateStr)  ·  1 note"
+            parts = [dateStr, "1 note"]
         default:
-            return "\(dateStr)  ·  \(count) notes"
+            parts = [dateStr, "\(count) notes"]
         }
+
+        // Museum-aesthetic subline: append today's weather + place when known.
+        // Sourced from existing memos — no extra network/location fetch (M1 is UI-only).
+        // e.g. "MAY 28 · 2 NOTES · 28° · VIENTIANE"
+        if let weather = todayWeatherShort() {
+            parts.append(weather)
+        }
+        if let place = todayPlaceShort() {
+            parts.append(place)
+        }
+        return parts.joined(separator: "  ·  ")
+    }
+
+    /// Today's weather temperature, taken from the most recent memo that carries
+    /// a weather string (e.g. "28° · 多云" → "28°"). Returns nil when unknown.
+    private func todayWeatherShort() -> String? {
+        for memo in viewModel.memos.reversed() {
+            if let w = memo.weather?.trimmingCharacters(in: .whitespaces), !w.isEmpty {
+                // Keep only the temperature token ("28° · 多云" → "28°").
+                let temp = w.split(separator: "·").first.map { $0.trimmingCharacters(in: .whitespaces) } ?? w
+                return temp.isEmpty ? nil : temp
+            }
+        }
+        return nil
+    }
+
+    /// Today's place name, taken from the most recent memo carrying a location.
+    private func todayPlaceShort() -> String? {
+        for memo in viewModel.memos.reversed() {
+            if let name = memo.location?.name?.trimmingCharacters(in: .whitespaces), !name.isEmpty {
+                return name
+            }
+        }
+        return nil
     }
 }
 
@@ -1594,6 +1654,9 @@ struct TimelineRow: View {
     var isSelected: Bool = false
     var onToggleSelection: (() -> Void)? = nil
 
+    /// Drives the right-swipe MORE confirmation dialog (pin / delete / …).
+    @State private var showMoreActions = false
+
     var body: some View {
         ZStack(alignment: .topTrailing) {
             // In selection mode the inner NavigationLink must be disabled
@@ -1604,6 +1667,8 @@ struct TimelineRow: View {
                 memo: memo,
                 onDelete: onDelete,
                 onPin: onPin,
+                onShare: onShare,            // left-swipe SHARE → share-as-card
+                onMore: { showMoreActions = true }, // right-swipe MORE → dialog
                 onRetranscribe: onRetranscribe,
                 isSelectionMode: isSelectionMode
             )
@@ -1657,6 +1722,23 @@ struct TimelineRow: View {
                     }
                 }
             }
+        }
+        // Right-swipe MORE → fuller action set (pin / quote / delete) kept
+        // out of the card's resting chrome per the content-first redesign.
+        .confirmationDialog("更多", isPresented: $showMoreActions, titleVisibility: .hidden) {
+            if let onPin {
+                Button(memo.pinnedAt != nil ? "取消置顶" : "置顶") { onPin() }
+            }
+            if let onShareAsQuote {
+                Button("分享为引用") { onShareAsQuote() }
+            }
+            if let onEnterSelectionMode {
+                Button("多选") { onEnterSelectionMode() }
+            }
+            if let onDelete {
+                Button("删除", role: .destructive) { onDelete() }
+            }
+            Button("取消", role: .cancel) { }
         }
     }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1350,7 +1350,7 @@ struct TodayView: View {
     /// Today's weather temperature, taken from the most recent memo that carries
     /// a weather string (e.g. "28° · 多云" → "28°"). Returns nil when unknown.
     private func todayWeatherShort() -> String? {
-        for memo in viewModel.memos.reversed() {
+        for memo in viewModel.memos {  // memos is already newest-first
             if let w = memo.weather?.trimmingCharacters(in: .whitespaces), !w.isEmpty {
                 // Keep only the temperature token ("28° · 多云" → "28°").
                 let temp = w.split(separator: "·").first.map { $0.trimmingCharacters(in: .whitespaces) } ?? w
@@ -1362,7 +1362,7 @@ struct TodayView: View {
 
     /// Today's place name, taken from the most recent memo carrying a location.
     private func todayPlaceShort() -> String? {
-        for memo in viewModel.memos.reversed() {
+        for memo in viewModel.memos {  // memos is already newest-first
             if let name = memo.location?.name?.trimmingCharacters(in: .whitespaces), !name.isEmpty {
                 return name
             }
@@ -1726,20 +1726,25 @@ struct TimelineRow: View {
         // Right-swipe MORE → fuller action set (pin / quote / delete) kept
         // out of the card's resting chrome per the content-first redesign.
         .confirmationDialog("更多", isPresented: $showMoreActions, titleVisibility: .hidden) {
-            if let onPin {
-                Button(memo.pinnedAt != nil ? "取消置顶" : "置顶") { onPin() }
-            }
-            if let onShareAsQuote {
-                Button("分享为引用") { onShareAsQuote() }
-            }
-            if let onEnterSelectionMode {
-                Button("多选") { onEnterSelectionMode() }
-            }
-            if let onDelete {
-                Button("删除", role: .destructive) { onDelete() }
-            }
-            Button("取消", role: .cancel) { }
+            moreActionsButtons
         }
+    }
+
+    @ViewBuilder
+    private var moreActionsButtons: some View {
+        if let onPin {
+            Button(memo.pinnedAt != nil ? "取消置顶" : "置顶") { onPin() }
+        }
+        if let onShareAsQuote {
+            Button("分享为引用") { onShareAsQuote() }
+        }
+        if let onEnterSelectionMode {
+            Button("多选") { onEnterSelectionMode() }
+        }
+        if let onDelete {
+            Button("删除", role: .destructive) { onDelete() }
+        }
+        Button("取消", role: .cancel) { }
     }
 
     private var selectionIndicator: some View {


### PR DESCRIPTION
Recreation of PR #483 after merge queue closed original.

Same content as PR #483 — museum-aesthetic Today screen with:
- Hero section
- AI summary card
- Swipe actions
- Fixes for Claude review feedback (DispatchQueue cancellation, reversed() order, TimelineRow extraction)