### PR TITLE
auto: Add a keyboard accessory toolbar with quick-Save to the WriteSheet composer

### DIFF
--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -288,6 +288,11 @@ struct WriteSheetView: View {
                 .lineLimit(3...10)
                 .focused($isFocused)
                 .accessibilityIdentifier("write-sheet-input")
+                .toolbar {
+                    ToolbarItemGroup(placement: .keyboard) {
+                        keyboardToolbarContent
+                    }
+                }
         }
         .padding(.horizontal, 22)
         .padding(.top, 20)
@@ -394,6 +399,53 @@ struct WriteSheetView: View {
         .padding(.horizontal, 22)
         .padding(.top, 10)
         .accessibilityHidden(true)
+    }
+
+    // MARK: - Keyboard accessory toolbar
+
+    @ViewBuilder
+    private var keyboardToolbarContent: some View {
+        // Done — collapses keyboard, reveals footer rail and saved caption.
+        Button(NSLocalizedString("write.sheet.done", comment: "完成")) {
+            isFocused = false
+        }
+        .font(DSFonts.inter(size: 14, weight: .medium))
+        .foregroundColor(DSTokens.Colors.fgMuted)
+        .accessibilityLabel(NSLocalizedString("write.sheet.done", comment: "完成"))
+
+        // Live word / char counter — reuses footer-rail mono10 style.
+        let wordsLabel = wordCount == 1
+            ? NSLocalizedString("writesheet.count.words.one", comment: "1 word")
+            : String(format: NSLocalizedString("writesheet.count.words.other", comment: "%d words"), wordCount)
+        Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+            .font(DSType.mono10)
+            .tracking(1.0)
+            .textCase(.uppercase)
+            .monospacedDigit()
+            .foregroundColor(wordCountColor)
+            .modifier(NumericTextContentTransition(value: Double(wordCount), reduceMotion: reduceMotion))
+            .animation(reduceMotion ? nil : Motion.spring, value: wordCount)
+            .accessibilityLabel("\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+
+        Spacer()
+
+        // Accent save button — same path as the footer-rail pill.
+        Button(action: handleSave) {
+            Text(NSLocalizedString("write.sheet.save", comment: "保存"))
+                .font(DSFonts.inter(size: 14, weight: .semibold))
+                .tracking(0.2)
+                .foregroundColor(canSave ? DSTokens.Colors.accentSoft : DSTokens.Colors.fgSubtle)
+                .padding(.horizontal, 14)
+                .frame(height: 32)
+                .background(
+                    Capsule().fill(canSave ? DSTokens.Colors.accent : DSTokens.Colors.surfaceSunken)
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(!canSave)
+        .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: canSave)
+        .accessibilityLabel(NSLocalizedString("write.sheet.save", comment: "保存"))
+        .accessibilityIdentifier("write-sheet-keyboard-save")
     }
 
     // MARK: - Actions

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -43,6 +43,7 @@
 "write.sheet.close"          = "Close";
 "write.sheet.placeholder"    = "What's on your mind?";
 "write.sheet.save"           = "Save";
+"write.sheet.done"           = "Done";
 "write.sheet.words_unit"     = "chars";
 "write.sheet.icon.camera"    = "Camera";
 "write.sheet.icon.photo"     = "Photos";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -43,6 +43,7 @@
 "write.sheet.close"          = "关闭";
 "write.sheet.placeholder"    = "此刻在想什么？";
 "write.sheet.save"           = "保存";
+"write.sheet.done"           = "完成";
 "write.sheet.words_unit"     = "字";
 "write.sheet.icon.camera"    = "拍照";
 "write.sheet.icon.photo"     = "相册";


### PR DESCRIPTION
## Add a keyboard accessory toolbar with quick-Save to the WriteSheet composer

The WriteSheetView bottom-sheet composer keeps its 「保存」 save pill in the footer rail, which the system keyboard overlays while typing — so on smaller iPhones the user can't reach Save without first dismissing the keyboard. Add a `.toolbar { ToolbarItemGroup(placement: .keyboard) }` accessory bar pinned above the keyboard with a live word count on the left and an accent 「保存」 button on the right that routes through the existing `handleSave()` path, plus a 'Done' affordance to drop focus and reveal the full sheet.

### Acceptance
Build the DayPage scheme on iPhone 17. Open Today → tap the dock's write affordance to present WriteSheet → keyboard rises automatically. A toolbar appears directly above the keyboard showing word/char count on the left and an accent 保存 button on the right; the 保存 button is disabled when the field is empty/whitespace-only and enabled once text is entered. Tapping 保存 saves the memo via submitCombinedMemo (verify the new entry appears in the timeline and in vault/raw/YYYY-MM-DD.md), shows the undo pill, and dismisses the sheet — identical behavior to the footer pill. Tapping 'Done' collapses the keyboard without closing the sheet, revealing the footer rail and SAVED-TO caption. VoiceOver reads the toolbar Save button label; with Reduce Motion on, no extra animations fire.