### PR TITLE
auto: Add VoiceOver accessibility to Archive summary cards & heatmap legend

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -874,6 +874,9 @@ struct ArchiveView: View {
 
             Spacer()
         }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Activity density legend")
+        .accessibilityValue("Ranges from empty to high")
     }
 
     // MARK: - Monthly Summary
@@ -1054,6 +1057,9 @@ struct ArchiveView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .frame(height: 110)
         .liquidGlassCard(cornerRadius: 12)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(unit != nil ? "\(value) \(unit!)" : value)
     }
 
     // MARK: - System Status Artifact


### PR DESCRIPTION
## Add VoiceOver accessibility to Archive summary cards & heatmap legend

The Archive view's monthly summary stat cards (TOTAL ENTRIES, VOICE DURATION, PHOTOS CAPTURED, TRAVEL LOCATIONS) render as bare VStack+Text with no accessibility grouping, so VoiceOver reads them as disconnected fragments. The activity heatmap legend's color swatches are likewise silent, leaving blind users unable to interpret the density scale. This wires up accessibilityElement/Label/Value on both so each stat is announced as a single coherent item and the legend conveys its empty→high meaning.

### Acceptance
Build the DayPage scheme succeeds. In iPhone 17 Simulator with VoiceOver (or Accessibility Inspector), swiping through the Archive monthly summary announces each of the four stat cards as a single element reading '<label>, <value>[ <unit>]' rather than label and number separately; the heatmap legend is announced as one element 'Activity density legend, Ranges from empty to high' instead of being skipped. No visual layout change versus the current Archive screen.