### PR TITLE
auto: Pulse the auto-centered node on first search match in Graph

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -422,10 +422,12 @@ struct GraphView: View {
                     Haptics.soft()
                     if simulationSteps >= maxSimSteps {
                         centerOn(match, in: size)
+                        pulseNode(match)
                     } else {
                         Task { @MainActor in
                             try? await Task.sleep(nanoseconds: 300_000_000)
                             centerOn(match, in: size)
+                            pulseNode(match)
                         }
                     }
                 }


### PR DESCRIPTION
## Pulse the auto-centered node on first search match in Graph

When a user types a search query in the knowledge Graph, the view auto-centers on the best match but — unlike the prev/next match steppers, which already call pulseNode(_:) — it never draws the tap-pulse locating ring. This adds the missing pulse so the first matched node visibly announces itself, making search-to-locate consistent and easier to follow in a dense graph.

### Acceptance
Build the DayPage scheme for iPhone 17 simulator with no errors. In the Graph tab with several nodes, typing a query that matches a node auto-centers on it AND shows the amber/colored pulse ring expanding once on that node (previously only bold+amber label appeared). Stepping prev/next still pulses each match exactly as before. Clearing the search produces no stray pulse. VoiceOver and reduceMotion behavior are unchanged from the existing pulseNode usage.