### PR TITLE
auto: Accessible dismiss action + entrance polish for the Undo pill

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -16,6 +16,7 @@ struct UndoPillView: View {
     @State private var countdownProgress: CGFloat = 1.0
     @State private var isUrgent: Bool = false
     @State private var secondsRemaining: Int = 5
+    @State private var appeared: Bool = false
     @GestureState private var dragOffset: CGFloat = 0
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -66,8 +67,9 @@ struct UndoPillView: View {
             .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: 2)
         }
         .buttonStyle(.plain)
+        .scaleEffect(reduceMotion ? 1 : (appeared ? 1 : 0.92))
+        .opacity((reduceMotion ? 1 : (appeared ? 1 : 0)) * (dragOffset > 0 ? Double(1 - dragOffset / 80) : 1))
         .offset(y: max(0, dragOffset))
-        .opacity(dragOffset > 0 ? Double(1 - dragOffset / 80) : 1)
         .highPriorityGesture(
             DragGesture(minimumDistance: 10)
                 .updating($dragOffset) { value, state, _ in
@@ -84,14 +86,19 @@ struct UndoPillView: View {
         )
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Undo send, \(secondsRemaining) seconds remaining")
-        .accessibilityHint("Restores the note you just submitted back to the input field")
+        .accessibilityHint("Activate to undo; use the Dismiss action to close without undoing")
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(.updatesFrequently)
+        .accessibilityAction(named: Text("Dismiss")) { onDismiss?() }
         .accessibilityIdentifier("undo-send-pill")
         .onAppear {
             if reduceMotion {
+                appeared = true
                 countdownProgress = 0
             } else {
+                withAnimation(Motion.spring) {
+                    appeared = true
+                }
                 withAnimation(.linear(duration: 5)) {
                     countdownProgress = 0
                 }


### PR DESCRIPTION
## Accessible dismiss action + entrance polish for the Undo pill

The UndoPillView (shown after every memo submit/delete) can only be dismissed via a downward swipe gesture, which is invisible and unreachable for VoiceOver users — they can fire Undo but have no way to dismiss the pill early. This adds a VoiceOver custom 'Dismiss' action mirroring the swipe, and a subtle scale-in on appear so the pill reads as an intentional, reversible affordance rather than popping in flat.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator and confirm no errors. With VoiceOver on, submitting a memo surfaces the Undo pill exposing two custom actions ('Undo send' activate + 'Dismiss'), and the Dismiss action removes the pill without firing undo. With Reduce Motion off, the pill scales in from 0.92→1.0; with Reduce Motion on, it appears statically with no scale animation. Existing 5s countdown, urgency ring color shift, and swipe-to-dismiss behavior are unchanged.