### PR TITLE
auto: Make the AI 今日一句 summary card tappable to open the Daily Page

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1115,7 +1115,7 @@ struct TodayView: View {
                 // at the very top once the day has a compiled summary.
                 if let summary = viewModel.dailyPageSummary,
                    !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    AISummaryCard(summary: summary)
+                    AISummaryCard(summary: summary, onTap: { showDailyPage = true })
                         .padding(.horizontal, 20)
                         .padding(.bottom, 4)
                         .transition(.opacity)


### PR DESCRIPTION
## Make the AI 今日一句 summary card tappable to open the Daily Page

The AISummaryCard at the top of the Today timeline already supports an onTap handler that reveals a chevron affordance and opens the Daily Page, but TodayView renders it without onTap — so the most prominent card on the screen looks tappable yet does nothing, while an near-identical daily-page card below it is the only way in. Wire onTap so a tap opens the Daily Page (matching the existing long-press-to-copy gesture), giving the card a clear, discoverable entry point.

### Acceptance
Tapping the AI 今日一句 card at the top of Today opens the full-screen Daily Page; a chevron.right now appears in the card header; long-press still copies the summary to clipboard; VoiceOver exposes a '打开 Daily Page' action and the .isButton trait. Build succeeds with `xcodebuild -scheme DayPage build` and the app shows the chevron + working tap in the iPhone 17 simulator.