### PR TITLE
ci: cancel superseded runs for the same ref

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,10 @@ on:
   schedule:
     - cron: "0 2 * * *"   # 每天 UTC 02:00（北京时间 10:00）对 main 跑全量回归
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   unit-tests:
     name: Swift Unit Tests (xcrun)


### PR DESCRIPTION
## Summary

- add workflow-level concurrency to CI
- isolate cancellation groups by workflow and ref
- cancel older in-progress CI runs when a newer run supersedes them
- leave TestFlight deployment unchanged because release cancellation has different semantics

Closes #582

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML parse OK"'`
- `git diff --check -- .github/workflows/ci.yml`
- `xcrun swift scripts/tests/test_raw_storage.swift`
- `xcrun swift scripts/tests/test_entity_page.swift`
- `xcrun swift scripts/tests/test_compilation_parsing.swift`
- `xcrun swift scripts/tests/test_voice_transcript.swift`
- `xcodebuild -scheme DayPage -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`

## Local build note

`xcodebuild -scheme DayPage build` cannot complete on this machine because the local provisioning profiles for `com.daypage.app` and `match AppStore com.daypage.app.DayPageWidget` are not installed. The unsigned Simulator build succeeds.

## Reference

- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#concurrency
