### PR TITLE
auto: Tappable empty-state in Today should focus the composer instead of doing nothing

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1060,7 +1060,7 @@ struct TodayView: View {
                 if viewModel.memos.isEmpty && viewModel.loadState == .ready {
                     let hasOnboarded = UserDefaults.standard.bool(forKey: AppSettings.Keys.hasOnboarded)
                     if !hasOnboarded {
-                        EmptyStateView.todayBlank { }
+                        EmptyStateView.todayBlank { orbFocusToggle.toggle() }
                             .padding(.top, 48)
                             .padding(.horizontal, 20)
                     } else {


### PR DESCRIPTION
## Tappable empty-state in Today should focus the composer instead of doing nothing

The first-run Today empty state (`EmptyStateView.todayBlank`) is rendered in TodayView with an empty CTA closure `{ }`, so its '写下第一条' button looks actionable but does nothing — a dead end on the most important first-launch screen. Wire the CTA to focus the composer input (the same path the Day Orb already uses via `orbFocusToggle`), giving new users a working call-to-action that drops them straight into typing their first memo.

### Acceptance
On a fresh install (hasOnboarded == false) with zero memos, the Today empty state shows its CTA button; tapping it raises the keyboard and focuses the composer input with a confirm haptic, identical to tapping the Day Orb. Existing onboarded/fallback states are unchanged. `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` succeeds and the app launches in the simulator with the focus behavior verified visually.