### PR TITLE
fix: repair linear-automation workflow + React 19 theme-script + v8 museum polish

### DIFF
--- a/.github/workflows/linear-automation.yml
+++ b/.github/workflows/linear-automation.yml
@@ -242,6 +242,7 @@ jobs:
           ISSUE_URL: ${{ github.event.issue.html_url }}
           ISSUE_NUMBER: ${{ github.event.issue.number }}
           ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Skip if already has Linear reference
           HAS_LINEAR=$(echo "${ISSUE_TITLE} ${ISSUE_BODY}" | grep -ci 'DAY-' || echo "0")
@@ -291,8 +292,6 @@ jobs:
             gh issue comment "$ISSUE_NUMBER" \
               --body "📋 Linear issue created: [$LINEAR_ISSUE_ID](https://linear.app/daypage/issue/$LINEAR_ISSUE_ID)"
           fi
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ─────────────────────────────────────────────────────────
   # Commit push → Comment on Linear with commit info

--- a/.github/workflows/linear-automation.yml
+++ b/.github/workflows/linear-automation.yml
@@ -66,22 +66,25 @@ jobs:
     steps:
       - name: Extract Linear issue ID from PR
         id: extract
+        env:
+          # Pass PR fields via env (NOT direct ${{ }} interpolation into the
+          # script body) so backticks/$/quotes/newlines in attacker-controlled
+          # title/body cannot break the shell or inject commands.
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
         run: |
           # Search for Linear issue references in PR title, body, branch name
-          TITLE="${{ github.event.pull_request.title }}"
-          BODY="${{ github.event.pull_request.body }}"
-          HEAD="${{ github.event.pull_request.head.ref }}"
-
-          COMBINED="${TITLE} ${BODY} ${HEAD}"
+          COMBINED="${PR_TITLE} ${PR_BODY} ${PR_HEAD}"
 
           # Look for: DAY-123, [DAY-123], closes DAY-123, fixes DAY-123, etc.
-          LINEAR_ID=$(echo "$COMBINED" | grep -oP '(?<![A-Za-z])DAY-\d+(?![A-Za-z0-9])' | head -1 || echo "")
+          LINEAR_ID=$(printf '%s' "$COMBINED" | grep -oP '(?<![A-Za-z])DAY-\d+(?![A-Za-z0-9])' | head -1 || true)
 
           # Also try Linear URL format
           if [ -z "$LINEAR_ID" ]; then
-            LINEAR_URL=$(echo "$COMBINED" | grep -oP 'linear\.app/[^/\s]+/issue/[A-Z]+-\d+' | head -1 || echo "")
+            LINEAR_URL=$(printf '%s' "$COMBINED" | grep -oP 'linear\.app/[^/\s]+/issue/[A-Z]+-\d+' | head -1 || true)
             if [ -n "$LINEAR_URL" ]; then
-              LINEAR_ID=$(echo "$LINEAR_URL" | grep -oP '[A-Z]+-\d+$' || echo "")
+              LINEAR_ID=$(printf '%s' "$LINEAR_URL" | grep -oP '[A-Z]+-\d+$' || true)
             fi
           fi
 
@@ -192,10 +195,11 @@ jobs:
     steps:
       - name: Extract Linear ID
         id: extract
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_HEAD: ${{ github.event.pull_request.head.ref }}
         run: |
-          TITLE="${{ github.event.pull_request.title }}"
-          HEAD="${{ github.event.pull_request.head.ref }}"
-          LINEAR_ID=$(echo "${TITLE} ${HEAD}" | grep -oP '(?<![A-Za-z])DAY-\d+(?![A-Za-z0-9])' | head -1 || echo "")
+          LINEAR_ID=$(printf '%s %s' "$PR_TITLE" "$PR_HEAD" | grep -oP '(?<![A-Za-z])DAY-\d+(?![A-Za-z0-9])' | head -1 || true)
           if [ -z "$LINEAR_ID" ]; then
             echo "found=false" >> "$GITHUB_OUTPUT"
           else
@@ -245,16 +249,16 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           # Skip if already has Linear reference
-          HAS_LINEAR=$(echo "${ISSUE_TITLE} ${ISSUE_BODY}" | grep -ci 'DAY-' || echo "0")
-          if [ "$HAS_LINEAR" -gt 0 ]; then
+          HAS_LINEAR=$(printf '%s %s' "$ISSUE_TITLE" "$ISSUE_BODY" | grep -ci 'DAY-' || true)
+          if [ "${HAS_LINEAR:-0}" -gt 0 ]; then
             echo "Issue already references a Linear issue — skipping creation"
             exit 0
           fi
 
           # Determine label based on issue content
-          if echo "${ISSUE_TITLE} ${ISSUE_BODY}" | grep -qi 'bug\|crash\|error\|fix'; then
+          if printf '%s %s' "$ISSUE_TITLE" "$ISSUE_BODY" | grep -qi 'bug\|crash\|error\|fix'; then
             LABEL_IDS='["'"$LABEL_BUG"'"]'
-          elif echo "${ISSUE_TITLE} ${ISSUE_BODY}" | grep -qi 'feature\|enhance\|add'; then
+          elif printf '%s %s' "$ISSUE_TITLE" "$ISSUE_BODY" | grep -qi 'feature\|enhance\|add'; then
             LABEL_IDS='["'"$LABEL_FEATURE"'"]'
           else
             LABEL_IDS='["'"$LABEL_IMPROVEMENT"'"]'
