### PR TITLE
auto: Add a live 'time of day' progress arc to the empty-state Day Orb

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -14,6 +14,8 @@ struct DayOrbView: View {
     /// Flip this bool to trigger a one-shot capture-reward glow pulse (scale 1.0→1.10→1.0).
     /// Only fires when a new memo is added; caller is responsible for only toggling on additions.
     var pulseToggle: Bool = false
+    /// Fraction of the current day elapsed (0 at local midnight, 1.0 at next midnight).
+    var dayProgress: CGFloat = 0
 
     @State private var breatheScale: CGFloat = 1.0
     @State private var pulse: Bool = false
@@ -26,10 +28,12 @@ struct DayOrbView: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     private var accessibilityLabelText: String {
-        if signalCount == 0 { return "Day orb, no signals yet" }
+        let pct = Int(dayProgress * 100)
+        let dayPart = "\(pct)% of the day elapsed"
+        if signalCount == 0 { return "Day orb, no signals yet, \(dayPart)" }
         let word = signalCount == 1 ? "signal" : "signals"
         let status = readoutLabel.lowercased()
-        return "Day orb, \(signalCount) \(word) today, \(status)"
+        return "Day orb, \(signalCount) \(word) today, \(status), \(dayPart)"
     }
 
     var body: some View {
@@ -38,6 +42,7 @@ struct DayOrbView: View {
             halo
             if pulse { pulseHalo }
             orb
+            dayProgressArc
         }
         .frame(width: size + 32, height: size + 32)
         .scaleEffect(isPressed ? breatheScale * 0.94 : breatheScale)
@@ -111,6 +116,22 @@ struct DayOrbView: View {
                 invitePulse = true
             }
         }
+    }
+
+    // MARK: - Day Progress Arc
+
+    // Thin amber arc around the orb outer edge filling from 0 (midnight) to 1.0 (next midnight).
+    private var dayProgressArc: some View {
+        Circle()
+            .trim(from: 0, to: dayProgress)
+            .stroke(
+                DSColor.accentAmber.opacity(0.55),
+                style: StrokeStyle(lineWidth: 2, lineCap: .round)
+            )
+            .rotationEffect(.degrees(-90))
+            .frame(width: size + 6, height: size + 6)
+            .animation(reduceMotion ? nil : .linear(duration: 1), value: dayProgress)
+            .allowsHitTesting(false)
     }
 
     // MARK: - Pulse Halo

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -114,6 +114,14 @@ struct TodayView: View {
         min(1, max(0, (-timelineScrollOffset - 240) / 1200))
     }
 
+    /// Fraction of the current local day elapsed (0.0 at midnight, 1.0 at next midnight).
+    private var dayProgress: CGFloat {
+        let now = currentTime
+        let start = Calendar.current.startOfDay(for: now)
+        let elapsed = now.timeIntervalSince(start)
+        return CGFloat(min(1, max(0, elapsed / 86400)))
+    }
+
     /// Live drag offset for the daily page card (negative = pulled left).
     @GestureState private var dailyPageDrag: CGFloat = 0
 
@@ -780,7 +788,7 @@ struct TodayView: View {
             DayOrbView(signalCount: signalCount, size: 140, onTap: {
                 Haptics.tapConfirm()
                 orbFocusToggle.toggle()
-            }, pulseToggle: orbCapturePulse)
+            }, pulseToggle: orbCapturePulse, dayProgress: dayProgress)
             .scaleEffect(reduceMotion ? 1.0 : (orbBreathing ? 1.03 : 0.985))
             .shadow(
                 color: DSColor.accentAmber.opacity(orbBreathing ? 0.28 + glowBoost : 0.12 + glowBoost),


### PR DESCRIPTION
## Add a live 'time of day' progress arc to the empty-state Day Orb

The Day Orb hero (shown when today has zero memos) currently only breathes and reacts to signal count, but conveys nothing about how much of the day has elapsed — a missed ambient cue for a daily-capture app aimed at nomads who lose track of time across zones. Add a thin amber progress arc around the orb that fills from 0 at local midnight to 1.0 at the next midnight, giving an at-a-glance 'the day is slipping by, capture something' nudge that reinforces the core daily-logging loop.

### Acceptance
Build the DayPage scheme succeeds. On iPhone 17 simulator with zero memos today, the Day Orb shows a thin amber arc whose filled fraction matches the current local time-of-day (e.g. ~50% fill at noon); the arc respects the app's configured time zone (verify by changing time zone in Settings). With Reduce Motion on, the arc renders at the correct static fraction without animating. When a memo is added and the orb hero hides, no regression occurs. VoiceOver reads the percent-of-day-elapsed value on the orb.