### PR TITLE
auto: Show longest writing streak (personal best) in the sidebar STREAK stat

### DIFF
--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -205,7 +205,14 @@ struct SidebarView: View {
     /// STREAK / PAGES / WORDS triplet on a single hairline-divided white card.
     private var statsSection: some View {
         HStack(spacing: 0) {
-            statCell(label: "STREAK", value: "\(sidebarVM.currentStreak)", unit: "DAYS", first: true)
+            let streakUnit = sidebarVM.longestStreak > sidebarVM.currentStreak
+                ? "BEST \(sidebarVM.longestStreak)"
+                : "DAYS"
+            statCell(label: "STREAK", value: "\(sidebarVM.currentStreak)", unit: streakUnit, first: true)
+                .accessibilityLabel(sidebarVM.longestStreak > sidebarVM.currentStreak
+                    ? "Streak \(sidebarVM.currentStreak) days, personal best \(sidebarVM.longestStreak) days"
+                    : "Streak \(sidebarVM.currentStreak) days"
+                )
             statDivider
             statCell(label: "PAGES", value: "\(sidebarVM.totalPages)", unit: "TOTAL", first: false)
             statDivider

--- a/DayPage/App/SidebarViewModel.swift
+++ b/DayPage/App/SidebarViewModel.swift
@@ -54,6 +54,33 @@ final class SidebarViewModel: ObservableObject {
 
     /// Consecutive calendar days ending today (or yesterday) with at least one memo.
     /// Starts counting from the most recent active day and stops at the first gap.
+    /// Longest consecutive-day writing run ever recorded within the 365-day
+    /// scan window. Returns 0 for an empty vault.
+    var longestStreak: Int {
+        let cal = Calendar.current
+        let activeDates = Set(streakDays.map(\.dateString))
+        guard !activeDates.isEmpty else { return 0 }
+
+        // Parse and sort dates ascending.
+        let sorted = activeDates
+            .compactMap { Self.isoFormatter.date(from: $0) }
+            .map { cal.startOfDay(for: $0) }
+            .sorted()
+
+        var maxRun = 1
+        var currentRun = 1
+        for i in 1 ..< sorted.count {
+            let gap = cal.dateComponents([.day], from: sorted[i - 1], to: sorted[i]).day ?? 0
+            if gap == 1 {
+                currentRun += 1
+                if currentRun > maxRun { maxRun = currentRun }
+            } else {
+                currentRun = 1
+            }
+        }
+        return maxRun
+    }
+
     var currentStreak: Int {
         let cal = Calendar.current
         let today = cal.startOfDay(for: Date())


### PR DESCRIPTION
## Show longest writing streak (personal best) in the sidebar STREAK stat

The sidebar already computes and displays the current writing streak, but there's no sense of a personal best to aim for once a streak breaks. Add a `longestStreak` computed property to SidebarViewModel (reusing the already-scanned 365-day `streakDays`) and surface it as a subtle 'BEST N' annotation beneath the STREAK value, turning a transient number into a motivating goal. This is the single highest-leverage retention nudge for a daily-logging app and reuses all existing scan infrastructure.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator. With memos logged across non-consecutive day ranges in vault/raw, open the sidebar: the STREAK cell shows the current streak as its value, and when a longer past streak exists its 'BEST N' label appears under the number; when the current streak IS the best (or no longer streak exists), the label stays 'DAYS'. longestStreak returns 0 for an empty vault and correctly handles single-day, fully-consecutive, and gapped histories. VoiceOver reads both current and best values. No SwiftData/@Model files touched; change is under 100 lines across the two files.