### PR TITLE
auto: Sync the Undo pill countdown text with its ring and fix the off-by-one timer

### DIFF
--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -122,7 +122,7 @@ private struct TappableCardAccessibility: ViewModifier {
             content
                 .accessibilityAddTraits(.isButton)
                 .accessibilityHint("打开今日 Daily Page")
-                .accessibilityAction(action)
+                .accessibilityAction(named: "打开 Daily Page") { action() }
         } else {
             content
         }

--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -18,8 +18,11 @@ struct AISummaryCard: View {
     let summary: String
     /// Timestamp shown in the header (defaults to now).
     var timestamp: Date = Date()
+    /// When set, the card becomes tappable and opens the Daily Page.
+    var onTap: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var isPressed: Bool = false
 
     private static let timeFmt: DateFormatter = {
         let f = DateFormatter()
@@ -60,9 +63,23 @@ struct AISummaryCard: View {
                 .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
         )
         .shadow(color: Color.black.opacity(0.04), radius: 1, x: 0, y: 1)
+        .scaleEffect((!reduceMotion && isPressed) ? 0.985 : 1.0)
+        .animation(Motion.spring, value: isPressed)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            guard let onTap else { return }
+            Haptics.tapConfirm()
+            onTap()
+        }
+        .simultaneousGesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { _ in if onTap != nil { isPressed = true } }
+                .onEnded { _ in isPressed = false }
+        )
         .accessibilityElement(children: .combine)
         .accessibilityLabel("AI 今日一句")
         .accessibilityValue(summary)
+        .modifier(TappableCardAccessibility(enabled: onTap != nil, action: { onTap?() }))
     }
 
     private var header: some View {
@@ -84,7 +101,30 @@ struct AISummaryCard: View {
                     .font(DSType.mono9)
                     .tracking(1.2)
                     .foregroundColor(DSColor.inkSubtle)
+                if onTap != nil {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .medium))
+                        .foregroundColor(DSColor.inkFaint)
+                }
             }
+        }
+    }
+}
+
+// MARK: - TappableCardAccessibility
+
+private struct TappableCardAccessibility: ViewModifier {
+    let enabled: Bool
+    let action: () -> Void
+
+    func body(content: Content) -> some View {
+        if enabled {
+            content
+                .accessibilityAddTraits(.isButton)
+                .accessibilityHint("打开今日 Daily Page")
+                .accessibilityAction(action)
+        } else {
+            content
         }
     }
 }


### PR DESCRIPTION
Recreation of PR #504 after merge queue closed original.

## Sync the Undo pill countdown text with its ring and fix the off-by-one timer

The Undo pill's numeric countdown ("Undo · 5s") and its circular ring progress can drift apart: the ring animates linearly over a true 5 seconds while the text task sleeps 1s *before* showing the first decrement, so the label lingers on "5s" for a full second and the pill is dismissed (at 5s by the parent's 5,000,000,000 ns task) while the label may still read "1s". This makes the countdown feel laggy and untrustworthy. The fix tightens the text timer to tick down in lockstep with the ring and guarantees the label reaches 0 exactly as the pill leaves.

### Acceptance
Build the DayPage scheme for iPhone 17 with no warnings. Submit a memo in Today and observe the Undo pill: the numeric label counts 5→4→3→2→1→0 in visible step with the shrinking ring, the digits roll smoothly via numericText, the ring turns red at ~1.5s remaining with one soft haptic, and the label reaches 0 as the pill auto-dismisses at 5s. Tapping Undo or submitting a second memo mid-countdown removes the pill immediately with no stray label updates afterward. VoiceOver announces the decreasing seconds-remaining value.