### PR TITLE
auto: Add a scroll-progress ring to the scroll-to-top chevron

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -109,6 +109,11 @@ struct TodayView: View {
 
     private var isInSelectionMode: Bool { selectedMemoIds != nil }
 
+    /// Progress of the scroll-to-top ring: 0 at 240pt (button appears), 1 after 1200pt more.
+    private var scrollProgress: CGFloat {
+        min(1, max(0, (-timelineScrollOffset - 240) / 1200))
+    }
+
     /// Live drag offset for the daily page card (negative = pulled left).
     @GestureState private var dailyPageDrag: CGFloat = 0
 
@@ -252,12 +257,23 @@ struct TodayView: View {
                                 .background(DSColor.glassStd)
                                 .background(.ultraThinMaterial, in: Circle())
                                 .overlay(Circle().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                                .overlay(
+                                    Circle()
+                                        .trim(from: 0, to: scrollProgress)
+                                        .stroke(
+                                            DSColor.accentAmber,
+                                            style: StrokeStyle(lineWidth: 1.5, lineCap: .round)
+                                        )
+                                        .rotationEffect(.degrees(-90))
+                                        .animation(reduceMotion ? nil : Motion.fade, value: scrollProgress)
+                                )
                                 .clipShape(Circle())
                         }
                         .padding(.trailing, 20)
                         .padding(.bottom, 96)
                         .transition(.opacity.combined(with: .scale(scale: 0.8)))
                         .accessibilityLabel("Scroll to top")
+                        .accessibilityHint("Returns to the top of today's timeline")
                         .accessibilityIdentifier("scroll-to-top-button")
                     }
                 }


### PR DESCRIPTION
## Add a scroll-progress ring to the scroll-to-top chevron

The Today timeline's scroll-to-top chevron (TodayView.swift:241) currently appears as a bare glass circle once the user scrolls past 240pt, giving no sense of how far down the timeline they are. Wrap it in a thin amber progress ring that fills as the user scrolls deeper, turning a pure utility affordance into an at-a-glance position indicator — a small, museum-aesthetic touch consistent with the app's existing glass + amber language.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator. Add 15+ memos (or scroll a long timeline) so the chevron appears; as you scroll further down, a thin amber arc around the chevron grows clockwise from empty toward a full ring, and shrinks as you scroll back up. Tapping the chevron still scrolls to the top with a soft haptic. With Reduce Motion enabled the ring updates without animating. VoiceOver reads the new hint. No regressions to the chevron's fade-in/out at the 240pt threshold.