### PR TITLE
auto: Suppress typewriter reveal in AISummaryCard when VoiceOver is running

### DIFF
--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -20,6 +20,8 @@ struct AISummaryCard: View {
     var onTap: (() -> Void)? = nil
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverEnabled
+    private var shouldAnimate: Bool { !reduceMotion && !voiceOverEnabled }
     @State private var isPressed: Bool = false
     /// True once the typewriter reveal has finished (or Reduce Motion is on).
     @State private var revealComplete: Bool = false
@@ -39,8 +41,8 @@ struct AISummaryCard: View {
                 header
                 TypewriterText(
                     fullText: summary,
-                    animated: !reduceMotion,
-                    hapticTexture: !reduceMotion,
+                    animated: shouldAnimate,
+                    hapticTexture: shouldAnimate,
                     isComplete: $revealComplete,
                     onCompleteHandler: $completeReveal
                 )
@@ -67,7 +69,7 @@ struct AISummaryCard: View {
             guard let onTap else { return }
             // First tap while typewriter is still animating: snap the text into
             // view with a soft haptic instead of navigating.
-            if !reduceMotion && !revealComplete {
+            if shouldAnimate && !revealComplete {
                 completeReveal?()
                 Haptics.soft()
                 return


### PR DESCRIPTION
## Suppress typewriter reveal in AISummaryCard when VoiceOver is running

The AI summary card animates its compiled one-line summary character-by-character with haptic texture, gated only on Reduce Motion. VoiceOver users who haven't enabled Reduce Motion still trigger the per-character DispatchQueue reveal, the blinking caret, and ~N/4 soft haptics — a wasteful, slightly jarring experience while the screen reader is already announcing the full text. Gate the animation on VoiceOver state as well so the summary appears instantly (and silently) for assistive-tech users.

### Acceptance
Build the DayPage scheme cleanly. With VoiceOver ON (Settings > Accessibility > VoiceOver) and Reduce Motion OFF, opening Today with a compiled daily summary shows the full summary text instantly with no caret, no per-character animation, and no haptic ticks; VoiceOver still reads 'AI 今日一句' followed by the full summary. With VoiceOver OFF and Reduce Motion OFF, the typewriter reveal and haptic texture behave exactly as before. Existing DayPageTests still pass.