### PR TITLE
auto: Add a milestone-aware status word to the Day Orb readout

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -28,7 +28,8 @@ struct DayOrbView: View {
     private var accessibilityLabelText: String {
         if signalCount == 0 { return "Day orb, no signals yet" }
         let word = signalCount == 1 ? "signal" : "signals"
-        return "Day orb, \(signalCount) \(word) today"
+        let status = readoutLabel.lowercased()
+        return "Day orb, \(signalCount) \(word) today, \(status)"
     }
 
     var body: some View {
@@ -241,9 +242,11 @@ struct DayOrbView: View {
 
     private var readoutLabel: String {
         switch signalCount {
-        case 0:  return "TAP TO BEGIN"
-        case 1:  return "SIGNAL TODAY"
-        default: return "SIGNALS TODAY"
+        case 0:        return "TAP TO BEGIN"
+        case 1:        return "SIGNAL TODAY"
+        case 2...4:    return "BUILDING"
+        case 5...9:    return "RICH DAY"
+        default:       return "PACKED"
         }
     }
 


### PR DESCRIPTION
## Add a milestone-aware status word to the Day Orb readout

The Day Orb currently shows a static 'SIGNALS TODAY' subtitle regardless of how productive the day has been. This change makes the orb's mono readout reflect today's capture momentum — e.g. 'BUILDING', 'RICH DAY', 'PACKED' at signal thresholds — turning the orb into a subtle motivational progress indicator that rewards continued capture, consistent with the existing escalating-haptic and glow-pulse reward language already in TodayView.

### Acceptance
Build the DayPage scheme for iPhone 17 with no warnings. In the Simulator, add memos one at a time on the Today empty state and confirm the orb's lower mono line cross-fades through 'SIGNAL TODAY' → 'BUILDING' → 'RICH DAY' → 'PACKED' at counts 1/2/5/10, the large count number still animates via numericText, and VoiceOver reads the status word as part of the orb's accessibility label. Reduce Motion users still see the correct word (only the cross-fade is suppressed).