### PR TITLE
auto: Announce graph search results to VoiceOver

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // MARK: - GraphView
 
@@ -189,8 +190,16 @@ struct GraphView: View {
                         if count == 0 && lastZeroQuery != query {
                             lastZeroQuery = query
                             Haptics.warn()
+                            if UIAccessibility.isVoiceOverRunning {
+                                let msg = NSLocalizedString("无匹配节点", comment: "Graph search zero-match pill")
+                                UIAccessibility.post(notification: .announcement, argument: msg)
+                            }
                         } else if count > 0 {
                             lastZeroQuery = nil
+                            if UIAccessibility.isVoiceOverRunning {
+                                let msg = "\(count) 个匹配"
+                                UIAccessibility.post(notification: .announcement, argument: msg)
+                            }
                         }
                     }
                 }


### PR DESCRIPTION
## Announce graph search results to VoiceOver

The Graph search already gives sighted users a live match-count pill and zero-match haptic, but VoiceOver users get no spoken feedback when the result set changes as they type. This adds a UIAccessibility announcement (e.g. "3 个匹配" / "无匹配节点") fired on each match-count change, mirroring the existing haptic, so the search experience is equivalent for VoiceOver users.

### Acceptance
With VoiceOver enabled on iPhone 17 simulator: typing a query that matches nodes announces the match count (e.g. "3 个匹配"); refining to a zero-match query announces "无匹配节点" once (not repeatedly per keystroke); clearing the search produces no spurious announcement. With VoiceOver off, behavior is unchanged (no extra haptics or work). The DayPage scheme builds cleanly and existing tests pass.