### PR TITLE
auto: Graph zoom-level indicator pill

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -485,6 +485,7 @@ struct GraphView: View {
                 }
 
                 if isTransformed { recenterButton }
+                if scale != 1.0 { zoomIndicator }
             }
             .onTapGesture(count: 2) {
                 guard isTransformed else { return }
@@ -556,6 +557,22 @@ struct GraphView: View {
         .accessibilityLabel("Recenter graph")
         .transition(.opacity.combined(with: .scale))
         .animation(Motion.spring, value: isTransformed)
+    }
+
+    private var zoomIndicator: some View {
+        Text("\(Int(scale * 100))%")
+            .font(DSFonts.jetBrainsMono(size: 10))
+            .foregroundColor(DSColor.inkPrimary)
+            .padding(.horizontal, DSSpacing.sm)
+            .padding(.vertical, 6)
+            .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+            .padding(DSSpacing.lg)
+            .padding(.bottom, 56)
+            .accessibilityLabel("Zoom level")
+            .accessibilityValue("\(Int(scale * 100)) percent")
+            .transition(.opacity.combined(with: .scale))
+            .animation(reduceMotion ? .default.speed(0) : Motion.spring, value: scale)
     }
 
     private func legendRow(type: String, color: Color, label: String, count: Int, isHidden: Bool) -> some View {


### PR DESCRIPTION
## Graph zoom-level indicator pill

The Graph canvas supports pinch-to-zoom (scale 0.3×–5.0×) but gives the user no readout of the current zoom level, so it's easy to get lost after pinching. Add a small mono 'NNN%' glass pill that fades in beside the recenter button whenever zoom is not at 100%, mirroring the existing recenter-button visibility logic and design-system glass styling.

### Acceptance
Building the DayPage scheme succeeds. In Simulator (iPhone 17) on the Graph tab with nodes present: pinching to zoom shows a glass 'NNN%' pill above the recenter button reflecting the live scale; it reads 100% baseline and hides (fades out) when zoom returns to exactly 100% (matching recenter-button behavior); tapping recenter resets to 100% and the pill fades out. VoiceOver announces 'Zoom level, NNN percent'. Reduce-Motion users see the pill appear without scale animation.