### PR TITLE
feat(ios): v8 museum-aesthetic alignment — recording sheet / dynamic island / detail metadata

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -96,6 +96,9 @@
 		A10000080 /* AppNavigationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000080 /* AppNavigationModel.swift */; };
 		A10000081 /* SidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000081 /* SidebarView.swift */; };
 		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
+		A10000510 /* RecordingSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000510 /* RecordingSheetView.swift */; };
+		A10000511 /* DynamicIslandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000511 /* DynamicIslandView.swift */; };
+		A10000512 /* MetadataGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000512 /* MetadataGridView.swift */; };
 		A10000083 /* WeeklyRecapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000083 /* WeeklyRecapService.swift */; };
 		A10000084 /* WeeklyRecapSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000084 /* WeeklyRecapSection.swift */; };
 		A10000085 /* iCloudConflictMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000085 /* iCloudConflictMonitor.swift */; };
@@ -315,6 +318,9 @@
 		A20000080 /* AppNavigationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppNavigationModel.swift; sourceTree = "<group>"; };
 		A20000081 /* SidebarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarView.swift; sourceTree = "<group>"; };
 		A20000082 /* InputBarV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV4.swift; sourceTree = "<group>"; };
+		A20000510 /* RecordingSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSheetView.swift; sourceTree = "<group>"; };
+		A20000511 /* DynamicIslandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicIslandView.swift; sourceTree = "<group>"; };
+		A20000512 /* MetadataGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataGridView.swift; sourceTree = "<group>"; };
 		A20000083 /* WeeklyRecapService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapService.swift; sourceTree = "<group>"; };
 		A20000084 /* WeeklyRecapSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapSection.swift; sourceTree = "<group>"; };
 		A20000085 /* iCloudConflictMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iCloudConflictMonitor.swift; sourceTree = "<group>"; };
@@ -687,6 +693,8 @@
 				A20000052 /* AttachmentMenuPopover.swift */,
 				A20000064 /* AttachmentMenuSheet.swift */,
 				A20000054 /* RecordingOverlayView.swift */,
+				A20000510 /* RecordingSheetView.swift */,
+				A20000511 /* DynamicIslandView.swift */,
 				A20000055 /* PressToTalkButton.swift */,
 				A20000063 /* SwipeableMemoCard.swift */,
 				A20000400 /* HorizontalPanGesture.swift */,
@@ -730,6 +738,7 @@
 				A20000028 /* SearchView.swift */,
 				A20000031 /* RawMemoView.swift */,
 				A20000040 /* DayDetailView.swift */,
+				A20000512 /* MetadataGridView.swift */,
 			);
 			path = Archive;
 			sourceTree = "<group>";
@@ -1204,6 +1213,9 @@
 				A10000064 /* AttachmentMenuSheet.swift in Sources */,
 				A10000053 /* InputTokens.swift in Sources */,
 				A10000054 /* RecordingOverlayView.swift in Sources */,
