### PR TITLE
fix(ios): disambiguate write sheet backdrop opacity

### DIFF
--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -118,7 +118,7 @@ struct WriteSheetView: View {
             // Fades proportionally as the sheet is dragged down.
             DSTokens.Colors.recordingBg.opacity(0.34)
                 .ignoresSafeArea()
-                .opacity(appeared ? max(0, 1 - dragOffset / 400) : 0)
+                .opacity(appeared ? Double(max(CGFloat.zero, CGFloat(1) - dragOffset / CGFloat(400))) : 0)
                 .onTapGesture { onClose() }
                 .accessibilityHidden(true)
 


### PR DESCRIPTION
## Summary

- compute the dragged backdrop opacity as `CGFloat`
- convert the final value explicitly to `Double` for SwiftUI `.opacity`
- preserve proportional fade behavior while removing Swift overload ambiguity

Closes #586

## Verification

- `git diff --check`
- `xcrun swift scripts/tests/test_raw_storage.swift`
- `xcrun swift scripts/tests/test_entity_page.swift`
- `xcrun swift scripts/tests/test_compilation_parsing.swift`
- `xcrun swift scripts/tests/test_voice_transcript.swift`
- `xcodebuild -scheme DayPage -sdk iphonesimulator -destination 'generic/platform=iOS Simulator' build CODE_SIGNING_ALLOWED=NO`

## Context

The CI failure reproduced on `main` at `DayPage/Features/Today/WriteSheetView.swift:121` with `ambiguous use of operator '-'`. A previous attempt using only decimal literals was reverted; this change makes both sides of the type boundary explicit.
