### PR TITLE
auto: Floating 'scroll to top' button on the Today timeline

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -236,6 +236,32 @@ struct TodayView: View {
                     }
                 }
                 .animation(Motion.rise, value: viewModel.lastDeletedMemo != nil)
+                // Scroll-to-top chevron — fades in at bottom-trailing when scrolled past 240pt
+                .overlay(alignment: .bottomTrailing) {
+                    if timelineScrollOffset < -240 && !viewModel.memos.isEmpty && !isInSelectionMode {
+                        Button {
+                            Haptics.soft()
+                            withAnimation(reduceMotion ? nil : Motion.spring) {
+                                timelineScrollProxy?.scrollTo("timelineTop", anchor: .top)
+                            }
+                        } label: {
+                            Image(systemName: "chevron.up")
+                                .font(DSType.bodySM)
+                                .foregroundColor(DSColor.inkMuted)
+                                .frame(width: 28, height: 28)
+                                .background(DSColor.glassStd)
+                                .background(.ultraThinMaterial, in: Circle())
+                                .overlay(Circle().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                                .clipShape(Circle())
+                        }
+                        .padding(.trailing, 20)
+                        .padding(.bottom, 96)
+                        .transition(.opacity.combined(with: .scale(scale: 0.8)))
+                        .accessibilityLabel("Scroll to top")
+                        .accessibilityIdentifier("scroll-to-top-button")
+                    }
+                }
+                .animation(reduceMotion ? nil : Motion.rise, value: timelineScrollOffset < -240)
                 // Submit error toast — scoped animation lives on the overlay
                 // container so only the toast itself animates, not the whole
                 // ZStack tree. (#217)


### PR DESCRIPTION
## Floating 'scroll to top' button on the Today timeline

When the Today timeline is scrolled down past the header, a small frosted-glass up-chevron button fades in at the bottom-trailing corner; tapping it springs the list back to the top with a soft haptic. All the plumbing already exists (`timelineScrollOffset` is tracked via `ScrollOffsetPreferenceKey`, and `timelineScrollProxy` can `scrollTo("timelineTop")`), so this is a purely additive, low-risk UX affordance that mirrors the existing glass-circle button styling used by the settings/export buttons.

### Acceptance
Build the DayPage scheme; launch in iPhone 17 simulator. With ≥4 memos, scroll the timeline down — the up-chevron button fades in at the bottom-trailing corner above the input bar. Tapping it springs the timeline back to the top with a soft haptic and the button fades out. The button never appears when memos are empty, when at the top, or in multi-select mode, and does not overlap the undo pill or input bar. With Reduce Motion on, the scroll is instant and no scale animation plays.