### PR TITLE
auto: Fix UndoPillView to honor its label for both send and delete (text + VoiceOver)

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -49,7 +49,7 @@ struct UndoPillView: View {
                         .animation(reduceMotion ? nil : .easeInOut(duration: 0.4), value: isUrgent)
                         .accessibilityHidden(true)
                 }
-                Text("Undo · \(secondsRemaining)s")
+                Text("\(label) · \(secondsRemaining)s")
                     .font(.custom("Inter-Medium", size: 13))
             }
             .foregroundColor(DSColor.inkPrimary)
@@ -85,7 +85,7 @@ struct UndoPillView: View {
                 }
         )
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("Undo send, \(secondsRemaining) seconds remaining")
+        .accessibilityLabel("\(label), \(secondsRemaining) seconds remaining")
         .accessibilityHint("Activate to undo; use the Dismiss action to close without undoing")
         .accessibilityAddTraits(.isButton)
         .accessibilityAddTraits(.updatesFrequently)


### PR DESCRIPTION
## Fix UndoPillView to honor its label for both send and delete (text + VoiceOver)

The undo pill is reused for both 'undo send' and 'undo delete', but its visible text is hardcoded to 'Undo · Ns' and its VoiceOver label/hint always say 'Undo send', so the delete-undo pill is mislabeled for sighted and VoiceOver users alike. This makes the pill render the wrong action text and announce the wrong intent. The fix threads the existing `label` parameter through the visible Text and the accessibility label/hint.

### Acceptance
Build the DayPage scheme on iPhone 17. Submit a memo → pill reads the send label · countdown; delete a memo → pill reads the delete label · countdown (not 'Undo'). With VoiceOver, the delete pill announces the delete label and seconds remaining, not 'Undo send'. Reduce Motion behavior and the 5s auto-dismiss are unchanged.