### PR TITLE
fix(web): cap db connection pool + reuse client across HMR (fixes authed API 500s)

### DIFF
--- a/web/src/lib/db/client.ts
+++ b/web/src/lib/db/client.ts
@@ -7,5 +7,29 @@ if (!connectionString) {
   throw new Error("DATABASE_URL is not set");
 }
 
-const queryClient = postgres(connectionString);
+// In dev, Next.js re-executes this module on every HMR hot-reload. A bare
+// `postgres(connectionString)` would open a NEW connection pool each time
+// without closing the old one, leaking idle connections until Postgres hits
+// max_connections and rejects new ones with FATAL 53300 ("too many clients").
+// Cache the underlying client on globalThis so hot-reloads reuse one pool.
+//
+// `max` is bounded so a single server instance can never monopolize the
+// database's connection budget (the local Supabase Postgres also hosts
+// PostgREST / pg_cron / pg_net, which need headroom).
+const globalForDb = globalThis as unknown as {
+  __dpQueryClient?: ReturnType<typeof postgres>;
+};
+
+const queryClient =
+  globalForDb.__dpQueryClient ??
+  postgres(connectionString, {
+    max: process.env.NODE_ENV === "production" ? 10 : 5,
+    idle_timeout: 20, // close idle connections after 20s instead of holding them
+    max_lifetime: 60 * 30, // recycle connections every 30 min
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForDb.__dpQueryClient = queryClient;
+}
+
 export const db = drizzle(queryClient, { schema });


### PR DESCRIPTION
## 症状
已登录态下 **所有** `/api/today/*` 和 `/api/stats/*` 返回 **500**（未登录正确 401）。后果：Today hero 兜底「无法加载」、侧边热力图空白塌陷、memo 卡/分享卡无数据。挡住了 v8 设计打磨（PR #538）的数据态视觉验证。

## 根因（Next dev 日志铁证）
```
PostgresError  severity: FATAL  code: 53300  routine: InitPostgres  (postinit.c)
```
`53300` = **too many clients**。每个请求的第一个查询（`resolveUserId` / `auth()`）在新建连接时就被 DB 拒绝。

`src/lib/db/client.ts` 用裸 `postgres(connectionString)` —— **无 `max`、无缓存**。Next.js 每次 HMR 热重载都重新执行该模块，于是每次重载都新建一个连接池（默认 max=10）却不关旧的。空闲连接持续堆积（实测 28 个 idle）直到本地 Supabase Postgres（`max_connections=100`，与 PostgREST/pg_cron/pg_net 共享）耗尽。

**证据链**：裸 `postgres(url,{max:1})` 直连同样的查询**始终成功** → DB 健康、SQL 正确，故障是**连接池泄漏**。

## 修复
- globalThis 缓存 query client，HMR 重载复用同一池（消除泄漏）
- 限制 `max`（dev 5 / prod 10），单实例不独占连接预算
- `idle_timeout` 20s + `max_lifetime` 30m 主动释放空闲连接

## 验证
修复后（Playwright + Dev login 实测）：`header/memos/unlock-status/stats-drawer/stats-heatmap` 全部 **200**（原 500）；`ai-summary` 返回 **404**（= 正常空态，之前被 500 掩盖）。**侧边热力图、stats 三联、真实时光轴数据** 现在正常渲染（118 entries / 41 days streak / 真实 daily 页），不再是兜底空态。typecheck 通过。

关联 PR #538（v8 web 对齐）—— 此修复解锁了那个 PR 的完整数据态验证。