### PR TITLE
fix(ui): compact header when memos exist + floating banners + bottom gradient

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1063,7 +1063,7 @@ struct TodayView: View {
     private var sidebarSection: some View {
         let isScrolled = timelineScrollOffset < -8
         ZStack(alignment: .bottom) {
-            // Glass background — animates in/out with scroll
+            // Glass background — height 0 when not scrolled so ZStack tracks the overlay HStack.
             Group {
                 if isScrolled {
                     Rectangle()
@@ -1073,7 +1073,7 @@ struct TodayView: View {
                                 .fill(DSColor.bgWarm.opacity(0.78))
                         )
                 } else {
-                    Color.clear
+                    Color.clear.frame(height: 0)
                 }
             }
             .animation(reduceMotion ? nil : .easeOut(duration: 0.2), value: isScrolled)


### PR DESCRIPTION
## Summary

- **iOS — compact header**: memo가 있을 때 `sidebarSection`이 56pt serif 「Sunday」를 숨기고 한 줄 mono 날짜 칩으로 전환. `Color.clear.frame(height:0)` 으로 ZStack이 overlay HStack 크기를 따르도록 수정.
- **iOS — AppBanner ZStack**: `BannerOverlayModifier`를 `content.overlay` → `ZStack` 으로 변경해 banner가 레이아웃을 밀지 않고 floating.
- **iOS — InputBarV4 STREAM dock**: design spec warm pill로 재구성 (36pt attach + italic serif placeholder + 50×44 amber mic).
- **iOS — Colors**: `bgWarm` → `#FAF8F6` (design token 정렬).
- **Web — floating toast**: compile service 단절 시 페이지 레벨 dark glass pill toast, MemoCard 인라인 중복 제거.
- **Web — ComposerPill**: warm-cream 그라디언트 마스크로 pill이 스크롤 콘텐츠와 자연스럽게 융합.
- **Web — TodayHero**: paddingTop/paddingBottom 축소로 상단 여백 감소.
- **Web — globals.css**: `@keyframes toast-in` spring 입장 애니메이션 추가.

## Test plan

- [ ] iOS: 첫 memo 저장 후 header가 대문자 → 소문자 날짜 칩으로 전환되는지 확인
- [ ] iOS: 빈 날(memo 0개)에 56pt serif hero가 정상 표시되는지 확인
- [ ] iOS: API key 에러 banner가 레이아웃을 밀지 않고 float하는지 확인
- [ ] Web: `serviceConnected=false` 시 toast pill이 상단에 등장, MemoCard 내 중복 없음 확인
- [ ] Web: ComposerPill 하단 그라디언트가 warm cream으로 자연스럽게 처리되는지 확인