### PR TITLE
auto: Show 'personal best' streak pill when current streak is broken (zero-state nudge)

### DIFF
--- a/DayPage/App/SidebarHeatmapView.swift
+++ b/DayPage/App/SidebarHeatmapView.swift
@@ -24,6 +24,8 @@ struct SidebarHeatmapView: View {
     let totalEntries: Int
     /// Current consecutive-day streak (footer pill).
     let streak: Int
+    /// All-time longest consecutive-day streak (footer fallback when streak == 0).
+    let longestStreak: Int
 
     private let weeks = 16
     private let cellSpacing: CGFloat = 3
@@ -64,7 +66,7 @@ struct SidebarHeatmapView: View {
         )
         .shadow(color: Color.black.opacity(0.04), radius: 1, x: 0, y: 1)
         .accessibilityElement(children: .ignore)
-        .accessibilityLabel("活动热力图，过去 16 周共 \(totalEntries) 条记录，当前连续 \(streak) 天")
+        .accessibilityLabel(accessibilityText)
     }
 
     // MARK: - Header
@@ -199,21 +201,49 @@ struct SidebarHeatmapView: View {
             }
             Spacer()
             if streak > 0 {
-                HStack(spacing: 5) {
-                    Image(systemName: "flame.fill")
-                        .font(.system(size: 10))
-                        .foregroundColor(DSColor.accentAmber)
-                    Text("\(streak) DAYS")
-                        .font(DSType.mono9)
-                        .tracking(1.2)
-                        .foregroundColor(DSColor.accentAmber)
-                        .fixedSize()
-                }
-                .padding(.init(top: 4, leading: 7, bottom: 4, trailing: 9))
-                .background(DSColor.accentSoft, in: Capsule())
-                .overlay(Capsule().strokeBorder(DSColor.accentBorder, lineWidth: 0.5))
+                streakPill(
+                    icon: "flame.fill",
+                    text: "\(streak) DAYS",
+                    fg: DSColor.accentAmber,
+                    bg: DSColor.accentSoft,
+                    border: DSColor.accentBorder
+                )
+            } else if longestStreak > 0 {
+                streakPill(
+                    icon: "flame",
+                    text: "BEST \(longestStreak) DAYS",
+                    fg: DSColor.inkSubtle,
+                    bg: DSColor.glassStd,
+                    border: DSColor.borderSubtle
+                )
             }
         }
+    }
+
+    private func streakPill(icon: String, text: String, fg: Color, bg: Color, border: Color) -> some View {
+        HStack(spacing: 5) {
+            Image(systemName: icon)
+                .font(.system(size: 10))
+                .foregroundColor(fg)
+            Text(text)
+                .font(DSType.mono9)
+                .tracking(1.2)
+                .foregroundColor(fg)
+                .fixedSize()
+        }
+        .padding(.init(top: 4, leading: 7, bottom: 4, trailing: 9))
+        .background(bg, in: Capsule())
+        .overlay(Capsule().strokeBorder(border, lineWidth: 0.5))
+    }
+
+    private var accessibilityText: String {
+        let base = "活动热力图，过去 16 周共 \(totalEntries) 条记录"
+        if streak > 0 {
+            return "\(base)，当前连续 \(streak) 天"
+        } else if longestStreak > 0 {
+            return "\(base)，当前连续 0 天，历史最佳 \(longestStreak) 天"
+        }
+        return base
     }
 
     // MARK: - Grid data

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -196,7 +196,8 @@ struct SidebarView: View {
         SidebarHeatmapView(
             counts: sidebarVM.heatmapCounts,
             totalEntries: sidebarVM.totalEntries16Weeks,
-            streak: sidebarVM.currentStreak
+            streak: sidebarVM.currentStreak,
+            longestStreak: sidebarVM.longestStreak
         )
         .padding(.horizontal, 20)
         .padding(.top, 4)


### PR DESCRIPTION
## Show 'personal best' streak pill when current streak is broken (zero-state nudge)

The sidebar heatmap footer renders the amber flame streak pill only when currentStreak > 0, so the moment a streak breaks the footer silently collapses to just the legend — removing all feedback at the exact point a gentle re-engagement nudge matters most. This adds a muted 'BEST N' pill (ghost flame + inkMuted tones) shown when currentStreak == 0 but a longestStreak exists, reusing the already-computed longestStreak value that the view currently ignores.

### Acceptance
With an active streak: amber flame pill shows '\(streak) DAYS' exactly as before (no visual regression). After a gap breaks the streak (currentStreak == 0) but prior history exists: a muted 'BEST N DAYS' pill with an outline flame appears in the footer-trailing slot instead of empty space. For a brand-new empty vault (longestStreak == 0): no pill renders. VoiceOver announces the best-streak fallback. Build passes (`xcodebuild -scheme DayPage build`) and the sidebar renders correctly in the iPhone 17 simulator in both states.