### PR TITLE
feat(ios): v8 round 2 — timeline kakejiku spine / write sheet / share templates

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -98,6 +98,8 @@
 		A10000082 /* InputBarV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000082 /* InputBarV4.swift */; };
 		A10000510 /* RecordingSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000510 /* RecordingSheetView.swift */; };
 		A10000511 /* DynamicIslandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000511 /* DynamicIslandView.swift */; };
+		A10000513 /* WriteSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000513 /* WriteSheetView.swift */; };
+		A10000514 /* TimelineRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000514 /* TimelineRow.swift */; };
 		A10000512 /* MetadataGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000512 /* MetadataGridView.swift */; };
 		A10000083 /* WeeklyRecapService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000083 /* WeeklyRecapService.swift */; };
 		A10000084 /* WeeklyRecapSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000084 /* WeeklyRecapSection.swift */; };
@@ -320,6 +322,8 @@
 		A20000082 /* InputBarV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputBarV4.swift; sourceTree = "<group>"; };
 		A20000510 /* RecordingSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSheetView.swift; sourceTree = "<group>"; };
 		A20000511 /* DynamicIslandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicIslandView.swift; sourceTree = "<group>"; };
+		A20000513 /* WriteSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WriteSheetView.swift; sourceTree = "<group>"; };
+		A20000514 /* TimelineRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineRow.swift; sourceTree = "<group>"; };
 		A20000512 /* MetadataGridView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MetadataGridView.swift; sourceTree = "<group>"; };
 		A20000083 /* WeeklyRecapService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapService.swift; sourceTree = "<group>"; };
 		A20000084 /* WeeklyRecapSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapSection.swift; sourceTree = "<group>"; };
@@ -695,6 +699,8 @@
 				A20000054 /* RecordingOverlayView.swift */,
 				A20000510 /* RecordingSheetView.swift */,
 				A20000511 /* DynamicIslandView.swift */,
+				A20000513 /* WriteSheetView.swift */,
+				A20000514 /* TimelineRow.swift */,
 				A20000055 /* PressToTalkButton.swift */,
 				A20000063 /* SwipeableMemoCard.swift */,
 				A20000400 /* HorizontalPanGesture.swift */,
@@ -1214,6 +1220,8 @@
 				A10000053 /* InputTokens.swift in Sources */,
 				A10000054 /* RecordingOverlayView.swift in Sources */,
 				A10000510 /* RecordingSheetView.swift in Sources */,
+				A10000513 /* WriteSheetView.swift in Sources */,
+				A10000514 /* TimelineRow.swift in Sources */,
 				A10000511 /* DynamicIslandView.swift in Sources */,
 				A10000512 /* MetadataGridView.swift in Sources */,
 				A10000055 /* PressToTalkButton.swift in Sources */,

--- a/DayPage/Features/Shared/ShareCard/PosterTemplates.swift
+++ b/DayPage/Features/Shared/ShareCard/PosterTemplates.swift
@@ -41,6 +41,45 @@ private enum PolaroidPalette {
     static let placeholderBg = UIColor(red: 0.910, green: 0.890, blue: 0.855, alpha: 1)
 }
 
