### PR TITLE
auto: Add a contextual greeting to the empty-state Day Orb hero

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -690,6 +690,13 @@ struct TodayView: View {
         // empty-state orb block only carries the orb + kicker to avoid a
         // duplicate weekday title.
         VStack(spacing: 6) {
+            Text(orbGreeting(currentTime))
+                .font(DSType.serifDisplay28)
+                .foregroundColor(DSColor.inkPrimary)
+                .dynamicTypeSize(.xSmall ... .accessibility2)
+                .minimumScaleFactor(0.7)
+                .padding(.bottom, 2)
+
             Text(orbKicker(currentTime))
                 .font(DSType.mono10)
                 .foregroundColor(DSColor.inkSubtle)
@@ -787,6 +794,16 @@ struct TodayView: View {
             RoundedRectangle(cornerRadius: 14, style: .continuous)
                 .strokeBorder(DSColor.inkFaint.opacity(0.6), lineWidth: 0.5)
         )
+    }
+
+    private func orbGreeting(_ date: Date) -> String {
+        let hour = Calendar.current.component(.hour, from: date)
+        switch hour {
+        case 5...11:  return NSLocalizedString("today.greeting.morning",   comment: "")
+        case 12...17: return NSLocalizedString("today.greeting.afternoon", comment: "")
+        case 18...22: return NSLocalizedString("today.greeting.evening",   comment: "")
+        default:      return NSLocalizedString("today.greeting.latenight", comment: "")
+        }
     }
 
     private func orbKicker(_ date: Date) -> String {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -53,6 +53,12 @@
 "today.subline.notes.one"    = "%d note";
 "today.subline.notes.other"  = "%d notes";
 
+/* Today orb greeting — time-of-day serif greeting above kicker */
+"today.greeting.morning"     = "Good morning.";
+"today.greeting.afternoon"   = "Good afternoon.";
+"today.greeting.evening"     = "Good evening.";
+"today.greeting.latenight"   = "Still up?";
+
 /* Today orb kicker — signal count */
 "today.kicker.signal.one"    = "SIGNAL";
 "today.kicker.signal.other"  = "SIGNALS";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -53,6 +53,12 @@
 "today.subline.notes.one"    = "%d 条记录";
 "today.subline.notes.other"  = "%d 条记录";
 
+/* Today orb greeting — time-of-day serif greeting above kicker */
+"today.greeting.morning"     = "早上好。";
+"today.greeting.afternoon"   = "下午好。";
+"today.greeting.evening"     = "晚上好。";
+"today.greeting.latenight"   = "还没睡？";
+
 /* Today orb kicker — signal count */
 "today.kicker.signal.one"    = "信号";
 "today.kicker.signal.other"  = "信号";


### PR DESCRIPTION
## Add a contextual greeting to the empty-state Day Orb hero

The empty-state orb hero currently shows only a mono date/time/signal kicker above the orb, which feels sterile on first open each day. Add a time-of-day-aware serif greeting ('Good morning' / 'Good afternoon' / 'Good evening' / 'Still up?') above the kicker so the zero-memo Today screen feels warm and personal, reinforcing the journaling ritual. The greeting derives purely from `currentTime` (already a refreshing @State) with no new services or network calls.

### Acceptance
On a day with zero memos, the Today screen shows a time-appropriate serif greeting directly above the date/time/signal kicker and orb. The greeting changes correctly at hour boundaries (verify by stubbing time or launching at different hours). It disappears with the rest of the orb hero once the first memo is added (existing `viewModel.memos.isEmpty` gate). VoiceOver reads the greeting before the kicker. Build succeeds via `xcodebuild -scheme DayPage build` and the app launches cleanly in the iPhone 17 simulator with the greeting rendered.