### PR TITLE
auto: First-run swipe-hint nudge on the top memo card

### DIFF
--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -154,6 +154,8 @@ extension AppSettings {
         static let dailyPageSwipeHintShown = "today.dailyPageSwipeHintShown"
         // WriteSheet rail hint — shown once to explain media is attached via the dock
         static let writeSheetRailHintShown = "today.writeSheetRailHintShown"
+        // Swipe-hint nudge — shown once on the newest memo card to teach left/right swipe actions
+        static let memoSwipeHintShown = "memoswipeHintShown"
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -90,6 +90,7 @@ struct TodayView: View {
 
     /// Hint offset for the one-time swipe-left nudge on the Daily Page card.
     @State private var dailyPageHintOffset: CGFloat = 0
+    @State private var memoCardHintOffset: CGFloat = 0
 
     /// Session-only: true once the 3-memo unlock celebration has fired this session.
     /// Resets to false when memo count drops back below 3 so delete+readd re-fires it.
@@ -1355,6 +1356,21 @@ struct TodayView: View {
                             },
                             onOpen: { openedMemoID = memo.id }
                         )
+                        .offset(x: idx == 0 ? memoCardHintOffset : 0)
+                        .onAppear {
+                            guard idx == 0,
+                                  !UserDefaults.standard.bool(forKey: AppSettings.Keys.memoSwipeHintShown),
+                                  !reduceMotion,
+                                  !isInSelectionMode else { return }
+                            UserDefaults.standard.set(true, forKey: AppSettings.Keys.memoSwipeHintShown)
+                            Task { @MainActor in
+                                try? await Task.sleep(for: .seconds(0.6))
+                                withAnimation(Motion.spring) { memoCardHintOffset = -28 }
+                                Haptics.soft()
+                                try? await Task.sleep(for: .seconds(0.45))
+                                withAnimation(Motion.spring) { memoCardHintOffset = 0 }
+                            }
+                        }
                         .padding(.horizontal, 20)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
                     }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1368,6 +1368,8 @@ struct TodayView: View {
                                 withAnimation(Motion.spring) { memoCardHintOffset = -28 }
                                 Haptics.soft()
                                 try? await Task.sleep(for: .seconds(0.45))
+                                withAnimation(Motion.spring) { memoCardHintOffset = 28 }
+                                try? await Task.sleep(for: .seconds(0.35))
                                 withAnimation(Motion.spring) { memoCardHintOffset = 0 }
                             }
                         }


### PR DESCRIPTION
## First-run swipe-hint nudge on the top memo card

Memo cards expose left-swipe (share) and right-swipe (more) actions, but unlike the Daily Page card there is no first-run affordance teaching users the gesture exists, so it goes undiscovered. Replicate the existing one-time hint-nudge pattern (dailyPageHintOffset, TodayView.swift:731-743) on the newest memo card: a single gentle horizontal bounce plus a soft haptic, gated by a UserDefaults flag and skipped under Reduce Motion.

### Acceptance
On a fresh install, after adding the first memo the top card performs a single subtle left-bounce with a soft haptic, hinting at the swipe actions; it never re-fires on subsequent launches (UserDefaults flag), is suppressed when Reduce Motion is enabled or while in multi-select mode, and does not interfere with the existing swipe gestures or tap-to-open. Build passes `xcodebuild -scheme DayPage build` and the app launches cleanly in the iPhone 17 simulator.