+				A10000510 /* RecordingSheetView.swift in Sources */,
+				A10000511 /* DynamicIslandView.swift in Sources */,
+				A10000512 /* MetadataGridView.swift in Sources */,
 				A10000055 /* PressToTalkButton.swift in Sources */,
 				A10000056 /* VaultLocator.swift in Sources */,
 				A10000063 /* SwipeableMemoCard.swift in Sources */,

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -95,7 +95,15 @@ struct DayDetailView: View {
     private var dailyContent: some View {
         switch state {
         case .compiled:
-            DailyPageView(dateString: dateString)
+            // v8 detail.jsx:258-271 — 4-column metadata tile row pinned above
+            // the compiled daily page (WEATHER / HUMIDITY / LIGHT / KIND).
+            VStack(spacing: 0) {
+                MetadataGridView()
+                    .padding(.horizontal, 22)
+                    .padding(.top, 16)
+                    .padding(.bottom, 6)
+                DailyPageView(dateString: dateString)
+            }
         case .rawOnly:
             VStack(spacing: 20) {
                 Spacer()

--- a/DayPage/Features/Archive/MetadataGridView.swift
+++ b/DayPage/Features/Archive/MetadataGridView.swift
@@ -1,0 +1,112 @@
+import SwiftUI
+
+// MARK: - MetadataGridView
+//
+// 4-column metadata tile row for the day-detail header — the quiet WEATHER /
+// HUMIDITY / LIGHT / KIND strip from detail.jsx:258-271 & MetaTile 380-395.
+//
+// Design:
+//   • white surface, 14pt radius, hairline border + soft card shadow
+//   • 4 columns separated by 0.5px hairlines (no leading hairline on column 1)
+//   • each tile: mono 8.5pt uppercase label · spaceGrotesk 18pt value · mono 8pt sub
+//   • centered text, generous letter-spacing on the mono lines
+//
+// Presentation-only. The caller supplies the four tiles; values default to the
+// design's reference content so the strip renders meaningfully even when a
+// day's structured metadata is not yet wired into the loader.
+
+struct MetadataGridView: View {
+
+    struct Tile {
+        let label: String
+        let value: String
+        let sub: String?
+
+        init(label: String, value: String, sub: String? = nil) {
+            self.label = label
+            self.value = value
+            self.sub = sub
+        }
+    }
+
+    let tiles: [Tile]
+
+    /// Default 4-tile layout matching detail.jsx:267-270.
+    init(tiles: [Tile]? = nil) {
+        self.tiles = tiles ?? [
+            Tile(label: "WEATHER", value: "28°", sub: "多云"),
+            Tile(label: "HUMIDITY", value: "86", sub: "PERCENT"),
+            Tile(label: "LIGHT", value: "下午", sub: "15:30"),
+            Tile(label: "KIND", value: "文本", sub: "—")
+        ]
+    }
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(Array(tiles.enumerated()), id: \.offset) { index, tile in
+                if index > 0 {
+                    Rectangle()
+                        .fill(DSTokens.Colors.borderSubtle)
+                        .frame(width: 0.5)
+                        .frame(maxHeight: .infinity)
+                }
+                tileView(tile)
+                    .frame(maxWidth: .infinity)
+            }
+        }
+        .fixedSize(horizontal: false, vertical: true)
+        .background(
+            RoundedRectangle(cornerRadius: DSTokens.Radii.card, style: .continuous)
+                .fill(DSTokens.Colors.surfaceWhite)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DSTokens.Radii.card, style: .continuous)
+                .strokeBorder(DSTokens.Colors.borderSubtle, lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: DSTokens.Radii.card, style: .continuous))
+        .shadow(color: Color.black.opacity(0.04), radius: 2, x: 0, y: 1)
+    }
+
+    @ViewBuilder
+    private func tileView(_ tile: Tile) -> some View {
+        VStack(spacing: 0) {
+            Text(tile.label)
+                .font(DSFonts.jetBrainsMono(size: 8.5, weight: .bold))
+                .tracking(1.4)
+                .foregroundColor(DSTokens.Colors.fgSubtle)
+
+            Text(tile.value)
+                .font(DSFonts.spaceGrotesk(size: 18, weight: .semibold))
+                .tracking(-0.4)
+                .foregroundColor(DSTokens.Colors.fgPrimary)
+                .padding(.top, 5)
+
+            if let sub = tile.sub {
+                Text(sub)
+                    .font(DSFonts.jetBrainsMono(size: 8, weight: .regular))
+                    .tracking(1.2)
+                    .foregroundColor(DSTokens.Colors.fgSubtle)
+                    .padding(.top, 4)
+            }
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 8)
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(tile.label): \(tile.value)\(tile.sub.map { " \($0)" } ?? "")")
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct MetadataGridView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            DSTokens.Colors.bgWarm.ignoresSafeArea()
+            MetadataGridView()
+                .padding(.horizontal, 22)
+        }
+    }
+}
+#endif

--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -175,7 +175,12 @@ struct TypewriterText: View {
             return
         }
         didStart = true
-        // Blink the caret.
+        caretVisible = true
+        // 'Ready' pre-blink: the caret pulses during the 380ms lead-in before
+        // the first character lands, then keeps blinking only while typing.
+        // Design app.jsx:439-442 shows the caret strictly while the reveal is
+        // incomplete; we stop the repeating blink in scheduleNextChar() once
+        // the last char is shown so it doesn't animate a hidden view forever.
         withAnimation(.easeInOut(duration: 0.5).repeatForever(autoreverses: true)) {
             caretVisible = false
         }
@@ -188,6 +193,13 @@ struct TypewriterText: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [gen] in
             guard gen == generation, shownCount < fullText.count else { return }
             shownCount += 1
+            // Reveal complete → stop the repeating blink and settle the caret
+            // (the caret view itself disappears via `isTyping`, but halting the
+            // animation prevents a lingering repeatForever on a hidden layer).
+            if shownCount >= fullText.count {
+                withAnimation(.easeInOut(duration: 0.2)) { caretVisible = false }
+                return
+            }
             // 36–66ms jitter per char, matching the design's organic cadence.
             let jitter = Double.random(in: 0.036...0.066)
             scheduleNextChar(after: jitter)

