### PR TITLE
auto: Anticipatory pulse on CompileUnlockCard's final progress dot

### DIFF
--- a/DayPage/Features/Today/CompileUnlockCard.swift
+++ b/DayPage/Features/Today/CompileUnlockCard.swift
@@ -29,8 +29,22 @@ struct CompileUnlockCard: View {
     @State private var shimmer = false
     @State private var lastFilled: Int = 0
     @State private var poppedIndex: Int? = nil
+    /// Anticipatory pulse on the next-empty dot when the user is one memo away.
+    @State private var nextDotPulse = false
 
     private var remaining: Int { max(1, 3 - memoCount) }
+    /// Index of the next dot to fill (the leftmost empty slot), or nil if full.
+    private var nextEmptyIndex: Int? { memoCount < 3 ? memoCount : nil }
+    /// True when a single memo separates the user from unlocking.
+    private var isOneAway: Bool { remaining == 1 }
+
+    /// Scale for a progress dot: the just-filled dot pops, the breathing
+    /// next-empty dot gently swells, everything else stays at rest.
+    private func dotScale(index: Int, isNext: Bool) -> CGFloat {
+        if poppedIndex == index { return 1.6 }
+        if isNext && isOneAway && nextDotPulse { return 1.25 }
+        return 1.0
+    }
 
     private var cardContent: some View {
         HStack(spacing: 14) {
@@ -47,7 +61,7 @@ struct CompileUnlockCard: View {
             }
 
             VStack(alignment: .leading, spacing: 6) {
-                Text("再记 \(remaining) 条解锁今日成稿")
+                Text(isOneAway ? "再记 1 条，今日成稿就解锁" : "再记 \(remaining) 条解锁今日成稿")
                     .font(DSFonts.jetBrainsMono(size: 10))
                     .tracking(1.2)
                     .foregroundColor(DSColor.accentAmber)
@@ -56,13 +70,23 @@ struct CompileUnlockCard: View {
                     .foregroundColor(DSColor.inkMuted)
                     .fixedSize(horizontal: false, vertical: true)
 
-                // Progress dots mirroring CompileProgressDock.
+                // Progress dots mirroring CompileProgressDock. The next-empty
+                // dot breathes when the user is one memo away, drawing the eye
+                // to the slot about to complete.
                 HStack(spacing: 5) {
                     ForEach(0..<3, id: \.self) { index in
+                        let isFilled = index < memoCount
+                        let isNext = index == nextEmptyIndex
                         Circle()
-                            .fill(index < memoCount ? DSColor.accentAmber : DSColor.glassStd)
+                            .fill(isFilled ? DSColor.accentAmber : DSColor.glassStd)
                             .frame(width: 5, height: 5)
-                            .scaleEffect(poppedIndex == index ? 1.6 : 1.0)
+                            .scaleEffect(dotScale(index: index, isNext: isNext))
+                            .overlay(
+                                Circle()
+                                    .stroke(DSColor.accentAmber, lineWidth: 1)
+                                    .scaleEffect(isNext && isOneAway && nextDotPulse ? 2.4 : 1.0)
+                                    .opacity(isNext && isOneAway && nextDotPulse ? 0 : (isNext && isOneAway ? 0.5 : 0))
+                            )
                             .animation(Motion.respectReduceMotion(.spring(response: 0.3, dampingFraction: 0.55)), value: poppedIndex)
                             .animation(Motion.respectReduceMotion(Motion.spring), value: memoCount)
                     }
@@ -124,6 +148,24 @@ struct CompileUnlockCard: View {
             ) {
                 shimmer = true
             }
+            startNextDotPulseIfNeeded()
+        }
+        .onChange(of: isOneAway) { _ in
+            startNextDotPulseIfNeeded()
+        }
+    }
+
+    /// Drive the expanding-ring + swell pulse on the next-empty dot, but only
+    /// while exactly one memo remains. Toggling `nextDotPulse` inside a
+    /// repeating animation produces the recurring ripple.
+    private func startNextDotPulseIfNeeded() {
+        guard isOneAway, !reduceMotion else {
+            nextDotPulse = false
+            return
+        }
+        nextDotPulse = false
+        withAnimation(.easeOut(duration: 1.4).repeatForever(autoreverses: false)) {
+            nextDotPulse = true
         }
     }
 }


### PR DESCRIPTION
## Anticipatory pulse on CompileUnlockCard's final progress dot

When a user is exactly one memo away from unlocking AI compilation, the CompileUnlockCard's three progress dots are static and convey no momentum. This adds a breathing expanding-ring ripple plus a gentle swell on the next-empty dot when only one memo remains, and switches the headline copy to '再记 1 条，今日成稿就解锁' — turning a flat hint into a near-finish-line invitation that drives the third capture.

### Acceptance
With 2 memos recorded today and motion enabled, the third (empty) progress dot in CompileUnlockCard emits a recurring expanding amber ring and gently swells, and the headline reads '再记 1 条，今日成稿就解锁'. With 0–1 memos the dots are calm and copy reads '再记 N 条解锁今日成稿'. Reaching 3 memos removes the card. Under Reduce Motion, dots are fully static with no ripple. VoiceOver label still reports the remaining/recorded counts. Project builds via xcodebuild -scheme DayPage on iPhone 17.