### PR TITLE
auto: Make the inline CompileUnlockCard show exact remaining memo count with progress dots and a sparkle shimmer

### DIFF
--- a/DayPage/Features/Today/CompileUnlockCard.swift
+++ b/DayPage/Features/Today/CompileUnlockCard.swift
@@ -2,19 +2,27 @@ import SwiftUI
 
 // MARK: - CompileUnlockCard
 //
-// Museum-aesthetic timeline placeholder card (Claude Design bundle — app.jsx
-// "再记一条解锁今日成稿"). A dashed accent-bordered card that sits inline in the
-// Today timeline, inviting one more memo before AI weaves the day into a page.
+// Museum-aesthetic timeline placeholder card that shows the precise number of
+// memos still needed before AI compilation unlocks. Three mini progress dots
+// mirror the CompileProgressDock visual language.
 //
 //   ┌╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┐
-//   ┆ (✦)  再记一条解锁今日成稿        ┆
-//   ┆      AI 将把今天的碎片连缀成日页   ┆
+//   ┆ (✦)  再记 N 条解锁今日成稿      ┆
+//   ┆      AI 将把今天的碎片连缀成日页  ┆
+//   ┆      ● ● ○                ┆
 //   └╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┘
 
 struct CompileUnlockCard: View {
+    let memoCount: Int
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var shimmer = false
+
+    private var remaining: Int { max(1, 3 - memoCount) }
+
     var body: some View {
         HStack(spacing: 14) {
-            // Accent-soft sparkle tile.
+            // Accent-soft sparkle tile with a subtle breathe shimmer.
             ZStack {
                 Circle()
                     .fill(DSColor.accentSoft)
@@ -22,10 +30,12 @@ struct CompileUnlockCard: View {
                 Image(systemName: "sparkles")
                     .font(.system(size: 16, weight: .semibold))
                     .foregroundColor(DSColor.accentAmber)
+                    .scaleEffect(shimmer ? 1.12 : 1.0)
+                    .opacity(shimmer ? 1.0 : 0.7)
             }
 
-            VStack(alignment: .leading, spacing: 4) {
-                Text("再记一条解锁今日成稿")
+            VStack(alignment: .leading, spacing: 6) {
+                Text("再记 \(remaining) 条解锁今日成稿")
                     .font(DSFonts.jetBrainsMono(size: 10))
                     .tracking(1.2)
                     .foregroundColor(DSColor.accentAmber)
@@ -33,6 +43,16 @@ struct CompileUnlockCard: View {
                     .font(.custom("Inter-Regular", size: 13))
                     .foregroundColor(DSColor.inkMuted)
                     .fixedSize(horizontal: false, vertical: true)
+
+                // Progress dots mirroring CompileProgressDock.
+                HStack(spacing: 5) {
+                    ForEach(0..<3, id: \.self) { index in
+                        Circle()
+                            .fill(index < memoCount ? DSColor.accentAmber : DSColor.glassStd)
+                            .frame(width: 5, height: 5)
+                    }
+                }
+                .padding(.top, 2)
             }
 
             Spacer(minLength: 0)
@@ -47,6 +67,14 @@ struct CompileUnlockCard: View {
                 )
         )
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("再记一条解锁今日成稿")
+        .accessibilityLabel("再记 \(remaining) 条解锁今日成稿，已记 \(memoCount) 条")
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(
+                .easeInOut(duration: 1.6).repeatForever(autoreverses: true)
+            ) {
+                shimmer = true
+            }
+        }
     }
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1139,7 +1139,7 @@ struct TodayView: View {
                 if !viewModel.memos.isEmpty
                     && !viewModel.isDailyPageCompiled
                     && viewModel.memos.count < 3 {
-                    CompileUnlockCard()
+                    CompileUnlockCard(memoCount: viewModel.memos.count)
                         .padding(.horizontal, 20)
                         .padding(.top, 4)
                         .transition(.opacity)


### PR DESCRIPTION
## Make the inline CompileUnlockCard show exact remaining memo count with progress dots and a sparkle shimmer

The inline timeline 'unlock today's page' card statically says '再记一条解锁今日成稿' (record one more) even when the user has only 1 memo and actually needs 2 more, contradicting the 3-segment CompileProgressDock shown in the compose area. This makes CompileUnlockCard accept the current memoCount, render the precise remaining count ('再记 N 条解锁今日成稿') with three mini progress dots that mirror the dock, and adds a subtle reduce-motion-respecting shimmer on the sparkle tile so the card reads as a live, motivating goal rather than a static label.

### Acceptance
Build the DayPage scheme with `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` succeeds. With exactly 1 memo on Today, the inline card reads '再记 2 条解锁今日成稿' and shows one filled + two empty dots; with 2 memos it reads '再记 1 条' and shows two filled dots. The sparkle tile gently shimmers, and with Reduce Motion enabled it is static. VoiceOver announces the remaining and current counts. No other call sites of CompileUnlockCard break.