### PR TITLE
auto: Graph search: zero-match haptic + visual feedback

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -34,6 +34,9 @@ struct GraphView: View {
     @State private var lastCenteredMatchID: String? = nil
     @State private var searchMatchIndex: Int = 0
 
+    // Zero-match haptic guard — fires warn() exactly once per zero-crossing
+    @State private var lastZeroQuery: String? = nil
+
     // Legend type-visibility filter
     @State private var hiddenTypes: Set<String> = []
 
@@ -104,53 +107,72 @@ struct GraphView: View {
                     HStack(spacing: DSSpacing.xs) {
                         let matches = searchMatches
                         let count = matches.count
-                        let pillText = count > 1
-                            ? "\(searchMatchIndex + 1)/\(count) 个匹配"
-                            : "\(count) 个匹配"
-                        Text(pillText)
-                            .font(DSFonts.jetBrainsMono(size: 11))
-                            .foregroundColor(DSColor.inkMuted)
+                        let isZero = count == 0
+
+                        if isZero {
+                            HStack(spacing: 5) {
+                                Image(systemName: "magnifyingglass.slash")
+                                    .font(.system(size: 11))
+                                    .foregroundColor(DSColor.inkMuted)
+                                Text(NSLocalizedString("无匹配节点", comment: "Graph search zero-match pill"))
+                                    .font(DSFonts.jetBrainsMono(size: 11))
+                                    .foregroundColor(DSColor.inkMuted)
+                            }
                             .padding(.horizontal, DSSpacing.md)
                             .padding(.vertical, 5)
                             .background(DSColor.glassLo)
                             .background(.ultraThinMaterial, in: Capsule())
-                            .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
-                            .accessibilityLabel("\(count) 个匹配结果")
-                        if count > 1 {
-                            Button {
-                                Haptics.soft()
-                                searchMatchIndex = (searchMatchIndex - 1 + matches.count) % matches.count
-                                let node = matches[searchMatchIndex]
-                                centerOn(node, in: simulationSize)
-                                pulseNode(node)
-                            } label: {
-                                Image(systemName: "chevron.up")
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundColor(DSColor.inkMuted)
-                                    .frame(width: 28, height: 28)
-                                    .background(DSColor.glassLo)
-                                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-                                    .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(DSColor.glassRim, lineWidth: 0.5))
-                                    .contentShape(Rectangle())
+                            .overlay(Capsule().strokeBorder(DSColor.amberAccent.opacity(0.5), lineWidth: 0.5))
+                            .accessibilityLabel(NSLocalizedString("无匹配节点", comment: ""))
+                        } else {
+                            let pillText = count > 1
+                                ? "\(searchMatchIndex + 1)/\(count) 个匹配"
+                                : "\(count) 个匹配"
+                            Text(pillText)
+                                .font(DSFonts.jetBrainsMono(size: 11))
+                                .foregroundColor(DSColor.inkMuted)
+                                .padding(.horizontal, DSSpacing.md)
+                                .padding(.vertical, 5)
+                                .background(DSColor.glassLo)
+                                .background(.ultraThinMaterial, in: Capsule())
+                                .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                                .accessibilityLabel("\(count) 个匹配结果")
+                            if count > 1 {
+                                Button {
+                                    Haptics.soft()
+                                    searchMatchIndex = (searchMatchIndex - 1 + matches.count) % matches.count
+                                    let node = matches[searchMatchIndex]
+                                    centerOn(node, in: simulationSize)
+                                    pulseNode(node)
+                                } label: {
+                                    Image(systemName: "chevron.up")
+                                        .font(.system(size: 12, weight: .medium))
+                                        .foregroundColor(DSColor.inkMuted)
+                                        .frame(width: 28, height: 28)
+                                        .background(DSColor.glassLo)
+                                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                                        .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                                        .contentShape(Rectangle())
+                                }
+                                .accessibilityLabel("上一个匹配")
+                                Button {
+                                    Haptics.soft()
+                                    searchMatchIndex = (searchMatchIndex + 1) % matches.count
+                                    let node = matches[searchMatchIndex]
+                                    centerOn(node, in: simulationSize)
+                                    pulseNode(node)
+                                } label: {
+                                    Image(systemName: "chevron.down")
+                                        .font(.system(size: 12, weight: .medium))
+                                        .foregroundColor(DSColor.inkMuted)
+                                        .frame(width: 28, height: 28)
+                                        .background(DSColor.glassLo)
+                                        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+                                        .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                                        .contentShape(Rectangle())
+                                }
+                                .accessibilityLabel("下一个匹配")
                             }
-                            .accessibilityLabel("上一个匹配")
-                            Button {
-                                Haptics.soft()
-                                searchMatchIndex = (searchMatchIndex + 1) % matches.count
-                                let node = matches[searchMatchIndex]
-                                centerOn(node, in: simulationSize)
-                                pulseNode(node)
-                            } label: {
-                                Image(systemName: "chevron.down")
-                                    .font(.system(size: 12, weight: .medium))
-                                    .foregroundColor(DSColor.inkMuted)
-                                    .frame(width: 28, height: 28)
-                                    .background(DSColor.glassLo)
-                                    .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
-                                    .overlay(RoundedRectangle(cornerRadius: 8, style: .continuous).strokeBorder(DSColor.glassRim, lineWidth: 0.5))
-                                    .contentShape(Rectangle())
-                            }
-                            .accessibilityLabel("下一个匹配")
                         }
                         Spacer()
                     }
@@ -159,8 +181,17 @@ struct GraphView: View {
                     .transition(.opacity)
                     .animation(Motion.fade, value: viewModel.searchMatchCount)
                     .onChange(of: viewModel.searchMatchCount) { count in
-                        guard !viewModel.searchQuery.isEmpty, count == 0 else { return }
-                        Haptics.warn()
+                        let query = viewModel.searchQuery
+                        guard !query.isEmpty else {
+                            lastZeroQuery = nil
+                            return
+                        }
+                        if count == 0 && lastZeroQuery != query {
+                            lastZeroQuery = query
+                            Haptics.warn()
+                        } else if count > 0 {
+                            lastZeroQuery = nil
+                        }
                     }
                 }
 


### PR DESCRIPTION
## Graph search: zero-match haptic + visual feedback

When a Graph node search returns no matches, the count pill silently shows "0 个匹配" with no haptic and identical styling to a successful search, so the user can't tell a typo from a genuinely-empty result. Add a one-shot warning haptic when the match count transitions to zero (non-empty query) and restyle the pill (amber-tinted border + 'magnifyingglass.slash' icon) so a dead-end search reads as such at a glance.

### Acceptance
Building the DayPage scheme succeeds. In the iPhone 17 Simulator on the Graph tab: typing a query that matches nodes shows the normal '1/N 个匹配' pill and navigation chevrons; typing a query with no matches shows a distinct '无匹配节点' pill with the slash icon and amber border, fires a single warning haptic on the transition to zero (not on every subsequent keystroke), and re-firing requires the count to leave and re-enter zero; clearing the search resets all state with no residual styling. Reduce Motion users see the same visual treatment with no regressions to existing search navigation.