### PR TITLE
auto: Animate CompileUnlockCard progress dots with a spring fill + pop on each new memo

### DIFF
--- a/DayPage/Features/Today/CompileUnlockCard.swift
+++ b/DayPage/Features/Today/CompileUnlockCard.swift
@@ -17,6 +17,8 @@ struct CompileUnlockCard: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var shimmer = false
+    @State private var lastFilled: Int = 0
+    @State private var poppedIndex: Int? = nil
 
     private var remaining: Int { max(1, 3 - memoCount) }
 
@@ -50,6 +52,9 @@ struct CompileUnlockCard: View {
                         Circle()
                             .fill(index < memoCount ? DSColor.accentAmber : DSColor.glassStd)
                             .frame(width: 5, height: 5)
+                            .scaleEffect(poppedIndex == index ? 1.6 : 1.0)
+                            .animation(Motion.respectReduceMotion(.spring(response: 0.3, dampingFraction: 0.55)), value: poppedIndex)
+                            .animation(Motion.respectReduceMotion(Motion.spring), value: memoCount)
                     }
                 }
                 .padding(.top, 2)
@@ -68,7 +73,20 @@ struct CompileUnlockCard: View {
         )
         .accessibilityElement(children: .combine)
         .accessibilityLabel("再记 \(remaining) 条解锁今日成稿，已记 \(memoCount) 条")
+        .onChange(of: memoCount) { newCount in
+            guard newCount > lastFilled, !reduceMotion else {
+                lastFilled = newCount
+                return
+            }
+            poppedIndex = newCount - 1
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 250_000_000)
+                poppedIndex = nil
+            }
+            lastFilled = newCount
+        }
         .onAppear {
+            lastFilled = memoCount
             guard !reduceMotion else { return }
             withAnimation(
                 .easeInOut(duration: 1.6).repeatForever(autoreverses: true)


### PR DESCRIPTION
## Animate CompileUnlockCard progress dots with a spring fill + pop on each new memo

The CompileUnlockCard's three progress dots currently snap between filled/empty with no animation, feeling flat against DayPage's otherwise heavily choreographed motion (orb pulses, glow reveals, escalating haptics). This adds a spring-driven fill transition and a one-shot scale 'pop' on the newest-filled dot when memoCount increments, so each captured memo gives tactile visual progress toward the 3-memo compile unlock.

### Acceptance
Build the DayPage scheme cleanly (xcodebuild -scheme DayPage build). In the iPhone 17 Simulator, with 0–2 memos today, add a memo and confirm the corresponding progress dot fills with a spring transition and briefly pops larger before settling. With Reduce Motion enabled (Settings > Accessibility), dots change color instantly with no pop. The card's existing sparkle shimmer and dashed border are unchanged, and VoiceOver still reads the combined '再记 N 条解锁今日成稿' label.