### PR TITLE
auto: Animate the Day Orb glow to pulse on every new signal capture

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -11,6 +11,9 @@ struct DayOrbView: View {
     var size: CGFloat = 140
     var haloOpacity: CGFloat = 0.15
     var onTap: (() -> Void)? = nil
+    /// Flip this bool to trigger a one-shot capture-reward glow pulse (scale 1.0→1.10→1.0).
+    /// Only fires when a new memo is added; caller is responsible for only toggling on additions.
+    var pulseToggle: Bool = false
 
     @State private var breatheScale: CGFloat = 1.0
     @State private var pulse: Bool = false
@@ -18,6 +21,7 @@ struct DayOrbView: View {
     @State private var isPressed: Bool = false
     @State private var countPop: CGFloat = 1.0
     @State private var invitePulse: Bool = false
+    @State private var capturePulse: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -36,6 +40,16 @@ struct DayOrbView: View {
         }
         .frame(width: size + 32, height: size + 32)
         .scaleEffect(isPressed ? breatheScale * 0.94 : breatheScale)
+        .scaleEffect(capturePulse ? 1.10 : 1.0)
+        .animation(reduceMotion ? nil : .spring(response: 0.25, dampingFraction: 0.55), value: capturePulse)
+        .onChange(of: pulseToggle) { _ in
+            guard !reduceMotion else { return }
+            Task { @MainActor in
+                capturePulse = true
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                capturePulse = false
+            }
+        }
         .gesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { _ in

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -67,6 +67,8 @@ struct TodayView: View {
 
     /// Toggled each time the Day Orb is tapped to focus the composer input.
     @State private var orbFocusToggle: Bool = false
+    /// Toggled each time a new memo is added while the orb hero is visible, triggering a capture-reward glow pulse.
+    @State private var orbCapturePulse: Bool = false
 
     /// US-019: controls the markdown export share sheet.
     @State private var showExportSheet: Bool = false
@@ -691,7 +693,7 @@ struct TodayView: View {
                 .tracking(1.0)
 
             let glowBoost = min(Double(viewModel.signalCount), 5) * 0.04
-            DayOrbView(signalCount: viewModel.signalCount, size: 140) {
+            DayOrbView(signalCount: viewModel.signalCount, size: 140, pulseToggle: orbCapturePulse) {
                 Haptics.tapConfirm()
                 orbFocusToggle.toggle()
             }
@@ -710,6 +712,11 @@ struct TodayView: View {
         .onAppear {
             if !reduceMotion {
                 orbBreathing = true
+            }
+        }
+        .onChange(of: viewModel.memos.count) { count in
+            if count > lastMemoCount {
+                orbCapturePulse.toggle()
             }
         }
     }


### PR DESCRIPTION
## Animate the Day Orb glow to pulse on every new signal capture

When a memo is submitted, the Day Orb's amber glow should give a brief one-shot expansion pulse to reward capture, distinct from its idle breathing. Currently the orb only breathes ambiently and the glowBoost is static per signalCount, so adding a signal produces no immediate visual acknowledgement on the hero. This adds a satisfying, on-brand moment of feedback tied to the core capture loop.

### Acceptance
Building the DayPage scheme succeeds. Submitting a new memo while the orb hero is visible (zero-to-few memos) produces a single visible expand-and-settle glow pulse on the orb, separate from idle breathing. With Reduce Motion enabled, no pulse animation runs. Deleting a memo does not trigger the pulse. Existing orb tap-to-focus haptic and breathing behavior are unchanged.