### PR TITLE
auto: Add weather & day-summary context to Markdown export frontmatter, with safe YAML escaping

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1146,7 +1146,8 @@ struct TodayView: View {
             if !viewModel.memos.isEmpty {
                 Button {
                     let content = MarkdownExportService.buildExportContent(
-                        memos: viewModel.memos, date: Date()
+                        memos: viewModel.memos, date: Date(),
+                        summary: viewModel.dailyPageSummary
                     )
                     let df = DateFormatter()
                     df.dateFormat = "yyyy-MM-dd"
@@ -1187,7 +1188,8 @@ struct TodayView: View {
                 .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 6 }
                 .onLongPressGesture(minimumDuration: 0.5) {
                     let content = MarkdownExportService.buildExportContent(
-                        memos: viewModel.memos, date: Date()
+                        memos: viewModel.memos, date: Date(),
+                        summary: viewModel.dailyPageSummary
                     )
                     UIPasteboard.general.string = content
                     Haptics.success()

--- a/DayPage/Services/MarkdownExportService.swift
+++ b/DayPage/Services/MarkdownExportService.swift
@@ -17,7 +17,12 @@ enum MarkdownExportService {
     // MARK: - Export
 
     /// Builds an Obsidian-compatible `.md` string from the given memos and date.
-    static func buildExportContent(memos: [Memo], date: Date) -> String {
+    static func buildExportContent(
+        memos: [Memo],
+        date: Date,
+        weather: String? = nil,
+        summary: String? = nil
+    ) -> String {
         let df = DateFormatter()
         df.dateFormat = "yyyy-MM-dd"
         df.locale = Locale(identifier: "en_US_POSIX")
@@ -26,6 +31,7 @@ enum MarkdownExportService {
 
         let moods = memos.compactMap { $0.mood }.filter { !$0.isEmpty }
         let entities = Array(Set(memos.flatMap { $0.entityMentions })).sorted()
+        let resolvedWeather = weather ?? memos.first(where: { $0.weather != nil && !($0.weather!.isEmpty) })?.weather
 
         var lines: [String] = ["---"]
         lines.append("date: \(dateString)")
@@ -33,7 +39,11 @@ enum MarkdownExportService {
         lines.append("memo_count: \(memos.count)")
 
         if let mood = moods.first {
-            lines.append("mood: \"\(mood)\"")
+            lines.append("mood: \(yamlQuoted(mood))")
+        }
+
+        if let w = resolvedWeather {
+            lines.append("weather: \(yamlQuoted(w))")
         }
 
         if entities.isEmpty {
@@ -41,13 +51,18 @@ enum MarkdownExportService {
         } else {
             lines.append("entity_mentions:")
             for e in entities {
-                lines.append("  - \"\(e)\"")
+                lines.append("  - \(yamlQuoted(e))")
             }
         }
         lines.append("---")
         lines.append("")
         lines.append("# DayPage — \(dateString)")
         lines.append("")
+
+        if let s = summary, !s.isEmpty {
+            lines.append("> AI · \(s)")
+            lines.append("")
+        }
 
         let sorted = memos.sorted { $0.created < $1.created }
         for (idx, memo) in sorted.enumerated() {
@@ -105,6 +120,15 @@ enum MarkdownExportService {
         let url = dir.appendingPathComponent("\(dateString).md")
         try content.write(to: url, atomically: true, encoding: .utf8)
         return url
+    }
+
+    // MARK: - Private Helpers
+
+    private static func yamlQuoted(_ s: String) -> String {
+        let escaped = s
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+        return "\"\(escaped)\""
     }
 
     /// Presents a share sheet for the exported markdown file.

--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -1,0 +1,130 @@
+import Testing
+@testable import DayPage
+
+@Suite("MarkdownExportService")
+struct MarkdownExportServiceTests {
+
+    // MARK: - Helpers
+
+    private func makeDate(year: Int = 2026, month: Int = 6, day: Int = 1) -> Date {
+        var c = DateComponents()
+        c.year = year; c.month = month; c.day = day
+        c.hour = 10; c.minute = 0; c.second = 0
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private func makeMemo(
+        body: String,
+        mood: String? = nil,
+        weather: String? = nil,
+        entityMentions: [String] = [],
+        secondsOffset: Double = 0
+    ) -> Memo {
+        Memo(
+            id: UUID(),
+            type: .text,
+            created: Date(timeIntervalSinceReferenceDate: 800_000_000 + secondsOffset),
+            weather: weather,
+            mood: mood,
+            entityMentions: entityMentions,
+            body: body
+        )
+    }
+
+    // MARK: - 1. Mood with embedded double-quote is escaped
+
+    @Test func moodWithEmbeddedQuote_isEscapedInFrontmatter() {
+        let memo = makeMemo(body: "test", mood: "feels like \"home\"")
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate()
+        )
+        // Must contain the escaped form, not a raw unescaped quote
+        #expect(content.contains("mood: \"feels like \\\"home\\\"\""))
+    }
+
+    @Test func entityWithEmbeddedQuote_isEscapedInFrontmatter() {
+        let memo = makeMemo(body: "test", entityMentions: ["say \"hello\""])
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate()
+        )
+        #expect(content.contains("\"say \\\"hello\\\"\""))
+    }
+
+    // MARK: - 2. Weather field appears when a memo carries weather
+
+    @Test func frontmatter_containsWeatherLine_whenMemoHasWeather() {
+        let memo = makeMemo(body: "test", weather: "晴 25°C")
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate()
+        )
+        #expect(content.contains("weather: \"晴 25°C\""))
+    }
+
+    @Test func frontmatter_omitsWeatherLine_whenNoMemoHasWeather() {
+        let memo = makeMemo(body: "test")
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate()
+        )
+        #expect(!content.contains("weather:"))
+    }
+
+    @Test func frontmatter_usesFirstNonEmptyWeather_fromMemos() {
+        let m1 = makeMemo(body: "no weather", secondsOffset: 0)
+        let m2 = makeMemo(body: "has weather", weather: "cloudy", secondsOffset: 10)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m1, m2], date: makeDate()
+        )
+        #expect(content.contains("weather: \"cloudy\""))
+    }
+
+    // MARK: - 3. Summary blockquote
+
+    @Test func summaryBlockquote_appearsUnderH1_whenSummarySupplied() {
+        let memo = makeMemo(body: "test")
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate(), summary: "A great day."
+        )
+        // Blockquote line must follow the H1 heading
+        let h1Range = content.range(of: "# DayPage —")
+        let blockquoteRange = content.range(of: "> AI · A great day.")
+        #expect(h1Range != nil)
+        #expect(blockquoteRange != nil)
+        if let h1 = h1Range, let bq = blockquoteRange {
+            #expect(h1.lowerBound < bq.lowerBound)
+        }
+    }
+
+    @Test func summaryBlockquote_isAbsent_whenSummaryIsNil() {
+        let memo = makeMemo(body: "test")
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate(), summary: nil
+        )
+        #expect(!content.contains("> AI ·"))
+    }
+
+    @Test func summaryBlockquote_isAbsent_whenSummaryIsEmpty() {
+        let memo = makeMemo(body: "test")
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate(), summary: ""
+        )
+        #expect(!content.contains("> AI ·"))
+    }
+
+    // MARK: - 4. Memo bodies ordered by created ascending
+
+    @Test func memoBodies_orderedByCreatedAscending() {
+        let m1 = makeMemo(body: "first", secondsOffset: 0)
+        let m2 = makeMemo(body: "second", secondsOffset: 60)
+        let m3 = makeMemo(body: "third", secondsOffset: 120)
+        // Pass in reverse order — output must still be ascending
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m3, m1, m2], date: makeDate()
+        )
+        let firstPos = content.range(of: "first")!.lowerBound
+        let secondPos = content.range(of: "second")!.lowerBound
+        let thirdPos = content.range(of: "third")!.lowerBound
+        #expect(firstPos < secondPos)
+        #expect(secondPos < thirdPos)
+    }
+}


### PR DESCRIPTION
## Add weather & day-summary context to Markdown export frontmatter, with safe YAML escaping

The Obsidian Markdown export currently emits date, mood, and entity mentions but drops the day's weather and AI summary — context users explicitly captured. It also injects mood/entity strings into double-quoted YAML without escaping embedded quotes or backslashes, which silently corrupts the frontmatter when a mood or entity contains a quote. This adds weather + summary fields and a small YAML-string escaper, making exported files richer and parse-safe.

### Acceptance
`xcodebuild -scheme DayPage build` succeeds; the new MarkdownExportServiceTests pass under the DayPageTests target on iPhone 17; exporting a day whose mood/entity contains a double-quote yields valid YAML frontmatter (quote escaped, no premature string termination); the exported file shows a `weather:` frontmatter field and an `AI ·` summary blockquote when those values exist, and omits the summary line cleanly when there is none.