### PR TITLE
auto: Double-tap a graph node to zoom & center on it

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -280,6 +280,30 @@ struct GraphView: View {
         showEntityPage = true
     }
 
+    private func focusNode(_ node: GraphNode, in size: CGSize) {
+        let targetScale: CGFloat = max(0.3, min(5.0, 2.2))
+        let newOffset = CGSize(
+            width:  (size.width  / 2 - node.position.x) * targetScale,
+            height: (size.height / 2 - node.position.y) * targetScale
+        )
+        Haptics.tapConfirm()
+        tapPulseNodeID = node.id
+        tapPulseProgress = 0
+        tapPulseGeneration += 1
+        let gen = tapPulseGeneration
+        withAnimation(reduceMotion ? nil : Motion.spring) {
+            scale = targetScale; lastScale = targetScale
+            offset = newOffset; lastOffset = newOffset
+        }
+        withAnimation(.easeOut(duration: 0.35)) {
+            tapPulseProgress = 1
+        }
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 400_000_000)
+            if tapPulseGeneration == gen { tapPulseNodeID = nil }
+        }
+    }
+
     // MARK: - Graph Canvas
 
     private var graphCanvas: some View {
@@ -367,6 +391,7 @@ struct GraphView: View {
                         .frame(width: r * 2, height: r * 2)
                         .contentShape(Circle())
                         .position(x: x, y: y)
+                        .onTapGesture(count: 2) { focusNode(node, in: size) }
                         .onTapGesture { openNode(node) }
                         .accessibilityElement()
                         .accessibilityLabel(node.name)


### PR DESCRIPTION
## Double-tap a graph node to zoom & center on it

The knowledge Graph supports pinch-zoom and pan, but inspecting a dense cluster requires fiddly manual pinch+drag, and double-tap only resets the canvas. This adds a double-tap-on-node gesture that smoothly zooms in and recenters the canvas on that node (with a focus pulse + haptic), making cluster exploration a single deliberate gesture while leaving the existing tap-to-open-EntityPage and double-tap-empty-canvas-to-reset behaviors intact.

### Acceptance
Build the DayPage scheme for iPhone 17 and launch in Simulator with a vault that has a populated graph. Verify: (1) double-tapping a node smoothly zooms the canvas to ~2.2x and centers that node, firing a focus-ring pulse + confirm haptic; (2) a single tap still opens the node's EntityPage; (3) double-tapping empty canvas (or tapping the recenter 'scope' button) still resets zoom/pan to 1.0/.zero; (4) with Reduce Motion enabled the recenter is instant (no spring); (5) zoom stays within the existing 0.3–5.0 clamp. No regressions to pinch-magnify or drag-pan.