### PR TITLE
auto: Undo pill: directional swipe-to-dismiss with threshold haptic + horizontal escape

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -17,7 +17,8 @@ struct UndoPillView: View {
     @State private var isUrgent: Bool = false
     @State private var secondsRemaining: Int = 5
     @State private var appeared: Bool = false
-    @GestureState private var dragOffset: CGFloat = 0
+    @GestureState private var dragOffset: CGSize = .zero
+    @State private var crossedDismissThreshold: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -68,20 +69,37 @@ struct UndoPillView: View {
         }
         .buttonStyle(.plain)
         .scaleEffect(reduceMotion ? 1 : (appeared ? 1 : 0.92))
-        .opacity((reduceMotion ? 1 : (appeared ? 1 : 0)) * (dragOffset > 0 ? Double(1 - dragOffset / 80) : 1))
-        .offset(y: max(0, dragOffset))
+        .opacity({
+            let baseOpacity: Double = reduceMotion ? 1 : (appeared ? 1 : 0)
+            if reduceMotion { return baseOpacity }
+            let dist = dragDistance(dragOffset)
+            return baseOpacity * Double(max(0, 1 - dist / 80))
+        }())
+        .offset(
+            x: reduceMotion ? 0 : (isDominantAxisHorizontal(dragOffset) ? dragOffset.width : 0),
+            y: reduceMotion ? 0 : (isDominantAxisHorizontal(dragOffset) ? 0 : max(0, dragOffset.height))
+        )
         .highPriorityGesture(
             DragGesture(minimumDistance: 10)
                 .updating($dragOffset) { value, state, _ in
-                    if value.translation.height > 0 {
-                        state = value.translation.height
+                    state = value.translation
+                }
+                .onChanged { value in
+                    guard !reduceMotion else { return }
+                    let dist = dragDistance(value.translation)
+                    if dist > 28 && !crossedDismissThreshold {
+                        crossedDismissThreshold = true
+                        Haptics.soft()
+                    } else if dist <= 28 && crossedDismissThreshold {
+                        crossedDismissThreshold = false
                     }
                 }
                 .onEnded { value in
-                    if value.translation.height > 28 {
-                        Haptics.soft()
+                    let dist = dragDistance(value.translation)
+                    if dist > 28 {
                         onDismiss?()
                     }
+                    crossedDismissThreshold = false
                 }
         )
         .accessibilityElement(children: .ignore)
@@ -124,6 +142,17 @@ struct UndoPillView: View {
                 secondsRemaining = tick
             }
         }
+    }
+
+    private func dragDistance(_ translation: CGSize) -> CGFloat {
+        if isDominantAxisHorizontal(translation) {
+            return abs(translation.width)
+        }
+        return max(0, translation.height)
+    }
+
+    private func isDominantAxisHorizontal(_ translation: CGSize) -> Bool {
+        abs(translation.width) > abs(translation.height)
     }
 
     private var ringColor: Color {


### PR DESCRIPTION
## Undo pill: directional swipe-to-dismiss with threshold haptic + horizontal escape

The UndoPillView currently only dismisses on a downward drag and gives no tactile cue that the release threshold has been crossed, so users swiping it away feel nothing until it vanishes. Add a light haptic the moment the drag passes the dismiss threshold (during the gesture, not on release), and let horizontal swipes dismiss too so the gesture matches the omnidirectional 'flick away' users expect from a transient toast. Also fade/translate the pill along the actual drag axis for a more physical feel.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator with no warnings. Submit a memo to surface the undo pill, then drag it down and to the side: a soft haptic fires once as the drag crosses the threshold, releasing past the threshold in either direction dismisses the pill, and a short drag springs back without dismissing. VoiceOver still announces the label, countdown, and exposes the Dismiss action; reduce-motion users see the pill appear/dismiss without the live-drag translation.