### PR TITLE
auto: Center search snippets on the matched keyword so the highlight is never clipped

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -957,14 +957,11 @@ struct SearchView: View {
         let kw = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !kw.isEmpty else { return snippet }
 
-        let lower = snippet.lowercased()
-        let kwLower = kw.lowercased()
-        guard let matchRange = lower.range(of: kwLower) else { return snippet }
+        guard let matchRange = snippet.range(of: kw, options: .caseInsensitive) else { return snippet }
 
-        let matchOffset = lower.distance(from: lower.startIndex, to: matchRange.lowerBound)
+        let matchOffset = snippet.distance(from: snippet.startIndex, to: matchRange.lowerBound)
         let windowStartOffset = max(0, matchOffset - context)
 
-        // Clamp to grapheme cluster boundaries
         let windowStart = snippet.index(snippet.startIndex, offsetBy: windowStartOffset)
         let windowEnd = snippet.index(windowStart,
                                       offsetBy: 80,

--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -943,9 +943,37 @@ struct SearchView: View {
                 .bodySMStyle()
                 .foregroundColor(DSColor.onSurface)
         } else {
-            Text(buildHighlightedString(snippet, keyword: trimmed))
+            let windowed = snippetWindow(snippet, keyword: trimmed)
+            Text(buildHighlightedString(windowed, keyword: trimmed))
                 .bodySMStyle()
         }
+    }
+
+    /// Returns a ~80-char window of `snippet` centered just before the first
+    /// case-insensitive match of `keyword`, so the highlight is always visible.
+    /// Prepends/appends '…' when the window doesn't reach the string boundaries.
+    /// Falls back to the original snippet when `keyword` is not found.
+    private func snippetWindow(_ snippet: String, keyword: String, context: Int = 24) -> String {
+        let kw = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !kw.isEmpty else { return snippet }
+
+        let lower = snippet.lowercased()
+        let kwLower = kw.lowercased()
+        guard let matchRange = lower.range(of: kwLower) else { return snippet }
+
+        let matchOffset = lower.distance(from: lower.startIndex, to: matchRange.lowerBound)
+        let windowStartOffset = max(0, matchOffset - context)
+
+        // Clamp to grapheme cluster boundaries
+        let windowStart = snippet.index(snippet.startIndex, offsetBy: windowStartOffset)
+        let windowEnd = snippet.index(windowStart,
+                                      offsetBy: 80,
+                                      limitedBy: snippet.endIndex) ?? snippet.endIndex
+
+        var result = String(snippet[windowStart..<windowEnd])
+        if windowStart != snippet.startIndex { result = "…" + result }
+        if windowEnd != snippet.endIndex { result += "…" }
+        return result
     }
 
     private func buildHighlightedString(_ text: String, keyword: String) -> AttributedString {


### PR DESCRIPTION
## Center search snippets on the matched keyword so the highlight is never clipped

In SearchView, result snippets render the raw text with lineLimit(2) and an amber highlight on the matched keyword. When a match occurs late in a long snippet, the highlighted term is clipped off and the user sees a 2-line preview with no visible match, making results look irrelevant. This change windows the snippet around the first match (with a leading ellipsis) so the highlighted keyword is always visible.

### Acceptance
Build the DayPage scheme cleanly (xcodebuild -scheme DayPage build). In the iPhone 17 simulator, search a keyword that appears only near the end of a long memo: the result row now shows the snippet windowed around the match with a leading '…' and the amber-highlighted keyword visible within the 2 displayed lines. Searches where the keyword appears early, or empty queries, render identically to before. VoiceOver still reads the result's date, match kind, status, and snippet prefix.