### PR TITLE
auto: Long-press the export button to copy today's Markdown to the clipboard

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -968,7 +968,7 @@ struct TodayView: View {
 
             Spacer()
 
-            // US-019: Export as Markdown
+            // US-019: Export as Markdown (tap → share sheet; long-press → copy to clipboard)
             if !viewModel.memos.isEmpty {
                 Button {
                     let content = MarkdownExportService.buildExportContent(
@@ -1006,10 +1006,23 @@ struct TodayView: View {
                         .clipShape(Circle())
                 }
                 .accessibilityLabel(NSLocalizedString("export.action.title", comment: ""))
+                .accessibilityHint(NSLocalizedString("export.action.hint", comment: ""))
                 .accessibilityIdentifier("export-markdown-button")
                 .frame(width: 44, height: 44)
                 .contentShape(Rectangle())
                 .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 6 }
+                .onLongPressGesture(minimumDuration: 0.5) {
+                    let content = MarkdownExportService.buildExportContent(
+                        memos: viewModel.memos, date: Date()
+                    )
+                    UIPasteboard.general.string = content
+                    Haptics.success()
+                    bannerCenter.show(AppBannerModel(
+                        kind: .info,
+                        title: NSLocalizedString("export.copied.title", comment: ""),
+                        autoDismiss: true
+                    ))
+                }
             }
 
             Button {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -199,7 +199,9 @@
 /* Markdown Export — US-019 */
 "export.action.title"  = "Export as Markdown";
 "export.action.label"  = "Export";
+"export.action.hint"   = "Double tap to share, long press to copy";
 "export.error.title"   = "Export failed, please try again";
+"export.copied.title"  = "Markdown copied";
 
 /* Voice attachment retry — US-016 */
 "voice.retry.button"           = "Retry transcription";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -227,7 +227,9 @@
 /* Markdown Export — US-019 */
 "export.action.title"  = "导出为 Markdown";
 "export.action.label"  = "导出";
+"export.action.hint"   = "双击分享，长按复制";
 "export.error.title"   = "导出失败，请重试";
+"export.copied.title"  = "已复制今日 Markdown";
 
 /* Voice attachment retry — US-016 */
 "voice.retry.button"           = "重试转写";


### PR DESCRIPTION
## Long-press the export button to copy today's Markdown to the clipboard

The Today export button currently only writes a file and opens the iOS share sheet, which is several taps to paste into another app. Adding a long-press gesture that copies the day's compiled Markdown straight to the clipboard (with a confirmation banner + haptic) gives nomads a fast, frictionless 'grab my notes as text' path that reuses the existing MarkdownExportService — no new file I/O or schema changes.

### Acceptance
Tapping the export icon still opens the share sheet unchanged. Long-pressing it for ~0.5s copies the full Markdown of today's memos to the system clipboard, triggers a success haptic, and shows an auto-dismissing 'copied' banner; pasting into Notes yields the same content the share sheet would have exported. With no memos the button (and gesture) are absent. Project builds clean on the DayPage scheme for iPhone 17.