### PR TITLE
auto: Localize and pluralize the Today header subline & orb kicker note count

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -795,10 +795,11 @@ struct TodayView: View {
         f.locale = Locale(identifier: "en_US_POSIX")
         f.timeZone = TimeZone.current
         let count = viewModel.signalCount
-        let plural = count == 1 ? "SIGNAL" : "SIGNALS"
+        let signalKey = count == 1 ? "today.kicker.signal.one" : "today.kicker.signal.other"
+        let signal = NSLocalizedString(signalKey, comment: "")
         let dateStr = f.string(from: date).uppercased()
         let timeStr = Self.headerTimeFmt.string(from: date)
-        return "\(dateStr) · \(timeStr) · \(count) \(plural)"
+        return "\(dateStr) · \(timeStr) · \(count) \(signal)"
     }
 
     // MARK: - InputBarV4 (variant D: Silent Press-to-Talk)
@@ -925,6 +926,7 @@ struct TodayView: View {
                         .tracking(1.0)
                         .dynamicTypeSize(.xSmall ... .accessibility5)
                         .minimumScaleFactor(0.75)
+                        .accessibilityLabel(headerSublineAccessibilityLabel(currentTime))
                 }
             }
             .buttonStyle(.plain)
@@ -1349,13 +1351,12 @@ struct TodayView: View {
 
         // Notes segment (empty-state shows time instead of count).
         var parts: [String]
-        switch count {
-        case 0:
+        if count == 0 {
             parts = [dateStr, Self.headerTimeFmt.string(from: date)]
-        case 1:
-            parts = [dateStr, "1 note"]
-        default:
-            parts = [dateStr, "\(count) notes"]
+        } else {
+            let notesKey = count == 1 ? "today.subline.notes.one" : "today.subline.notes.other"
+            let notesStr = String(format: NSLocalizedString(notesKey, comment: ""), count)
+            parts = [dateStr, notesStr]
         }
 
         // Museum-aesthetic subline: append today's weather + place when known.
@@ -1368,6 +1369,24 @@ struct TodayView: View {
             parts.append(place)
         }
         return parts.joined(separator: "  ·  ")
+    }
+
+    /// Comma-separated version of the header subline for VoiceOver.
+    /// e.g. "May 28, 2 notes, 28°, Vientiane"
+    private func headerSublineAccessibilityLabel(_ date: Date) -> String {
+        let count = viewModel.memos.count
+        let dateStr = Self.headerDateFmt.string(from: date)
+        var parts: [String]
+        if count == 0 {
+            parts = [dateStr, Self.headerTimeFmt.string(from: date)]
+        } else {
+            let notesKey = count == 1 ? "today.subline.notes.one" : "today.subline.notes.other"
+            let notesStr = String(format: NSLocalizedString(notesKey, comment: ""), count)
+            parts = [dateStr, notesStr]
+        }
+        if let weather = todayWeatherShort() { parts.append(weather) }
+        if let place = todayPlaceShort() { parts.append(place) }
+        return parts.joined(separator: ", ")
     }
 
     /// Today's weather temperature, taken from the most recent memo that carries

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -48,6 +48,15 @@
 "undo_pill.label.send"       = "Undo send";
 "undo_pill.label.delete"     = "Deleted · Undo";
 
+/* Today header subline — note count */
+"today.subline.notes.zero"   = "%d notes";
+"today.subline.notes.one"    = "%d note";
+"today.subline.notes.other"  = "%d notes";
+
+/* Today orb kicker — signal count */
+"today.kicker.signal.one"    = "SIGNAL";
+"today.kicker.signal.other"  = "SIGNALS";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "Recompile";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -48,6 +48,15 @@
 "undo_pill.label.send"       = "撤销发送";
 "undo_pill.label.delete"     = "已删除 · 撤销";
 
+/* Today header subline — note count */
+"today.subline.notes.zero"   = "%d 条记录";
+"today.subline.notes.one"    = "%d 条记录";
+"today.subline.notes.other"  = "%d 条记录";
+
+/* Today orb kicker — signal count */
+"today.kicker.signal.one"    = "信号";
+"today.kicker.signal.other"  = "信号";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "重新编译";
 


### PR DESCRIPTION
## Localize and pluralize the Today header subline & orb kicker note count

The Today screen's header subline (`headerSubline`) and Day Orb kicker (`orbKicker`) hardcode English strings — "1 note"/"N notes" and "SIGNAL"/"SIGNALS" — while the rest of the UI uses `NSLocalizedString` and Chinese copy, producing an inconsistent mixed-language header. This swaps the hardcoded literals for localized, properly-pluralized strings via `Localizable.stringsdict`/`NSLocalizedString`, so the count line reads natively in both English and Chinese. It also adds an `accessibilityLabel` to the header subline so VoiceOver reads a clean "2 notes, 28 degrees, Vientiane" instead of the raw mono-spaced glyph string.

### Acceptance
Build the DayPage scheme on iPhone 17 with no warnings. With device language set to English the header reads e.g. "MAY 28 · 2 NOTES · 28° · VIENTIANE"; switching to Simplified Chinese shows the localized note/signal words instead of English. Singular/plural is correct at counts 0, 1, and 2+. VoiceOver announces the subline as a comma-separated phrase. No layout regression in the always-on 56pt header.