### PR TITLE
auto: Undo for cleared recent searches in Search

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -20,6 +20,8 @@ final class SearchViewModel: ObservableObject {
     private let recentKey = "search.recentQueries"
     private let maxRecent = 10
 
+    @Published var lastClearedSearches: [String]? = nil
+
     var recentSearches: [String] {
         get { UserDefaults.standard.stringArray(forKey: recentKey) ?? [] }
         set {
@@ -111,7 +113,17 @@ final class SearchViewModel: ObservableObject {
     }
 
     func clearRecentSearches() {
+        let current = recentSearches
+        guard !current.isEmpty else { return }
+        lastClearedSearches = current
         recentSearches = []
+        objectWillChange.send()
+    }
+
+    func undoClearRecentSearches() {
+        guard let snapshot = lastClearedSearches else { return }
+        recentSearches = snapshot
+        lastClearedSearches = nil
         objectWillChange.send()
     }
 
@@ -218,6 +230,21 @@ struct SearchView: View {
                         .animation(.easeInOut(duration: 0.2), value: vm.hasSearched)
                         .animation(.easeInOut(duration: 0.2), value: vm.results.isEmpty)
                 }
+                .overlay(alignment: .bottom) {
+                    if vm.lastClearedSearches != nil {
+                        UndoPillView(
+                            label: NSLocalizedString("search.undo.cleared", comment: "Undo clear recent searches pill label")
+                        ) {
+                            Haptics.soft()
+                            vm.undoClearRecentSearches()
+                        } onDismiss: {
+                            vm.lastClearedSearches = nil
+                        }
+                        .padding(.bottom, 40)
+                        .transition(.move(edge: .bottom).combined(with: .opacity))
+                    }
+                }
+                .animation(Motion.rise, value: vm.lastClearedSearches != nil)
             }
             .navigationBarHidden(true)
             .animation(.easeInOut(duration: 0.2), value: showFilters)

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -237,4 +237,4 @@
 "voice.retry.failed_permanent" = "Transcription unavailable";
 "voice.retry.failed_permanent_a11y" = "Transcription permanently failed after 3 attempts. Audio is saved.";
 
-"search.undo.cleared" = "已清除搜索记录";
+"search.undo.cleared" = "Recent searches cleared";

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -236,3 +236,5 @@
 "voice.retry.transcribing"     = "Transcribing…";
 "voice.retry.failed_permanent" = "Transcription unavailable";
 "voice.retry.failed_permanent_a11y" = "Transcription permanently failed after 3 attempts. Audio is saved.";
+
+"search.undo.cleared" = "已清除搜索记录";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -264,3 +264,5 @@
 "voice.retry.transcribing"     = "正在转写…";
 "voice.retry.failed_permanent" = "转写不可用";
 "voice.retry.failed_permanent_a11y" = "已重试 3 次，转写失败。音频已保存。";
+
+"search.undo.cleared" = "已清除搜索记录";


### PR DESCRIPTION
## Undo for cleared recent searches in Search

Clearing recent searches in SearchView is instantly destructive with no recovery, unlike memo send/delete elsewhere in the app which both surface a 5-second UndoPillView. Add a snapshot-and-restore undo so a mis-tapped '清除' (Clear all) is reversible, matching the app's established undo pattern and reusing the existing UndoPillView component.

### Acceptance
Tapping '清除' on the 最近搜索 header clears the list AND surfaces a bottom undo pill for ~5s; tapping 撤销/Undo restores every previously-listed query in its original order and dismisses the pill; the pill auto-dismisses after 5s if untouched; reduce-motion is respected (inherited from UndoPillView); the same component (UndoPillView) and Motion.rise transition as the memo-undo pills are used. `xcodebuild -scheme DayPage build` succeeds and existing tests pass.