### PR TITLE
auto: Add a subtle haptic 'writing' texture to the AI 今日一句 typewriter reveal

### DIFF
--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -45,7 +45,8 @@ struct AISummaryCard: View {
                 header
                 TypewriterText(
                     fullText: summary,
-                    animated: !reduceMotion
+                    animated: !reduceMotion,
+                    hapticTexture: !reduceMotion
                 )
                 .font(DSType.serifQuote) // 18pt serif italic ≈ design 19pt
                 .foregroundColor(DSColor.inkPrimary)
@@ -137,6 +138,8 @@ private struct TappableCardAccessibility: ViewModifier {
 struct TypewriterText: View {
     let fullText: String
     var animated: Bool = true
+    /// When true, a soft haptic tick fires every 4th character during the reveal.
+    var hapticTexture: Bool = true
 
     @State private var shownCount: Int = 0
     @State private var caretVisible: Bool = true
@@ -193,6 +196,10 @@ struct TypewriterText: View {
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [gen] in
             guard gen == generation, shownCount < fullText.count else { return }
             shownCount += 1
+            // Soft haptic texture: every 4th char (skip final — completion has its own celebration).
+            if hapticTexture && animated && shownCount % 4 == 0 && shownCount < fullText.count {
+                Haptics.soft()
+            }
             // Reveal complete → stop the repeating blink and settle the caret
             // (the caret view itself disappears via `isTyping`, but halting the
             // animation prevents a lingering repeatForever on a hidden layer).


### PR DESCRIPTION
## Add a subtle haptic 'writing' texture to the AI 今日一句 typewriter reveal

The AISummaryCard reveals the compiled daily summary with a typewriter animation, but unlike every other signature moment in DayPage (orb capture pulse, compile celebration, escalating memo ticks) the reveal is silent. Add a throttled, very-soft haptic tick that fires every few characters as the summary types itself out, making the 'AI is writing your day' moment feel alive and on-brand with the app's haptic-rich language. Fully gated on Reduce Motion so it never fires when the animation is disabled.

### Acceptance
Build succeeds for the DayPage scheme on iPhone 17 simulator. When a daily summary is compiled and the AISummaryCard reveals on Today, a faint periodic haptic accompanies the typewriter reveal (~one soft tick per 4 characters) and stops cleanly when the text finishes. With Reduce Motion enabled, the text appears instantly with NO haptics. Changing/recompiling the summary restarts the reveal and its haptic texture without leftover ticks from the prior generation. No regression to the existing tap-to-open and long-press-to-copy interactions on the card.