### PR TITLE
auto: Add consistent haptic feedback to TodayView header buttons (settings gear & AI summary tap)

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -690,10 +690,12 @@ struct TodayView: View {
                 summary: viewModel.dailyPageSummary,
                 onTap: {
                     if dailyPageRevealed {
+                        Haptics.soft()
                         withAnimation(Motion.spring) {
                             dailyPageRevealed = false
                         }
                     } else {
+                        Haptics.tapConfirm()
                         showDailyPage = true
                     }
                 }
@@ -1161,6 +1163,7 @@ struct TodayView: View {
             }
 
             Button {
+                Haptics.soft()
                 showSettings = true
             } label: {
                 Image(systemName: "gearshape")
@@ -1213,7 +1216,7 @@ struct TodayView: View {
                 // at the very top once the day has a compiled summary.
                 if let summary = viewModel.dailyPageSummary,
                    !summary.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    AISummaryCard(summary: summary, onTap: { showDailyPage = true })
+                    AISummaryCard(summary: summary, onTap: { Haptics.tapConfirm(); showDailyPage = true })
                         .padding(.horizontal, 20)
                         .padding(.bottom, 4)
                         .transition(.opacity)


### PR DESCRIPTION
## Add consistent haptic feedback to TodayView header buttons (settings gear & AI summary tap)

Nearly every interactive element in TodayView fires a Haptics.* call on tap (orb, compile, share, scroll-to-top, selection toolbar), but the header Settings gear button and the AISummaryCard tap navigate with no tactile response, making the header feel inconsistent and less responsive. This adds the missing soft/tapConfirm haptics so every tap target in the primary screen feels uniformly alive, a small accessibility and polish win.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator with no errors. Tapping the Settings gear, the top AI one-line summary card, and the Daily Page card each produce a haptic on a physical device (verify the Haptics.* calls are wired and compile). No change to navigation behavior, layout, or VoiceOver labels; reduce-motion and existing accessibility actions remain intact.