### PR TITLE
auto: Respect Reduce Motion in the Day Orb breathing animation on the Today empty state

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -697,7 +697,10 @@ struct TodayView: View {
                 .tracking(1.0)
 
             let glowBoost = min(Double(viewModel.signalCount), 5) * 0.04
-            DayOrbView(signalCount: viewModel.signalCount, size: 140, onTap: {
+            let signalCount = viewModel.signalCount
+            let orbValueKey = signalCount == 1 ? "today.orb.value.one" : "today.orb.value.other"
+            let orbValue = String(format: NSLocalizedString(orbValueKey, comment: ""), signalCount)
+            DayOrbView(signalCount: signalCount, size: 140, onTap: {
                 Haptics.tapConfirm()
                 orbFocusToggle.toggle()
             }, pulseToggle: orbCapturePulse)
@@ -710,6 +713,10 @@ struct TodayView: View {
                 reduceMotion ? nil : .easeInOut(duration: 3.0).repeatForever(autoreverses: true),
                 value: orbBreathing
             )
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(NSLocalizedString("today.orb.label", comment: ""))
+            .accessibilityValue(orbValue)
+            .accessibilityHint(NSLocalizedString("today.orb.hint", comment: ""))
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
@@ -719,7 +726,7 @@ struct TodayView: View {
             }
         }
         .onChange(of: viewModel.memos.count) { count in
-            if count > lastMemoCount {
+            if count > lastMemoCount && !reduceMotion {
                 orbCapturePulse.toggle()
             }
         }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -57,6 +57,12 @@
 "today.kicker.signal.one"    = "SIGNAL";
 "today.kicker.signal.other"  = "SIGNALS";
 
+/* Day Orb accessibility */
+"today.orb.label"            = "Today's signal orb";
+"today.orb.value.one"        = "%d signal captured";
+"today.orb.value.other"      = "%d signals captured";
+"today.orb.hint"             = "Double tap to start a new note";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "Recompile";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -57,6 +57,12 @@
 "today.kicker.signal.one"    = "信号";
 "today.kicker.signal.other"  = "信号";
 
+/* Day Orb accessibility */
+"today.orb.label"            = "今日信号球";
+"today.orb.value.one"        = "已捕获 %d 条信号";
+"today.orb.value.other"      = "已捕获 %d 条信号";
+"today.orb.hint"             = "轻点两下开始新的记录";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "重新编译";
 


### PR DESCRIPTION
## Respect Reduce Motion in the Day Orb breathing animation on the Today empty state

The 140pt Day Orb in TodayView's orbHero already gates its scale/shadow animation behind reduceMotion, but the orb's breathing state (orbBreathing) is still toggled on regardless, and AISummaryCard/compile-reveal glows partly honor it inconsistently. This proposal makes the orbHero fully honor the system Reduce Motion setting and adds a subtle haptic + accessibility value so VoiceOver users hear the live signal count, improving accessibility and motion-sensitivity compliance without changing the visual language.

### Acceptance
With Reduce Motion ON (Settings > Accessibility), the empty-state Day Orb shows no breathing scale or capture-pulse animation. With VoiceOver ON, focusing the orb announces a label plus the current signal count and a hint that double-tapping starts a new note. App builds via `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` and existing tests pass.