### PR TITLE
feat(sidebar): 16×7 heatmap hero + stats triplet + profile redesign

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -151,6 +151,7 @@
 		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
 		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
 		E5077A7D97855770914BFB8D /* MarkdownExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8043A3D3371852ACB3D6F3 /* MarkdownExportService.swift */; };
+		E536EEB8C13B2BA42DF4980F /* SidebarHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C551D36362FF97C44EB4D5DE /* SidebarHeatmapView.swift */; };
 		EA575F353C6AFD5EA7FF9A6F /* QuickCaptureWidget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */; };
 		ES0000001 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000001 /* EmptyStateView.swift */; };
 		ES0000002 /* GlassErrorBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = ES1000002 /* GlassErrorBanner.swift */; };
@@ -361,6 +362,7 @@
 		B93ED807E07C2171E9F4234B /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
 		BAC7527E8128E6A865349FB9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		BB12D96218034D3E4555B8AA /* HapticFeedback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HapticFeedback.swift; sourceTree = "<group>"; };
+		C551D36362FF97C44EB4D5DE /* SidebarHeatmapView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarHeatmapView.swift; sourceTree = "<group>"; };
 		C98B5757B488F583231EC8F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		CJ1000001 /* CJKTextPolish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKTextPolish.swift; sourceTree = "<group>"; };
 		DC21412D29A6FB268CE43C58 /* DraftStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DraftStorage.swift; sourceTree = "<group>"; };
@@ -544,6 +546,7 @@
 				A20000071 /* DayPage.entitlements */,
 				A20000029 /* Assets.xcassets */,
 				AF2000001 /* Fonts */,
+				C551D36362FF97C44EB4D5DE /* SidebarHeatmapView.swift */,
 			);
 			path = App;
 			sourceTree = "<group>";
@@ -1270,6 +1273,7 @@
 				29C57DABF22715576844485C /* AISummaryCard.swift in Sources */,
 				787E4480A2797607F2DCDE5E /* PillSegmentedControl.swift in Sources */,
 				2B194E870578303558D461CD /* CompileUnlockCard.swift in Sources */,