+// Film palette — dark "film gate" (detail.jsx:861-887).
+// #0d0a07 bg, #f5ede3 perforation/ink, #e36b4a Kodak orange, #a39f99 mono grey,
+// #e8dccc serif body. Hex values transcribed directly from FilmTemplate.tsx.
+private enum FilmPalette {
+    static let bg        = UIColor(red: 0.051, green: 0.039, blue: 0.027, alpha: 1) // #0d0a07
+    static let perf      = UIColor(red: 0.961, green: 0.929, blue: 0.890, alpha: 1) // #f5ede3
+    static let photoBg   = UIColor(red: 0.102, green: 0.082, blue: 0.059, alpha: 1) // #1A150F
+    static let orange    = UIColor(red: 0.890, green: 0.420, blue: 0.290, alpha: 1) // #e36b4a
+    static let mutedGrey = UIColor(red: 0.639, green: 0.624, blue: 0.600, alpha: 1) // #a39f99
+    static let serifInk  = UIColor(red: 0.910, green: 0.863, blue: 0.800, alpha: 1) // #e8dccc
+    static let iconStroke = UIColor(red: 0.290, green: 0.267, blue: 0.235, alpha: 1) // #4a443c
+}
+
+// Journal palette — ruled cream paper + washi tape (detail.jsx:904-933).
+private enum JournalPalette {
+    static let bg          = UIColor(red: 0.984, green: 0.965, blue: 0.910, alpha: 1) // #FBF6E8
+    static let rule        = UIColor(red: 0.706, green: 0.588, blue: 0.353, alpha: 0.18) // rgba(180,150,90,.18)
+    static let marginLine  = UIColor(red: 0.890, green: 0.420, blue: 0.290, alpha: 0.30) // rgba(227,107,74,.3)
+    static let washiOrange = UIColor(red: 0.890, green: 0.420, blue: 0.290, alpha: 0.55) // rgba(227,107,74,.55)
+    static let washiGreen  = UIColor(red: 0.416, green: 0.525, blue: 0.267, alpha: 0.50) // rgba(106,134,68,.5)
+    static let titleInk    = UIColor(red: 0.227, green: 0.165, blue: 0.094, alpha: 1) // #3a2a18
+    static let subInk      = UIColor(red: 0.541, green: 0.416, blue: 0.227, alpha: 1) // #8a6a3a
+    static let divider     = UIColor(red: 0.788, green: 0.651, blue: 0.467, alpha: 0.70) // #c9a677 @ .7
+    static let redDot      = UIColor(red: 0.890, green: 0.420, blue: 0.290, alpha: 1) // #E36B4A
+    static let photoBg     = UIColor(red: 0.910, green: 0.890, blue: 0.855, alpha: 1)
+}
+
+// Postcard palette — clean white card + dashed stamp (detail.jsx:935-965).
+private enum PostcardPalette {
+    static let bg        = UIColor.white
+    static let photoBg   = UIColor(red: 0.847, green: 0.812, blue: 0.768, alpha: 1) // #D8CFC4
+    static let border    = UIColor(red: 0.839, green: 0.808, blue: 0.753, alpha: 1) // #D6CEC0
+    static let serifInk  = UIColor(red: 0.169, green: 0.157, blue: 0.133, alpha: 1) // #2B2822
+    static let muted     = UIColor(red: 0.420, green: 0.396, blue: 0.376, alpha: 1) // #6B6560
+    static let subtle    = UIColor(red: 0.639, green: 0.624, blue: 0.600, alpha: 1) // #A39F99
+    static let accent    = UIColor(red: 0.365, green: 0.188, blue: 0.000, alpha: 1) // #5D3000
+    static let iconStroke = UIColor(red: 0.659, green: 0.596, blue: 0.502, alpha: 1) // #A89880
+}
+
 private enum CardGeom {
     static let width: CGFloat = 1080
     static let inset: CGFloat = 72
@@ -130,6 +169,125 @@ private func parseDailyDate(_ s: String) -> Date {
     f.locale = posixLocale
     f.dateFormat = "yyyy-MM-dd"
     return f.date(from: s) ?? Date()
+}
+
+// Film header date — "28 / MAY / 2026" (FilmTemplate.tsx:4-9).
+private func filmDate(from date: Date) -> String {
+    let f = DateFormatter()
+    f.locale = posixLocale
+    f.dateFormat = "dd / MMM / yyyy"
+    return f.string(from: date).uppercased()
+}
+
+// Postcard date — "28 · MAY · 2026" (PostcardTemplate.tsx:3-9).
+private func postcardDate(from date: Date) -> String {
+    let f = DateFormatter()
+    f.locale = posixLocale
+    f.dateFormat = "dd · MMM · yyyy"
+    return f.string(from: date).uppercased()
+}
+
+// Journal title — full weekday e.g. "Thursday" (JournalTemplate.tsx:3-5).
+private func journalWeekday(from date: Date) -> String {
+    let f = DateFormatter()
+    f.locale = posixLocale
+    f.dateFormat = "EEEE"
+    return f.string(from: date)
+}
+
+// Journal subtitle — lowercase "may 28" (JournalTemplate.tsx:7-11).
+private func journalMonthDay(from date: Date) -> String {
+    let f = DateFormatter()
+    f.locale = posixLocale
+    f.dateFormat = "MMMM d"
+    return f.string(from: date).lowercased()
+}
+
+// Serif italic — Film body uses Fraunces italic; system serif italic is the
+// reliable off-screen-context equivalent (PosterTemplates header note on TTFs).
+private extension UIFont {
+    static func serifItalic(size: CGFloat, weight: UIFont.Weight = .regular) -> UIFont {
+        let base = UIFont.systemFont(ofSize: size, weight: weight)
+        var traits: UIFontDescriptor.SymbolicTraits = [.traitItalic]
+        if let serif = base.fontDescriptor.withDesign(.serif) {
+            traits.formUnion(serif.symbolicTraits)
+            if let italic = serif.withSymbolicTraits(traits) {
+                return UIFont(descriptor: italic, size: size)
+            }
+            return UIFont(descriptor: serif, size: size)
+        }
+        if let italic = base.fontDescriptor.withSymbolicTraits(traits) {
+            return UIFont(descriptor: italic, size: size)
+        }
+        return base
+    }
+}
+
+// Draws a repeating horizontal dashed strip (35mm perforations) across `rect`.
+// Mirrors the CSS `repeating-linear-gradient(90deg, perf 0 8px, transparent 8px 14px)`
+// from FilmTemplate.tsx:12 — scaled ×3 to the 1080 canvas (dash 24, gap 18).
+private func drawPerforations(in rect: CGRect, color: UIColor, ctx: CGContext) {
+    ctx.saveGState()
+    color.setFill()
+    let dash: CGFloat = 24
+    let period: CGFloat = 42 // 24 dash + 18 transparent
+    var x = rect.minX
+    while x < rect.maxX {
+        let w = min(dash, rect.maxX - x)
+        ctx.fill(CGRect(x: x, y: rect.minY, width: w, height: rect.height))
+        x += period
+    }
+    ctx.restoreGState()
+}
+
+// Stroke a rounded rect with a dashed border (postcard stamp + divider).
+private func strokeDashedRoundedRect(_ rect: CGRect, radius: CGFloat, lineWidth: CGFloat,
+                                     dash: [CGFloat], color: UIColor, in ctx: CGContext) {
+    ctx.saveGState()
+    color.setStroke()
+    let path = UIBezierPath(roundedRect: rect, cornerRadius: radius)
+    path.lineWidth = lineWidth
+    path.setLineDash(dash, count: dash.count, phase: 0)
+    path.stroke()
+    ctx.restoreGState()
+}
+
+// Horizontal dashed hairline (postcard header divider, JournalTemplate margin).
+private func drawDashedHLine(from start: CGPoint, length: CGFloat, lineWidth: CGFloat,
+                            dash: [CGFloat], color: UIColor, in ctx: CGContext) {
+    ctx.saveGState()
+    color.setStroke()
+    let path = UIBezierPath()
+    path.move(to: start)
+    path.addLine(to: CGPoint(x: start.x + length, y: start.y))
+    path.lineWidth = lineWidth
+    path.setLineDash(dash, count: dash.count, phase: 0)
+    path.stroke()
+    ctx.restoreGState()
+}
+
+// Draws a rotated solid washi-tape strip with a soft shadow.
+private func drawWashiTape(center: CGPoint, width: CGFloat, height: CGFloat,
+                          rotation: CGFloat, color: UIColor, in ctx: CGContext) {
+    ctx.saveGState()
+    ctx.translateBy(x: center.x, y: center.y)
+    ctx.rotate(by: rotation)
+    ctx.setShadow(offset: CGSize(width: 0, height: 4),
+                  blur: 6,
+                  color: UIColor(red: 0.235, green: 0.157, blue: 0.059, alpha: 0.15).cgColor)
+    color.setFill()
+    ctx.fill(CGRect(x: -width / 2, y: -height / 2, width: width, height: height))
+    ctx.restoreGState()
+}
+
+// Faux-coordinate footer for film cards. The design hardcodes Vientiane coords
+// (FilmTemplate.tsx:127) as flavour; we keep that string only when no real
+// location/coords exist, otherwise show the memo's actual place name.
+private func filmFooter(location: String?) -> String {
+    if let l = location, !l.isEmpty {
+        return l.uppercased()
+    }
+    return "VIENTIANE · 18.04°N 102.64°E"
 }
 
 private func imageFormat1x() -> UIGraphicsImageRendererFormat {
@@ -1733,5 +1891,539 @@ enum MinimalCollageTemplate: PosterTemplate {
         bodyAttr.draw(with: bodyRect,
                       options: [.usesLineFragmentOrigin, .truncatesLastVisibleLine],
                       context: nil)
+    }
+}
+
+// MARK: - Film shared chrome
+//
+// FILM (detail.jsx:861-887 / FilmTemplate.tsx). Dark gate #0d0a07, a mono
+// "● 35 mm · Kodak 400" header opposite the date, a 4:5 photo flanked top and
+// bottom by 35mm perforation strips, a serif-italic body, and a mono coords
+// footer. Canvas width is the standard 1080; geometry is scaled ~3× from the
+// 320pt web mock.
+
+private enum FilmGeom {
+    static let inset: CGFloat = 54          // 18pt × 3
+    static let perfHeight: CGFloat = 18     // 6pt × 3
+    static let headerH: CGFloat = 30
+}
+
+private func drawFilmHeader(at origin: CGPoint, width: CGFloat, date: Date, ctx: CGContext) {
+    let left = NSAttributedString(string: "\u{25CF} 35 mm \u{00B7} Kodak 400", attributes: [
+        .font: UIFont.monospacedSystemFont(ofSize: 30, weight: .regular),
+        .foregroundColor: FilmPalette.orange,
+        .kern: 0.5
+    ])
+    left.draw(at: origin)
+
+    let right = NSAttributedString(string: filmDate(from: date), attributes: [
+        .font: UIFont.monospacedSystemFont(ofSize: 30, weight: .regular),
+        .foregroundColor: FilmPalette.mutedGrey,
+        .kern: 0.5
+    ])
+    let rsize = right.size()
+    right.draw(at: CGPoint(x: origin.x + width - rsize.width, y: origin.y))
+}
+
+// 4:5 photo (or placeholder) with perforation strips above + below.
+private func drawFilmPhoto(in rect: CGRect, image: UIImage?, ctx cg: CGContext) {
+    if let image = image {
+        drawAspectFill(image, in: rect, ctx: cg)
+    } else {
+        FilmPalette.photoBg.setFill()
+        cg.fill(rect)
+        // Simple "image" glyph centred, matching the web SVG placeholder.
+        let glyph = NSAttributedString(string: "\u{25A2}", attributes: [
+            .font: UIFont.systemFont(ofSize: 140, weight: .ultraLight),
+            .foregroundColor: FilmPalette.iconStroke
+        ])
+        let gsz = glyph.size()
+        glyph.draw(at: CGPoint(x: rect.midX - gsz.width / 2, y: rect.midY - gsz.height / 2))
+    }
+    let topStrip = CGRect(x: rect.minX, y: rect.minY - FilmGeom.perfHeight,
+                          width: rect.width, height: FilmGeom.perfHeight)
+    let botStrip = CGRect(x: rect.minX, y: rect.maxY,
+                          width: rect.width, height: FilmGeom.perfHeight)
+    drawPerforations(in: topStrip, color: FilmPalette.perf, ctx: cg)
+    drawPerforations(in: botStrip, color: FilmPalette.perf, ctx: cg)
+}
+
+// MARK: - FilmMemoTemplate
+
+enum FilmMemoTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .memo(let s) = payload else { return UIImage() }
+        return draw(body: s.body, date: s.createdAt, location: s.locationName, image: s.coverImage)
+    }
+
+    static func draw(body rawBody: String, date: Date, location: String?, image: UIImage?) -> UIImage {
+        let W = CardGeom.width
+        let inset = FilmGeom.inset
+        let bodyW = W - inset * 2
+
+        // 4:5 photo fills the column width.
+        let photoW = bodyW
+        let photoH = photoW * 5.0 / 4.0
+
+        let body = truncate(rawBody.trimmingCharacters(in: .whitespacesAndNewlines), to: 130)
+        let bodyPara = NSMutableParagraphStyle()
+        bodyPara.lineHeightMultiple = 1.6
+        let bodyAttr = NSAttributedString(string: body, attributes: [
+            .font: UIFont.serifItalic(size: 40),
+            .foregroundColor: FilmPalette.serifInk,
+            .paragraphStyle: bodyPara
+        ])
+        let bodyMeasure = bodyAttr.measure(width: bodyW)
+
+        let totalH = inset + FilmGeom.headerH + 30 + FilmGeom.perfHeight
+            + photoH + FilmGeom.perfHeight + 48
+            + ceil(bodyMeasure.height) + 42 + 36 + inset
+        let size = CGSize(width: W, height: max(1200, totalH))
+        let renderer = UIGraphicsImageRenderer(size: size, format: imageFormat1x())
+
+        return renderer.image { ctx in
+            let cg = ctx.cgContext
+            FilmPalette.bg.setFill()
+            cg.fill(CGRect(origin: .zero, size: size))
+
+            var y = inset
+            drawFilmHeader(at: CGPoint(x: inset, y: y), width: bodyW, date: date, ctx: cg)
+            y += FilmGeom.headerH + 30 + FilmGeom.perfHeight
+
+            let photoRect = CGRect(x: inset, y: y, width: photoW, height: photoH)
+            drawFilmPhoto(in: photoRect, image: image, ctx: cg)
+            y += photoH + FilmGeom.perfHeight + 48
+
+            bodyAttr.draw(with: CGRect(x: inset, y: y, width: bodyW, height: bodyMeasure.height),
+                          options: [.usesLineFragmentOrigin], context: nil)
+            y += ceil(bodyMeasure.height) + 42
+
+            let footer = NSAttributedString(string: truncate(filmFooter(location: location), to: 60), attributes: [
+                .font: UIFont.monospacedSystemFont(ofSize: 30, weight: .regular),
+                .foregroundColor: FilmPalette.mutedGrey,
+                .kern: 1.2
+            ])
+            footer.draw(at: CGPoint(x: inset, y: y))
+        }
+    }
+}
+
+// MARK: - FilmDailyTemplate
+//
+// Reuses the film gate but leads with the daily summary as the serif-italic
+// body and the daily cover as the 4:5 photo. (Sections are intentionally not
+// listed — the film aesthetic is a single contemplative frame.)
+
+enum FilmDailyTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .daily(let s) = payload else { return UIImage() }
+        let date = parseDailyDate(s.dateString)
+        let loc = s.locationPrimary.isEmpty ? nil : s.locationPrimary
+        return FilmMemoTemplate.draw(body: s.summary, date: date, location: loc, image: s.coverImage)
+    }
+}
+
+// MARK: - FilmPhotoTemplate
+
+enum FilmPhotoTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .photo(let s) = payload else { return UIImage() }
+        let f = DateFormatter()
+        f.locale = posixLocale
+        f.dateFormat = "HH:mm"
+        // PhotoSnapshot has no Date; use today's date for the header day stamp
+        // and keep its captured time inside the EXIF/location footer.
+        let footer: String = {
+            var parts: [String] = []
+            if let l = s.location, !l.isEmpty { parts.append(l.uppercased()) }
+            if let e = s.exif, !e.isEmpty { parts.append(e) }
+            if parts.isEmpty { return filmFooter(location: nil) }
+            return parts.joined(separator: " \u{00B7} ")
+        }()
+        return drawPhoto(image: s.image, caption: s.caption, footer: footer)
+    }
+
+    private static func drawPhoto(image: UIImage, caption: String, footer: String) -> UIImage {
+        let W = CardGeom.width
+        let inset = FilmGeom.inset
+        let bodyW = W - inset * 2
+        let photoW = bodyW
+        let photoH = photoW * 5.0 / 4.0
+
+        let body = truncate(caption.trimmingCharacters(in: .whitespacesAndNewlines), to: 130)
+        let bodyPara = NSMutableParagraphStyle()
+        bodyPara.lineHeightMultiple = 1.6
+        let bodyAttr = NSAttributedString(string: body, attributes: [
+            .font: UIFont.serifItalic(size: 40),
+            .foregroundColor: FilmPalette.serifInk,
+            .paragraphStyle: bodyPara
+        ])
+        let bodyBlock = body.isEmpty ? 0 : ceil(bodyAttr.measure(width: bodyW).height) + 48
+
+        let totalH = inset + FilmGeom.headerH + 30 + FilmGeom.perfHeight
+            + photoH + FilmGeom.perfHeight + bodyBlock + 42 + 36 + inset
+        let size = CGSize(width: W, height: max(1200, totalH))
+        let renderer = UIGraphicsImageRenderer(size: size, format: imageFormat1x())
+
+        return renderer.image { ctx in
+            let cg = ctx.cgContext
+            FilmPalette.bg.setFill()
+            cg.fill(CGRect(origin: .zero, size: size))
+
+            var y = inset
+            drawFilmHeader(at: CGPoint(x: inset, y: y), width: bodyW, date: Date(), ctx: cg)
+            y += FilmGeom.headerH + 30 + FilmGeom.perfHeight
+
+            let photoRect = CGRect(x: inset, y: y, width: photoW, height: photoH)
+            drawFilmPhoto(in: photoRect, image: image, ctx: cg)
+            y += photoH + FilmGeom.perfHeight + 48
+
+            if !body.isEmpty {
+                let m = bodyAttr.measure(width: bodyW)
+                bodyAttr.draw(with: CGRect(x: inset, y: y, width: bodyW, height: m.height),
+                              options: [.usesLineFragmentOrigin], context: nil)
+                y += ceil(m.height) + 42
+            }
+
+            let foot = NSAttributedString(string: truncate(footer, to: 70), attributes: [
+                .font: UIFont.monospacedSystemFont(ofSize: 30, weight: .regular),
+                .foregroundColor: FilmPalette.mutedGrey,
+                .kern: 1.2
+            ])
+            foot.draw(at: CGPoint(x: inset, y: y))
+        }
+    }
+}
+
+// MARK: - Journal shared chrome
+//
+// JOURNAL (detail.jsx:904-933 / JournalTemplate.tsx). Cream #FBF6E8 paper with
+// repeating 28pt ruled hairlines, a faint red left-margin line, two rotated
+// washi-tape strips peeking over the top edge, a serif weekday title with a
+// muted "· month day" subtitle, a 5:4 photo, the body, and a red-dot footer
+// chip. Scaled ~3× from the 320pt web mock (20pt padding → 60pt inset).
+
+private enum JournalGeom {
+    static let inset: CGFloat = 60          // 20pt × 3
+    static let rulePeriod: CGFloat = 84     // 28pt × 3
+    static let marginX: CGFloat = 132       // 44pt × 3
+}
+
+private func drawJournalBackground(in size: CGSize, ctx cg: CGContext) {
+    JournalPalette.bg.setFill()
+    cg.fill(CGRect(origin: .zero, size: size))
+
+    // Ruled lines: a 1.5pt hairline every 84pt (CSS 27/28 → ~28 period ×3).
+    JournalPalette.rule.setFill()
+    var ly: CGFloat = JournalGeom.rulePeriod
+    while ly < size.height {
+        cg.fill(CGRect(x: 0, y: ly, width: size.width, height: 3))
+        ly += JournalGeom.rulePeriod
+    }
+
+    // Red left-margin line (CSS left:44px ×3).
+    JournalPalette.marginLine.setFill()
+    cg.fill(CGRect(x: JournalGeom.marginX, y: 0, width: 3, height: size.height))
+}
+
+private func drawJournalWashiTape(width: CGFloat, in cg: CGContext) {
+    // Orange strip top-left, rotated -5° (CSS top:-6,left:30,90×18 ×3).
+    drawWashiTape(center: CGPoint(x: 90 + 135, y: 6),
+                  width: 270, height: 54,
+                  rotation: -5 * .pi / 180,
+                  color: JournalPalette.washiOrange, in: cg)
+    // Green strip top-right, rotated +8° (CSS top:-4,right:24,64×14 ×3).
+    drawWashiTape(center: CGPoint(x: width - 72 - 96, y: 12),
+                  width: 192, height: 42,
+                  rotation: 8 * .pi / 180,
+                  color: JournalPalette.washiGreen, in: cg)
+}
+
+// MARK: - JournalMemoTemplate
+
+enum JournalMemoTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .memo(let s) = payload else { return UIImage() }
+        let temp = s.weather ?? ""
+        return draw(body: s.body, date: s.createdAt, location: s.locationName,
+                    temp: temp, image: s.coverImage)
+    }
+
+    static func draw(body rawBody: String, date: Date, location: String?,
+                     temp: String, image: UIImage?) -> UIImage {
+        let W = CardGeom.width
+        let inset = JournalGeom.inset
+        let bodyW = W - inset * 2
+
+        let body = truncate(rawBody.trimmingCharacters(in: .whitespacesAndNewlines), to: 160)
+        let bodyPara = NSMutableParagraphStyle()
+        bodyPara.lineHeightMultiple = 1.7
+        let bodyAttr = NSAttributedString(string: body, attributes: [
+            .font: UIFont.systemFont(ofSize: 38, weight: .regular),
+            .foregroundColor: JournalPalette.titleInk,
+            .paragraphStyle: bodyPara
+        ])
+        let bodyMeasure = bodyAttr.measure(width: bodyW)
+
+        let hasPhoto = image != nil
+        let photoH: CGFloat = hasPhoto ? bodyW * 4.0 / 5.0 : 0   // 5:4 aspect
+        let photoGap: CGFloat = hasPhoto ? 42 : 0
+
+        let totalH = inset + 30 + 64 + 14 + 42      // top pad + title + divider
+            + photoH + photoGap
+            + ceil(bodyMeasure.height) + 42
+            + 54 + inset                            // footer chip
+        let size = CGSize(width: W, height: max(1200, totalH))
+        let renderer = UIGraphicsImageRenderer(size: size, format: imageFormat1x())
+
+        return renderer.image { ctx in
+            let cg = ctx.cgContext
+            drawJournalBackground(in: size, ctx: cg)
+            drawJournalWashiTape(width: W, in: cg)
+
+            var y = inset + 30
+
+            // Serif title: weekday + muted "· month day"
+            let title = NSAttributedString(string: journalWeekday(from: date), attributes: [
+                .font: UIFont.editorialTitle(size: 64),
+                .foregroundColor: JournalPalette.titleInk
+            ])
+            title.draw(at: CGPoint(x: inset, y: y))
+            let tWidth = title.size().width
+            let sub = NSAttributedString(string: "  \u{00B7} " + journalMonthDay(from: date), attributes: [
+                .font: UIFont.systemFont(ofSize: 40, weight: .medium),
+                .foregroundColor: JournalPalette.subInk
+            ])
+            sub.draw(at: CGPoint(x: inset + tWidth, y: y + 22))
+            y += 64 + 14
+
+            // Divider
+            JournalPalette.divider.setFill()
+            cg.fill(CGRect(x: inset, y: y, width: bodyW, height: 3))
+            y += 42
+
+            if let image = image {
+                let photoRect = CGRect(x: inset, y: y, width: bodyW, height: photoH)
+                cg.saveGState()
+                UIBezierPath(roundedRect: photoRect, cornerRadius: 24).addClip()
+                drawAspectFill(image, in: photoRect, ctx: cg)
+                cg.restoreGState()
+                y += photoH + photoGap
+            }
+
+            bodyAttr.draw(with: CGRect(x: inset, y: y, width: bodyW, height: bodyMeasure.height),
+                          options: [.usesLineFragmentOrigin], context: nil)
+            y += ceil(bodyMeasure.height) + 42
+
+            // Footer: red dot + LOCATION · TEMP
+            let dotSize: CGFloat = 30
+            JournalPalette.redDot.setFill()
+            cg.fillEllipse(in: CGRect(x: inset, y: y, width: dotSize, height: dotSize))
+            var footParts: [String] = []
+            if let l = location, !l.isEmpty { footParts.append(l.uppercased()) }
+            if !temp.isEmpty { footParts.append(temp) }
+            if footParts.isEmpty { footParts.append("VIENTIANE") }
+            let foot = NSAttributedString(string: truncate(footParts.joined(separator: " \u{00B7} "), to: 50), attributes: [
+                .font: UIFont.monospacedSystemFont(ofSize: 28, weight: .regular),
+                .foregroundColor: JournalPalette.subInk,
+                .kern: 1.2
+            ])
+            foot.draw(at: CGPoint(x: inset + dotSize + 16, y: y + 1))
+        }
+    }
+}
+
+// MARK: - JournalDailyTemplate
+
+enum JournalDailyTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .daily(let s) = payload else { return UIImage() }
+        let date = parseDailyDate(s.dateString)
+        let loc = s.locationPrimary.isEmpty ? nil : s.locationPrimary
+        return JournalMemoTemplate.draw(body: s.summary, date: date, location: loc,
+                                        temp: "", image: s.coverImage)
+    }
+}
+
+// MARK: - JournalPhotoTemplate
+
+enum JournalPhotoTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .photo(let s) = payload else { return UIImage() }
+        // PhotoSnapshot has no Date — use today's date for the title stamp; its
+        // captured HH:mm/EXIF flavour lives in the footer location instead.
+        return JournalMemoTemplate.draw(body: s.caption, date: Date(),
+                                        location: s.location, temp: s.exif ?? "",
+                                        image: s.image)
+    }
+}
+
+// MARK: - Postcard shared chrome
+//
+// POSTCARD (detail.jsx:935-965 / PostcardTemplate.tsx). White card, 3:2 photo
+// spanning the top, then a padded body section: a serif place name opposite a
+// mono date over a dashed divider, then the body text beside a dashed stamp box
+// (DAYPAGE / time / hairline / LAOS). Scaled ~3× from the 320pt web mock.
+
+private enum PostcardGeom {
+    static let pad: CGFloat = 54            // 18pt × 3
+    static let stampW: CGFloat = 168        // 56pt × 3
+    static let stampH: CGFloat = 192        // 64pt × 3
+}
+
+private func drawPostcardStamp(at origin: CGPoint, time: String, place: String, ctx cg: CGContext) {
+    let rect = CGRect(x: origin.x, y: origin.y, width: PostcardGeom.stampW, height: PostcardGeom.stampH)
+    strokeDashedRoundedRect(rect, radius: 12, lineWidth: 4.5,
+                            dash: [12, 8], color: PostcardPalette.border, in: cg)
+
+    // DAYPAGE (display, accent)
+    let brand = NSAttributedString(string: "DAYPAGE", attributes: [
+        .font: UIFont.systemFont(ofSize: 27, weight: .heavy),
+        .foregroundColor: PostcardPalette.accent,
+        .kern: 1
+    ])
+    let bsz = brand.size()
+    brand.draw(at: CGPoint(x: rect.midX - bsz.width / 2, y: rect.minY + 36))
+
+    // time (mono, muted)
+    let timeAttr = NSAttributedString(string: time, attributes: [
+        .font: UIFont.monospacedSystemFont(ofSize: 24, weight: .regular),
+        .foregroundColor: PostcardPalette.muted
+    ])
+    let tsz = timeAttr.size()
+    timeAttr.draw(at: CGPoint(x: rect.midX - tsz.width / 2, y: rect.minY + 78))
+
+    // hairline (30pt ×3 = 90)
+    PostcardPalette.border.setFill()
+    cg.fill(CGRect(x: rect.midX - 45, y: rect.minY + 116, width: 90, height: 3))
+
+    // place (mono, subtle)
+    let placeAttr = NSAttributedString(string: place.uppercased(), attributes: [
+        .font: UIFont.monospacedSystemFont(ofSize: 21, weight: .regular),
+        .foregroundColor: PostcardPalette.subtle
+    ])
+    let psz = placeAttr.size()
+    placeAttr.draw(at: CGPoint(x: rect.midX - psz.width / 2, y: rect.minY + 132))
+}
+
+// MARK: - PostcardMemoTemplate
+
+enum PostcardMemoTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .memo(let s) = payload else { return UIImage() }
+        let place = (s.locationName?.isEmpty == false ? s.locationName! : "Vientiane")
+        let country = (s.locationName?.isEmpty == false) ? "" : "LAOS"
+        return draw(body: s.body, date: s.createdAt, place: place,
+                    country: country, image: s.coverImage)
+    }
+
+    static func draw(body rawBody: String, date: Date, place: String,
+                     country: String, image: UIImage?) -> UIImage {
+        let W = CardGeom.width
+        let pad = PostcardGeom.pad
+
+        // 3:2 photo across the full width.
+        let photoH = W * 2.0 / 3.0
+        let bodyW = W - pad * 2
+
+        // Body sits left of the stamp; text column is bodyW - stamp - gap.
+        let stampGap: CGFloat = 42
+        let textColW = bodyW - PostcardGeom.stampW - stampGap
+
+        let body = truncate(rawBody.trimmingCharacters(in: .whitespacesAndNewlines), to: 120)
+        let bodyPara = NSMutableParagraphStyle()
+        bodyPara.lineHeightMultiple = 1.6
+        let bodyAttr = NSAttributedString(string: body, attributes: [
+            .font: UIFont.systemFont(ofSize: 36, weight: .regular),
+            .foregroundColor: PostcardPalette.serifInk,
+            .paragraphStyle: bodyPara
+        ])
+        let bodyMeasure = bodyAttr.measure(width: textColW)
+
+        // The text/stamp row height is the taller of the two columns.
+        let rowH = max(ceil(bodyMeasure.height), PostcardGeom.stampH)
+        let headerH: CGFloat = 64 + 30     // place/date row + dashed divider gap
+        let totalH = photoH + pad + headerH + 42 + rowH + pad
+        let size = CGSize(width: W, height: max(1100, totalH))
+        let renderer = UIGraphicsImageRenderer(size: size, format: imageFormat1x())
+
+        return renderer.image { ctx in
+            let cg = ctx.cgContext
+            PostcardPalette.bg.setFill()
+            cg.fill(CGRect(origin: .zero, size: size))
+
+            // 3:2 photo across the top
+            let photoRect = CGRect(x: 0, y: 0, width: W, height: photoH)
+            if let image = image {
+                drawAspectFill(image, in: photoRect, ctx: cg)
+            } else {
+                PostcardPalette.photoBg.setFill()
+                cg.fill(photoRect)
+                let glyph = NSAttributedString(string: "\u{25A2}", attributes: [
+                    .font: UIFont.systemFont(ofSize: 160, weight: .ultraLight),
+                    .foregroundColor: PostcardPalette.iconStroke
+                ])
+                let gsz = glyph.size()
+                glyph.draw(at: CGPoint(x: photoRect.midX - gsz.width / 2,
+                                       y: photoRect.midY - gsz.height / 2))
+            }
+
+            var y = photoH + pad
+
+            // Header: serif place name + mono date
+            let placeAttr = NSAttributedString(string: truncate(place, to: 24), attributes: [
+                .font: UIFont.editorialTitle(size: 60),
+                .foregroundColor: PostcardPalette.serifInk
+            ])
+            placeAttr.draw(at: CGPoint(x: pad, y: y))
+
+            let dateAttr = NSAttributedString(string: postcardDate(from: date), attributes: [
+                .font: UIFont.monospacedSystemFont(ofSize: 28, weight: .regular),
+                .foregroundColor: PostcardPalette.muted
+            ])
+            let dsz = dateAttr.size()
+            dateAttr.draw(at: CGPoint(x: W - pad - dsz.width, y: y + 24))
+            y += 64
+
+            // Dashed divider
+            drawDashedHLine(from: CGPoint(x: pad, y: y + 16), length: bodyW,
+                            lineWidth: 3, dash: [9, 9], color: PostcardPalette.border, in: cg)
+            y += 30 + 42
+
+            // Body text (left) + stamp (right)
+            bodyAttr.draw(with: CGRect(x: pad, y: y, width: textColW, height: bodyMeasure.height),
+                          options: [.usesLineFragmentOrigin], context: nil)
+
+            let stampX = pad + textColW + stampGap
+            drawPostcardStamp(at: CGPoint(x: stampX, y: y),
+                              time: headerTime(from: date),
+                              place: country.isEmpty ? "LAOS" : country, ctx: cg)
+        }
+    }
+}
+
+// MARK: - PostcardDailyTemplate
+
+enum PostcardDailyTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .daily(let s) = payload else { return UIImage() }
+        let date = parseDailyDate(s.dateString)
+        let place = s.locationPrimary.isEmpty ? "Vientiane" : s.locationPrimary
+        let country = s.locationPrimary.isEmpty ? "LAOS" : ""
+        return PostcardMemoTemplate.draw(body: s.summary, date: date, place: place,
+                                         country: country, image: s.coverImage)
+    }
+}
+
+// MARK: - PostcardPhotoTemplate
+
+enum PostcardPhotoTemplate: PosterTemplate {
+    static func render(_ payload: SharePayload) -> UIImage {
+        guard case .photo(let s) = payload else { return UIImage() }
+        let place = (s.location?.isEmpty == false ? s.location! : "Vientiane")
+        let country = (s.location?.isEmpty == false) ? "" : "LAOS"
+        // PhotoSnapshot has no Date; use today's date for the postcard stamp.
+        return PostcardMemoTemplate.draw(body: s.caption, date: Date(), place: place,
+                                         country: country, image: s.image)
     }
 }

