### PR TITLE
fix(ui): compact header when memos exist + floating banners + bottom gradient

### DIFF
--- a/DayPage/DesignSystem/Colors.swift
+++ b/DayPage/DesignSystem/Colors.swift
@@ -49,7 +49,7 @@ enum DSColor {
     // migrates.
 
     /// Page background — warm cream in light, deep charcoal-brown in dark.
-    static let bgWarm        = Color(light: Color(hex: "FAF7F2"), dark: Color(hex: "1A1410"))
+    static let bgWarm        = Color(light: Color(hex: "FAF8F6"), dark: Color(hex: "1A1410"))
     /// Standard glass fill — adaptive opacity glass layer.
     static let glassStd      = Color(light: Color(red: 1, green: 252/255, blue: 250/255, opacity: 0.62),
                                      dark: Color(red: 30/255, green: 22/255, blue: 14/255, opacity: 0.62))

--- a/DayPage/Features/Shared/AppBanner.swift
+++ b/DayPage/Features/Shared/AppBanner.swift
@@ -187,7 +187,9 @@ struct BannerOverlayModifier: ViewModifier {
     @ObservedObject private var bannerCenter = BannerCenter.shared
 
     func body(content: Content) -> some View {
-        content.overlay(alignment: .top) {
+        // ZStack keeps the banner floating above content without shifting layout.
+        ZStack(alignment: .top) {
+            content
             if let banner = bannerCenter.currentBanner {
                 AppBanner(model: banner)
                     .padding(.top, 8)

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -4,6 +4,20 @@ import Photos
 import PhotosUI
 import UIKit
 
+// MARK: - BlinkingModifier (composer.jsx caret animation)
+private struct BlinkingModifier: ViewModifier {
+    @State private var visible = true
+    func body(content: Content) -> some View {
+        content
+            .opacity(visible ? 1 : 0)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 0.6).repeatForever()) {
+                    visible = false
+                }
+            }
+    }
+}
+
 // MARK: - InputBarV4  "Capture v2 · STREAM dock"
 //
 // Capture v2 surface, faithful to the design-handoff STREAM variation:
@@ -372,20 +386,53 @@ struct InputBarV4: View {
     // shadow stack approximating the iOS 26 Liquid Glass treatment from the
     // design canvas (inner highlight + soft drop shadow).
 
-    // STREAM dock — glass capsule wrapping three keys (design spec: glassStyle hi + radius 999).
-    // US-008: matchedGeometryEffect on the capsule background so it morphs into
-    // the composing card shape. The mic orb also carries its own effect so it
-    // slides to the card's bottom-left corner rather than disappearing.
+    // STREAM dock — full-width warm pill (design composer.jsx:82-166).
+    // Layout: [+36] [记下此刻 italic flex] [mic 50×44]
+    // Background: rgba(255,253,250,0.84) warm-white blur, 4-layer shadow stack.
     private var streamDockMorph: some View {
-        HStack(spacing: 6) {
-            // LEFT — More (+)
-            dockSideButton(systemImage: "plus", accessibilityLabel: NSLocalizedString("input.a11y.more_attachments", comment: "")) {
+        HStack(spacing: 4) {
+            // LEFT — attach (+), 36×44 transparent
+            Button {
+                Haptics.soft()
                 showAttachmentMenu = true
+            } label: {
+                Image(systemName: "plus")
+                    .font(.system(size: 18, weight: .regular))
+                    .foregroundStyle(DSColor.inkMuted)
+                    .frame(width: 36, height: 44)
+                    .contentShape(Rectangle())
             }
+            .buttonStyle(.plain)
+            .accessibilityLabel(NSLocalizedString("input.a11y.more_attachments", comment: ""))
 
-            // CENTER — amber mic orb.
-            // US-010: matchedGeometryEffect removed — the composing card no longer
-            // hosts the orb landing target (toolbar moved to .keyboard placement).
+            // CENTER — italic text stub, taps to open WriteSheet
+            Button {
+                Haptics.soft()
+                if let openSheet = onOpenWriteSheet {
+                    openSheet()
+                } else {
+                    transition(to: .expanding)
+                    isFocused = true
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(NSLocalizedString("input.hint.placeholder", comment: "记下此刻"))
+                        .font(DSFonts.serif(size: 15.5, italic: true))
+                        .foregroundStyle(DSColor.inkSubtle)
+                        .lineLimit(1)
+                    Rectangle()
+                        .fill(DSColor.amberDeep.opacity(0.5))
+                        .frame(width: 2, height: 14)
+                        .modifier(BlinkingModifier())
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 4)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(NSLocalizedString("input.a11y.write_text", comment: ""))
+            .accessibilityIdentifier("expand-text-composer")
+
+            // RIGHT — mic orb, 50×44, deep amber gradient
             PressToTalkButton(
                 onPressStart: handlePressToTalkStart,
                 onReleaseSend: handlePressToTalkReleaseSend,
@@ -394,46 +441,31 @@ struct InputBarV4: View {
                 onPhaseChange: { pressToTalkPhase = $0 },
                 onTapShortRelease: handleMicTap,
                 size: 44,
-                idleBackgroundColor: DSColor.amberAccent,
+                idleBackgroundColor: DSColor.amberDeep,
                 idleIconColor: .white
             )
-            // Design composer.jsx:139-141 — slim 50×44 pill, not a 64 square.
-            // The button core is a 44 circle centered in a 50-wide frame so the
-            // mic reads as a restrained accent rather than an oversized orb.
             .frame(width: 50, height: 44)
             .shadow(color: Color(hex: "5D3000").opacity(0.45), radius: 10, x: 0, y: 4)
             .shadow(color: Color(hex: "5D3000").opacity(0.18), radius: 1, x: 0, y: 1)
             .accessibilityLabel(NSLocalizedString("input.a11y.mic", comment: ""))
             .accessibilityHint(NSLocalizedString("input.a11y.mic_hint_full", comment: ""))
-
-            // RIGHT — Aa (text affordance). v8: opens the WriteSheet bottom
-            // sheet (composer.jsx:116-129 text stub → WriteSheet). Falls back to
-            // the inline morph when no sheet handler is wired (previews / tests).
-            dockTextButton(accessibilityLabel: NSLocalizedString("input.a11y.write_text", comment: "")) {
-                if let openSheet = onOpenWriteSheet {
-                    openSheet()
-                } else {
-                    transition(to: .expanding)
-                    isFocused = true
-                }
-            }
-            .accessibilityIdentifier("expand-text-composer")
         }
-        .padding(6)
-        // NOTE: matchedGeometryEffect was removed — the idle Capsule and the
-        // composing RoundedRectangle (20pt) cannot be linearly interpolated
-        // by SwiftUI as a single shape, and sharing one ID across two
-        // mutually-exclusive branches caused the layout system to re-measure
-        // both candidates on every body re-evaluation. The branches simply
-        // cross-fade now via the existing isComposing condition. (#258)
-        .background(.ultraThinMaterial, in: Capsule())
-        .overlay(Capsule().strokeBorder(
-            LinearGradient(
-                colors: [Color.white.opacity(0.55), Color.white.opacity(0.12)],
-                startPoint: .top, endPoint: .bottom),
-            lineWidth: 0.6))
-        .shadow(color: Color(hex: "2D1E0A").opacity(0.10), radius: 24, x: 0, y: 8)
-        .shadow(color: Color(hex: "2D1E0A").opacity(0.06), radius: 4, x: 0, y: 1)
+        .padding(.leading, 10)
+        .padding(.trailing, 6)
+        .padding(.vertical, 6)
+        .background(
+            Capsule()
+                .fill(Color(red: 1, green: 253/255, blue: 250/255).opacity(0.84))
+                .background(.ultraThinMaterial, in: Capsule())
+        )
+        .overlay(
+            Capsule().strokeBorder(
+                Color(red: 214/255, green: 206/255, blue: 192/255).opacity(0.55),
+                lineWidth: 0.5
+            )
+        )
+        .shadow(color: Color(hex: "3C280F").opacity(0.22), radius: 16, x: 0, y: 9)
+        .shadow(color: Color(hex: "3C280F").opacity(0.08), radius: 3, x: 0, y: 1)
     }
 
     @ViewBuilder

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1092,14 +1092,26 @@ struct TodayView: View {
             Button {
                 nav.openSidebar()
             } label: {
-                VStack(alignment: .leading, spacing: 8) {
-                    // Museum-aesthetic hero title — always-on 56pt serif.
-                    Text(weekdayName(currentTime))
-                        .font(DSType.serifDisplay56)
-                        .foregroundColor(DSColor.inkPrimary)
-                        .lineLimit(1)
-                        .dynamicTypeSize(.xSmall ... .accessibility2)
-                        .minimumScaleFactor(0.6)
+                // Compact header when memos exist: content first, date chip only.
+                // Full 56pt hero reserved for the empty-day capture prompt.
+                if viewModel.memos.isEmpty {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text(weekdayName(currentTime))
+                            .font(DSType.serifDisplay56)
+                            .foregroundColor(DSColor.inkPrimary)
+                            .lineLimit(1)
+                            .dynamicTypeSize(.xSmall ... .accessibility2)
+                            .minimumScaleFactor(0.6)
+                        Text(headerSubline(currentTime))
+                            .font(DSType.mono10)
+                            .foregroundColor(DSColor.inkSubtle)
+                            .textCase(.uppercase)
+                            .tracking(1.0)
+                            .dynamicTypeSize(.xSmall ... .accessibility5)
+                            .minimumScaleFactor(0.75)
+                            .accessibilityLabel(headerSublineAccessibilityLabel(currentTime))
+                    }
+                } else {
                     Text(headerSubline(currentTime))
                         .font(DSType.mono10)
                         .foregroundColor(DSColor.inkSubtle)
@@ -1203,8 +1215,9 @@ struct TodayView: View {
             .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 6 }
         }
         .padding(.horizontal, 14)
-        .padding(.top, 16)
-        .padding(.bottom, 10)
+        .padding(.top, viewModel.memos.isEmpty ? 16 : 10)
+        .padding(.bottom, viewModel.memos.isEmpty ? 10 : 6)
+        .animation(reduceMotion ? nil : Motion.fade, value: viewModel.memos.isEmpty)
         .onReceive(headerTimer) { date in
             currentTime = date
         }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -20,7 +20,8 @@
 "compile.dock.unlocked" = "Daily compilation unlocked";
 
 /* InputBarV4 — press-to-talk hint states */
-"input.hint.idle"            = "Hold to record · Release to transcribe";
+"input.hint.placeholder"     = "记下此刻";
+"input.hint.idle"            = "轻点书写 · 长按录音";
 "input.hint.pre_recording"   = "Hold a moment longer";
 "input.hint.recording"       = "Swipe up to cancel · Left to transcribe · Release to send";
 "input.hint.cancel_armed"    = "Release to cancel";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -20,7 +20,8 @@
 "compile.dock.unlocked" = "已解锁今日编译";
 
 /* InputBarV4 — press-to-talk hint states */
-"input.hint.idle"            = "按住录音 · 松手转文字";
+"input.hint.placeholder"     = "记下此刻";
+"input.hint.idle"            = "轻点书写 · 长按录音";
 "input.hint.pre_recording"   = "再按住一下";
 "input.hint.recording"       = "上滑取消 · 左滑转文字 · 松开发送";
 "input.hint.cancel_armed"    = "松开取消";

--- a/web/src/app/(app)/today/ComposerPill.tsx
+++ b/web/src/app/(app)/today/ComposerPill.tsx
@@ -136,10 +136,13 @@ export function ComposerPill({
     <div
       style={{
         position: "absolute",
-        bottom: "calc(26px + env(safe-area-inset-bottom, 0px))",
+        bottom: 0,
         left: 0,
         right: 0,
-        padding: "0 14px",
+        paddingTop: 48,
+        paddingLeft: 14,
+        paddingRight: 14,
+        paddingBottom: "calc(22px + env(safe-area-inset-bottom, 0px))",
         display: "flex",
         flexDirection: "column",
         alignItems: "center",
@@ -147,6 +150,8 @@ export function ComposerPill({
         opacity: isRecording ? 0 : 1,
         transition: "opacity 180ms ease-out",
         zIndex: 20,
+        background:
+          "linear-gradient(to bottom, transparent 0%, rgba(250,248,246,0.72) 38%, rgba(250,248,246,0.96) 68%, #FAF8F6 100%)",
       }}
     >
       {/* Permission denied toast */}

--- a/web/src/app/(app)/today/MemoCard.tsx
+++ b/web/src/app/(app)/today/MemoCard.tsx
@@ -373,17 +373,15 @@ function CompileStatusBar({
   const isPending = status === "pending";
   const isRunning = status === "running";
   const isFailed = status === "failed";
-  const showDisconnected = isPending && !serviceConnected;
+  // When disconnected, a page-level toast already notifies the user — don't
+  // crowd every card with a repetitive inline notice.
+  if (isPending && !serviceConnected) return null;
 
   let icon: React.ReactNode;
   let label: string;
   let tone: string; // text color
 
-  if (showDisconnected) {
-    icon = <AlertCircle size={12} strokeWidth={1.9} aria-hidden="true" />;
-    label = "编译服务未连接（运行 pnpm run dev:inngest）";
-    tone = "var(--fg-muted)";
-  } else if (isFailed) {
+  if (isFailed) {
     icon = <AlertCircle size={12} strokeWidth={1.9} aria-hidden="true" />;
     label = memo.compile_error?.trim() || "编译失败";
     tone = "var(--accent, #c2410c)";

--- a/web/src/app/(app)/today/TodayHero.tsx
+++ b/web/src/app/(app)/today/TodayHero.tsx
@@ -70,7 +70,7 @@ export function TodayHero() {
   // Loading state
   if (!data && !error) {
     return (
-      <div style={{ paddingTop: 8, paddingBottom: 24 }}>
+      <div style={{ paddingTop: 4, paddingBottom: 18 }}>
         <div
           style={{
             height: 56,
@@ -90,7 +90,7 @@ export function TodayHero() {
   // "MAY 28 · — · — · —" string with a single quiet retry affordance.
   if (error || !data) {
     return (
-      <div style={{ paddingTop: 8, paddingBottom: 24 }}>
+      <div style={{ paddingTop: 4, paddingBottom: 18 }}>
         <h1
           style={{
             fontFamily: "var(--font-serif)",
@@ -143,7 +143,7 @@ export function TodayHero() {
   const weatherTemp = weather.temp !== null ? `${weather.temp}°` : null;
 
   return (
-    <div style={{ paddingTop: 8, paddingBottom: 24 }}>
+    <div style={{ paddingTop: 4, paddingBottom: 18 }}>
       <h1
         style={{
           fontFamily: "var(--font-serif)",

--- a/web/src/app/(app)/today/page.tsx
+++ b/web/src/app/(app)/today/page.tsx
@@ -22,9 +22,11 @@ import { MobileOnlyGuard } from "./MobileOnlyGuard";
 function MemoFeed({
   composerMicRef,
   onShare,
+  onServiceDisconnected,
 }: {
   composerMicRef: React.RefObject<HTMLButtonElement | null>;
   onShare: (memo: ShareCardMemo) => void;
+  onServiceDisconnected?: () => void;
 }) {
   const [memos, setMemos] = useState<MemoCardData[]>([]);
   const [serviceConnected, setServiceConnected] = useState(true);
@@ -43,10 +45,13 @@ function MemoFeed({
     fetch("/api/compile/status")
       .then((r) => (r.ok ? r.json() : null))
       .then((d: { connected: boolean } | null) => {
-        if (d) setServiceConnected(d.connected);
+        if (d) {
+          setServiceConnected(d.connected);
+          if (!d.connected) onServiceDisconnected?.();
+        }
       })
       .catch(() => {});
-  }, [reloadMemos]);
+  }, [reloadMemos, onServiceDisconnected]);
 
   const handleRetry = useCallback(
     (id: string) => {
@@ -98,6 +103,7 @@ function TodayMobileFlow() {
   const [writeOpen, setWriteOpen] = useState(false);
   const [showAttachSheet, setShowAttachSheet] = useState(false);
   const [shareMemo, setShareMemo] = useState<ShareCardMemo | null>(null);
+  const [showServiceToast, setShowServiceToast] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
   const rafRef = useRef<number | null>(null);
   const composerMicRef = useRef<HTMLButtonElement | null>(null);
@@ -170,7 +176,7 @@ function TodayMobileFlow() {
         position: "relative",
         height: "100%",
         overflowY: "auto",
-        paddingTop: 60,
+        paddingTop: 52,
         paddingLeft: 14,
         paddingRight: 14,
         paddingBottom: 10,
@@ -185,16 +191,15 @@ function TodayMobileFlow() {
           top: 0,
           left: 0,
           right: 0,
-          height: 60,
+          height: 52,
           display: "flex",
           alignItems: "center",
           justifyContent: "space-between",
           paddingLeft: 14,
           paddingRight: 14,
-          paddingBottom: 10,
-          background: scrolled ? "rgba(250,248,246,0.78)" : "transparent",
-          backdropFilter: scrolled ? "blur(20px) saturate(150%)" : "none",
-          WebkitBackdropFilter: scrolled ? "blur(20px) saturate(150%)" : "none",
+          background: scrolled ? "rgba(250,248,246,0.82)" : "transparent",
+          backdropFilter: scrolled ? "blur(20px) saturate(160%)" : "none",
+          WebkitBackdropFilter: scrolled ? "blur(20px) saturate(160%)" : "none",
           borderBottom: scrolled
             ? "0.5px solid var(--border-subtle)"
             : "0.5px solid transparent",
@@ -217,6 +222,75 @@ function TodayMobileFlow() {
         </div>
       </div>
 
+      {/* Service disconnected toast — floats at top, auto-dismiss after 6s */}
+      {showServiceToast && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            position: "fixed",
+            top: "calc(64px + env(safe-area-inset-top, 0px))",
+            left: "50%",
+            transform: "translateX(-50%)",
+            zIndex: 50,
+            display: "flex",
+            alignItems: "center",
+            gap: 8,
+            padding: "9px 14px 9px 12px",
+            borderRadius: 999,
+            background: "rgba(43,40,34,0.88)",
+            backdropFilter: "blur(16px) saturate(140%)",
+            WebkitBackdropFilter: "blur(16px) saturate(140%)",
+            boxShadow: "0 4px 20px rgba(0,0,0,0.22), inset 0 0.5px 0 rgba(255,255,255,0.08)",
+            animation: "toast-in 280ms var(--motion-spring) both",
+            whiteSpace: "nowrap",
+          }}
+        >
+          <span
+            style={{
+              width: 6,
+              height: 6,
+              borderRadius: 999,
+              background: "var(--warning)",
+              flexShrink: 0,
+            }}
+          />
+          <span
+            style={{
+              fontFamily: "var(--font-family-mono), monospace",
+              fontSize: 11.5,
+              letterSpacing: "0.3px",
+              color: "rgba(240,237,232,0.9)",
+            }}
+          >
+            AI 编译服务未连接
+          </span>
+          <button
+            type="button"
+            aria-label="关闭提示"
+            onClick={() => setShowServiceToast(false)}
+            style={{
+              marginLeft: 2,
+              width: 18,
+              height: 18,
+              borderRadius: 999,
+              border: "none",
+              background: "rgba(255,255,255,0.12)",
+              color: "rgba(240,237,232,0.7)",
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "center",
+              cursor: "pointer",
+              fontSize: 12,
+              lineHeight: 1,
+              flexShrink: 0,
+            }}
+          >
+            ×
+          </button>
+        </div>
+      )}
+
       {/* Today Hero — US-006 */}
       <TodayHero />
 
@@ -233,7 +307,11 @@ function TodayMobileFlow() {
       </div>
 
       {/* Memo Feed + Unlock Placeholder — US-009, US-010 */}
-      <MemoFeed composerMicRef={composerMicRef} onShare={setShareMemo} />
+      <MemoFeed
+        composerMicRef={composerMicRef}
+        onShare={setShareMemo}
+        onServiceDisconnected={() => setShowServiceToast(true)}
+      />
 
       {/* Week Wiki Spine Feed — US-011 */}
       <div style={{ paddingTop: 24 }}>

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1547,3 +1547,22 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
     transform: none;
   }
 }
+
+/* === Service toast animation === */
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-8px) scale(0.94);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0) scale(1);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  @keyframes toast-in {
+    from { opacity: 0; }
+    to   { opacity: 1; }
+  }
+}


### PR DESCRIPTION
## Summary

- **iOS — compact header**: `sidebarSection` 在有 memo 时折叠为单行 mono 日期芯片，56pt serif「Sunday」大字只在空日（无 memo）时显示，消除有内容时的大量顶部留白
- **iOS — floating banner**: `BannerOverlayModifier` 从 `content.overlay` 改为 `ZStack` 包裹，banner（如「DeepSeek API Key 未配置」）浮动覆盖而不是把内容往下推
- **iOS — InputBarV4 STREAM dock**: 重构为 design spec warm pill（36pt attach + italic serif 占位 + 50×44 amber mic）
- **iOS — Colors**: `bgWarm` 对齐 design token `#FAF8F6`（原 FAF7F2）
- **Web — floating toast**: compile service 断开时展示页面级黑色毛玻璃 pill toast，移除每张 MemoCard 内嵌的重复提示
- **Web — ComposerPill**: 底部容器加 warm-cream 渐变遮罩，pill 与滚动内容自然融合
- **Web — TodayHero**: 减少 paddingTop/paddingBottom，收紧顶部空白
- **Web — globals.css**: 新增 `@keyframes toast-in` 弹入动画

## Test plan

- [ ] iOS: 发送第一条 memo 后确认 header 从大字折叠为小字日期
- [ ] iOS: 触发 API key 错误，确认 banner 浮动覆盖，不推动 memo 列表下移
- [ ] iOS: 空日（无 memo）时确认大字 Hero 仍然显示
- [ ] Web: `serviceConnected=false` 时，toast pill 出现在顶部，MemoCard 内无重复提示
- [ ] Web: 底部 ComposerPill 渐变过渡自然，warm cream 色调一致