@@ -305,14 +309,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Extract and post commit to Linear
+        env:
+          # Pass commit fields via env (NOT direct ${{ }} interpolation) — a
+          # commit message is fully attacker-controlled and routinely contains
+          # backticks/$/quotes/newlines that would break or inject the shell.
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
+          COMMIT_URL: ${{ github.event.head_commit.url }}
+          COMMIT_AUTHOR: ${{ github.event.head_commit.author.username }}
+          COMMIT_ID: ${{ github.event.head_commit.id }}
         run: |
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
-          COMMIT_URL="${{ github.event.head_commit.url }}"
-          COMMIT_AUTHOR="${{ github.event.head_commit.author.username }}"
-          COMMIT_SHA_SHORT=$(echo "${{ github.event.head_commit.id }}" | cut -c1-7)
+          COMMIT_SHA_SHORT=$(printf '%s' "$COMMIT_ID" | cut -c1-7)
 
           # Find all DAY-* references
-          LINEAR_IDS=$(echo "$COMMIT_MSG" | grep -oP '(?<![A-Za-z])DAY-\d+(?![A-Za-z0-9])' | sort -u || echo "")
+          LINEAR_IDS=$(printf '%s' "$COMMIT_MSG" | grep -oP '(?<![A-Za-z])DAY-\d+(?![A-Za-z0-9])' | sort -u || true)
 
           if [ -z "$LINEAR_IDS" ]; then
             echo "No Linear references in commit — skipping"

--- a/web/src/app/layout.tsx
+++ b/web/src/app/layout.tsx
@@ -1,15 +1,14 @@
 import type { Metadata } from "next";
 import { Space_Grotesk, Inter, JetBrains_Mono, Fraunces } from "next/font/google";
-import Script from "next/script";
 import { QueryProvider } from "@/components/QueryProvider";
 import { ThemeProvider } from "@/components/ThemeProvider";
 import "./globals.css";
 
 // Inline script runs synchronously before React hydration to avoid theme flash.
-// Use next/script with `beforeInteractive` — React 19 refuses to execute a raw
-// <script> rendered as a React child, so the previous inline form produced a
-// console warning ("Scripts inside React components are never executed…") and
-// on client-side re-renders simply did not run.
+// In Next.js 16 / React 19 App Router, a raw <script dangerouslySetInnerHTML>
+// in <head> is hoisted into the SSR HTML stream and executed by the browser
+// parser before hydration. (next/script `beforeInteractive` rendered as a React
+// child throws "Scripts inside React components are never executed…" here.)
 const themeScript = `
 (function(){try{var s=localStorage.getItem('codex.settings.v1');var t=s?JSON.parse(s).theme:'system';document.documentElement.setAttribute('data-theme',t||'system');}catch(e){}})();
 `;
@@ -64,12 +63,12 @@ export default function RootLayout({
     >
       <head>
         {/* Prevents theme flash by setting data-theme before first paint.
-            beforeInteractive is the only safe strategy here — it lets Next.js
-            emit the <script> into the SSR HTML stream so the browser parser
-            executes it synchronously, before React hydrates. */}
-        <Script id="theme-no-flash" strategy="beforeInteractive">
-          {themeScript}
-        </Script>
+            A raw <script> in <head> is emitted into the SSR HTML stream and run
+            synchronously by the browser parser, before React hydrates. */}
+        <script
+          id="theme-no-flash"
+          dangerouslySetInnerHTML={{ __html: themeScript }}
+        />
       </head>
       <body className="min-h-full bg-bg-warm text-fg-primary font-body">
         <ThemeProvider />


### PR DESCRIPTION
## 本次 loop：检查 PR 和 actions 并修复

### 🔧 CI 修复（核心）
- **`linear-automation.yml` 每次 push 都 0s 失败**：`issue-to-linear` job 的 "Create Linear issue" step 声明了**两个 `env:` 块**（顶部 `ISSUE_*` + 底部 `GH_TOKEN`）。GitHub Actions 用严格 YAML，重复键导致整个 workflow 解析失败（"workflow file issue"，无 run log）。
- 修复：把 `GH_TOKEN` 合并进唯一的 `env:` 块。
- 验证：仓库内全部 10 个 workflow 现已通过 YAML 解析、无重复键。

### 🐛 Web fix
- **`layout.tsx`**：主题防闪脚本从 `next/script beforeInteractive` 改为原生 `<script dangerouslySetInnerHTML>`。Next.js 16 / React 19 App Router 下，作为 React child 的 `next/script` 会抛 "Scripts inside React components are never executed…"。原生 `<head>` script 会被 SSR HTML 流注入并在 hydration 前由浏览器解析器执行，正是防闪需要的行为。

### 🎨 v8 museum polish（已含在 dc482b6）
- Today / drawer heatmap / timeline 的 v8 日式美术馆风格打磨（14 个文件）。

## 验证
- ✅ 全部 workflow YAML 解析通过
- ✅ web typecheck 仅剩一个**预存在**的本地缺依赖报错（`html-to-image` 已在 package.json，CI 的 `npm ci` 会装上），与本次改动无关