### PR TITLE
auto: Sync the Undo pill countdown text with its ring and fix the off-by-one timer

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -48,8 +48,15 @@ struct UndoPillView: View {
                         .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: isUrgent)
                         .accessibilityHidden(true)
                 }
-                Text("Undo · \(secondsRemaining)s")
-                    .font(.custom("Inter-Medium", size: 13))
+                Group {
+                    if #available(iOS 16.0, *) {
+                        Text("Undo · \(secondsRemaining)s")
+                            .contentTransition(.numericText())
+                    } else {
+                        Text("Undo · \(secondsRemaining)s")
+                    }
+                }
+                .font(.custom("Inter-Medium", size: 13))
             }
             .foregroundColor(DSColor.inkPrimary)
             .padding(.horizontal, 16)
@@ -114,7 +121,10 @@ struct UndoPillView: View {
         .task {
             for tick in stride(from: 4, through: 0, by: -1) {
                 try? await Task.sleep(for: .seconds(1))
-                secondsRemaining = tick
+                guard !Task.isCancelled else { return }
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.15)) {
+                    secondsRemaining = tick
+                }
             }
         }
     }


### PR DESCRIPTION
## Sync the Undo pill countdown text with its ring and fix the off-by-one timer

The Undo pill's numeric countdown ("Undo · 5s") and its circular ring progress can drift apart: the ring animates linearly over a true 5 seconds while the text task sleeps 1s *before* showing the first decrement, so the label lingers on "5s" for a full second and the pill is dismissed (at 5s by the parent's 5,000,000,000 ns task) while the label may still read "1s". This makes the countdown feel laggy and untrustworthy. The fix tightens the text timer to tick down in lockstep with the ring and guarantees the label reaches 0 exactly as the pill leaves.

### Acceptance
Build the DayPage scheme for iPhone 17 with no warnings. Submit a memo in Today and observe the Undo pill: the numeric label counts 5→4→3→2→1→0 in visible step with the shrinking ring, the digits roll smoothly via numericText, the ring turns red at ~1.5s remaining with one soft haptic, and the label reaches 0 as the pill auto-dismisses at 5s. Tapping Undo or submitting a second memo mid-countdown removes the pill immediately with no stray label updates afterward. VoiceOver announces the decreasing seconds-remaining value.