--- a/DayPage/Features/Shared/ShareCard/ShareCardSystem.swift
+++ b/DayPage/Features/Shared/ShareCard/ShareCardSystem.swift
@@ -393,14 +393,24 @@ struct CollageSnapshot: Equatable {
 
 enum PosterStyle: String, CaseIterable, Identifiable {
     case minimal  = "minimal"   // 极简编辑器风
-    case polaroid = "polaroid"  // 拍立得/胶片风
+    case polaroid = "polaroid"  // 拍立得风
+    case film     = "film"      // 35mm 胶片风（暗场 + 齿孔）
+    case journal  = "journal"   // 手账风（横线 + 和纸胶带）
+    case postcard = "postcard"  // 明信片风（上图 + 邮票框）
 
     var id: String { rawValue }
 
+    // Picker order mirrors detail.jsx:760 SHARE_TEMPLATES
+    // (minimal, film, polaroid, journal, postcard).
+    static var pickerOrder: [PosterStyle] { [.minimal, .film, .polaroid, .journal, .postcard] }
+
     var displayName: String {
         switch self {
-        case .minimal:  return "极简"
-        case .polaroid: return "胶片"
+        case .minimal:  return "极简"   // detail.jsx:761
+        case .polaroid: return "拍立得"  // detail.jsx:761
+        case .film:     return "胶片"   // detail.jsx:761
+        case .journal:  return "手账"   // detail.jsx:761
+        case .postcard: return "明信片"  // detail.jsx:761
         }
     }
 }
@@ -416,16 +426,25 @@ protocol PosterTemplate {
 enum PosterDispatcher {
 
     /// Routes (payload, style) → concrete `PosterTemplate.render`. Adding a new
-    /// style means: extend `PosterStyle`, add 4 new template enums, add a row
-    /// in this switch.
+    /// style means: extend `PosterStyle`, add template enums, add rows in this
+    /// switch. Every (style × payload) pair MUST return a valid UIImage — no
+    /// case may be left unhandled or crash.
     ///
-    /// Collage currently only has one template (Minimal). Selecting Polaroid
-    /// from the style picker on a collage payload falls back to the Minimal
-    /// renderer — the IG-Story-tall canvas doesn't have room for the
-    /// Polaroid frame chrome around 6 stacked items, and trying to honour
-    /// the style would shrink each item below readable thumbnail size.
+    /// Collage currently only has one template (Minimal). Selecting any other
+    /// style from the picker on a collage payload falls back to the Minimal
+    /// renderer — the IG-Story-tall canvas doesn't have room for decorative
+    /// frame chrome around 6 stacked items, and honouring the style would
+    /// shrink each item below readable thumbnail size.
+    ///
+    /// The film / journal / postcard styles (detail.jsx:861-965) are designed
+    /// around a single photo/text card, so dedicated renderers exist for the
+    /// CORE share types — memo, daily, photo. For monthly / quote / voice the
+    /// new styles fall back to the closest existing renderer (Minimal for the
+    /// editorial film/postcard look, Polaroid for the warm journal look) so a
+    /// shared card is still on-brand without 12 extra rarely-used templates.
     static func render(payload: SharePayload, style: PosterStyle) -> UIImage {
         switch (style, payload) {
+        // MARK: Minimal
         case (.minimal,  .memo):    return MinimalMemoTemplate.render(payload)
         case (.minimal,  .daily):   return MinimalDailyTemplate.render(payload)
         case (.minimal,  .monthly): return MinimalMonthlyTemplate.render(payload)
@@ -433,6 +452,8 @@ enum PosterDispatcher {
         case (.minimal,  .photo):   return MinimalPhotoTemplate.render(payload)
         case (.minimal,  .voice):   return MinimalVoiceTemplate.render(payload)
         case (.minimal,  .collage): return MinimalCollageTemplate.render(payload)
+
+        // MARK: Polaroid
         case (.polaroid, .memo):    return PolaroidMemoTemplate.render(payload)
         case (.polaroid, .daily):   return PolaroidDailyTemplate.render(payload)
         case (.polaroid, .monthly): return PolaroidMonthlyTemplate.render(payload)
@@ -440,6 +461,36 @@ enum PosterDispatcher {
         case (.polaroid, .photo):   return PolaroidPhotoTemplate.render(payload)
         case (.polaroid, .voice):   return PolaroidVoiceTemplate.render(payload)
         case (.polaroid, .collage): return MinimalCollageTemplate.render(payload)
+
+        // MARK: Film (dark gate, 35mm perforations)
+        case (.film, .memo):     return FilmMemoTemplate.render(payload)
+        case (.film, .daily):    return FilmDailyTemplate.render(payload)
+        case (.film, .photo):    return FilmPhotoTemplate.render(payload)
+        // Fallbacks: Minimal carries the editorial/quote/stat look closest to film.
+        case (.film, .monthly):  return MinimalMonthlyTemplate.render(payload)
+        case (.film, .quote):    return MinimalQuoteTemplate.render(payload)
+        case (.film, .voice):    return MinimalVoiceTemplate.render(payload)
+        case (.film, .collage):  return MinimalCollageTemplate.render(payload)
+
+        // MARK: Journal (ruled paper, washi tape)
+        case (.journal, .memo):     return JournalMemoTemplate.render(payload)
+        case (.journal, .daily):    return JournalDailyTemplate.render(payload)
+        case (.journal, .photo):    return JournalPhotoTemplate.render(payload)
+        // Fallbacks: Polaroid's warm paper aesthetic is the nearest journal cousin.
+        case (.journal, .monthly):  return PolaroidMonthlyTemplate.render(payload)
+        case (.journal, .quote):    return PolaroidQuoteTemplate.render(payload)
+        case (.journal, .voice):    return PolaroidVoiceTemplate.render(payload)
+        case (.journal, .collage):  return MinimalCollageTemplate.render(payload)
+
+        // MARK: Postcard (photo top, stamp box)
+        case (.postcard, .memo):     return PostcardMemoTemplate.render(payload)
+        case (.postcard, .daily):    return PostcardDailyTemplate.render(payload)
+        case (.postcard, .photo):    return PostcardPhotoTemplate.render(payload)
+        // Fallbacks: Minimal keeps the clean white postcard tone for the rest.
+        case (.postcard, .monthly):  return MinimalMonthlyTemplate.render(payload)
+        case (.postcard, .quote):    return MinimalQuoteTemplate.render(payload)
+        case (.postcard, .voice):    return MinimalVoiceTemplate.render(payload)
+        case (.postcard, .collage):  return MinimalCollageTemplate.render(payload)
         }
     }
 }
@@ -520,29 +571,33 @@ struct ShareCardSheet: View {
         }
     }
 
+    // Five style chips now exceed the screen width, so the picker scrolls
+    // horizontally — mirrors the `overflowX:'auto'` row in detail.jsx:790.
     private var stylePicker: some View {
-        HStack(spacing: 12) {
-            ForEach(PosterStyle.allCases) { s in
-                Button {
-                    Haptics.soft()
-                    style = s
-                } label: {
-                    Text(s.displayName)
-                        .monoLabelStyle(size: 12)
-                        .foregroundColor(style == s ? DSColor.glassHi : DSColor.inkPrimary)
-                        .padding(.horizontal, 16)
-                        .padding(.vertical, 10)
-                        .background(
-                            style == s ? DSColor.amberDeep : DSColor.glassLo,
-                            in: Capsule()
-                        )
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                ForEach(PosterStyle.pickerOrder) { s in
+                    Button {
+                        Haptics.soft()
+                        style = s
+                    } label: {
+                        Text(s.displayName)
+                            .monoLabelStyle(size: 12)
+                            .foregroundColor(style == s ? DSColor.glassHi : DSColor.inkPrimary)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 10)
+                            .background(
+                                style == s ? DSColor.amberDeep : DSColor.glassLo,
+                                in: Capsule()
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("\(s.displayName) 风格")
+                    .accessibilityAddTraits(style == s ? [.isSelected] : [])
                 }
-                .buttonStyle(.plain)
-                .accessibilityLabel("\(s.displayName) 风格")
-                .accessibilityAddTraits(style == s ? [.isSelected] : [])
             }
+            .padding(.horizontal, 24)
         }
-        .padding(.horizontal, 24)
     }
 
     private var actionBar: some View {

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -47,6 +47,10 @@ struct InputBarV4: View {
     var onCapturePhoto: () -> Void
     var onRemoveAttachment: (String) -> Void
     var onStartVoiceRecording: () -> Void
+    /// Opens the v8 WriteSheet bottom-sheet composer (design composer.jsx:183).
+    /// The dock's text affordance routes here; if unset it falls back to the
+    /// inline morph so the dock keeps working in isolation/previews.
+    var onOpenWriteSheet: (() -> Void)? = nil
     var onPressToTalkSend: (VoiceRecordingResult) -> Void
     var onPressToTalkTranscribe: (String) -> Void
     var onAddFile: () -> Void
@@ -402,10 +406,16 @@ struct InputBarV4: View {
             .accessibilityLabel(NSLocalizedString("input.a11y.mic", comment: ""))
             .accessibilityHint(NSLocalizedString("input.a11y.mic_hint_full", comment: ""))
 
-            // RIGHT — Aa (text expand). Fades out as composer opens (AC: Aa 淡出).
+            // RIGHT — Aa (text affordance). v8: opens the WriteSheet bottom
+            // sheet (composer.jsx:116-129 text stub → WriteSheet). Falls back to
+            // the inline morph when no sheet handler is wired (previews / tests).
             dockTextButton(accessibilityLabel: NSLocalizedString("input.a11y.write_text", comment: "")) {
-                transition(to: .expanding)
-                isFocused = true
+                if let openSheet = onOpenWriteSheet {
+                    openSheet()
+                } else {
+                    transition(to: .expanding)
+                    isFocused = true
+                }
             }
             .accessibilityIdentifier("expand-text-composer")
         }

--- a/DayPage/Features/Today/TimelineRow.swift
+++ b/DayPage/Features/Today/TimelineRow.swift
@@ -1,0 +1,227 @@
+import SwiftUI
+
+// MARK: - Timeline kakejiku spine — shared row scaffold + marker shapes
+//
+// One continuous museum spine runs through the whole Today timeline. Each row
+// is a `52pt nameplate | content` layout; a marker shape centered on the spine
+// encodes the granularity (dot → bar → ring → concentric) so the unit reads
+// without words. Content floats on `bgWarm` — no card chrome, no rounded
+// corners, no shadow.
+//
+// Design source of truth: .design-handoff/v8/app.jsx:630-720 +
+// web/src/app/(app)/today/WeekFeedSpine.tsx (faithful web port).
+
+// Spine x-coordinate inside a row's own coordinate space. Rows are a
+// `52pt | gap(24) | content` layout, so the spine sits at the gap-center:
+// 52 + 12 = 64 (app.jsx:654 `left: 52 + 12 - …`). The section wrapper places
+// the continuous hairline at the same x (sectionPad 22 + 52 + 12 = 86).
+private enum Spine {
+    static let nameplateWidth: CGFloat = 52
+    static let gap: CGFloat = 24
+    /// Marker center, measured from the row's leading edge.
+    static let x: CGFloat = nameplateWidth + gap / 2  // 64
+    /// bg-warm halo that sits the marker on top of the hairline.
+    static let halo: CGFloat = 4
+}
+
+// MARK: - Marker granularity
+
+/// Shape encodes the time unit. Day = point, Week = span, Month/Year = ring.
+enum TimelineMarker {
+    /// Solid 7pt accent dot — a single day (app.jsx:654).
+    case day
+    /// Short 18×3pt accent bar — denotes a span (app.jsx:666).
+    case week
+    /// Hollow 11pt accent ring (1.6pt border) — a month (app.jsx:678).
+    case month
+    /// Concentric 15pt ring + 5pt inner dot — a year (app.jsx:691).
+    case year
+}
+
+// MARK: - SpineMarker
+
+/// A single marker centered on the spine, with a `bgWarm` halo so the hairline
+/// reads as passing *behind* it. Self-positions horizontally on the spine; the
+/// caller positions it vertically via each marker's design `top` inset.
+private struct SpineMarker: View {
+
+    let marker: TimelineMarker
+
+    var body: some View {
+        switch marker {
+        case .day:
+            dot(diameter: 7, top: 11)
+        case .week:
+            bar(width: 18, height: 3, top: 13)
+        case .month:
+            ring(diameter: 11, top: 9)
+        case .year:
+            concentric(diameter: 15, inner: 5, top: 7)
+        }
+    }
+
+    // MARK: Shapes
+
+    private func dot(diameter: CGFloat, top: CGFloat) -> some View {
+        Circle()
+            .fill(DSTokens.Colors.accent)
+            .frame(width: diameter, height: diameter)
+            .background(halo(Circle()))
+            .offset(x: Spine.x - diameter / 2, y: top)
+    }
+
+    private func bar(width: CGFloat, height: CGFloat, top: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 2, style: .continuous)
+            .fill(DSTokens.Colors.accent)
+            .frame(width: width, height: height)
+            .background(halo(RoundedRectangle(cornerRadius: 2, style: .continuous)))
+            .offset(x: Spine.x - width / 2, y: top)
+    }
+
+    private func ring(diameter: CGFloat, top: CGFloat) -> some View {
+        Circle()
+            .fill(DSTokens.Colors.bgWarm)
+            .overlay(Circle().strokeBorder(DSTokens.Colors.accent, lineWidth: 1.6))
+            .frame(width: diameter, height: diameter)
+            .background(halo(Circle(), inset: 3))
+            .offset(x: Spine.x - diameter / 2, y: top)
+    }
+
+    private func concentric(diameter: CGFloat, inner: CGFloat, top: CGFloat) -> some View {
+        Circle()
+            .fill(DSTokens.Colors.bgWarm)
+            .overlay(Circle().strokeBorder(DSTokens.Colors.accent, lineWidth: 1.6))
+            .overlay(Circle().fill(DSTokens.Colors.accent).frame(width: inner, height: inner))
+            .frame(width: diameter, height: diameter)
+            .background(halo(Circle(), inset: 3))
+            .offset(x: Spine.x - diameter / 2, y: top)
+    }
+
+    /// bgWarm halo: a `shape` filled with bgWarm, padded outward so it peeks
+    /// past the marker edges and masks the hairline running behind it.
+    private func halo<S: Shape>(_ shape: S, inset: CGFloat = Spine.halo) -> some View {
+        shape
+            .fill(DSTokens.Colors.bgWarm)
+            .padding(-inset)
+    }
+}
+
+// MARK: - RowTitle / RowLede / RowMeta
+
+/// Serif (fraunces) title. Size scales with granularity: 20/20/22/24pt for
+/// day/week/month/year; letterSpacing tightens as it grows (app.jsx:655-695).
+struct TimelineRowTitle: View {
+    let text: String
+    let size: CGFloat
+
+    var body: some View {
+        let tracking: CGFloat = size >= 24 ? -0.6 : (size >= 22 ? -0.5 : -0.4)
+        Text(text)
+            .font(DSFonts.serif(size: size, weight: .semibold))
+            .tracking(tracking)
+            .lineSpacing(size >= 24 ? 4 : 3)
+            .foregroundColor(DSTokens.Colors.fgPrimary)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+}
+
+/// Body lede in inter at 0.85 opacity, clamped to 3 lines (app.jsx:656).
+struct TimelineRowLede: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(DSFonts.inter(size: 14))
+            .tracking(0.1)
+            .lineSpacing(4)
+            .foregroundColor(DSTokens.Colors.fgPrimary.opacity(0.85))
+            .lineLimit(3)
+            .multilineTextAlignment(.leading)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(.top, 10)
+    }
+}
+
+/// Footer: mono tags separated by `·`, then a right-aligned trailing slot
+/// (word / entry counts). Mirrors `RowMeta` (app.jsx:702-719).
+struct TimelineRowMeta<Trailing: View>: View {
+    let tags: [String]
+    @ViewBuilder let trailing: () -> Trailing
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 9) {
+            ForEach(Array(tags.enumerated()), id: \.offset) { index, tag in
+                if index > 0 {
+                    Text("·")
+                        .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                        .foregroundColor(DSTokens.Colors.fgSubtle.opacity(0.55))
+                }
+                Text(tag)
+                    .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                    .tracking(1.6)
+                    .foregroundColor(DSTokens.Colors.fgSubtle)
+            }
+            Spacer(minLength: 12)
+            trailing()
+                .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                .foregroundColor(DSTokens.Colors.fgMuted)
+        }
+        .padding(.top, 14)
+    }
+}
+
+// MARK: - TimelineRow
+
+/// Shared row scaffold: right-aligned nameplate column | spine marker | content.
+/// `leftTop` is a mono granularity label (e.g. `MON`, `W·21`, `APR`, `YEAR`);
+/// `leftBot` is a display/serif date or year. The marker overlays the gap
+/// between nameplate and content, centered on the continuous spine.
+///
+/// Named `TimelineRowScaffold` to avoid colliding with the pre-existing
+/// `TimelineRow` in TodayView.swift (a different, still-used view).
+struct TimelineRowScaffold<Content: View>: View {
+
+    let leftTop: String
+    let leftBot: String?
+    /// Serif for YEAR's big year label; display (Space Grotesk) otherwise.
+    let leftBotSerif: Bool
+    let marker: TimelineMarker
+    let first: Bool
+    let last: Bool
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        HStack(alignment: .top, spacing: Spine.gap) {
+            nameplate
+                .frame(width: Spine.nameplateWidth, alignment: .trailing)
+            content()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 6)
+        }
+        .padding(.top, first ? 0 : 26)
+        .padding(.bottom, last ? 6 : 26)
+        .overlay(alignment: .topLeading) {
+            SpineMarker(marker: marker)
+        }
+    }
+
+    // MARK: Nameplate (left column)
+
+    private var nameplate: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            Text(leftTop)
+                .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                .tracking(1.8)
+                .foregroundColor(DSTokens.Colors.fgSubtle)
+            if let leftBot {
+                Text(leftBot)
+                    .font(leftBotSerif
+                        ? DSFonts.serif(size: 13, weight: .semibold)
+                        : DSFonts.spaceGrotesk(size: 13, weight: .semibold))
+                    .tracking(-0.1)
+                    .foregroundColor(DSTokens.Colors.fgPrimary)
+            }
+        }
+        .padding(.top, 6)
+    }
+}

