### PR TITLE
auto: Streak milestone celebration toast on Today

### DIFF
--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -13,6 +13,7 @@ struct RootView: View {
     @EnvironmentObject private var authService: AuthService
     @EnvironmentObject private var nav: AppNavigationModel
     @StateObject private var bannerCenter = BannerCenter.shared
+    @StateObject private var sidebarVM = SidebarViewModel()
     @ObservedObject private var appSettings = AppSettings.shared
 
     @State private var phase: AppPhase = RootView.initialPhase()
@@ -43,6 +44,7 @@ struct RootView: View {
 
     var body: some View {
         mainContent
+            .environmentObject(sidebarVM)
             .fullScreenCover(isPresented: Binding(
                 get: { phase != .ready },
                 set: { _ in }   // dismissal is handled by the content view callbacks

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -9,7 +9,7 @@ struct SidebarView: View {
     @EnvironmentObject private var authService: AuthService
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    @StateObject private var sidebarVM = SidebarViewModel()
+    @EnvironmentObject private var sidebarVM: SidebarViewModel
     @State private var showSettings = false
     @State private var showAccountSheet = false
 

--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -156,6 +156,8 @@ extension AppSettings {
         static let writeSheetRailHintShown = "today.writeSheetRailHintShown"
         // Swipe-hint nudge — shown once on the newest memo card to teach left/right swipe actions
         static let memoSwipeHintShown = "memoswipeHintShown"
+        // Streak milestone celebrations — comma-joined Int set, e.g. "3,7,14"
+        static let streakMilestonesShown = "streakMilestonesShown"
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -11,7 +11,7 @@ struct TodayView: View {
     @StateObject private var voiceQueue = VoiceAttachmentQueue.shared
     @StateObject private var migrationService = VaultMigrationService.shared
     @StateObject private var compilationService = CompilationService.shared
-    @StateObject private var sidebarVM = SidebarViewModel()
+    @EnvironmentObject private var sidebarVM: SidebarViewModel
 
     @Environment(\.scenePhase) private var scenePhase
 
@@ -1550,6 +1550,7 @@ struct TodayView: View {
         case 14:  return NSLocalizedString("today.streak.milestone.subtitle.14",  comment: "")
         case 30:  return NSLocalizedString("today.streak.milestone.subtitle.30",  comment: "")
         case 100: return NSLocalizedString("today.streak.milestone.subtitle.100", comment: "")
+        case 365: return NSLocalizedString("today.streak.milestone.subtitle.365", comment: "")
         default:  return NSLocalizedString("today.streak.milestone.subtitle.365", comment: "")
         }
     }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -11,6 +11,7 @@ struct TodayView: View {
     @StateObject private var voiceQueue = VoiceAttachmentQueue.shared
     @StateObject private var migrationService = VaultMigrationService.shared
     @StateObject private var compilationService = CompilationService.shared
+    @StateObject private var sidebarVM = SidebarViewModel()
 
     @Environment(\.scenePhase) private var scenePhase
 
@@ -1500,6 +1501,15 @@ struct TodayView: View {
             } else if count < 3 {
                 didCelebrateUnlock = false
             }
+            // Celebrate streak milestone when today's first memo is added.
+            if lastMemoCount == 0 && count == 1 {
+                sidebarVM.refreshRecentDays()
+                Task { @MainActor in
+                    // Let the async vault scan in refreshRecentDays complete.
+                    try? await Task.sleep(nanoseconds: 400_000_000)
+                    celebrateStreakIfNeeded()
+                }
+            }
             // Scroll to top on additions only, not deletions.
             if count > lastMemoCount, let proxy = timelineScrollProxy {
                 withAnimation(reduceMotion ? nil : Motion.spring) {
@@ -1528,6 +1538,57 @@ struct TodayView: View {
     }
 
     // MARK: - Helpers
+
+    // MARK: - Streak Milestone Celebration
+
+    private static let streakMilestones: [Int] = [3, 7, 14, 30, 100, 365]
+
+    private func milestoneEncouragement(for n: Int) -> String {
+        switch n {
+        case 3:   return NSLocalizedString("today.streak.milestone.subtitle.3",   comment: "")
+        case 7:   return NSLocalizedString("today.streak.milestone.subtitle.7",   comment: "")
+        case 14:  return NSLocalizedString("today.streak.milestone.subtitle.14",  comment: "")
+        case 30:  return NSLocalizedString("today.streak.milestone.subtitle.30",  comment: "")
+        case 100: return NSLocalizedString("today.streak.milestone.subtitle.100", comment: "")
+        default:  return NSLocalizedString("today.streak.milestone.subtitle.365", comment: "")
+        }
+    }
+
+    private func shownMilestones() -> Set<Int> {
+        let raw = UserDefaults.standard.string(forKey: AppSettings.Keys.streakMilestonesShown) ?? ""
+        return Set(raw.split(separator: ",").compactMap { Int($0) })
+    }
+
+    private func markMilestoneShown(_ n: Int) {
+        var shown = shownMilestones()
+        shown.insert(n)
+        UserDefaults.standard.set(shown.map(String.init).joined(separator: ","),
+                                  forKey: AppSettings.Keys.streakMilestonesShown)
+    }
+
+    private func celebrateStreakIfNeeded() {
+        let streak = sidebarVM.currentStreak
+        guard let milestone = Self.streakMilestones.first(where: { $0 == streak }) else { return }
+        guard !shownMilestones().contains(milestone) else { return }
+
+        markMilestoneShown(milestone)
+        Haptics.success()
+        if !reduceMotion {
+            orbCapturePulse.toggle()
+            refreshGlow = true
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 600_000_000)
+                refreshGlow = false
+            }
+        }
+        let title = String(format: NSLocalizedString("today.streak.milestone.title", comment: ""), milestone)
+        bannerCenter.show(AppBannerModel(
+            kind: .info,
+            title: title,
+            subtitle: milestoneEncouragement(for: milestone),
+            autoDismiss: true
+        ))
+    }
 
     // US-009: Show undo pill for 5 seconds after submitting a memo.
     private func showUndoPill(for text: String) {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -240,3 +240,12 @@
 "voice.retry.failed_permanent_a11y" = "Transcription permanently failed after 3 attempts. Audio is saved.";
 
 "search.undo.cleared" = "Recent searches cleared";
+
+/* Streak milestone celebration (TodayView) */
+"today.streak.milestone.title"        = "%d day streak! 🔥";
+"today.streak.milestone.subtitle.3"   = "Three days in a row — the habit is forming.";
+"today.streak.milestone.subtitle.7"   = "One full week. You're on a roll.";
+"today.streak.milestone.subtitle.14"  = "Two weeks straight. This is becoming part of you.";
+"today.streak.milestone.subtitle.30"  = "A whole month of daily logging. Remarkable.";
+"today.streak.milestone.subtitle.100" = "100 days. This journey is yours.";
+"today.streak.milestone.subtitle.365" = "One full year. A nomad's complete orbit.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -268,3 +268,12 @@
 "voice.retry.failed_permanent_a11y" = "已重试 3 次，转写失败。音频已保存。";
 
 "search.undo.cleared" = "已清除搜索记录";
+
+/* Streak milestone celebration (TodayView) */
+"today.streak.milestone.title"        = "连续 %d 天！🔥";
+"today.streak.milestone.subtitle.3"   = "连续三天，习惯正在形成。";
+"today.streak.milestone.subtitle.7"   = "整整一周，势头不错。";
+"today.streak.milestone.subtitle.14"  = "两周不间断，这已成为你的一部分。";
+"today.streak.milestone.subtitle.30"  = "整整一个月的每日记录，了不起。";
+"today.streak.milestone.subtitle.100" = "100 天，这段旅程属于你。";
+"today.streak.milestone.subtitle.365" = "整整一年，游牧者完整的轨迹。";


### PR DESCRIPTION
## Streak milestone celebration toast on Today

DayPage tracks a daily-logging streak (SidebarViewModel.currentStreak) and shows it passively in the sidebar heatmap footer, but never celebrates when the user crosses a habit milestone. Add a one-time-per-milestone celebratory banner with confetti-style amber glow and success haptic when the streak first reaches 3, 7, 14, 30, 100, or 365 days, fired from TodayView after a memo is saved — reinforcing the core habit loop for the nomad target user.

### Acceptance
Logging the first memo of the day that brings the consecutive-day streak to 3/7/14/30/100/365 shows a single celebratory banner with a success haptic and a one-shot amber orb glow; subsequent memos the same day (or relaunches) do not re-fire that milestone; non-milestone streak lengths show nothing; the existing sidebar heatmap streak pill is unaffected; `xcodebuild -scheme DayPage build` succeeds and the app launches in the iPhone 17 simulator without regression.