### PR TITLE
auto: Animated count-up on the Day Orb signal kicker

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -697,11 +697,29 @@ struct TodayView: View {
                 .minimumScaleFactor(0.7)
                 .padding(.bottom, 2)
 
-            Text(orbKicker(currentTime))
-                .font(DSType.mono10)
-                .foregroundColor(DSColor.inkSubtle)
-                .textCase(.uppercase)
-                .tracking(1.0)
+            // Split the kicker so the signal count can animate with numericText
+            // while date/time remain stable. HStack(spacing:0) keeps the line
+            // visually identical to the old single-Text layout.
+            HStack(spacing: 0) {
+                Text(orbKickerPrefix(currentTime))
+                    .font(DSType.mono10)
+                    .foregroundColor(DSColor.inkSubtle)
+                    .textCase(.uppercase)
+                    .tracking(1.0)
+                Text("\(viewModel.signalCount)")
+                    .font(DSType.mono10)
+                    .foregroundColor(DSColor.inkSubtle)
+                    .textCase(.uppercase)
+                    .tracking(1.0)
+                    .contentTransition(reduceMotion ? .identity : .numericText(value: Double(viewModel.signalCount)))
+                    .animation(reduceMotion ? nil : Motion.spring, value: viewModel.signalCount)
+                Text(orbKickerSuffix())
+                    .font(DSType.mono10)
+                    .foregroundColor(DSColor.inkSubtle)
+                    .textCase(.uppercase)
+                    .tracking(1.0)
+            }
+            .accessibilityLabel(orbKicker(currentTime))
 
             let glowBoost = min(Double(viewModel.signalCount), 5) * 0.04
             let signalCount = viewModel.signalCount
@@ -824,6 +842,25 @@ struct TodayView: View {
         let dateStr = f.string(from: date).uppercased()
         let timeStr = Self.headerTimeFmt.string(from: date)
         return "\(dateStr) · \(timeStr) · \(count) \(signal)"
+    }
+
+    /// Date + time prefix for the split kicker: "29 MAY · 14:30 · "
+    private func orbKickerPrefix(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.dateFormat = "d MMM"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        let dateStr = f.string(from: date).uppercased()
+        let timeStr = Self.headerTimeFmt.string(from: date)
+        return "\(dateStr) · \(timeStr) · "
+    }
+
+    /// Signal-word suffix for the split kicker: " SIGNALS"
+    private func orbKickerSuffix() -> String {
+        let count = viewModel.signalCount
+        let signalKey = count == 1 ? "today.kicker.signal.one" : "today.kicker.signal.other"
+        let signal = NSLocalizedString(signalKey, comment: "")
+        return " \(signal)"
     }
 
     // MARK: - InputBarV4 (variant D: Silent Press-to-Talk)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -711,7 +711,7 @@ struct TodayView: View {
                     .foregroundColor(DSColor.inkSubtle)
                     .textCase(.uppercase)
                     .tracking(1.0)
-                    .contentTransition(reduceMotion ? .identity : .numericText(value: Double(viewModel.signalCount)))
+                    .modifier(NumericTextContentTransition(value: Double(viewModel.signalCount), reduceMotion: reduceMotion))
                     .animation(reduceMotion ? nil : Motion.spring, value: viewModel.signalCount)
                 Text(orbKickerSuffix())
                     .font(DSType.mono10)
@@ -1875,5 +1875,21 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
+    }
+}
+
+// ViewModifier to wrap .numericText(value:) which requires iOS 17+
+private struct NumericTextContentTransition: ViewModifier {
+    let value: Double
+    let reduceMotion: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content
+                .contentTransition(reduceMotion ? .identity : .numericText(value: value))
+        } else {
+            content
+                .contentTransition(.identity)
+        }
     }
 }


### PR DESCRIPTION
Closes #523

## Animated count-up on the Day Orb signal kicker

When a new memo is captured, the orb hero's kicker text ('… · 2 SIGNALS') swaps the new number in abruptly with no transition, while the orb itself gets a satisfying pulse + haptic. This adds a subtle numeric content-transition so the signal count rolls up like a counter, reinforcing the capture-reward moment that the orb pulse and escalating haptics already establish. It's a pure, isolated polish change on an already-prominent hero surface.

### Acceptance
Build succeeds via `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'`. In the Simulator on the empty/low-memo Today screen, adding a memo makes the orb kicker's signal number roll up (numericText transition) in sync with the existing orb pulse, rather than swapping instantly. With Reduce Motion enabled, the number updates instantly with no roll. Date, time, separators, font, tracking, casing, and color are visually unchanged from before; the kicker remains a single line. VoiceOver still reads the full kicker string.