--- a/DayPage/Features/Today/TimelineSectionView.swift
+++ b/DayPage/Features/Today/TimelineSectionView.swift
@@ -1,109 +1,121 @@
 import SwiftUI
 
 // MARK: - TimelineSectionView
+//
+// One band of the Today historical timeline rendered as a continuous
+// "kakejiku" (掛軸) museum spine — a single 0.5pt vertical hairline running
+// through every row, with a marker shape that encodes granularity
+// (dot → bar → ring → concentric). Content floats on bg-warm with NO card
+// chrome, NO rounded corners, NO shadow — the serif title and inter lede
+// hang off the spine like a scroll.
+//
+// Design source of truth: .design-handoff/v8/app.jsx:590-720
+// (Timeline / TimelineSection / TimelineRow / DayRow / WeekRowItem /
+//  MonthRow / YearRow / RowMeta). Faithful web port:
+// web/src/app/(app)/today/WeekFeedSpine.tsx.
+//
+// The iOS data model currently only produces day-level entries
+// (`TimelineSectionKind` = thisWeekOthers / lastWeek / weekBeforeLast /
+// month). The four marker shapes & row builders are all implemented so the
+// week/month/year granularities are structurally ready the moment the
+// view-model starts emitting coarser buckets — matching how the web groups
+// 本周 BY DAY · 本月 BY WEEK · 今年 BY MONTH · 历年 BY YEAR.
 
