### PR TITLE
auto: Graph: auto-center the canvas on the best search match

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -30,6 +30,9 @@ struct GraphView: View {
     // Filter state
     @State private var showFilters: Bool = false
 
+    // Search auto-center state
+    @State private var lastCenteredMatchID: String? = nil
+
     // Empty state animation + ClearFiltersPressStyle (do not remove this @Environment:
     // both `emptyState` and `clearFiltersButton` read `reduceMotion`; deleting it
     // breaks the build — see incident around PR #466).
@@ -307,6 +310,23 @@ struct GraphView: View {
                 .accessibilityHidden(true)
                 .onAppear { simulationSize = size }
                 .onChange(of: size) { simulationSize = $0 }
+                .onChange(of: viewModel.searchQuery) { query in
+                    guard !query.isEmpty else {
+                        lastCenteredMatchID = nil
+                        return
+                    }
+                    guard let match = bestSearchMatch, match.id != lastCenteredMatchID else { return }
+                    lastCenteredMatchID = match.id
+                    Haptics.soft()
+                    if simulationSteps >= maxSimSteps {
+                        centerOn(match, in: size)
+                    } else {
+                        Task { @MainActor in
+                            try? await Task.sleep(nanoseconds: 300_000_000)
+                            centerOn(match, in: size)
+                        }
+                    }
+                }
 
                 // Node labels (filtered only) — hidden from VoiceOver; the tap target below announces the name
                 ForEach(viewModel.filteredNodes) { node in
@@ -433,6 +453,34 @@ struct GraphView: View {
             Text(label)
                 .font(DSFonts.jetBrainsMono(size: 10))
                 .foregroundColor(DSColor.inkPrimary)
+        }
+    }
+
+    // MARK: - Search Auto-Center
+
+    private var bestSearchMatch: GraphNode? {
+        guard !viewModel.searchQuery.isEmpty else { return nil }
+        let q = viewModel.searchQuery
+        let candidates = viewModel.filteredNodes.filter {
+            $0.name.localizedCaseInsensitiveContains(q)
+        }
+        if let exact = candidates.first(where: { $0.name.localizedCaseInsensitiveCompare(q) == .orderedSame }) {
+            return exact
+        }
+        if let prefix = candidates.first(where: { $0.name.localizedCaseInsensitiveContains(q) && $0.name.lowercased().hasPrefix(q.lowercased()) }) {
+            return prefix
+        }
+        return candidates.min(by: { $0.name.count < $1.name.count })
+    }
+
+    private func centerOn(_ node: GraphNode, in size: CGSize) {
+        let newOffset = CGSize(
+            width: -node.position.x * scale,
+            height: -node.position.y * scale
+        )
+        withAnimation(reduceMotion ? nil : Motion.spring) {
+            offset = newOffset
+            lastOffset = newOffset
         }
     }
 


### PR DESCRIPTION
## Graph: auto-center the canvas on the best search match

When the user types in the Graph search field, the matching node is highlighted (amber/bold) but can sit anywhere on the force-layout canvas — often off-screen after the user has panned or zoomed — with no way to bring it into view. This adds a smooth auto-pan that animates the canvas offset so the top search match is centered in the viewport, making search a real navigation tool instead of just a visual highlight.

### Acceptance
Build the DayPage scheme for iPhone 17 with no warnings. In the Simulator with a compiled graph of several entities: (1) pan/zoom the canvas so a known node is off-screen, type that node's name in the search field — the canvas smoothly animates so the matched node sits at the viewport center and its label shows amber/bold; (2) the recenter ('scope') button still appears since the canvas is transformed, and tapping it resets to origin; (3) clearing the search does not move the canvas again; (4) typing a query with no node match does not move or crash the canvas; (5) with Reduce Motion enabled the centering is instant (no animation). No changes to GraphViewModel @Published state or any @Model/persistence file.