### PR TITLE
auto: Move vault search off the main thread to eliminate keystroke jank

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -188,6 +188,7 @@ struct SearchView: View {
     @State private var filters: SearchFilters = SearchFilters.empty
     @State private var showFilters: Bool = false
     @State private var cancellable: AnyCancellable? = nil
+    @State private var searchTask: Task<Void, Never>? = nil
     @State private var appearedIDs: Set<UUID> = []
     @State private var didBuzzEmpty: Bool = false
 
@@ -229,6 +230,7 @@ struct SearchView: View {
             }
             .onDisappear {
                 cancellable?.cancel()
+                searchTask?.cancel()
             }
         }
     }
@@ -247,14 +249,23 @@ struct SearchView: View {
 
     private func runSearch(keyword: String) {
         let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+        let capturedFilters = filters
         let wasEmpty = vm.results.isEmpty
-        let hits = SearchService.search(keyword: trimmed, filters: filters)
-        appearedIDs = []
-        didBuzzEmpty = false
-        vm.results = hits
-        vm.hasSearched = !trimmed.isEmpty || filters.isActive
-        if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
-        if hits.isEmpty { didBuzzEmpty = false }
+        searchTask?.cancel()
+        searchTask = Task {
+            let hits = await Task.detached(priority: .userInitiated) {
+                SearchService.search(keyword: trimmed, filters: capturedFilters)
+            }.value
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                appearedIDs = []
+                didBuzzEmpty = false
+                vm.results = hits
+                vm.hasSearched = !trimmed.isEmpty || capturedFilters.isActive
+                if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
+                if hits.isEmpty { didBuzzEmpty = false }
+            }
+        }
     }
 
     // MARK: - Search Bar

--- a/DayPage/Services/SearchService.swift
+++ b/DayPage/Services/SearchService.swift
@@ -45,8 +45,8 @@ enum SearchService {
     /// 搜索原始 memo + 编译的日记页面，匹配 ``keyword`` 并应用可选的 ``filters``。
     /// 返回按日期降序排列的结果（最新优先）。
     /// 空关键字 + 无活跃过滤器时返回空数组。
-    static func search(keyword rawKeyword: String,
-                       filters: SearchFilters = .empty) -> [SearchResult] {
+    nonisolated static func search(keyword rawKeyword: String,
+                                   filters: SearchFilters = .empty) -> [SearchResult] {
         let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
         let lowered = keyword.lowercased()
         let hasKeyword = !keyword.isEmpty


### PR DESCRIPTION
## Move vault search off the main thread to eliminate keystroke jank

SearchService.search() synchronously reads and scans every vault/raw/*.md and wiki/daily file from disk, yet runSearch() calls it on the MainActor on every 200ms debounced keystroke. For a nomad with months of daily entries this blocks the main thread per query, causing visible typing/scroll jank. Move the scan to a detached background task (mirroring the existing scanTopEntities pattern) with per-query cancellation so only the latest query's results are applied.

### Acceptance
DayPage scheme builds clean for iPhone 17. Typing in Search no longer blocks the main thread: rapid typing in a vault with many .md files stays at 60fps and results still appear after the 200ms debounce. Stale queries never overwrite a newer query's results (type 'a' then quickly 'abc' → only 'abc' results show). Empty-query, empty-result, and grouped-result states, the first-results Haptics.soft(), and all filter interactions behave exactly as before. Searching off-main introduces no data races (results applied only on MainActor).