### PR TITLE
auto: Add destructive-action haptic on memo deletion

### DIFF
--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -303,6 +303,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         withAnimation(Motion.rise) {
             memos = remaining
         }
+        Haptics.warn()
         persistMemos(remaining, capturedDate: date, previous: previous, failureMessagePrefix: "删除失败")
 
         // Start 5-second undo window


### PR DESCRIPTION
## Add destructive-action haptic on memo deletion

The memo delete flow in TodayViewModel.deleteMemo animates the row out and starts the 5-second undo window, but fires no haptic at the moment of deletion — unlike every other persist action (save fires successNotification, edit fires commit, undo fires soft). This adds a single Haptics.warn() pulse so a destructive, irreversible-feeling action gets the standard iOS tactile confirmation, even with the device on silent.

### Acceptance
Building the DayPage scheme succeeds (xcodebuild -scheme DayPage build). In the iPhone 17 Simulator, deleting a memo (swipe-to-delete) produces exactly one warning haptic at the moment the row animates away; the undo pill still appears and undo still fires its existing soft haptic; no double-buzz occurs. Existing HapticFeedbackTests and TodayViewModelTests still pass. The .md file under vault/raw/ correctly reflects the removed memo after deletion.