### PR TITLE
auto: Make the CompileUnlockCard tappable to focus the composer

### DIFF
--- a/DayPage/Features/Today/CompileUnlockCard.swift
+++ b/DayPage/Features/Today/CompileUnlockCard.swift
@@ -12,8 +12,18 @@ import SwiftUI
 //   ┆      ● ● ○                ┆
 //   └╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴╴┘
 
+private struct PressScaleStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect((!reduceMotion && configuration.isPressed) ? 0.98 : 1.0)
+            .animation(.easeInOut(duration: 0.12), value: configuration.isPressed)
+    }
+}
+
 struct CompileUnlockCard: View {
     let memoCount: Int
+    var onTap: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var shimmer = false
@@ -22,7 +32,7 @@ struct CompileUnlockCard: View {
 
     private var remaining: Int { max(1, 3 - memoCount) }
 
-    var body: some View {
+    private var cardContent: some View {
         HStack(spacing: 14) {
             // Accent-soft sparkle tile with a subtle breathe shimmer.
             ZStack {
@@ -71,8 +81,29 @@ struct CompileUnlockCard: View {
                     style: StrokeStyle(lineWidth: 1.5, dash: [6, 5])
                 )
         )
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("再记 \(remaining) 条解锁今日成稿，已记 \(memoCount) 条")
+        .contentShape(Rectangle())
+    }
+
+    var body: some View {
+        Group {
+            if let onTap {
+                Button {
+                    Haptics.soft()
+                    onTap()
+                } label: {
+                    cardContent
+                }
+                .buttonStyle(PressScaleStyle())
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("再记 \(remaining) 条解锁今日成稿，已记 \(memoCount) 条")
+                .accessibilityHint("轻点聚焦输入框记录新内容")
+                .accessibilityAddTraits(.isButton)
+            } else {
+                cardContent
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel("再记 \(remaining) 条解锁今日成稿，已记 \(memoCount) 条")
+            }
+        }
         .onChange(of: memoCount) { newCount in
             guard newCount > lastFilled, !reduceMotion else {
                 lastFilled = newCount

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1271,7 +1271,7 @@ struct TodayView: View {
                 if !viewModel.memos.isEmpty
                     && !viewModel.isDailyPageCompiled
                     && viewModel.memos.count < 3 {
-                    CompileUnlockCard(memoCount: viewModel.memos.count)
+                    CompileUnlockCard(memoCount: viewModel.memos.count, onTap: { orbFocusToggle.toggle() })
                         .padding(.horizontal, 20)
                         .padding(.top, 4)
                         .transition(.opacity)


### PR DESCRIPTION
## Make the CompileUnlockCard tappable to focus the composer

The 'unlock today's page' card on Today tells the user to record N more memos but is a dead end — tapping it does nothing. Wire it to focus the composer input (reusing TodayView's existing `orbFocusToggle` plumbing, the same mechanism the empty-state orb already uses), turning the hint into a discoverable call-to-action with a confirming haptic.

### Acceptance
Build the DayPage scheme for iPhone 17 simulator and confirm it compiles. With 1–2 memos recorded today (uncompiled), the unlock card appears; tapping anywhere on it fires a soft haptic and focuses the composer input (keyboard rises). Existing dot-pop animation and dashed border are unchanged. VoiceOver announces the card as a button with the focus hint, and the card still reads its combined label. Reduce Motion users see no press-scale animation.