### PR TITLE
auto: Polish the first-run WelcomeScreen with staggered entrance, button press feedback, and accessibility

### DIFF
--- a/DayPage/Features/Onboarding/WelcomeScreen.swift
+++ b/DayPage/Features/Onboarding/WelcomeScreen.swift
@@ -1,5 +1,15 @@
 import SwiftUI
 
+// MARK: - PressableButtonStyle
+
+private struct PressableButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.96 : 1)
+            .animation(Motion.spring, value: configuration.isPressed)
+    }
+}
+
 // MARK: - WelcomeScreen
 
 /// First-run welcome shown once after onboarding — a fading Day Orb, bilingual serif line, Begin pill.
@@ -8,7 +18,11 @@ struct WelcomeScreen: View {
 
     @Binding var hasSeenWelcome: Bool
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     @State private var orbOpacity: Double = 0
+    @State private var taglineAppeared: Bool = false
+    @State private var buttonAppeared: Bool = false
 
     var body: some View {
         ZStack {
@@ -23,6 +37,17 @@ struct WelcomeScreen: View {
                     .onAppear {
                         withAnimation(.easeOut(duration: 0.8)) {
                             orbOpacity = 1
+                        }
+                        Task { @MainActor in
+                            if reduceMotion {
+                                taglineAppeared = true
+                                buttonAppeared = true
+                            } else {
+                                try? await Task.sleep(nanoseconds: 400_000_000)
+                                withAnimation(Motion.rise) { taglineAppeared = true }
+                                try? await Task.sleep(nanoseconds: 200_000_000)
+                                withAnimation(Motion.rise) { buttonAppeared = true }
+                            }
                         }
                     }
 
@@ -39,6 +64,10 @@ struct WelcomeScreen: View {
                         .multilineTextAlignment(.center)
                 }
                 .padding(.horizontal, 32)
+                .opacity(taglineAppeared ? 1 : 0)
+                .offset(y: taglineAppeared ? 0 : 12)
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("Welcome to DayPage. Every day deserves a record.")
 
                 Spacer()
 
@@ -58,7 +87,11 @@ struct WelcomeScreen: View {
                         .background(DSColor.amberDeep)
                         .clipShape(Capsule())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(PressableButtonStyle())
+                .opacity(buttonAppeared ? 1 : 0)
+                .offset(y: buttonAppeared ? 0 : 12)
+                .accessibilityLabel("Begin")
+                .accessibilityHint("Starts using DayPage")
 
                 Spacer().frame(height: 40)
             }


### PR DESCRIPTION
## Polish the first-run WelcomeScreen with staggered entrance, button press feedback, and accessibility

The WelcomeScreen is the very first thing a new user sees, yet only the Day Orb animates in — the bilingual tagline and 'Begin' pill pop in abruptly, the button has no press-down feedback, and the screen has no accessibility labels. This adds a staggered fade+rise entrance for the tagline and button, an interactive scale-down on the Begin pill, and VoiceOver labels, turning a flat intro into a deliberate, refined first impression.

### Acceptance
Build the DayPage scheme succeeds. Launch on iPhone 17 simulator with a fresh install (hasSeenWelcome unset): the orb fades in, then the tagline and Begin button rise+fade in sequentially rather than appearing instantly. Pressing the Begin button visibly scales it down and back up before dismissing. With Reduce Motion enabled, all elements appear in their final position with no movement. VoiceOver reads the tagline as one element and announces the button as 'Begin'. Tapping Begin still persists hasSeenWelcome and dismisses the screen.