### PR TITLE
fix(today): 修复空状态标题重叠 + 橙色光晕降饱和

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -105,13 +105,15 @@ struct EmptyStateView: View {
         }
     }
 
+    // amberAccent (#A8541B) at low opacity — a soft warm bloom behind the title
+    // rather than the old saturated peach blob. (#590)
     private var orbAccent: some View {
         Circle()
             .fill(
                 RadialGradient(
                     colors: [
-                        Color(hex: "E8974D").opacity(0.55),
-                        Color(hex: "A8541B").opacity(0.28),
+                        Color(hex: "A8541B").opacity(0.22),
+                        Color(hex: "A8541B").opacity(0.10),
                         Color.clear
                     ],
                     center: .center,

--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -161,12 +161,14 @@ struct DayOrbView: View {
     // MARK: - Invite Halo
 
     // Looping amber glow-pulse shown only when signalCount == 0 to signal tappability.
+    // Uses the restrained amberAccent (#A8541B) rather than the hot peach (#E8974D)
+    // so the halo reads as warm light bleeding through paper, not a glowing blob. (#590)
     private var inviteHalo: some View {
         Circle()
             .fill(
                 RadialGradient(
                     colors: [
-                        Color(red: 232/255, green: 151/255, blue: 77/255).opacity(invitePulse ? 0.5 : 0.15),
+                        Color(red: 168/255, green: 84/255, blue: 27/255).opacity(invitePulse ? 0.18 : 0.08),
                         Color.clear
                     ],
                     center: .center,
@@ -184,12 +186,13 @@ struct DayOrbView: View {
     // MARK: - Halo
 
     // Blurred radial gradient that bleeds +16pt past the orb edge on every side.
+    // amberAccent (#A8541B) for a warmer, less saturated bleed than the old peach. (#590)
     private var halo: some View {
         Circle()
             .fill(
                 RadialGradient(
                     colors: [
-                        Color(red: 232/255, green: 151/255, blue: 77/255).opacity(haloOpacity),
+                        Color(red: 168/255, green: 84/255, blue: 27/255).opacity(haloOpacity),
                         Color.clear
                     ],
                     center: .center,

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1063,32 +1063,11 @@ struct TodayView: View {
     @ViewBuilder
     private var sidebarSection: some View {
         let isScrolled = timelineScrollOffset < -8
-        ZStack(alignment: .bottom) {
-            // Glass background — height 0 when not scrolled so ZStack tracks the overlay HStack.
-            Group {
-                if isScrolled {
-                    Rectangle()
-                        .fill(.ultraThinMaterial)
-                        .overlay(
-                            Rectangle()
-                                .fill(DSColor.bgWarm.opacity(0.78))
-                        )
-                } else {
-                    Color.clear.frame(height: 0)
-                }
-            }
-            .animation(reduceMotion ? nil : .easeOut(duration: 0.2), value: isScrolled)
-
-            // Bottom separator line
-            if isScrolled {
-                Rectangle()
-                    .fill(DSColor.borderSubtle)
-                    .frame(height: 0.5)
-                    .transition(.opacity)
-                    .animation(reduceMotion ? nil : .easeOut(duration: 0.2), value: isScrolled)
-            }
-        }
-        .overlay(alignment: .center) {
+        // The header HStack now participates in normal layout (it owns its
+        // height), with the glass/separator drawn as a `.background` behind it.
+        // Previously the HStack lived inside `.overlay()` on a zero-height
+        // ZStack, so it contributed 0pt to the parent VStack and the orbHero
+        // below it slid up and overlapped the 56pt hero title. (#590)
         HStack(alignment: .firstTextBaseline, spacing: 0) {
             Button {
                 nav.openSidebar()
@@ -1222,8 +1201,27 @@ struct TodayView: View {
         .onReceive(headerTimer) { date in
             currentTime = date
         }
-        } // end overlay
         .frame(maxWidth: .infinity)
+        // US-005: frosted glass + separator fade in behind the header once the
+        // timeline scrolls > 8pt. Drawn as a background so it never affects the
+        // header's intrinsic height (the cause of the old overlap bug). (#590)
+        .background(alignment: .bottom) {
+            ZStack(alignment: .bottom) {
+                if isScrolled {
+                    Rectangle()
+                        .fill(.ultraThinMaterial)
+                        .overlay(
+                            Rectangle()
+                                .fill(DSColor.bgWarm.opacity(0.78))
+                        )
+                    Rectangle()
+                        .fill(DSColor.borderSubtle)
+                        .frame(height: 0.5)
+                        .transition(.opacity)
+                }
+            }
+            .animation(reduceMotion ? nil : .easeOut(duration: 0.2), value: isScrolled)
+        }
     }
 
     /// Scrollable timeline: daily page card, skeleton, memo cards, history supplement.


### PR DESCRIPTION
## 问题

Today 空状态（0 memo）实机截图暴露两个视觉问题：

1. **标题四行重叠**：`Tuesday`(56pt) / `Good afternoon.`(28pt) / 日期 kicker ×2 叠在一起糊成一团。
2. **橙色光晕过饱和**：Day Orb 圆环、`Nothing surfaced yet.` 标题背后各一坨亮橙径向渐变，与暖米/深咖色谱冲突。

## 根因

标题重叠是布局 bug：`sidebarSection` 把 header HStack 放在 `.overlay()` 里，叠在一个未滚动时高度为 0 的 ZStack 上，导致 header 在父 `VStack` 里只占 0pt，紧随其后的 `orbHero` 向上贴住、压住 56pt 大标题。

光晕用了色谱里最跳的亮橙 `#E8974D` @0.5/0.55 高透明度。

## 改动

- **`TodayView.sidebarSection`**：header HStack 改为正常参与布局、自带高度；滚动时的 frosted glass + 分隔线移到 `.background`，不再影响 header 固有高度。
- **`DayOrbView`** `inviteHalo` + `halo`：`#E8974D` → `amberAccent #A8541B`，透明度 0.5/0.15 → 0.18/0.08。
- **`EmptyStateView.orbAccent`**：`#E8974D`@0.55 → `#A8541B`@0.22，标题背后变成柔和暖光晕而非饱和团块。

不涉及任何 view-model / 持久化逻辑，纯视觉修复。

## 验证

- iPhone 17 Pro 模拟器实机：标题各行干净分层、留白充足；两处光晕收敛、与整体色温协调。
- `xcodebuild -scheme DayPage build` → **BUILD SUCCEEDED**
- `DayPageTests/TodayViewModelTests` → **TEST SUCCEEDED**

### 修复前 → 修复后
（标题从重叠糊成一团 → 四行清晰分层；亮橙光晕 → 温润锈红暖光）

Fixes #590