### PR TITLE
auto: Fix OnThisDay card tap targets & accessibility (44pt dismiss, VoiceOver grouping, press feedback)

### DIFF
--- a/DayPage/Features/Today/OnThisDayCard.swift
+++ b/DayPage/Features/Today/OnThisDayCard.swift
@@ -8,51 +8,81 @@ struct OnThisDayCard: View {
     let onDismiss: () -> Void
     let onTap: (OnThisDayEntry) -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
         Button {
             onTap(entry)
         } label: {
-            VStack(alignment: .leading, spacing: 10) {
-                HStack(alignment: .top) {
-                    // "ON THIS DAY · N YEAR(S) AGO" label
-                    Text(headerLabel)
-                        .labelText()
-                        .foregroundColor(DSColor.accentAmber)
-                    Spacer()
-                    // Dismiss X
-                    Button(action: onDismiss) {
-                        Image(systemName: "xmark")
-                            .font(.system(size: 12, weight: .medium))
-                            .foregroundColor(DSColor.onBackgroundMuted)
-                            .frame(width: 24, height: 24)
-                    }
-                    .buttonStyle(.plain)
-                }
+            cardContent
+        }
+        .buttonStyle(OnThisDayPressStyle(reduceMotion: reduceMotion))
+        .padding(.horizontal, 20)
+        // Single accessible element: card body + dismiss action
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityCardLabel)
+        .accessibilityHint("翻开那天")
+        .accessibilityAddTraits(.isButton)
+        .accessibilityAction(named: Text("Dismiss")) {
+            onDismiss()
+        }
+        // 44pt dismiss overlay wins hit-testing over the card button
+        .overlay(alignment: .topTrailing) {
+            dismissButton
+                .padding(.trailing, 2)
+                .padding(.top, 2)
+        }
+    }
 
-                // Preview text (2 lines)
-                Text(entry.preview.isEmpty ? "查看那一天的记录" : entry.preview)
-                    .bodyText()
-                    .foregroundColor(DSColor.onBackgroundPrimary)
-                    .lineLimit(2)
+    // MARK: - Subviews
 
-                // "Open that day ->" link
-                HStack {
-                    Spacer()
-                    Text("翻开那天 →")
-                        .captionText()
-                        .foregroundColor(DSColor.accentAmber)
-                }
+    private var cardContent: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top) {
+                Text(headerLabel)
+                    .labelText()
+                    .foregroundColor(DSColor.accentAmber)
+                Spacer()
+                // Spacer reserves room for the 44pt dismiss overlay
+                Color.clear.frame(width: 44, height: 24)
             }
-            .padding(DSSpacing.cardInner)
-            .background(DSColor.accentSoft)
-            .overlay(
-                RoundedRectangle(cornerRadius: DSSpacing.radiusCard)
-                    .stroke(DSColor.accentBorder, lineWidth: 1)
-            )
-            .cornerRadius(DSSpacing.radiusCard)
+
+            Text(entry.preview.isEmpty ? "查看那一天的记录" : entry.preview)
+                .bodyText()
+                .foregroundColor(DSColor.onBackgroundPrimary)
+                .lineLimit(2)
+
+            HStack {
+                Spacer()
+                Text("翻开那天 →")
+                    .captionText()
+                    .foregroundColor(DSColor.accentAmber)
+            }
+        }
+        .padding(DSSpacing.cardInner)
+        .background(DSColor.accentSoft)
+        .overlay(
+            RoundedRectangle(cornerRadius: DSSpacing.radiusCard)
+                .stroke(DSColor.accentBorder, lineWidth: 1)
+        )
+        .cornerRadius(DSSpacing.radiusCard)
+    }
+
+    private var dismissButton: some View {
+        Button {
+            Haptics.soft()
+            onDismiss()
+        } label: {
+            Image(systemName: "xmark")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundColor(DSColor.onBackgroundMuted)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .padding(.horizontal, 20)
+        .accessibilityLabel("Dismiss")
+        .accessibilityIdentifier("onthisday-dismiss")
+        .zIndex(1)
     }
 
     // MARK: - Helpers
@@ -64,5 +94,26 @@ struct OnThisDayCard: View {
             return "ON THIS DAY · \(days) DAYS AGO"
         }
         return "ON THIS DAY"
+    }
+
+    private var accessibilityCardLabel: String {
+        let preview = entry.preview.isEmpty ? "查看那一天的记录" : entry.preview
+        return "\(headerLabel), \(preview)"
+    }
+}
+
+// MARK: - OnThisDayPressStyle
+
+private struct OnThisDayPressStyle: ButtonStyle {
+    let reduceMotion: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect((!reduceMotion && configuration.isPressed) ? 0.97 : 1)
+            .opacity(configuration.isPressed ? 0.94 : 1)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7),
+                value: configuration.isPressed
+            )
     }
 }


### PR DESCRIPTION
## Fix OnThisDay card tap targets & accessibility (44pt dismiss, VoiceOver grouping, press feedback)

The 'On This Day' reminiscence card has a 24×24pt dismiss 'X' (well below the 44pt HIG minimum) nested directly inside the card's outer Button, which causes gesture ambiguity and is hard to hit, and the card exposes no VoiceOver structure (no combined element, label, hint, or named 'Dismiss' action). This polish enlarges the dismiss tap target to 44pt with a haptic + accessibility label, groups the card as a single accessible element with a 'translated' label and a custom dismiss action, and adds a subtle press-scale to match the app's PressableScaleStyle interaction language.

### Acceptance
Build succeeds with `xcodebuild -scheme DayPage build`. In Simulator (iPhone 17) with VoiceOver: the card reads as a single element announcing the 'ON THIS DAY' label plus preview text, exposes a 'Dismiss' rotor action, and the dismiss X is tappable across a full 44×44pt area. Tapping the X dismisses with a soft haptic and does not also trigger card navigation; tapping the card body navigates to that day. With Reduce Motion off, pressing the card shows a subtle scale-down; with Reduce Motion on, no scale animation occurs.