### PR TITLE
auto: Haptic + glow milestone when the scroll-to-top progress ring completes

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -109,6 +109,10 @@ struct TodayView: View {
     /// Drives the one-shot amber glow pulse on the orb / timeline top after pull-to-refresh.
     @State private var refreshGlow: Bool = false
 
+    /// Milestone feedback when the scroll-to-top progress ring fills to 100%.
+    @State private var didReachScrollEnd: Bool = false
+    @State private var scrollRingGlow: Bool = false
+
     /// Scroll proxy captured from the timeline ScrollViewReader; used by composeSection
     /// to scroll to the top anchor after a new memo is added.
     @State private var timelineScrollProxy: ScrollViewProxy? = nil
@@ -285,6 +289,11 @@ struct TodayView: View {
                                         .rotationEffect(.degrees(-90))
                                         .animation(reduceMotion ? nil : Motion.fade, value: scrollProgress)
                                 )
+                                .shadow(
+                                    color: DSColor.accentAmber.opacity(scrollRingGlow ? 0.5 : 0),
+                                    radius: scrollRingGlow ? 14 : 0
+                                )
+                                .animation(.easeOut(duration: 0.6), value: scrollRingGlow)
                                 .clipShape(Circle())
                         }
                         .padding(.trailing, 20)
@@ -296,6 +305,21 @@ struct TodayView: View {
                     }
                 }
                 .animation(reduceMotion ? nil : Motion.rise, value: timelineScrollOffset < -240)
+                .onChange(of: scrollProgress) { progress in
+                    if progress >= 1.0 && !didReachScrollEnd {
+                        didReachScrollEnd = true
+                        Haptics.soft()
+                        if !reduceMotion {
+                            scrollRingGlow = true
+                            Task {
+                                try? await Task.sleep(nanoseconds: 600_000_000)
+                                scrollRingGlow = false
+                            }
+                        }
+                    } else if progress < 0.95 {
+                        didReachScrollEnd = false
+                    }
+                }
                 // Submit error toast — scoped animation lives on the overlay
                 // container so only the toast itself animates, not the whole
                 // ZStack tree. (#217)


### PR DESCRIPTION
## Haptic + glow milestone when the scroll-to-top progress ring completes

The Today timeline's floating scroll-to-top button draws an amber progress ring (scrollProgress 0→1 over ~1200pt of deep scroll) but gives no feedback when it fills, so the affordance goes unnoticed on long days. Add a one-shot soft haptic and a brief amber glow pulse the moment the ring reaches 100%, matching the app's existing reward-pulse vocabulary (refreshGlow, orbCapturePulse) and confirming the user has reached the deepest part of their timeline.

### Acceptance
On a Today timeline long enough that scrollProgress reaches 1.0, scrolling to the deepest point fires exactly one soft haptic and a single amber glow pulse on the scroll-to-top button; scrolling back up past the 95% threshold and down again re-fires it once. With Reduce Motion enabled the glow is suppressed but the project still builds (`xcodebuild -scheme DayPage build`) and no existing tests regress; the change touches only TodayView.swift and is under 100 lines.