### PR TITLE
auto: Live match-count pill for Graph search

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -100,6 +100,29 @@ struct GraphView: View {
                 .padding(.horizontal, DSSpacing.lg)
                 .padding(.vertical, DSSpacing.sm)
 
+                if !viewModel.searchQuery.isEmpty {
+                    HStack {
+                        Text("\(viewModel.searchMatchCount) 个匹配")
+                            .font(DSFonts.jetBrainsMono(size: 11))
+                            .foregroundColor(DSColor.inkMuted)
+                            .padding(.horizontal, DSSpacing.md)
+                            .padding(.vertical, 5)
+                            .background(DSColor.glassLo)
+                            .background(.ultraThinMaterial, in: Capsule())
+                            .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                            .accessibilityLabel("\(viewModel.searchMatchCount) 个匹配结果")
+                        Spacer()
+                    }
+                    .padding(.horizontal, DSSpacing.lg)
+                    .padding(.bottom, DSSpacing.sm)
+                    .transition(.opacity)
+                    .animation(Motion.fade, value: viewModel.searchMatchCount)
+                    .onChange(of: viewModel.searchMatchCount) { count in
+                        guard !viewModel.searchQuery.isEmpty, count == 0 else { return }
+                        Haptics.warn()
+                    }
+                }
+
                 if showFilters {
                     VStack(alignment: .leading, spacing: 6) {
                         HStack(spacing: DSSpacing.sm) {

--- a/DayPage/Features/Graph/GraphViewModel.swift
+++ b/DayPage/Features/Graph/GraphViewModel.swift
@@ -74,6 +74,9 @@ final class GraphViewModel: ObservableObject {
         }
     }
 
+    /// Live count of nodes matching the current search query.
+    var searchMatchCount: Int { searchQuery.isEmpty ? 0 : filteredNodes.count }
+
     /// Edges where both endpoints are in filteredNodes.
     var filteredEdges: [GraphEdge] {
         let ids = Set(filteredNodes.map { $0.id })


### PR DESCRIPTION
## Live match-count pill for Graph search

When searching the knowledge graph, the user gets no feedback on how many nodes matched a query — matches just scatter among the rest, and the only signal is the all-or-nothing no-matches empty state. Add a small mono-font glass pill beneath the search field that shows the live filtered match count (e.g. "3 个匹配") whenever a search query is active, with a light haptic when the count transitions to zero so a dead-end query is felt as well as seen.

### Acceptance
Build the DayPage scheme for iPhone 17 and launch in Simulator. With graph entities present: typing a query that matches some nodes shows a pill reading the correct live count that updates per keystroke; clearing the query (X button) hides the pill with a fade; a query matching zero nodes shows "0 个匹配" briefly before the existing no-matches empty state and fires a warning haptic on the 0-transition; VoiceOver announces the match count; reduce-motion disables the fade but the pill still appears. No regression to existing search filtering or the clear button.