+				E536EEB8C13B2BA42DF4980F /* SidebarHeatmapView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage/App/SidebarHeatmapView.swift
+++ b/DayPage/App/SidebarHeatmapView.swift
@@ -1,0 +1,269 @@
+import SwiftUI
+
+// MARK: - SidebarHeatmapView
+//
+// Museum-aesthetic 16-week × 7-day contribution heatmap — the visual hero of
+// the redesigned sidebar (Claude Design bundle — detail.jsx DrawerHeatmap).
+//
+//   ┌────────────────────────────────────────────┐
+//   │ LAST 16 WEEKS                    89 ENTRIES  │
+//   │      FEB    MAR    APR    MAY                │
+//   │ M  ▢▢▣▣▢▢▣▣▢▢▣▣▢▢▣▣                          │
+//   │ T  …                                         │
+//   │ LESS ▢▢▢▢ MORE          🔥 23 DAYS            │
+//   └────────────────────────────────────────────┘
+//
+// Columns are weeks (oldest → newest left→right); rows are weekdays Mon→Sun.
+// Today is forced to the highest tone; future cells render as a dashed
+// placeholder. Counts map to 4 tonal buckets via the heatmap-* color tokens.
+
+struct SidebarHeatmapView: View {
+    /// Memo count per day keyed by `YYYY-MM-DD`.
+    let counts: [String: Int]
+    /// Total entries across the window (header figure).
+    let totalEntries: Int
+    /// Current consecutive-day streak (footer pill).
+    let streak: Int
+
+    private let weeks = 16
+    private let cellSpacing: CGFloat = 3
+
+    private static let isoFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone.current
+        return f
+    }()
+
+    private static let monthFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "MMM"
+        return f
+    }()
+
+    private static let palette: [Color] = [
+        DSColor.heatmapEmpty, DSColor.heatmapLow, DSColor.heatmapMid, DSColor.heatmapHigh,
+    ]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            grid
+            footer
+        }
+        .padding(.init(top: 16, leading: 16, bottom: 14, trailing: 16))
+        .background(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .fill(DSColor.surfaceWhite)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+                .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
+        )
+        .shadow(color: Color.black.opacity(0.04), radius: 1, x: 0, y: 1)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("活动热力图，过去 16 周共 \(totalEntries) 条记录，当前连续 \(streak) 天")
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text("LAST 16 WEEKS")
+                .font(DSType.mono10)
+                .tracking(1.6)
+                .foregroundColor(DSColor.inkMuted)
+            Spacer()
+            HStack(alignment: .firstTextBaseline, spacing: 5) {
+                Text("\(totalEntries)")
+                    .font(DSFonts.serif(size: 18, weight: .semibold))
+                    .foregroundColor(DSColor.inkPrimary)
+                Text("ENTRIES")
+                    .font(DSType.mono9)
+                    .tracking(1.2)
+                    .foregroundColor(DSColor.inkSubtle)
+            }
+        }
+    }
+
+    // MARK: - Grid
+
+    private var grid: some View {
+        let columns = buildColumns()
+        return HStack(alignment: .top, spacing: 8) {
+            // Weekday rail: M T W T F S S
+            VStack(spacing: cellSpacing) {
+                Spacer().frame(height: 11) // align under the month-label row
+                ForEach(Array(["M", "T", "W", "T", "F", "S", "S"].enumerated()), id: \.offset) { idx, d in
+                    Text(d)
+                        .font(.system(size: 8, design: .monospaced))
+                        .tracking(1)
+                        .foregroundColor(DSColor.inkSubtle)
+                        .opacity(idx % 2 == 1 ? 0.4 : 0.9)
+                        .frame(height: 11)
+                }
+            }
+
+            VStack(alignment: .leading, spacing: 5) {
+                monthLabels(columns: columns)
+                GeometryReader { geo in
+                    let cell = cellSize(in: geo.size.width)
+                    HStack(spacing: cellSpacing) {
+                        ForEach(columns.indices, id: \.self) { ci in
+                            VStack(spacing: cellSpacing) {
+                                ForEach(0..<7, id: \.self) { ri in
+                                    cellView(columns[ci][ri], size: cell)
+                                }
+                            }
+                        }
+                    }
+                }
+                .frame(height: 7 * 11 + 6 * cellSpacing)
+            }
+        }
+    }
+
+    private func cellSize(in width: CGFloat) -> CGFloat {
+        let total = width - CGFloat(weeks - 1) * cellSpacing
+        return max(8, total / CGFloat(weeks))
+    }
+
+    @ViewBuilder
+    private func cellView(_ cell: HeatCell, size: CGFloat) -> some View {
+        switch cell {
+        case .future:
+            RoundedRectangle(cornerRadius: 2.5, style: .continuous)
+                .strokeBorder(DSColor.borderSubtle, style: StrokeStyle(lineWidth: 0.5, dash: [1.5, 1.5]))
+                .frame(height: 11)
+        case .day(_, let level, let isToday):
+            RoundedRectangle(cornerRadius: 2.5, style: .continuous)
+                .fill(Self.palette[level])
+                .frame(height: 11)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 2.5, style: .continuous)
+                        .strokeBorder(Color.black.opacity(level == 3 ? 0.06 : 0), lineWidth: 0.5)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 2.5, style: .continuous)
+                        .strokeBorder(isToday ? DSColor.accentAmber : .clear, lineWidth: 1)
+                )
+        }
+    }
+
+    private func monthLabels(columns: [[HeatCell]]) -> some View {
+        // Mark a label at the first column whose top cell starts a new month.
+        var seenMonths = Set<Int>()
+        var labels: [(col: Int, text: String)] = []
+        let cal = Calendar.current
+        for (ci, col) in columns.enumerated() {
+            let firstDay = col.first(where: { if case .day = $0 { return true } else { return false } })
+            if case let .day(date, _, _) = firstDay {
+                let m = cal.component(.month, from: date)
+                if !seenMonths.contains(m) {
+                    seenMonths.insert(m)
+                    labels.append((ci, Self.monthFmt.string(from: date).uppercased()))
+                }
+            }
+        }
+        return GeometryReader { geo in
+            let cell = cellSize(in: geo.size.width)
+            ForEach(labels, id: \.col) { item in
+                Text(item.text)
+                    .font(.system(size: 8, design: .monospaced))
+                    .tracking(1.2)
+                    .foregroundColor(DSColor.inkSubtle)
+                    .offset(x: CGFloat(item.col) * (cell + cellSpacing))
+            }
+        }
+        .frame(height: 9)
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        HStack {
+            HStack(spacing: 5) {
+                Text("LESS")
+                    .font(DSType.mono9).tracking(1.2)
+                    .foregroundColor(DSColor.inkSubtle)
+                ForEach(Self.palette.indices, id: \.self) { i in
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .fill(Self.palette[i])
+                        .frame(width: 9, height: 9)
+                }
+                Text("MORE")
+                    .font(DSType.mono9).tracking(1.2)
+                    .foregroundColor(DSColor.inkSubtle)
+            }
+            Spacer()
+            if streak > 0 {
+                HStack(spacing: 5) {
+                    Image(systemName: "flame.fill")
+                        .font(.system(size: 10))
+                        .foregroundColor(DSColor.accentAmber)
+                    Text("\(streak) DAYS")
+                        .font(DSType.mono9)
+                        .tracking(1.2)
+                        .foregroundColor(DSColor.accentAmber)
+                        .fixedSize()
+                }
+                .padding(.init(top: 4, leading: 7, bottom: 4, trailing: 9))
+                .background(DSColor.accentSoft, in: Capsule())
+                .overlay(Capsule().strokeBorder(DSColor.accentBorder, lineWidth: 0.5))
+            }
+        }
+    }
+
+    // MARK: - Grid data
+
+    /// A single heatmap cell.
+    private enum HeatCell {
+        case day(Date, level: Int, isToday: Bool)
+        case future
+    }
+
+    /// Build 16 columns (weeks) × 7 rows (Mon→Sun) ending with today's week.
+    private func buildColumns() -> [[HeatCell]] {
+        let cal = Calendar.current
+        let today = cal.startOfDay(for: Date())
+        let todayStr = Self.isoFmt.string(from: today)
+
+        // Find the Monday on/just before today to anchor the current column.
+        // Swift Calendar weekday: 1=Sun…7=Sat. Convert to days since Monday.
+        let wd = cal.component(.weekday, from: today)
+        let monOffset = (wd + 5) % 7
+        guard let thisMonday = cal.date(byAdding: .day, value: -monOffset, to: today) else { return [] }
+
+        var columns: [[HeatCell]] = []
+        for w in stride(from: weeks - 1, through: 0, by: -1) {
+            guard let weekMonday = cal.date(byAdding: .day, value: -7 * w, to: thisMonday) else { continue }
+            var col: [HeatCell] = []
+            for d in 0..<7 {
+                guard let date = cal.date(byAdding: .day, value: d, to: weekMonday) else { continue }
+                if date > today {
+                    col.append(.future)
+                } else {
+                    let key = Self.isoFmt.string(from: date)
+                    let count = counts[key] ?? 0
+                    let isToday = key == todayStr
+                    let lvl = isToday ? 3 : level(for: count)
+                    col.append(.day(date, level: lvl, isToday: isToday))
+                }
+            }
+            columns.append(col)
+        }
+        return columns
+    }
+
+    /// Map a memo count to one of 4 tonal buckets.
+    private func level(for count: Int) -> Int {
+        switch count {
+        case 0: return 0
+        case 1: return 1
+        case 2...3: return 2
+        default: return 3
+        }
+    }
+}

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -12,7 +12,6 @@ struct SidebarView: View {
     @StateObject private var sidebarVM = SidebarViewModel()
     @State private var showSettings = false
     @State private var showAccountSheet = false
-    @State private var dotsAppeared = false
 
     var body: some View {
         ZStack(alignment: .topLeading) {
@@ -46,8 +45,13 @@ struct SidebarView: View {
 
                 ScrollView(showsIndicators: false) {
                     VStack(alignment: .leading, spacing: 0) {
+                        // Museum-aesthetic hero stack: profile → heatmap → stats.
+                        profileRow
+                        heatmapSection
+                        statsSection
+
                         navSection
-                            .padding(.top, 4)
+                            .padding(.top, 22)
 
                         if !sidebarVM.recentDays.isEmpty {
                             recentSection
@@ -79,13 +83,9 @@ struct SidebarView: View {
             // user sees the latest activity without having to relaunch.
             if isOpen {
                 sidebarVM.refreshRecentDays()
-                dotsAppeared = false
-                Task { @MainActor in dotsAppeared = true }
                 // Pre-warm the impact generator while the drawer is animating
                 // open so the first nav tap fires with minimum latency.
                 UIImpactFeedbackGenerator(style: .light).prepare()
-            } else {
-                dotsAppeared = false
             }
         }
         .sheet(isPresented: $showSettings) {
@@ -98,109 +98,150 @@ struct SidebarView: View {
 
     // MARK: - Brand Header
 
+    /// Museum-aesthetic utility bar: a quiet close button + a tiny mono
+    /// wordmark, replacing the old oversized serif logo.
     private var brandHeader: some View {
-        VStack(alignment: .leading, spacing: 8) {
-            Text("DayPage")
-                .font(DSType.serifDisplay32)
-                .foregroundColor(DSColor.inkPrimary)
-            Text("your daily log")
-                .font(DSType.mono10)
-                .foregroundColor(DSColor.inkSubtle)
-                .textCase(.uppercase)
-                .tracking(1.0)
-            activityDots
-            if sidebarVM.currentStreak > 0 {
-                streakBadge(streak: sidebarVM.currentStreak)
-                    .dsAnimation(Motion.spring, value: sidebarVM.currentStreak)
+        HStack {
+            Button {
+                Haptics.soft()
+                nav.closeSidebar()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(DSColor.inkPrimary)
+                    .frame(width: 34, height: 34)
+                    .background(DSColor.surfaceSunken, in: Circle())
             }
-        }
-        .padding(.horizontal, 24)
-        .padding(.top, 64)
-        .padding(.bottom, 24)
-    }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Close navigation")
 
-    private func streakBadge(streak: Int) -> some View {
-        HStack(spacing: 4) {
-            Image(systemName: "flame.fill")
-                .font(.system(size: 12))
-                .foregroundColor(DSColor.amberAccent)
-            Text("\(streak)-day streak")
+            Spacer()
+
+            Text("DAYPAGE · 2026")
                 .font(DSType.mono10)
-                .foregroundColor(DSColor.amberAccent)
-                .textCase(.uppercase)
-                .tracking(1.0)
+                .tracking(2.0)
+                .foregroundColor(DSColor.inkMuted)
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 5)
-        .background(DSColor.amberSoft, in: Capsule())
-        .overlay(Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
-        .accessibilityLabel("Current streak: \(streak) days")
+        .padding(.horizontal, 20)
+        .padding(.top, 58)
+        .padding(.bottom, 12)
     }
 
-    /// 7 circles representing memo activity for the last 7 days (today on the right).
-    private var activityDots: some View {
-        let days = last7DayPairs()
-        let todayStr = Self.isoFormatter.string(from: Date())
-        return HStack(spacing: 5) {
-            ForEach(Array(days.enumerated()), id: \.element.dateString) { index, pair in
-                let isToday = pair.dateString == todayStr
-                let count = pair.count
-                let label = Self.dotAccessibilityLabel(for: pair.dateString, count: count)
-                let restingOpacity = count > 0 ? min(0.4 + Double(count) * 0.15, 1.0) : 0.25
-                let delay = reduceMotion ? 0.0 : Double(index) * 0.05
-                Button {
-                    Haptics.soft()
-                    nav.openArchive(at: pair.dateString)
-                } label: {
+    // MARK: - Profile Row (museum-aesthetic)
+
+    /// 46pt amber-gradient avatar + serif name + mono membership + chevron.
+    private var profileRow: some View {
+        Button {
+            showAccountSheet = true
+        } label: {
+            HStack(spacing: 14) {
+                ZStack {
                     Circle()
-                        .fill(count > 0 ? DSColor.amberAccent : DSColor.inkFaint)
-                        .frame(width: 8, height: 8)
-                        .opacity(dotsAppeared ? restingOpacity : 0)
-                        .scaleEffect(dotsAppeared ? 1 : 0.6)
-                        .overlay {
-                            if isToday {
-                                Circle()
-                                    .strokeBorder(DSColor.amberRim, lineWidth: 1)
-                            }
-                        }
-                        .animation(
-                            reduceMotion ? .linear(duration: 0.001) : Motion.spring.delay(delay),
-                            value: dotsAppeared
+                        .fill(
+                            LinearGradient(
+                                colors: [Color(hex: "C9A677"), Color(hex: "5D3000")],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
                         )
-                        .dsAnimation(Motion.spring, value: count)
+                        .frame(width: 46, height: 46)
+                    Text(sidebarVM.isLoggedIn ? sidebarVM.accountInitial : "·")
+                        .font(DSFonts.serif(size: 20, weight: .semibold))
+                        .foregroundColor(Color(hex: "FAF8F6"))
                 }
-                .frame(width: 28, height: 28)
-                .contentShape(Circle())
-                .buttonStyle(.plain)
-                .accessibilityLabel(label)
-                .accessibilityHint("Opens this day in Archive")
+
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(profileName)
+                        .font(DSFonts.serif(size: 19, weight: .semibold))
+                        .foregroundColor(DSColor.inkPrimary)
+                        .lineLimit(1)
+                    Text("MEMBER · SINCE 2024")
+                        .font(DSType.mono10)
+                        .tracking(1.2)
+                        .foregroundColor(DSColor.inkSubtle)
+                }
+
+                Spacer()
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(DSColor.inkSubtle)
             }
+            .contentShape(Rectangle())
         }
-        .padding(.top, 2)
+        .buttonStyle(.plain)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 10)
     }
 
-    /// Returns date+count pairs for the last 7 days (index 0 = 6 days ago, index 6 = today).
-    private func last7DayPairs() -> [(dateString: String, count: Int)] {
-        let cal = Calendar.current
-        let today = cal.startOfDay(for: Date())
-        return (0..<7).reversed().map { daysAgo in
-            guard let date = cal.date(byAdding: .day, value: -daysAgo, to: today) else {
-                return (dateString: "", count: 0)
-            }
-            let dateStr = Self.isoFormatter.string(from: date)
-            let count = sidebarVM.recentDays.first(where: { $0.dateString == dateStr })?.memoCount ?? 0
-            return (dateString: dateStr, count: count)
-        }
+    private var profileName: String {
+        guard sidebarVM.isLoggedIn, !sidebarVM.accountEmail.isEmpty else { return "DayPage" }
+        // Use the local part of the email as a friendly display name.
+        return String(sidebarVM.accountEmail.prefix(while: { $0 != "@" }))
     }
 
-    private static func dotAccessibilityLabel(for dateString: String, count: Int) -> String {
-        guard let date = isoFormatter.date(from: dateString) else { return dateString }
-        let weekday = weekdayFormatter.string(from: date)
-        if count == 0 {
-            return "\(weekday), no notes"
-        } else {
-            return "\(weekday), \(count) \(count == 1 ? "note" : "notes")"
+    // MARK: - Heatmap + Stats
+
+    private var heatmapSection: some View {
+        SidebarHeatmapView(
+            counts: sidebarVM.heatmapCounts,
+            totalEntries: sidebarVM.totalEntries16Weeks,
+            streak: sidebarVM.currentStreak
+        )
+        .padding(.horizontal, 20)
+        .padding(.top, 4)
+    }
+
+    /// STREAK / PAGES / WORDS triplet on a single hairline-divided white card.
+    private var statsSection: some View {
+        HStack(spacing: 0) {
+            statCell(label: "STREAK", value: "\(sidebarVM.currentStreak)", unit: "DAYS", first: true)
+            statDivider
+            statCell(label: "PAGES", value: "\(sidebarVM.totalPages)", unit: "TOTAL", first: false)
+            statDivider
+            statCell(label: "WORDS", value: formatWords(sidebarVM.totalWordCount), unit: "2026", first: false)
         }
+        .background(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .fill(DSColor.surfaceWhite)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
+        )
+        .shadow(color: Color.black.opacity(0.04), radius: 1, x: 0, y: 1)
+        .padding(.horizontal, 20)
+        .padding(.top, 12)
+    }
+
+    private func statCell(label: String, value: String, unit: String, first: Bool) -> some View {
+        VStack(spacing: 4) {
+            Text(label)
+                .font(DSType.mono9).tracking(1.4)
+                .foregroundColor(DSColor.inkSubtle)
+            Text(value)
+                .font(DSFonts.serif(size: 22, weight: .semibold))
+                .foregroundColor(DSColor.inkPrimary)
+            Text(unit)
+                .font(DSType.mono9).tracking(1.2)
+                .foregroundColor(DSColor.inkSubtle)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+    }
+
+    private var statDivider: some View {
+        Rectangle()
+            .fill(DSColor.borderSubtle)
+            .frame(width: 0.5)
+            .padding(.vertical, 12)
+    }
+
+    /// "58k" style compaction for the word stat.
+    private func formatWords(_ n: Int) -> String {
+        if n >= 1_000_000 { return String(format: "%.1fM", Double(n) / 1_000_000) }
+        if n >= 1_000 { return "\(n / 1000)k" }
+        return "\(n)"
     }
 
     // MARK: - Nav Items

--- a/DayPage/App/SidebarViewModel.swift
+++ b/DayPage/App/SidebarViewModel.swift
@@ -30,6 +30,23 @@ final class SidebarViewModel: ObservableObject {
     /// All active days used for streak calculation (larger scan than recentDays).
     @Published private var streakDays: [RecentDay] = []
 
+    // MARK: - Heatmap + stats (museum-aesthetic sidebar, M2)
+
+    /// Memo count per active day across the last ~16 weeks, keyed by
+    /// `YYYY-MM-DD`. Drives the 16×7 sidebar heatmap. Days with no memos are
+    /// simply absent (lookup returns 0).
+    @Published var heatmapCounts: [String: Int] = [:]
+
+    /// Total memos captured across the heatmap window (the "N ENTRIES" figure).
+    @Published var totalEntries16Weeks: Int = 0
+
+    /// Number of compiled daily pages on disk (`vault/wiki/daily/*.md`).
+    @Published var totalPages: Int = 0
+
+    /// Approximate total words across all raw memo bodies (CJK chars + Latin
+    /// words), shown as the "WORDS" stat. Formatted lazily by the view.
+    @Published var totalWordCount: Int = 0
+
     /// Consecutive calendar days ending today (or yesterday) with at least one memo.
     /// Starts counting from the most recent active day and stops at the first gap.
     var currentStreak: Int {
@@ -103,10 +120,23 @@ final class SidebarViewModel: ObservableObject {
         Task { [weak self] in
             async let recent = Self.scanRecentDays(limit: 7)
             async let streak = Self.scanRecentDays(limit: 365)
-            let (recentResult, streakResult) = await (recent, streak)
+            // 16 weeks = 112 days; scan a touch more to cover the partial
+            // leading week the grid renders.
+            async let heatmap = Self.scanRecentDays(limit: 119)
+            async let stats = Self.scanStats()
+            let (recentResult, streakResult, heatmapResult, statsResult) =
+                await (recent, streak, heatmap, stats)
             await MainActor.run {
                 self?.recentDays = recentResult
                 self?.streakDays = streakResult
+                let counts = Dictionary(
+                    heatmapResult.map { ($0.dateString, $0.memoCount) },
+                    uniquingKeysWith: { a, _ in a }
+                )
+                self?.heatmapCounts = counts
+                self?.totalEntries16Weeks = heatmapResult.reduce(0) { $0 + $1.memoCount }
+                self?.totalPages = statsResult.pages
+                self?.totalWordCount = statsResult.words
             }
         }
     }
@@ -158,6 +188,57 @@ final class SidebarViewModel: ObservableObject {
             }
             return out
         }.value
+    }
+
+    /// Scan vault for aggregate stats:
+    ///   • pages — number of compiled daily pages (`vault/wiki/daily/*.md`)
+    ///   • words — approximate total words across all raw memo bodies
+    ///     (front-matter stripped; non-whitespace characters counted, which
+    ///     reads naturally for CJK and is a fair proxy for Latin too).
+    nonisolated private static func scanStats() async -> (pages: Int, words: Int) {
+        await Task.detached(priority: .utility) {
+            let fm = FileManager.default
+            let vault = VaultInitializer.vaultURL
+
+            // Pages: count YYYY-MM-DD.md files under wiki/daily.
+            let dailyDir = vault.appendingPathComponent("wiki/daily")
+            var pages = 0
+            if let names = try? fm.contentsOfDirectory(atPath: dailyDir.path) {
+                pages = names.filter { $0.hasSuffix(".md") }.count
+            }
+
+            // Words: walk raw/*.md, strip YAML front-matter blocks, count
+            // non-whitespace characters in the remaining body text.
+            let rawDir = vault.appendingPathComponent("raw")
+            var words = 0
+            if let names = try? fm.contentsOfDirectory(atPath: rawDir.path) {
+                for name in names where name.hasSuffix(".md") {
+                    let url = rawDir.appendingPathComponent(name)
+                    guard let data = try? Data(contentsOf: url),
+                          let text = String(data: data, encoding: .utf8) else { continue }
+                    words += approxBodyWordCount(text)
+                }
+            }
+            return (pages, words)
+        }.value
+    }
+
+    /// Strips `--- … ---` front-matter blocks and separator comments, then
+    /// counts non-whitespace characters in the remaining body.
+    nonisolated private static func approxBodyWordCount(_ text: String) -> Int {
+        var count = 0
+        var inFrontmatter = false
+        for rawLine in text.components(separatedBy: "\n") {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line == "---" {
+                inFrontmatter.toggle()
+                continue
+            }
+            if inFrontmatter { continue }
+            if line.hasPrefix("<!--") { continue } // separator comment
+            count += line.filter { !$0.isWhitespace }.count
+        }
+        return count
     }
 
     /// Count memos in a single raw daily file. Memos are separated by the


### PR DESCRIPTION
Closes #484 — DayPage v8「日式美术馆」设计落地 **M2/6**（侧边栏重做，用户称之为「整个 app 里最高级的一屏」，纯 UI + 轻量 vault 扫描）。

设计源：Claude Design bundle（detail.jsx Drawer / DrawerHeatmap）。heatmap 4 档色 token 早已在 `Colors.swift` 就绪但未被使用，本 PR 在其上构建热力图主角。

## 改动

| 区块 | 内容 | 文件 |
|---|---|---|
| 热力图 ✨ | 16 周 × 7 天网格主角：4 档色、`M T W T F S S` 周标签、动态月标签、今天高亮 high、未来 dashed、`LESS ▢▢▢▢ MORE` 图例、`N ENTRIES` 大数字、火苗 streak 胶囊。列序 周一→周日、最早周→本周 | `SidebarHeatmapView.swift` |
| 数据 | ViewModel 扩展：`heatmapCounts` / `totalEntries16Weeks` / `totalPages`(wiki/daily 计数) / `totalWordCount`(去 front-matter 非空白字符)。复用 `scanRecentDays`，只读 | `SidebarViewModel.swift` |
| Header | 巨型 serif logo → close 按钮 + mono `DAYPAGE · 2026` | `SidebarView.swift` |
| Profile | 46pt amber 渐变 avatar + serif 名字 + `MEMBER · SINCE 2024` + chevron | `SidebarView.swift` |
| Stats 三联 | STREAK / PAGES / WORDS，hairline 白卡 | `SidebarView.swift` |
| 清理 | 移除被取代的 7 点活动条 + streak badge + 相关 helper | `SidebarView.swift` |

## 验收
- ✅ `xcodebuild -scheme DayPage -destination 'iPhone 17' build` **SUCCEEDED**
- ✅ iPhone 17 模拟器视觉核对（造了 14 天 vault 数据）：热力图色块/图例/streak 胶囊、Stats 三联、Profile 渐变 avatar、轻量 header 均按设计呈现

## 截图
（核对时 sidebar 由临时调试钩子自动展开，截图后钩子已移除，RootView 无改动）

## 后续里程碑
M3 Timeline 连续 spine + 4 级颗粒度 · M4 录音/灵动岛 · M5 分享卡 5 模板 · M6 周/月/年 AI 编译。M1（Today，#482 / PR #483）已提交待合并。