-/// Renders one band of the Today historical timeline — a labelled divider
-/// followed by one card per day. Expanding a card reveals that day's raw
-/// memos inline (no navigation, see issue #276).
-///
-/// Visual language mirrors `WeeklyRecapSection`: low-contrast section header
-/// and surface-container cards, signalling "settled history" rather than the
-/// active composer day above.
 struct TimelineSectionView: View {
 
     let section: TimelineSection
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            sectionDivider
-            ForEach(section.days) { day in
-                TimelineDayCard(entry: day)
+        VStack(alignment: .leading, spacing: 0) {
+            TimelineSpine.SectionHeader(label: headerLabel, sub: headerSub)
+            spineBody
+        }
+        // app.jsx:609 — section { marginBottom: 22 } (12 for the last band).
+        .padding(.bottom, TimelineSpine.sectionGap)
+    }
+
+    // MARK: Spine + rows
+
+    /// The relative-positioned region: a fixed-x hairline behind the rows.
+    /// app.jsx:617-624 — `padding: 8px 22px 4px`, spine inset top:18 bottom:6.
+    private var spineBody: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            ForEach(Array(section.days.enumerated()), id: \.element.id) { index, day in
+                TimelineDayRow(
+                    entry: day,
+                    isFirst: index == 0,
+                    isLast: index == section.days.count - 1
+                )
             }
         }