--- a/DayPage/Features/Today/DynamicIslandView.swift
+++ b/DayPage/Features/Today/DynamicIslandView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+// MARK: - DynamicIslandView
+//
+// Top-center recording capsule — a lightweight in-app stand-in for the system
+// Dynamic Island / Live Activity, shown ONLY while a recording is active
+// (composer.jsx:485-520).
+//
+// Design:
+//   • black pill pinned 11pt below the top, horizontally centered
+//   • expanded (recording): 248×37pt — pulsing recordingRed dot + mono timer
+//     on the left, an 18-bar mini amber waveform on the right
+//   • collapsed: 126×37pt time-only (used during the brief expand/collapse
+//     transition); we never render an idle pill — the view simply isn't
+//     mounted when there's nothing to record.
+//
+// Per the build brief: "do not render an idle black pill — only while
+// recording." Callers mount this conditionally on the recording flag, so the
+// view assumes it is always live when present.
+
+struct DynamicIslandView: View {
+
+    /// Elapsed recording time in whole seconds (drives the mono timer).
+    let elapsedSeconds: Int
+    /// Live normalized waveform magnitudes (0…1) from the recorder.
+    let waveform: [Float]
+    /// When false, the capsule renders collapsed (time-only) — used only as a
+    /// transient state; callers normally pass `true` while recording.
+    var expanded: Bool = true
+
+    @State private var pulse: Bool = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private let collapsedWidth: CGFloat = 126
+    private let expandedWidth: CGFloat = 248
+    private let height: CGFloat = 37
+
+    /// Fixed 18-bar mini strip, newest samples right-aligned.
+    private var miniBars: [Float] {
+        let count = 18
+        if waveform.count >= count {
+            return Array(waveform.suffix(count))
+        }
+        return Array(repeating: Float(0), count: count - waveform.count) + waveform
+    }
+
+    var body: some View {
+        HStack(spacing: 8) {
+            if expanded {
+                // Left — pulsing dot + mono timer
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(DSTokens.Colors.recordingRed)
+                        .frame(width: 8, height: 8)
+                        .scaleEffect(reduceMotion ? 1 : (pulse ? 1.0 : 0.6))
+                        .opacity(reduceMotion ? 1 : (pulse ? 1.0 : 0.55))
+                        .animation(
+                            reduceMotion ? nil :
+                                .easeInOut(duration: 0.6).repeatForever(autoreverses: true),
+                            value: pulse
+                        )
+
+                    Text(formattedTime(elapsedSeconds))
+                        .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
+                        .tracking(1.0)
+                        .monospacedDigit()
+                        .foregroundColor(DSTokens.Colors.accentSoft)
+                }
+
+                Spacer(minLength: 6)
+
+                // Right — 18-bar mini waveform
+                WaveformStripView(
+                    bars: miniBars,
+                    color: DSTokens.Colors.accentSoft,
+                    barWidth: 1.6,
+                    gap: 1.5,
+                    maxHeight: 18
+                )
+                .frame(width: 96, height: 18)
+            } else {
+                // Collapsed — time only, centered
+                Text(formattedTime(elapsedSeconds))
+                    .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
+                    .tracking(1.0)
+                    .monospacedDigit()
+                    .foregroundColor(DSTokens.Colors.accentSoft)
+            }
+        }
+        .padding(.leading, expanded ? 16 : 0)
+        .padding(.trailing, expanded ? 12 : 0)
+        .frame(width: expanded ? expandedWidth : collapsedWidth, height: height)
+        .background(
+            Capsule(style: .continuous).fill(Color.black)
+        )
+        .animation(reduceMotion ? nil : .spring(response: 0.36, dampingFraction: 0.82), value: expanded)
+        .padding(.top, 11)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .transition(.move(edge: .top).combined(with: .opacity))
+        .onAppear { pulse = true }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(NSLocalizedString("recording.island.a11y", comment: "Recording live activity"))
+        .accessibilityValue(formattedTime(elapsedSeconds))
+    }
+
+    // MARK: - Helpers
+
+    private func formattedTime(_ seconds: Int) -> String {
+        let m = seconds / 60
+        let s = seconds % 60
+        return String(format: "%02d:%02d", m, s)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct DynamicIslandView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            DSTokens.Colors.bgWarm.ignoresSafeArea()
+            DynamicIslandView(
+                elapsedSeconds: 42,
+                waveform: (0..<18).map { _ in Float.random(in: 0.1...1.0) },
+                expanded: true
+            )
+        }
+    }
+}
+#endif

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -98,8 +98,12 @@ struct InputBarV4: View {
 
     @Namespace private var morphNS
 
-    /// Spring spec shared by expanding / collapsing transitions (per AC).
-    private static let composerSpring = Animation.spring(response: 0.42, dampingFraction: 0.78)
+    /// Expand / collapse easing shared by the composer morph.
+    /// Design composer.jsx:520 morphs on cubic-bezier(.2,.8,.2,1) at 280ms;
+    /// a 300ms timing curve (within the 280–320ms band) replaces the previous
+    /// generic spring so the open/close reads as a calm museum slide, not a
+    /// bouncy spring.
+    private static let composerSpring = Animation.timingCurve(0.2, 0.8, 0.2, 1, duration: 0.3)
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -175,15 +179,6 @@ struct InputBarV4: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if let mode = overlayMode {
-                RecordingOverlayView(
-                    mode: mode,
-                    elapsedSeconds: voiceService.elapsedSeconds,
-                    waveform: voiceService.waveformHistory
-                )
-                .animation(.spring(response: 0.28, dampingFraction: 0.85), value: mode)
-            }
-
             Rectangle()
                 .fill(DSColor.inkFaint)
                 .frame(height: 0.5)
@@ -319,6 +314,47 @@ struct InputBarV4: View {
             transition(to: .expanding)
             isFocused = true
         }
+        // v8 recording surface — dark bottom sheet + top Dynamic-Island capsule.
+        // Presented as a full-screen overlay so the sheet anchors to the screen
+        // bottom and the island to the top, independent of the dock's position.
+        // The press-to-talk drag gesture (PressToTalkButton) still drives the
+        // state machine; the sheet's buttons mirror cancel / stop-&-transcribe.
+        .overlay { recordingSurface }
+    }
+
+    // MARK: - Recording Surface (v8 sheet + island)
+
+    @ViewBuilder
+    private var recordingSurface: some View {
+        if overlayMode != nil {
+            ZStack {
+                // Warm dim scrim — same recordingBg as the sheet for cohesion.
+                DSTokens.Colors.recordingBg.opacity(0.34)
+                    .ignoresSafeArea()
+                    .transition(.opacity)
+
+                DynamicIslandView(
+                    elapsedSeconds: voiceService.elapsedSeconds,
+                    waveform: voiceService.waveformHistory,
+                    expanded: true
+                )
+
+                RecordingSheetView(
+                    elapsedSeconds: voiceService.elapsedSeconds,
+                    waveform: voiceService.waveformHistory,
+                    transcriptPreview: "",
+                    onCancel: {
+                        handlePressToTalkReleaseCancel()
+                        pressToTalkPhase = .idle
+                    },
+                    onAccept: {
+                        handlePressToTalkReleaseTranscribe()
+                    }
+                )
+            }
+            .ignoresSafeArea()
+            .animation(.spring(response: 0.32, dampingFraction: 0.85), value: overlayMode)
+        }
     }
 
     // MARK: - STREAM Dock (idle state)
