### PR TITLE
auto: Tap-to-top search results header with animated count

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -773,16 +773,28 @@ struct SearchView: View {
     // MARK: - Grouped result list
 
     private var groupedResultList: some View {
+        ScrollViewReader { proxy in
         ScrollView {
             LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                // Invisible anchor for scroll-to-top
+                Color.clear.frame(height: 0).id("searchTop")
+
                 let groups = vm.groupedResults()
                 let total = vm.results.count
 
-                // Total count header
+                // Total count header — tappable to scroll back to top
+                Button(action: {
+                    Haptics.tapConfirm()
+                    withAnimation(reduceMotion ? nil : Motion.spring) {
+                        proxy.scrollTo("searchTop", anchor: .top)
+                    }
+                }) {
                 HStack {
                     Text("\(total) 条结果")
                         .monoLabelStyle(size: 10)
                         .foregroundColor(DSColor.onSurfaceVariant)
+                        .modifier(NumericTextContentTransition(value: Double(total), reduceMotion: reduceMotion))
+                        .animation(reduceMotion ? nil : Motion.spring, value: total)
                     Spacer()
                     if filters.isActive {
                         Label("已筛选", systemImage: "line.3.horizontal.decrease.circle.fill")
@@ -793,6 +805,10 @@ struct SearchView: View {
                 .padding(.horizontal, 20)
                 .padding(.top, 12)
                 .padding(.bottom, 8)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("\(total) 条结果，双击回到顶部")
+                .accessibilityHint("双击滚动回列表顶部")
 
                 ForEach(groups, id: \.section) { group in
                     Section {
@@ -828,6 +844,7 @@ struct SearchView: View {
             .padding(.bottom, 24)
         }
         .scrollDismissesKeyboard(.interactively)
+        } // end ScrollViewReader
     }
 
     private func resultRow(_ result: SearchResult) -> some View {
@@ -1109,6 +1126,23 @@ private extension Memo.MemoType {
         case .photo:    return "photo"
         case .location: return "mappin"
         case .mixed:    return "square.grid.2x2"
+        }
+    }
+}
+
+// MARK: - NumericTextContentTransition
+
+private struct NumericTextContentTransition: ViewModifier {
+    let value: Double
+    let reduceMotion: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content
+                .contentTransition(reduceMotion ? .identity : .numericText(value: value))
+        } else {
+            content
+                .contentTransition(.identity)
         }
     }
 }


### PR DESCRIPTION
## Tap-to-top search results header with animated count

Make the '<N> 条结果' header in SearchView's grouped result list tappable to smoothly scroll back to the top (with a confirm haptic), and animate the count value with a numericText content transition so it ticks rather than hard-cuts as results stream in. This fixes a real friction point — after scrolling deep through grouped history results there is currently no fast way back to the top — using interaction patterns already established elsewhere in the app (timelineScrollProxy scroll-to-top in TodayView, NumericTextContentTransition on the Day Orb).

### Acceptance
Build the DayPage scheme for iPhone 17 simulator with no warnings. In Archive → Search, run a query returning enough results to scroll past several pinned section headers; tapping the '<N> 条结果' header smoothly scrolls back to the top and fires a confirm haptic. As results update (e.g. adding a type filter), the count animates with a rolling numericText transition instead of a hard cut. With Reduce Motion enabled, the scroll and count update are instant (no animation). VoiceOver reads the count header as a button with the 'double tap to return to top' hint.