### PR TITLE
auto: Warm up the onboarded zero-memo empty state with an orb accent + capture CTA

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -189,11 +189,13 @@ extension EmptyStateView {
     }
 
     /// Today tab — memos exist but no signal cards generated.
-    static func todayNoSignals() -> EmptyStateView {
+    static func todayNoSignals(ctaAction: (() -> Void)? = nil) -> EmptyStateView {
         EmptyStateView(
             title: L10n.Empty.todayNoSignalsTitle,
             subtitle: L10n.Empty.todayNoSignalsSubtitle,
-            showOrbAccent: false
+            ctaLabel: ctaAction != nil ? L10n.Empty.todayBlankCta : nil,
+            ctaAction: ctaAction,
+            showOrbAccent: true
         )
     }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -558,7 +558,7 @@ struct TodayView: View {
                 onThisDayDateString = dateString
             }
         case .pureEmpty:
-            EmptyStateView.todayNoSignals()
+            EmptyStateView.todayNoSignals(ctaAction: { orbFocusToggle.toggle() })
                 .padding(.horizontal, 20)
         }
     }


### PR DESCRIPTION
## Warm up the onboarded zero-memo empty state with an orb accent + capture CTA

When an onboarded user opens Today on a day with no memos and no fallback content (the .pureEmpty branch), EmptyStateView.todayNoSignals() currently renders a flat title+subtitle with showOrbAccent:false and no CTA — unlike the first-run todayBlank state which gets the warm breathing orb and a call-to-action. This is a daily-recurring moment for active users, so give it the same breathing orb accent and a 'start capturing' CTA that focuses the composer, making the two empty states visually consistent and the pure-empty state actionable.

### Acceptance
Build the DayPage scheme cleanly. On iPhone 17 Simulator, with an onboarded account on a day that has zero memos and no yesterday/on-this-day/recap fallback, the Today timeline empty state shows the warm breathing amber orb accent above the title and a capital 'capture' CTA capsule that, when tapped, focuses the composer input (keyboard rises). The reveal animation stages (orb → title → subtitle → CTA glow) play once on appear and respect Reduce Motion (instant, no breathing). The existing 'No Signals' SwiftUI preview (no CTA passed) still renders without a button and without crashing.