### PR TITLE
auto: Long-press the AI 今日一句 summary to copy it to the clipboard

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1069,6 +1069,24 @@ struct TodayView: View {
                         .padding(.horizontal, 20)
                         .padding(.bottom, 4)
                         .transition(.opacity)
+                        .onLongPressGesture(minimumDuration: 0.4) {
+                            UIPasteboard.general.string = summary
+                            Haptics.tapConfirm()
+                            bannerCenter.show(AppBannerModel(
+                                kind: .info,
+                                title: NSLocalizedString("today.summary.copied", comment: ""),
+                                autoDismiss: true
+                            ))
+                        }
+                        .accessibilityAction(named: Text("Copy summary")) {
+                            UIPasteboard.general.string = summary
+                            Haptics.tapConfirm()
+                            bannerCenter.show(AppBannerModel(
+                                kind: .info,
+                                title: NSLocalizedString("today.summary.copied", comment: ""),
+                                autoDismiss: true
+                            ))
+                        }
                 }
 
                 if viewModel.isDailyPageCompiled {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -75,6 +75,9 @@
 /* DailyPage card accessibility hint */
 "today.accessibility.dailypage.hint" = "Opens today's compiled page. Use the Actions menu to recompile.";
 
+/* AI summary card long-press copy confirmation */
+"today.summary.copied" = "Summary copied";
+
 /* Archive Day Empty */
 "empty.archive_day.title" = "No page for this day.";
 "empty.archive_day.subtitle" = "This day hasn't been compiled yet. Head to Today to add memos first.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -75,6 +75,9 @@
 /* DailyPage card accessibility hint */
 "today.accessibility.dailypage.hint" = "打开今日编译页。通过操作菜单可重新编译。";
 
+/* AI summary card long-press copy confirmation */
+"today.summary.copied" = "已复制今日一句";
+
 /* Archive Day Empty */
 "empty.archive_day.title" = "这一天还没有日记页。";
 "empty.archive_day.subtitle" = "这天尚未编译。先去「今天」添加备忘吧。";


### PR DESCRIPTION
## Long-press the AI "今日一句" summary to copy it to the clipboard

The AISummaryCard pinned at the top of the Today timeline shows the day's compiled one-liner but offers no way to reuse it — users have no path to copy this AI-generated sentence for sharing or pasting elsewhere. Adding a long-press-to-copy gesture with haptic confirmation and a transient banner gives the summary a lightweight, discoverable affordance consistent with the app's existing long-press interactions (memo share, On This Day refresh).

### Acceptance
Build the DayPage scheme for iPhone 17. On a day with a compiled daily page, the AI summary card is visible at the top of the timeline; long-pressing it triggers a haptic, copies the exact summary text to the system clipboard (verify by pasting into the composer input bar), and shows an auto-dismissing 'copied' banner. VoiceOver exposes a 'Copy summary' custom action. No regression to the card's existing tap-to-open behavior, and Reduce Motion users still get the haptic + banner.