-        .padding(.horizontal, 20)
-        .padding(.top, 24)
-    }
-
-    // MARK: Section header
-
-    private var sectionDivider: some View {
-        HStack(spacing: 12) {
+        .padding(.top, 8)
+        .padding(.bottom, 4)
+        .padding(.horizontal, TimelineSpine.sectionPadH)
+        .background(alignment: .topLeading) {
+            // ONE continuous hairline, fixed left x, behind every row.
+            // app.jsx:618 — width:0.5, var(--border-subtle), top:18 bottom:6.
             Rectangle()
-                .fill(DSColor.outlineVariant)
-                .frame(height: 1)
-                .frame(maxWidth: 24)
-            Text(headerTitle)
-                .sectionLabelStyle()
-                .foregroundColor(DSColor.onSurfaceVariant)
-            Rectangle()
-                .fill(DSColor.outlineVariant)
-                .frame(height: 1)
-                .frame(maxWidth: .infinity)
+                .fill(DSTokens.Colors.borderSubtle)
+                .frame(width: 0.5)
+                .padding(.leading, TimelineSpine.spineX - 0.25)
+                .padding(.top, 18)
+                .padding(.bottom, 6)
+                .frame(maxHeight: .infinity, alignment: .top)
         }
     }
 
-    /// Localized header. Month buckets format as "MMMM yyyy" in the user's
-    /// current locale so it reads naturally in either English or Chinese.
-    private var headerTitle: String {
+    // MARK: Section header copy
+
+    /// Left display caption — 本周 / 本月 / 今年 + month name. app.jsx:612.
+    private var headerLabel: String {
         switch section.kind {
         case .thisWeekOthers:
-            return NSLocalizedString("today.timeline.thisWeek", value: "THIS WEEK", comment: "Timeline band")
+            return NSLocalizedString("today.timeline.thisWeek", value: "本周", comment: "Timeline band")
         case .lastWeek:
-            return NSLocalizedString("today.timeline.lastWeek", value: "LAST WEEK", comment: "Timeline band")
+            return NSLocalizedString("today.timeline.lastWeek", value: "上周", comment: "Timeline band")
         case .weekBeforeLast:
-            return NSLocalizedString("today.timeline.weekBeforeLast", value: "TWO WEEKS AGO", comment: "Timeline band")
+            return NSLocalizedString("today.timeline.weekBeforeLast", value: "前两周", comment: "Timeline band")
         case .month(let date):
             let f = DateFormatter()
             f.dateFormat = "MMMM yyyy"
             f.locale = Locale.current
             f.timeZone = TimeZone.current
-            return f.string(from: date).uppercased()
+            return f.string(from: date)
         }
+    }
+
+    /// Right mono caption — "BY DAY · N条". app.jsx:598-601, 614.
+    private var headerSub: String {
+        let n = section.days.count
+        return "BY DAY · \(n) 条"
     }
 }
 
-// MARK: - TimelineDayCard
+// MARK: - TimelineDayRow
 
-/// One day card inside a timeline section. Tap to expand — the card grows
-/// downward to show that day's raw memos, loaded lazily via TimelineService.
-struct TimelineDayCard: View {
+/// One day row hung off the spine. Tap to expand — that day's raw memos load
+/// lazily inline (no navigation, see #276). The collapsed presentation is the
+/// faithful museum row: mono day / display date nameplate · accent dot ·
+/// serif title · inter lede · mono meta footer.
+struct TimelineDayRow: View {
 
     let entry: TimelineDayEntry
+    let isFirst: Bool
+    let isLast: Bool
 
     @State private var isExpanded: Bool = false
     @State private var loadedMemos: [Memo] = []
     @State private var hasLoaded: Bool = false
 
     var body: some View {
-        VStack(spacing: 0) {
-            header
-            if isExpanded {
-                Divider()
-                    .padding(.vertical, 8)
-                    .padding(.horizontal, 16)
-                expandedMemos
-                    .transition(.opacity.combined(with: .move(edge: .top)))
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(DSColor.surfaceContainer)
-        .cornerRadius(DSSpacing.radiusCard)
-    }
-
-    // MARK: Header (always visible)
-
-    private var header: some View {
         Button(action: toggle) {
-            HStack(alignment: .top, spacing: 14) {
-                dateRail
-                summaryColumn
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.right")
-                    .font(.system(size: 12, weight: .semibold))
-                    .foregroundColor(DSColor.onSurfaceVariant)
-                    .padding(.top, 4)
+            VStack(alignment: .leading, spacing: 0) {
+                rowScaffold
+                if isExpanded {
+                    expandedMemos
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                }
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 14)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -113,34 +125,76 @@ struct TimelineDayCard: View {
             : NSLocalizedString("today.timeline.expand", value: "Expand", comment: ""))
     }
 
-    private var dateRail: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(weekdayLabel)
-                .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
-                .foregroundColor(DSColor.onSurfaceVariant)
-            Text(monthDayLabel)
-                .font(.custom("SpaceGrotesk-Bold", size: 16))
-                .foregroundColor(DSColor.onSurface)
+    // MARK: Row scaffold — nameplate | marker | content
+
+    /// app.jsx:631-647 — grid 52px | 1fr, columnGap 24, paddingTop 26
+    /// (0 first), paddingBottom 26 (6 last). The marker is overlaid in the
+    /// gap so it sits exactly on the spine.
+    private var rowScaffold: some View {
+        HStack(alignment: .top, spacing: TimelineSpine.columnGap) {
+            nameplate
+            content
         }
-        .frame(width: 56, alignment: .leading)
+        .padding(.top, isFirst ? 0 : 26)
+        .padding(.bottom, isLast ? 6 : 26)
+        // Marker overlaid on the spine — top-leading so the dot lines up with
+        // the title regardless of content height. app.jsx:654.
+        .overlay(alignment: .topLeading) {
+            TimelineSpine.DayMarker()
+                .offset(
+                    x: TimelineSpine.rowSpineX - TimelineSpine.DayMarker.size / 2,
+                    y: (isFirst ? 0 : 26) + 11
+                )
+        }
     }
 
-    private var summaryColumn: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            if let summary = entry.summary, !summary.isEmpty {
-                Text(summary)
-                    .bodySMStyle()
-                    .foregroundColor(DSColor.onSurface)
-                    .lineLimit(isExpanded ? nil : 2)
-                    .multilineTextAlignment(.leading)
-            }
-            Text(memoCountLabel)
-                .font(.custom("JetBrainsMono-Regular", fixedSize: 10))
-                .foregroundColor(DSColor.onSurfaceVariant)
+    /// Left nameplate column — right-aligned mono weekday + display date.
+    /// app.jsx:638-643 (mono 9.5 / display 13).
+    private var nameplate: some View {
+        VStack(alignment: .trailing, spacing: 4) {
+            Text(weekdayLabel)
+                .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                .tracking(1.8)
                 .textCase(.uppercase)
-                .tracking(1.0)
+                .foregroundColor(DSTokens.Colors.fgSubtle)
+            Text(monthDayLabel)
+                .font(DSFonts.spaceGrotesk(size: 13, weight: .semibold))
+                .tracking(-0.1)
+                .foregroundColor(DSTokens.Colors.fgPrimary)
         }
+        .frame(width: TimelineSpine.nameplateWidth, alignment: .trailing)
+        .padding(.top, 6)
+    }
+
+    /// Right content column — serif title, inter lede, mono meta footer.
+    private var content: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if let title = displayTitle {
+                TimelineSpine.RowTitle(text: title, size: 20)
+            }
+            if let lede = displayLede {
+                TimelineSpine.RowLede(text: lede)
+                    .padding(.top, 10)        // app.jsx:656 margin:'10px 0 0'
+                    .lineLimit(isExpanded ? nil : 3)
+            }
+            TimelineSpine.RowMeta(tags: metaTags, right: { wordsRight })
+                .padding(.top, 14)            // app.jsx:705 marginTop:14
+        }
+        .padding(.leading, 6)                 // app.jsx:645 paddingLeft:6
         .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    /// Right-aligned word count for a day row. app.jsx:657.
+    private var wordsRight: some View {
+        HStack(spacing: 4) {
+            Text("\(approxWordCount)")
+                .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                .foregroundColor(DSTokens.Colors.fgMuted)
+            Text("WORDS")
+                .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                .foregroundColor(DSTokens.Colors.fgMuted.opacity(0.6))
+        }
+        .tracking(1.3)
     }
 
     // MARK: Expanded memo list
@@ -152,17 +206,14 @@ struct TimelineDayCard: View {
                     .frame(maxWidth: .infinity)
             }
         }
-        .padding(.horizontal, 16)
-        .padding(.bottom, 14)
+        .padding(.leading, TimelineSpine.nameplateWidth + TimelineSpine.columnGap + 6)
+        .padding(.bottom, 18)
     }
 
     // MARK: Interaction
 
     private func toggle() {
         if !hasLoaded {
-            // First expand: parse the day's file once and cache. Subsequent
-            // toggles just flip the flag — no extra I/O. Load off-main to
-            // avoid blocking the UI thread on synchronous file I/O.
             Task {
                 let memos = TimelineService.memos(for: entry)
                 await MainActor.run {
@@ -171,9 +222,41 @@ struct TimelineDayCard: View {
                 }
             }
         }
-        withAnimation(.easeInOut(duration: 0.22)) {
+        withAnimation(.easeInOut(duration: DSTokens.Motion.fast)) {
             isExpanded.toggle()
         }
+    }
+
+    // MARK: Derived content
+
+    /// Compiled summary acts as the serif title (the day's "成稿" headline).
+    /// Falls back to the formatted date when the day hasn't compiled yet so
+    /// the row still reads as a museum plate rather than an empty card.
+    private var displayTitle: String? {
+        if let summary = entry.summary, !summary.isEmpty {
+            // First sentence / line as the title; keeps the serif headline tight.
+            let firstLine = summary
+                .split(whereSeparator: { $0 == "\n" || $0 == "。" })
+                .first.map(String.init) ?? summary
+            return firstLine
+        }
+        return longDateLabel
+    }
+
+    /// Lede only when a compiled summary spills past its title line.
+    private var displayLede: String? {
+        guard let summary = entry.summary, !summary.isEmpty else { return nil }
+        guard let title = displayTitle, summary.count > title.count + 1 else { return nil }
+        let remainder = summary.dropFirst(title.count)
+            .drop(while: { $0 == "\n" || $0 == "。" || $0 == " " })
+        let text = String(remainder)
+        return text.isEmpty ? nil : text
+    }
+
+    private var metaTags: [String] {
+        // No tag model on TimelineDayEntry yet — surface memo count as a
+        // single mono tag so the footer keeps its rhythm (web shows item.tags).
+        [memoCountTag]
     }
 
     // MARK: Formatters
@@ -186,6 +269,7 @@ struct TimelineDayCard: View {
         return f.string(from: entry.date).uppercased()
     }
 
+    /// Display date for the nameplate — mirrors web's `item.date` (e.g. 05.30).
     private var monthDayLabel: String {
         let f = DateFormatter()
         f.dateFormat = "MM.dd"
@@ -194,16 +278,207 @@ struct TimelineDayCard: View {
         return f.string(from: entry.date)
     }
 
-    private var memoCountLabel: String {
+    private var longDateLabel: String {
+        let f = DateFormatter()
+        f.dateFormat = "M月d日"
+        f.locale = Locale.current
+        f.timeZone = TimeZone.current
+        return f.string(from: entry.date)
+    }
+
+    private var memoCountTag: String {
         let n = entry.memoCount
-        let key = n == 1 ? "today.timeline.memoCount.one" : "today.timeline.memoCount.other"
         let fallback = n == 1 ? "1 MEMO" : "\(n) MEMOS"
+        let key = n == 1 ? "today.timeline.memoCount.one" : "today.timeline.memoCount.other"
         let format = NSLocalizedString(key, value: fallback, comment: "Memo count chip")
         return String(format: format, n)
     }
 
+    /// Rough word/character count to mirror the web's `item.words`. Uses the
+    /// summary length as a cheap proxy (no raw file read when collapsed).
+    private var approxWordCount: Int {
+        guard let summary = entry.summary, !summary.isEmpty else { return entry.memoCount }
+        return summary.count
+    }
+
     private var accessibilityLabel: String {
-        let summaryText = entry.summary.flatMap { $0.isEmpty ? nil : $0 } ?? memoCountLabel
+        let summaryText = entry.summary.flatMap { $0.isEmpty ? nil : $0 } ?? memoCountTag
         return "\(entry.dateString), \(summaryText)"
+    }
+}
+
+// MARK: - TimelineSpine
+
+/// Shared geometry, markers, and typed text primitives for the museum spine.
+/// All four granularity markers are implemented so coarser buckets render
+/// faithfully the moment the view-model emits them. app.jsx:606-718.
+enum TimelineSpine {
+
+    // MARK: Geometry
+
+    /// Section internal horizontal padding. app.jsx:611/617 — 22.
+    static let sectionPadH: CGFloat = 22
+    /// Left nameplate column width. app.jsx:634 — 52.
+    static let nameplateWidth: CGFloat = 52
+    /// Gap between nameplate and content. app.jsx:634 — columnGap 24.
+    static let columnGap: CGFloat = 24
+    /// Trailing band margin. app.jsx:609 — marginBottom 22.
+    static let sectionGap: CGFloat = 22
+
+    /// Spine x within the padded spine body (nameplate + half the gap).
+    /// app.jsx:607 — `const SPINE = 22 + 52 + 12` minus the section's own
+    /// 22 left padding (already applied) → 52 + 12 = 64.
+    static let rowSpineX: CGFloat = nameplateWidth + columnGap / 2   // 64
+    /// Spine x relative to the spine-body's leading edge (post-padding).
+    static let spineX: CGFloat = rowSpineX                            // 64
+
+    // MARK: Markers (shape encodes granularity)
+
+    /// DAY — solid 7pt accent dot. app.jsx:654.
+    struct DayMarker: View {
+        static let size: CGFloat = 7
+        var body: some View {
+            Circle()
+                .fill(DSTokens.Colors.accent)
+                .frame(width: Self.size, height: Self.size)
+                .background(halo(radius: 4))
+        }
+    }
+
+    /// WEEK — short 18×3pt horizontal bar (a span, not a point). app.jsx:666.
+    struct WeekMarker: View {
+        static let width: CGFloat = 18
+        static let height: CGFloat = 3
+        var body: some View {
+            RoundedRectangle(cornerRadius: 2, style: .continuous)
+                .fill(DSTokens.Colors.accent)
+                .frame(width: Self.width, height: Self.height)
+                .background(halo(radius: 4))
+        }
+    }
+
+    /// MONTH — hollow 11pt accent ring (1.6pt border). app.jsx:678.
+    struct MonthMarker: View {
+        static let size: CGFloat = 11
+        var body: some View {
+            Circle()
+                .fill(DSTokens.Colors.bgWarm)
+                .frame(width: Self.size, height: Self.size)
+                .overlay(
+                    Circle().strokeBorder(DSTokens.Colors.accent, lineWidth: 1.6)
+                )
+                .background(halo(radius: 3))
+        }
+    }
+
+    /// YEAR — concentric 15pt ring + 5pt inner accent dot. app.jsx:690-693.
+    struct YearMarker: View {
+        static let size: CGFloat = 15
+        var body: some View {
+            Circle()
+                .fill(DSTokens.Colors.bgWarm)
+                .frame(width: Self.size, height: Self.size)
+                .overlay(
+                    Circle().strokeBorder(DSTokens.Colors.accent, lineWidth: 1.6)
+                )
+                .overlay(
+                    Circle()
+                        .fill(DSTokens.Colors.accent)
+                        .frame(width: 5, height: 5)
+                )
+                .background(halo(radius: 3))
+        }
+    }
+
+    /// bg-warm halo behind a marker so it punches cleanly through the spine.
+    /// CSS `boxShadow: 0 0 0 Npx var(--bg-warm)`.
+    private static func halo(radius: CGFloat) -> some View {
+        Circle()
+            .fill(DSTokens.Colors.bgWarm)
+            .padding(-radius)
+    }
+
+    // MARK: Typed text primitives
+
+    /// Serif row title. Size scales 20/20/22/24 across day/week/month/year;
+    /// letter-spacing tightens as it grows. app.jsx:655/667/679/695.
+    struct RowTitle: View {
+        let text: String
+        let size: CGFloat
+        var body: some View {
+            let tracking: CGFloat = size >= 24 ? -0.6 : (size >= 22 ? -0.5 : -0.4)
+            return Text(text)
+                .font(DSFonts.serif(size: size, weight: .semibold))
+                .tracking(tracking)
+                .foregroundColor(DSTokens.Colors.fgPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+                .multilineTextAlignment(.leading)
+        }
+    }
+
+    /// Inter body lede, 3-line clamp, 0.85 opacity. app.jsx:656.
+    struct RowLede: View {
+        let text: String
+        var body: some View {
+            Text(text)
+                .font(DSFonts.inter(size: 14))
+                .tracking(0.1)
+                .lineSpacing(14 * 0.7)        // line-height 1.7 ≈ +0.7em leading
+                .foregroundColor(DSTokens.Colors.fgPrimary.opacity(0.85))
+                .multilineTextAlignment(.leading)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    /// Mono meta footer — tags separated by · with a right-aligned count.
+    /// app.jsx:702-718.
+    struct RowMeta<Right: View>: View {
+        let tags: [String]
+        @ViewBuilder let right: () -> Right
+        var body: some View {
+            HStack(alignment: .center, spacing: 9) {
+                ForEach(Array(tags.enumerated()), id: \.offset) { index, tag in
+                    if index > 0 {
+                        Text("·")
+                            .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                            .foregroundColor(DSTokens.Colors.fgSubtle.opacity(0.55))
+                    }
+                    Text(tag)
+                        .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                        .tracking(1.6)
+                        .foregroundColor(DSTokens.Colors.fgSubtle)
+                }
+                Spacer(minLength: 12)
+                right()
+            }
+        }
+    }
+
+    // MARK: Section header
+
+    /// Hairline-bounded mono caption. app.jsx:611-615.
+    struct SectionHeader: View {
+        let label: String
+        let sub: String
+        var body: some View {
+            HStack(alignment: .lastTextBaseline, spacing: 14) {
+                Text(label)
+                    .font(DSFonts.spaceGrotesk(size: 13, weight: .bold))
+                    .tracking(1.5)
+                    .foregroundColor(DSTokens.Colors.fgPrimary)
+                Rectangle()
+                    .fill(DSTokens.Colors.borderSubtle)
+                    .frame(height: 0.5)
+                    .frame(maxWidth: .infinity)
+                    .padding(.bottom, 2)
+                Text(sub)
+                    .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                    .tracking(1.6)
+                    .foregroundColor(DSTokens.Colors.fgSubtle)
+            }
+            .padding(.horizontal, sectionPadH)
+            .padding(.top, 10)
+            .padding(.bottom, 14)
+        }
     }
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -65,6 +65,11 @@ struct TodayView: View {
     // across launches; selection is always an immediate action.
     @State private var selectedMemoIds: Set<UUID>? = nil
 
+    /// v8 WriteSheet — bottom-sheet text composer opened from the dock's text
+    /// affordance (composer.jsx:183). Routes saves through `submitCombinedMemo`
+    /// (the same path the inline composer uses) via `draftText`.
+    @State private var showWriteSheet: Bool = false
+
     /// Toggled each time the Day Orb is tapped to focus the composer input.
     @State private var orbFocusToggle: Bool = false
     /// Toggled each time a new memo is added while the orb hero is visible, triggering a capture-reward glow pulse.
@@ -417,6 +422,11 @@ struct TodayView: View {
             .sheet(item: $sharePayload) { payload in
                 ShareCardSheet(payload: payload)
             }
+            // v8 WriteSheet — custom bottom sheet (scrim + drag handle + sheet-up
+            // anim are drawn inside the view), so it presents as a full-screen
+            // overlay rather than a system `.sheet`. Saves route through the same
+            // `submitCombinedMemo` path the dock composer uses (draftText binding).
+            .overlay { writeSheetOverlay }
             .onAppear {
                 evaluateSyncBanner()
                 // Handle a Quick Capture trigger that fired before TodayView
@@ -888,6 +898,10 @@ struct TodayView: View {
             onCapturePhoto: { viewModel.startCameraCapture() },
             onRemoveAttachment: { id in viewModel.removePendingAttachment(id: id) },
             onStartVoiceRecording: { viewModel.startVoiceRecording() },
+            onOpenWriteSheet: {
+                Haptics.soft()
+                showWriteSheet = true
+            },
             onPressToTalkSend: { result in
                 viewModel.addVoiceAttachment(result: result)
                 let body = draftText
@@ -914,6 +928,32 @@ struct TodayView: View {
             batchPhotoTotal: viewModel.batchPhotoTotal,
             requestFocusToggle: orbFocusToggle
         )
+    }
+
+    // MARK: - WriteSheet Overlay (v8)
+    //
+    // Bottom-sheet text composer (composer.jsx:183-345). Bound to the same
+    // `draftText` the inline composer uses; on save it calls the identical
+    // sequence as `inputBarV4.onSubmit` — submitCombinedMemo(body:) + undo pill —
+    // so there is a single persistence path, never a second one.
+
+    @ViewBuilder
+    private var writeSheetOverlay: some View {
+        if showWriteSheet {
+            WriteSheetView(
+                text: $draftText,
+                onSave: {
+                    let body = draftText
+                    draftText = ""
+                    showWriteSheet = false
+                    viewModel.submitCombinedMemo(body: body)
+                    showUndoPill(for: body)
+                },
+                onClose: { showWriteSheet = false }
+            )
+            .transition(.opacity)
+            .zIndex(50)
+        }
     }
 
     // MARK: - Compile Progress Dots

--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -1,0 +1,340 @@
+import SwiftUI
+
+// MARK: - WriteSheetView
+//
+// Elegant text composer presented as a bottom sheet — the v8 「日式美术馆」 write
+// surface (composer.jsx:183-345, web WriteSheet.tsx). It slides up from the
+// Today dock's text affordance and routes its saved text through the SAME
+// persistence path the inline composer uses (submitCombinedMemo via draftText).
+//
+// Layout, top → bottom (design composer.jsx:222-341):
+//   • drag handle — 36×4 capsule, centered
+//   • header — Fraunces weekday (18pt) + JetBrains Mono "MAY 28 · 15:47" stamp
+//     (real now), trailing close button
+//   • 0.5px hairline
+//   • textarea — 18pt serif, italic placeholder「此刻在想什么？」, accent caret,
+//     auto-grow (lineLimit 3…10)
+//   • 0.5px hairline
+//   • footer rail — camera/photo/location/tag icons · spacer · mono「N 字」·
+//     accent「保存」pill (disabled when empty) with checkmark
+//   • mono caption「SAVED TO  VAULT / YYYY-MM-DD.md」(real date)
+//
+// Entrance: sheet-up via timingCurve(.2,.8,.2,1) ~320ms — mirrors
+// composer.jsx:219 `sheet-up 320ms cubic-bezier(.2,.8,.2,1)`. The icon rail is
+// presentation-only in this round (no wiring) to match the design's quiet rail;
+// the inline composer remains the full multimodal capture surface.
+
+struct WriteSheetView: View {
+
+    /// Live draft text — bound to the same `draftText` the inline composer uses
+    /// so save flows through the existing `submitCombinedMemo` path.
+    @Binding var text: String
+    /// Save — commits the current text via the parent's existing persistence.
+    let onSave: () -> Void
+    /// Close — dismiss the sheet without saving.
+    let onClose: () -> Void
+
+    @FocusState private var isFocused: Bool
+    @State private var appeared: Bool = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Sheet-up easing — composer.jsx:219 `cubic-bezier(.2,.8,.2,1)` @ 320ms.
+    private static let sheetUp = Animation.timingCurve(0.2, 0.8, 0.2, 1, duration: 0.32)
+
+    /// Non-whitespace character count (design composer.jsx:201).
+    private var words: Int {
+        text.filter { !$0.isWhitespace }.count
+    }
+
+    private var canSave: Bool {
+        !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    // MARK: - Date / time strings (museum-tag style)
+
+    /// Captured once so the stamp doesn't reshuffle while the sheet is open.
+    private let now = Date()
+
+    /// Full weekday, e.g. "Thursday" (design composer.jsx:236).
+    private var weekday: String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "EEEE"
+        return f.string(from: now)
+    }
+
+    /// Mono stamp "MAY 28 · 15:47" (design composer.jsx:239).
+    private var stamp: String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "MMM d · HH:mm"
+        return f.string(from: now).uppercased()
+    }
+
+    /// ISO date for the vault caption "YYYY-MM-DD" (design composer.jsx:340).
+    private var isoDate: String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f.string(from: now)
+    }
+
+    // MARK: - Body
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            // Backdrop scrim — composer.jsx:206-209 rgba(30,24,18,0.34).
+            DSTokens.Colors.recordingBg.opacity(0.34)
+                .ignoresSafeArea()
+                .opacity(appeared ? 1 : 0)
+                .onTapGesture { onClose() }
+                .accessibilityHidden(true)
+
+            sheet
+                .offset(y: appeared ? 0 : sheetTravel)
+        }
+        .animation(reduceMotion ? .easeOut(duration: 0.2) : Self.sheetUp, value: appeared)
+        .onAppear {
+            appeared = true
+            // Let the sheet-up settle before raising the keyboard.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                isFocused = true
+            }
+        }
+    }
+
+    /// Off-screen travel distance for the sheet-up entrance.
+    private var sheetTravel: CGFloat { reduceMotion ? 0 : 420 }
+
+    // MARK: - Sheet
+
+    private var sheet: some View {
+        VStack(spacing: 0) {
+            dragHandle
+            header
+            hairline
+            textArea
+            hairline
+            footerRail
+            savedCaption
+        }
+        .padding(.bottom, 28)
+        .frame(maxWidth: .infinity)
+        .background(
+            DSColor.glassHi
+                .background(.ultraThinMaterial)
+        )
+        .clipShape(
+            UnevenRoundedRectangle(
+                topLeadingRadius: DSTokens.Radii.sheet,
+                topTrailingRadius: DSTokens.Radii.sheet,
+                style: .continuous
+            )
+        )
+        .overlay(alignment: .top) {
+            // 0.5px top hairline (composer.jsx:217 borderTop var(--border-subtle)).
+            Rectangle()
+                .fill(DSTokens.Colors.borderSubtle)
+                .frame(height: 0.5)
+        }
+        .shadow(color: DSTokens.Colors.recordingBg.opacity(0.32), radius: 30, x: 0, y: -16)
+    }
+
+    // MARK: - Drag handle (composer.jsx:222-225)
+
+    private var dragHandle: some View {
+        Capsule()
+            .fill(DSTokens.Colors.borderDefault)
+            .frame(width: 36, height: 4)
+            .padding(.top, 8)
+            .frame(maxWidth: .infinity)
+            .contentShape(Rectangle())
+            .accessibilityHidden(true)
+    }
+
+    // MARK: - Header (composer.jsx:227-249)
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            HStack(alignment: .firstTextBaseline, spacing: 10) {
+                Text(weekday)
+                    .font(DSFonts.serif(size: 18, weight: .semibold))
+                    .tracking(-0.2)
+                    .foregroundColor(DSTokens.Colors.fgPrimary)
+
+                Text(stamp)
+                    .font(DSFonts.jetBrainsMono(size: 10, weight: .bold))
+                    .tracking(1.6)
+                    .foregroundColor(DSTokens.Colors.fgSubtle)
+            }
+
+            Spacer()
+
+            // Close button — 30pt sunken circle (composer.jsx:241-248).
+            Button(action: onClose) {
+                Image(systemName: "xmark")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(DSTokens.Colors.fgMuted)
+                    .frame(width: 30, height: 30)
+                    .background(Circle().fill(DSTokens.Colors.surfaceSunken))
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(NSLocalizedString("write.sheet.close", comment: "Close write sheet"))
+        }
+        .padding(.horizontal, 22)
+        .padding(.top, 14)
+        .padding(.bottom, 12)
+    }
+
+    // MARK: - 0.5px hairline (composer.jsx:252 / 279)
+
+    private var hairline: some View {
+        Rectangle()
+            .fill(DSTokens.Colors.borderSubtle)
+            .frame(height: 0.5)
+            .padding(.horizontal, 22)
+    }
+
+    // MARK: - Textarea (composer.jsx:255-276)
+
+    private var textArea: some View {
+        // 18pt serif body, accent caret, auto-grow (lineLimit 3…10 ≈ min 90 /
+        // max 280pt of the design). The placeholder is italic serif at fgSubtle.
+        ZStack(alignment: .topLeading) {
+            if text.isEmpty {
+                Text(NSLocalizedString("write.sheet.placeholder", comment: "此刻在想什么？"))
+                    .font(DSFonts.serif(size: 18, italic: true))
+                    .foregroundColor(DSTokens.Colors.fgSubtle.opacity(0.6))
+                    .allowsHitTesting(false)
+            }
+
+            TextField("", text: $text, axis: .vertical)
+                .font(DSFonts.serif(size: 18))
+                .tracking(0.2)
+                .lineSpacing(6) // ≈ lineHeight 1.7 on 18pt
+                .foregroundColor(DSTokens.Colors.fgPrimary)
+                .tint(DSTokens.Colors.accent)
+                .lineLimit(3...10)
+                .focused($isFocused)
+                .accessibilityIdentifier("write-sheet-input")
+        }
+        .padding(.horizontal, 22)
+        .padding(.top, 20)
+        .padding(.bottom, 18)
+        .frame(minHeight: 90, alignment: .topLeading)
+    }
+
+    // MARK: - Footer rail (composer.jsx:282-330)
+
+    private var footerRail: some View {
+        HStack(spacing: 2) {
+            railIcon("camera", label: NSLocalizedString("write.sheet.icon.camera", comment: "拍照"))
+            railIcon("photo", label: NSLocalizedString("write.sheet.icon.photo", comment: "相册"))
+            railIcon("mappin.and.ellipse", label: NSLocalizedString("write.sheet.icon.location", comment: "位置"))
+            railIcon("tag", label: NSLocalizedString("write.sheet.icon.tag", comment: "标签"))
+
+            Spacer()
+
+            // Word count — mono, brightens once the user has typed.
+            Text("\(words) \(NSLocalizedString("write.sheet.words_unit", comment: "字"))")
+                .font(DSFonts.jetBrainsMono(size: 10, weight: .semibold))
+                .tracking(1.3)
+                .monospacedDigit()
+                .foregroundColor(words > 0 ? DSTokens.Colors.fgMuted : DSTokens.Colors.fgSubtle)
+                .padding(.trailing, 10)
+
+            savePill
+        }
+        .padding(.horizontal, 18)
+        .padding(.top, 14)
+    }
+
+    private func railIcon(_ systemName: String, label: String) -> some View {
+        // Presentation-only quiet rail (design parity); capture flows live in
+        // the inline composer. Tapping closes to the dock so the user reaches
+        // the full multimodal surface rather than a dead control.
+        Button {
+            Haptics.soft()
+            onClose()
+        } label: {
+            Image(systemName: systemName)
+                .font(.system(size: 18, weight: .regular))
+                .foregroundColor(DSTokens.Colors.fgMuted)
+                .frame(width: 40, height: 40)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(label)
+    }
+
+    // MARK: - Save pill (composer.jsx:312-329)
+
+    private var savePill: some View {
+        Button(action: handleSave) {
+            HStack(spacing: 6) {
+                Text(NSLocalizedString("write.sheet.save", comment: "保存"))
+                    .font(DSFonts.inter(size: 13.5, weight: .semibold))
+                    .tracking(0.2)
+                Image(systemName: "checkmark")
+                    .font(.system(size: 11, weight: .bold))
+            }
+            .foregroundColor(canSave ? DSTokens.Colors.accentSoft : DSTokens.Colors.fgSubtle)
+            .padding(.horizontal, 16)
+            .frame(height: 38)
+            .background(
+                Capsule().fill(canSave ? DSTokens.Colors.accent : DSTokens.Colors.surfaceSunken)
+            )
+        }
+        .buttonStyle(.plain)
+        .disabled(!canSave)
+        .animation(.easeOut(duration: 0.18), value: canSave)
+        .accessibilityIdentifier("write-sheet-save")
+        .accessibilityLabel(NSLocalizedString("write.sheet.save", comment: "保存"))
+    }
+
+    // MARK: - Saved-to caption (composer.jsx:333-341)
+
+    private var savedCaption: some View {
+        HStack(spacing: 8) {
+            Text("SAVED TO")
+                .foregroundColor(DSTokens.Colors.fgSubtle)
+            Text("VAULT / \(isoDate).md")
+                .foregroundColor(DSTokens.Colors.fgMuted)
+        }
+        .font(DSFonts.jetBrainsMono(size: 9, weight: .semibold))
+        .tracking(1.4)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 22)
+        .padding(.top, 10)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: - Actions
+
+    private func handleSave() {
+        guard canSave else { return }
+        Haptics.medium()
+        isFocused = false
+        onSave()
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct WriteSheetView_Previews: PreviewProvider {
+    struct Harness: View {
+        @State private var text = ""
+        var body: some View {
+            ZStack {
+                DSTokens.Colors.bgWarm.ignoresSafeArea()
+                WriteSheetView(text: $text, onSave: {}, onClose: {})
+            }
+        }
+    }
+
+    static var previews: some View {
+        Harness()
+    }
+}
+#endif

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -39,6 +39,16 @@
 "recording.sheet.a11y"       = "Recording in progress";
 "recording.island.a11y"      = "Recording live activity";
 
+/* v8 WriteSheet — bottom-sheet text composer */
+"write.sheet.close"          = "Close";
+"write.sheet.placeholder"    = "What's on your mind?";
+"write.sheet.save"           = "Save";
+"write.sheet.words_unit"     = "chars";
+"write.sheet.icon.camera"    = "Camera";
+"write.sheet.icon.photo"     = "Photos";
+"write.sheet.icon.location"  = "Location";
+"write.sheet.icon.tag"       = "Tag";
+
 /* InputBarV4 — accessibility */
 "input.a11y.too_short"       = "Recording too short. Hold the mic and keep speaking.";
 "input.a11y.mic_hint"        = "Tap to open recorder; hold to send voice";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -39,6 +39,16 @@
 "recording.sheet.a11y"       = "正在录音";
 "recording.island.a11y"      = "录音进行中";
 
+/* v8 WriteSheet — bottom-sheet text composer */
+"write.sheet.close"          = "关闭";
+"write.sheet.placeholder"    = "此刻在想什么？";
+"write.sheet.save"           = "保存";
+"write.sheet.words_unit"     = "字";
+"write.sheet.icon.camera"    = "拍照";
+"write.sheet.icon.photo"     = "相册";
+"write.sheet.icon.location"  = "位置";
+"write.sheet.icon.tag"       = "标签";
+
 /* InputBarV4 — accessibility */
 "input.a11y.too_short"       = "录音太短，请按住麦克风继续说";
 "input.a11y.mic_hint"        = "单击打开录音页，长按发送语音";


### PR DESCRIPTION
## 概要
iOS 第二轮 v8「日式美术馆」对齐，承接 #541，补齐上一轮注明的三件后续。**`xcodebuild -scheme DayPage -destination 'iPhone 17'` → BUILD SUCCEEDED**（独立验证），App 启动未崩。**全自动 agent teams** 编排（Timeline→WriteSheet→ShareCard→pbxproj+build）。

## 三件
### 🎯 Timeline 挂轴 spine（重写）
`TimelineSectionView` 从「卡片带壳」重写为美术馆挂轴：一条连续 0.5pt hairline spine + 四种颗粒度 marker（日=实心点 / 周=横条 / 月=空心环 / 年=同心圆），52pt mono 铭牌列，fraunces 标题随颗粒度 20/22/24pt，内容浮于 bg-warm（无卡壳/圆角/阴影）。新文件 `TimelineRow.swift` 放 marker enum + 行脚手架 + title/lede/meta 子视图。保留 iOS 原生的「点击行内懒展开当日 raw memo」（优于 web 的跳 wiki）。

### ✍️ WriteSheet（新建）
`WriteSheetView.swift` 底部 sheet：drag handle + serif 星期 + mono 日期·时间 header + hairline 夹 18pt serif textarea（italic 占位、accent caret、auto-grow）+ 图标 rail + 「N 字」+ accent 保存胶囊 + 「SAVED TO VAULT / YYYY-MM-DD.md」caption。接入 InputBarV4 的 Aa 入口 + TodayView；保存复用既有 `submitCombinedMemo`（无新持久化路径）。

### 🎨 ShareCard 3 新模板
PosterStyle 加 `.film/.journal/.postcard`（中文 displayName 胶片/手账/明信片，并修正 polaroid→拍立得）。9 个新 renderer 覆盖核心 payload（memo/daily/photo），忠实装饰（胶片齿孔、手账胶带+横线、明信片虚线分隔+邮票）。PosterDispatcher 穷尽（5×7=35 行；monthly/quote/voice/collage 回退最近 renderer，无崩溃组合）。picker 按设计顺序显示 5 个。

## pbxproj
两个新文件已注册（TimelineRow A10000514/A20000514、WriteSheetView A10000513/A20000513），各 4 处平衡。新泛型脚手架改名 `TimelineRowScaffold` 以避开 TodayView.swift 既有的同名 `TimelineRow` 视图（agent 漏检的命名冲突，已修）。

## 已知
- 既有的 2 处重复 build-file 条目（TimelineSectionView/TimelineService，Xcode 自动跳过，非本 PR 引入）。
- 实机观感建议在干净 Xcode 手动确认（Simulator 环境干扰 GUI 截图，但编译通过、启动未崩）。