### PR TITLE
ci: use merge_group checks without branch push duplicates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
     paths-ignore:
       - "design/**"
       - "scripts/ralph/**"
@@ -15,6 +17,9 @@ on:
       - "tasks/**"
       - "**.md"
       - ".gitignore"
+  merge_group:
+    types:
+      - checks_requested
   schedule:
     - cron: "0 2 * * *"   # 每天 UTC 02:00（北京时间 10:00）对 main 跑全量回归
 


### PR DESCRIPTION
## Summary

- limit CI `push` triggers to `main`
- add the dedicated `merge_group: checks_requested` trigger required for merge queue validation
- retain pull request checks, scheduled regression, `main` post-merge safeguards, and ref-scoped cancellation

Closes #584

## Why

The previous workflow listened to every push. A single change could therefore enqueue macOS work for the feature branch push, pull request merge ref, merge queue temporary branch, and final `main` push. GitHub documents `merge_group` as the correct Actions event for merge queue checks.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "YAML parse OK"'`
- `git diff --check -- .github/workflows/ci.yml`
- confirmed queued Actions run count was `0` before opening this PR
- `xcodebuild -scheme DayPage build` attempted; local signing profiles for `com.daypage.app` and `match AppStore com.daypage.app.DayPageWidget` are not installed

## References

- https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/configuring-pull-request-merges/managing-a-merge-queue#triggering-merge-group-checks-with-github-actions
- https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#merge_group