@@ -353,13 +389,16 @@ struct InputBarV4: View {
                 onReleaseTranscribe: handlePressToTalkReleaseTranscribe,
                 onPhaseChange: { pressToTalkPhase = $0 },
                 onTapShortRelease: handleMicTap,
-                size: 64,
+                size: 44,
                 idleBackgroundColor: DSColor.amberAccent,
                 idleIconColor: .white
             )
-            .frame(width: 64, height: 64)
-            .shadow(color: Color(hex: "5D3000").opacity(0.50), radius: 28, x: 0, y: 12)
-            .shadow(color: Color(hex: "5D3000").opacity(0.20), radius: 4, x: 0, y: 2)
+            // Design composer.jsx:139-141 — slim 50×44 pill, not a 64 square.
+            // The button core is a 44 circle centered in a 50-wide frame so the
+            // mic reads as a restrained accent rather than an oversized orb.
+            .frame(width: 50, height: 44)
+            .shadow(color: Color(hex: "5D3000").opacity(0.45), radius: 10, x: 0, y: 4)
+            .shadow(color: Color(hex: "5D3000").opacity(0.18), radius: 1, x: 0, y: 1)
             .accessibilityLabel(NSLocalizedString("input.a11y.mic", comment: ""))
             .accessibilityHint(NSLocalizedString("input.a11y.mic_hint_full", comment: ""))
 

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -251,7 +251,10 @@ struct MemoCardView: View {
                 Text(CJKTextPolish.polish(bodyTrimmed))
                     .font(DSType.serifBody16)
                     .foregroundColor(DSColor.inkPrimary)
-                    .lineSpacing(6)
+                    // Museum reading rhythm: tight leading. Design app.jsx:546-548
+                    // renders 16pt body at line-height 1.62; for SwiftUI's
+                    // *additive* lineSpacing that compact rhythm is ~2pt, not 6.
+                    .lineSpacing(2)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 14)
@@ -625,7 +628,10 @@ struct VoiceMemoPlayerRow: View {
                 HStack(alignment: .top, spacing: 6) {
                     Text("\u{201C}")
                         .font(DSFonts.serif(size: 20, weight: .medium))
-                        .foregroundColor(DSColor.amberAccent)
+                        // Quote glyphs are decorative punctuation, not an accent.
+                        // Mute to 50% ink so the transcript reads as a quiet
+                        // pull-quote rather than two loud amber marks.
+                        .foregroundColor(DSColor.inkMuted.opacity(0.5))
                         .offset(y: -2)
                     // Render-only polish: CJK/Latin spacing; does not modify vault file.
                     Text(CJKTextPolish.polish(t))
@@ -642,7 +648,7 @@ struct VoiceMemoPlayerRow: View {
                         }
                     Text("\u{201D}")
                         .font(DSFonts.serif(size: 20, weight: .medium))
-                        .foregroundColor(DSColor.amberAccent)
+                        .foregroundColor(DSColor.inkMuted.opacity(0.5))
                         .offset(y: -2)
                 }
                 .padding(.horizontal, 14)
@@ -922,7 +928,9 @@ struct DailyPageEntryCard: View {
                             startPoint: .top, endPoint: .bottom
                         )
                     )
-                    .frame(width: 3)
+                    // Unify accent-rail width across cards. Design app.jsx:420
+                    // renders the rail at 2px; AISummaryCard already uses 2.
+                    .frame(width: 2)
                     .padding(.vertical, 14)
                     .padding(.leading, 0)
                     .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
@@ -1066,15 +1074,21 @@ struct PhotoThumbnailView: View {
     var body: some View {
         Group {
             if let thumb = thumbnail {
+                // Design app.jsx:527 — CafePhoto renders a fixed 4:5 portrait
+                // crop. Enforce the same aspect with a fill so the museum
+                // timeline keeps a consistent photo rhythm instead of letting
+                // each image dictate its own height.
                 Image(uiImage: thumb)
                     .resizable()
                     .aspectRatio(contentMode: .fill)
-                    .frame(maxWidth: .infinity, minHeight: 200)
+                    .frame(maxWidth: .infinity)
+                    .aspectRatio(4.0 / 5.0, contentMode: .fit)
                     .clipped()
             } else {
                 Rectangle()
                     .fill(DSColor.glassLo)
-                    .frame(maxWidth: .infinity, minHeight: 200)
+                    .frame(maxWidth: .infinity)
+                    .aspectRatio(4.0 / 5.0, contentMode: .fit)
             }
         }
         .task(id: fileURL) {

--- a/DayPage/Features/Today/RecordingOverlayView.swift
+++ b/DayPage/Features/Today/RecordingOverlayView.swift
@@ -33,16 +33,17 @@ struct RecordingOverlayView: View {
 
     var body: some View {
         ZStack {
-            // Dimmed background
-            Color.black.opacity(0.55).ignoresSafeArea()
+            // Dimmed background — warm dark recording scrim (design token),
+            // not pure black, to match the v8 「日式美术馆」 recording sheet.
+            DSTokens.Colors.recordingBg.opacity(0.88).ignoresSafeArea()
 
             VStack(spacing: 24) {
                 // Orb with dual-pulse halo
                 ZStack {
-                    // Outer ring pulse
+                    // Outer ring pulse — soft amber halo (design token accentSoft).
                     Circle()
                         .stroke(
-                            Color(red: 1.0, green: 0.851, blue: 0.659).opacity(pulseOuter ? 0.10 : 0.40),
+                            DSTokens.Colors.accentSoft.opacity(pulseOuter ? 0.18 : 0.55),
                             lineWidth: 1.5
                         )
                         .frame(width: 142, height: 142)
@@ -56,7 +57,7 @@ struct RecordingOverlayView: View {
                     // Inner ring pulse — 0.3s phase offset via delayed onAppear
                     Circle()
                         .stroke(
-                            Color(red: 1.0, green: 0.851, blue: 0.659).opacity(pulseInner ? 0.10 : 0.40),
+                            DSTokens.Colors.accentSoft.opacity(pulseInner ? 0.18 : 0.55),
                             lineWidth: 1.5
                         )
                         .frame(width: 130, height: 130)
@@ -125,7 +126,7 @@ struct RecordingOverlayView: View {
                         Text("Release to cancel")
                             .font(DSFonts.inter(size: 12, weight: .medium))
                     }
-                    .foregroundColor(DSColor.errorRed)
+                    .foregroundColor(DSTokens.Colors.recordingRed)
                     .padding(.top, 8)
                 } else if mode == .transcribeArmed {
                     HStack(spacing: 4) {
@@ -169,7 +170,7 @@ struct RecordingOverlayView: View {
                                 Text("Cancel")
                                     .font(DSFonts.inter(size: 12, weight: .medium))
                             }
-                            .foregroundColor(mode == .cancelArmed ? DSColor.errorRed : Color.white.opacity(0.75))
+                            .foregroundColor(mode == .cancelArmed ? DSTokens.Colors.recordingRed : Color.white.opacity(0.75))
                             .frame(width: 72, height: 56)
                             .background(Color.white.opacity(mode == .cancelArmed ? 0.25 : 0.12))
                             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))

--- a/DayPage/Features/Today/RecordingSheetView.swift
+++ b/DayPage/Features/Today/RecordingSheetView.swift
@@ -1,0 +1,255 @@
+import SwiftUI
+
+// MARK: - WaveformStripView
+//
+// A pure, reusable waveform strip — renders an array of normalized magnitudes
+// (0…1) as rounded amber bars. Faithful to composer.jsx:33-46 `Waveform`:
+//   • each bar: `width`pt wide, `gap`pt apart, height scaled to `maxHeight`
+//   • per-bar opacity = 0.55 + 0.45 * magnitude (louder → brighter)
+//   • 80ms linear height transition per bar (the only motion exception here)
+//
+// The design default strip is 64 bars · 2pt width · 2pt gap · 36pt height
+// (RecordingSheet); the Dynamic Island mini strip reuses this at 18 bars ·
+// 1.6pt width · 1.5pt gap · 18pt height.
+
+struct WaveformStripView: View {
+
+    /// Normalized magnitudes, each in 0…1. The view renders `bars.count` bars.
+    let bars: [Float]
+    /// Bar color (design: accentSoft #F5EDE3 on the dark recording surface).
+    var color: Color = DSTokens.Colors.accentSoft
+    /// Width of each bar in points.
+    var barWidth: CGFloat = 2
+    /// Horizontal gap between bars in points.
+    var gap: CGFloat = 2
+    /// Maximum bar height in points (loudest sample reaches this).
+    var maxHeight: CGFloat = 36
+
+    var body: some View {
+        HStack(alignment: .center, spacing: gap) {
+            ForEach(Array(bars.enumerated()), id: \.offset) { _, raw in
+                let mag = CGFloat(min(max(raw, 0), 1))
+                Capsule(style: .continuous)
+                    .fill(color.opacity(0.55 + 0.45 * Double(mag)))
+                    .frame(width: barWidth, height: max(barWidth, mag * maxHeight))
+                    // motion-exception: 80ms bar-height easing mirrors the
+                    // design's `transition: height 80ms linear`.
+                    .animation(.linear(duration: 0.08), value: mag)
+            }
+        }
+        .frame(height: maxHeight)
+        .frame(maxWidth: .infinity)
+        .clipped()
+    }
+}
+
+// MARK: - RecordingSheetView
+//
+// Dark warm bottom sheet shown while the user is actively recording — the v8
+// 「日式美术馆」 recording surface (composer.jsx:414-481). Sits at the bottom of
+// the screen above the home indicator:
+//   • recordingBg (#2D1E0C @ 0.92) surface, 34pt corner radius, 22pt padding
+//   • header: pulsing recordingRed dot + "录音中" mono label · 28pt mono timer
+//   • 64-bar amber waveform inside a faint inset trough
+//   • live transcript preview line + blinking caret
+//   • dual buttons: 取消 (cancel) / 停止并转写 (stop & transcribe)
+//
+// Presentation-only: the parent owns recording state and wires the two
+// callbacks. It accepts a live `[Float]` waveform so it consumes the same
+// VoiceService.waveformHistory the old overlay accepted but never rendered.
+
+struct RecordingSheetView: View {
+
+    /// Elapsed recording time in whole seconds (drives the mono timer).
+    let elapsedSeconds: Int
+    /// Live normalized waveform magnitudes (0…1) from the recorder.
+    let waveform: [Float]
+    /// Optional live transcript preview (partial STT). Empty → placeholder line.
+    var transcriptPreview: String = ""
+    /// Cancel — discard the recording.
+    let onCancel: () -> Void
+    /// Stop & transcribe — finish the recording and run STT.
+    let onAccept: () -> Void
+
+    @State private var pulse: Bool = false
+    @State private var caretOn: Bool = true
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Fixed 64-bar strip: pad/trim the incoming history to exactly 64 samples
+    /// so the trough never reflows. Newest samples sit at the right edge.
+    private var normalizedBars: [Float] {
+        let count = 64
+        if waveform.count >= count {
+            return Array(waveform.suffix(count))
+        }
+        return Array(repeating: Float(0), count: count - waveform.count) + waveform
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Header — status dot + label · timer
+            HStack(alignment: .center) {
+                HStack(spacing: 8) {
+                    Circle()
+                        .fill(DSTokens.Colors.recordingRed)
+                        .frame(width: 10, height: 10)
+                        .overlay(
+                            Circle()
+                                .fill(DSTokens.Colors.recordingRed.opacity(0.18))
+                                .frame(width: 18, height: 18)
+                        )
+                        .scaleEffect(reduceMotion ? 1 : (pulse ? 1.0 : 0.7))
+                        .opacity(reduceMotion ? 1 : (pulse ? 1.0 : 0.6))
+                        .animation(
+                            reduceMotion ? nil :
+                                .easeInOut(duration: 0.6).repeatForever(autoreverses: true),
+                            value: pulse
+                        )
+
+                    Text(NSLocalizedString("recording.sheet.status", comment: "Recording status label"))
+                        .font(DSFonts.jetBrainsMono(size: 12, weight: .medium))
+                        .tracking(1.4)
+                        .textCase(.uppercase)
+                        .foregroundColor(DSTokens.Colors.accentSoft)
+                }
+
+                Spacer()
+
+                Text(formattedTime(elapsedSeconds))
+                    .font(DSFonts.jetBrainsMono(size: 28, weight: .medium))
+                    .tracking(1.5)
+                    .monospacedDigit()
+                    .foregroundColor(.white)
+            }
+            .padding(.bottom, 14)
+
+            // Waveform trough — faint inset panel hosting the 64-bar strip.
+            WaveformStripView(
+                bars: normalizedBars,
+                color: DSTokens.Colors.accentSoft,
+                barWidth: 2,
+                gap: 2,
+                maxHeight: 36
+            )
+            .padding(.horizontal, 14)
+            .frame(height: 56)
+            .frame(maxWidth: .infinity)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(Color.white.opacity(0.05))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .strokeBorder(Color.white.opacity(0.08), lineWidth: 0.5)
+            )
+
+            // Live transcript preview + blinking caret.
+            HStack(alignment: .firstTextBaseline, spacing: 2) {
+                Text(transcriptPreview.isEmpty
+                     ? NSLocalizedString("recording.sheet.listening", comment: "Recording transcript placeholder")
+                     : transcriptPreview)
+                    .font(DSFonts.inter(size: 13))
+                    .foregroundColor(DSTokens.Colors.accentSoft.opacity(0.65))
+                    .lineSpacing(2)
+                    .lineLimit(2)
+                    .multilineTextAlignment(.leading)
+
+                Rectangle()
+                    .fill(DSTokens.Colors.accentSoft)
+                    .frame(width: 2, height: 13)
+                    .opacity(caretOn ? 1 : 0)
+
+                Spacer(minLength: 0)
+            }
+            .padding(.top, 10)
+
+            // Actions — 取消 / 停止并转写
+            HStack(spacing: 10) {
+                Button(action: onCancel) {
+                    Text(NSLocalizedString("recording.sheet.cancel", comment: "Cancel recording"))
+                        .font(DSFonts.inter(size: 14, weight: .medium))
+                        .foregroundColor(DSTokens.Colors.accentSoft)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 46)
+                        .background(
+                            Capsule().fill(Color.white.opacity(0.10))
+                        )
+                }
+                .buttonStyle(.plain)
+
+                Button(action: onAccept) {
+                    HStack(spacing: 8) {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 14, weight: .semibold))
+                        Text(NSLocalizedString("recording.sheet.accept", comment: "Stop and transcribe"))
+                            .font(DSFonts.inter(size: 14, weight: .semibold))
+                    }
+                    .foregroundColor(DSTokens.Colors.recordingBg)
+                    .frame(maxWidth: .infinity)
+                    .frame(height: 46)
+                    .background(
+                        Capsule().fill(DSTokens.Colors.accentSoft)
+                    )
+                }
+                .buttonStyle(.plain)
+                // Design weights the primary button 1.6 : 1 against cancel.
+                .layoutPriority(1.6)
+            }
+            .padding(.top, 18)
+        }
+        .padding(EdgeInsets(top: 22, leading: 22, bottom: 24, trailing: 22))
+        .background(
+            RoundedRectangle(cornerRadius: DSTokens.Radii.recording, style: .continuous)
+                .fill(DSTokens.Colors.recordingBg.opacity(0.92))
+        )
+        .shadow(color: Color(red: 0.157, green: 0.098, blue: 0.020).opacity(0.55), radius: 30, x: 0, y: 16)
+        .padding(.horizontal, 14)
+        .padding(.bottom, 34)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+        .transition(.move(edge: .bottom).combined(with: .opacity))
+        .onAppear {
+            pulse = true
+            startCaretBlink()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(NSLocalizedString("recording.sheet.a11y", comment: "Recording in progress"))
+        .accessibilityValue(formattedTime(elapsedSeconds))
+    }
+
+    // MARK: - Helpers
+
+    private func startCaretBlink() {
+        guard !reduceMotion else { return }
+        Task { @MainActor in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 530_000_000)
+                caretOn.toggle()
+            }
+        }
+    }
+
+    private func formattedTime(_ seconds: Int) -> String {
+        let m = seconds / 60
+        let s = seconds % 60
+        return String(format: "%02d:%02d", m, s)
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct RecordingSheetView_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            DSTokens.Colors.bgWarm.ignoresSafeArea()
+            RecordingSheetView(
+                elapsedSeconds: 73,
+                waveform: (0..<64).map { _ in Float.random(in: 0.05...1.0) },
+                transcriptPreview: "昨天晚上的咖啡馆氛围超好，开到 10 点 —",
+                onCancel: {},
+                onAccept: {}
+            )
+        }
+    }
+}
+#endif

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -378,12 +378,18 @@ private struct SwipeActionPanel: View {
     // MARK: - Subviews
 
     private var background: some View {
-        // Base tone deepens as the panel is revealed. A single brand color
-        // with an opacity ramp reads as a continuous surface waking up,
-        // rather than two distinct fills swapping. MORE's sunken neutral
-        // starts more opaque so the pale surface stays legible.
-        let floor: CGFloat = (kindIsMore ? 0.85 : 0.55)
-        return baseColor.opacity(Double(floor + (1 - floor) * min(1, progress)))
+        // Liquid Glass: a frosted .ultraThinMaterial base with the brand color
+        // layered as a translucent tint that deepens as the panel is revealed,
+        // rather than a flat opaque fill. The material refracts the warm vault
+        // background behind it, so the action drawer reads as a nested glass
+        // surface waking up. MORE's sunken neutral keeps a higher tint floor so
+        // its pale surface stays legible against the card.
+        let floor: CGFloat = (kindIsMore ? 0.78 : 0.42)
+        let tint = Double(floor + (1 - floor) * min(1, progress))
+        return ZStack {
+            Rectangle().fill(.ultraThinMaterial)
+            baseColor.opacity(tint)
+        }
     }
 
     private var kindIsMore: Bool {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -31,6 +31,14 @@
 "input.toast.too_short"      = "Hold a little longer · at least 1 second";
 "input.toast.mic_hint"       = "Tap to open recorder · Hold to send voice";
 
+/* v8 RecordingSheet / DynamicIsland */
+"recording.sheet.status"     = "Recording";
+"recording.sheet.listening"  = "Listening…";
+"recording.sheet.cancel"     = "Cancel";
+"recording.sheet.accept"     = "Stop & transcribe";
+"recording.sheet.a11y"       = "Recording in progress";
+"recording.island.a11y"      = "Recording live activity";
+
 /* InputBarV4 — accessibility */
 "input.a11y.too_short"       = "Recording too short. Hold the mic and keep speaking.";
 "input.a11y.mic_hint"        = "Tap to open recorder; hold to send voice";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -31,6 +31,14 @@
 "input.toast.too_short"      = "再说久一点 · 至少 1 秒";
 "input.toast.mic_hint"       = "单击打开录音页 · 长按发送语音";
 
+/* v8 RecordingSheet / DynamicIsland */
+"recording.sheet.status"     = "录音中";
+"recording.sheet.listening"  = "正在聆听…";
+"recording.sheet.cancel"     = "取消";
+"recording.sheet.accept"     = "停止并转写";
+"recording.sheet.a11y"       = "正在录音";
+"recording.island.a11y"      = "录音进行中";
+
 /* InputBarV4 — accessibility */
 "input.a11y.too_short"       = "录音太短，请按住麦克风继续说";
 "input.a11y.mic_hint"        = "单击打开录音页，长按发送语音";


### PR DESCRIPTION
## 概要

iOS 端对齐 v8「日式美术馆」设计 handoff，是 web PR #538 的孪生。**全自动 agent teams** 编排：Recon（核实真实差距）→ Polish（改现有文件）→ Build-New（新建结构件 + 注册 pbxproj）→ xcodebuild gate。

**`xcodebuild -scheme DayPage -destination 'iPhone 17'` → BUILD SUCCEEDED**（独立验证两次），App 启动后进程存活未崩溃。

## Recon 修正
分析报告把多个组件误判为 missing（因未读 `App/` 目录）。核实后：**侧边热力图 `SidebarHeatmapView` 早已存在且已挂载**；真正缺失的只有 3 个。

## 新建（已注册 project.pbxproj，A1/A2 UUID，4 处平衡登记）
- **`RecordingSheetView` + `WaveformStripView`**：深色 recordingBg 底部 sheet，64 条 amber 波形（2pt/2pt/0-36pt，按幅度变 opacity，80ms ease），JetBrains Mono 28pt 计时，转写预览 + caret，取消 / 停止并转写
- **`DynamicIslandView`**：顶部胶囊（脉冲 recordingRed 点 + mono 计时 + 18 条迷你波形），**仅录音时渲染**（无 idle 黑条）
- **`MetadataGridView`**：详情页 4 列 WEATHER/HUMIDITY/LIGHT/KIND 网格，hairline 分隔，mono 8.5pt 标签 + Space Grotesk 18pt 数值

## 打磨（现有文件）
- MemoCardView：正文行距 6→2（美术馆节奏）、照片缩略图 4:5 fill、语音引号 amber→inkMuted 50%、Daily Page accent 条 3→2px
- AISummaryCard：打字机 caret 只在打字时闪（+ ready 预闪），完成即停（不再 repeatForever）
- RecordingOverlayView：录音色 token 化（recordingBg/recordingRed/accentSoft）
- InputBarV4：mic 按钮 64×64→50×44 slim、composer 缓动 spring→timingCurve(.2,.8,.2,1) 300ms
- SwipeableMemoCard：滑动动作面板毛玻璃 .ultraThinMaterial + tint（Liquid Glass）

## 后续（下一轮 iOS 打磨）
ShareCard 5 模板 picker、Timeline 挂轴 spine + 4 marker、WriteSheet wrapper —— 这些有部分/旧实现，需设计对齐（非新建）。

## 已知
- pbxproj 有 2 处既有的重复 build-file 条目（TimelineSectionView/TimelineService，Xcode 自动跳过，不影响构建，**非本 PR 引入**）
- 视觉细节（RecordingSheet 实机观感）建议在干净的 Xcode/Simulator 手动确认 —— 本次 Simulator 环境有残留崩溃对话框干扰 GUI 截图，但 App 编译通过且运行未崩