### PR TITLE
auto: Fix streak-milestone celebration race: await the vault scan instead of a fixed 400ms sleep

### DIFF
--- a/DayPage/App/SidebarViewModel.swift
+++ b/DayPage/App/SidebarViewModel.swift
@@ -163,40 +163,47 @@ final class SidebarViewModel: ObservableObject {
     /// off the main actor. Safe to call repeatedly (e.g. whenever the sidebar opens).
     func refreshRecentDays() {
         Task { [weak self] in
-            async let recent = Self.scanRecentDays(limit: 7)
-            async let streak = Self.scanRecentDays(limit: 365)
-            // 16 weeks = 112 days; scan a touch more to cover the partial
-            // leading week the grid renders.
-            async let heatmap = Self.scanRecentDays(limit: 119)
-            async let stats = Self.scanStats()
-            let (recentResult, streakResult, heatmapResult, statsResult) =
-                await (recent, streak, heatmap, stats)
-            await MainActor.run {
-                self?.recentDays = recentResult
-                self?.streakDays = streakResult
-                let counts = Dictionary(
-                    heatmapResult.map { ($0.dateString, $0.memoCount) },
-                    uniquingKeysWith: { a, _ in a }
-                )
-                self?.heatmapCounts = counts
-                // Count only memos within the 112-day (16-week) heatmap window.
-                // scanRecentDays limits by *file count*, so an intermittent
-                // journaler's 119 files can reach back well beyond 16 weeks;
-                // filter by calendar date so the "N ENTRIES" figure matches the
-                // grid the user actually sees.
-                let cal = Calendar.current
-                let windowStart = cal.date(
-                    byAdding: .day, value: -111, to: cal.startOfDay(for: Date())
-                )
-                self?.totalEntries16Weeks = heatmapResult.reduce(0) { acc, day in
-                    guard let windowStart,
-                          let date = Self.isoFormatter.date(from: day.dateString),
-                          date >= windowStart else { return acc }
-                    return acc + day.memoCount
-                }
-                self?.totalPages = statsResult.pages
-                self?.totalWordCount = statsResult.words
+            await self?.refreshRecentDaysAsync()
+        }
+    }
+
+    /// Awaitable variant of `refreshRecentDays`. Callers that need to act on
+    /// fresh streak data immediately after the scan (e.g. milestone celebration)
+    /// should `await` this instead of calling `refreshRecentDays()` + sleeping.
+    func refreshRecentDaysAsync() async {
+        async let recent = Self.scanRecentDays(limit: 7)
+        async let streak = Self.scanRecentDays(limit: 365)
+        // 16 weeks = 112 days; scan a touch more to cover the partial
+        // leading week the grid renders.
+        async let heatmap = Self.scanRecentDays(limit: 119)
+        async let stats = Self.scanStats()
+        let (recentResult, streakResult, heatmapResult, statsResult) =
+            await (recent, streak, heatmap, stats)
+        await MainActor.run {
+            self.recentDays = recentResult
+            self.streakDays = streakResult
+            let counts = Dictionary(
+                heatmapResult.map { ($0.dateString, $0.memoCount) },
+                uniquingKeysWith: { a, _ in a }
+            )
+            self.heatmapCounts = counts
+            // Count only memos within the 112-day (16-week) heatmap window.
+            // scanRecentDays limits by *file count*, so an intermittent
+            // journaler's 119 files can reach back well beyond 16 weeks;
+            // filter by calendar date so the "N ENTRIES" figure matches the
+            // grid the user actually sees.
+            let cal = Calendar.current
+            let windowStart = cal.date(
+                byAdding: .day, value: -111, to: cal.startOfDay(for: Date())
+            )
+            self.totalEntries16Weeks = heatmapResult.reduce(0) { acc, day in
+                guard let windowStart,
+                      let date = Self.isoFormatter.date(from: day.dateString),
+                      date >= windowStart else { return acc }
+                return acc + day.memoCount
             }
+            self.totalPages = statsResult.pages
+            self.totalWordCount = statsResult.words
         }
     }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1529,10 +1529,8 @@ struct TodayView: View {
             }
             // Celebrate streak milestone when today's first memo is added.
             if lastMemoCount == 0 && count == 1 {
-                sidebarVM.refreshRecentDays()
                 Task { @MainActor in
-                    // Let the async vault scan in refreshRecentDays complete.
-                    try? await Task.sleep(nanoseconds: 400_000_000)
+                    await sidebarVM.refreshRecentDaysAsync()
                     celebrateStreakIfNeeded()
                 }
             }


### PR DESCRIPTION
## Fix streak-milestone celebration race: await the vault scan instead of a fixed 400ms sleep

The Today screen celebrates streak milestones (3/7/14/30/100/365 days) when the first memo of the day is added, but it reads `sidebarVM.currentStreak` after a hardcoded `Task.sleep(400ms)` that hopes the async `refreshRecentDays()` vault scan has finished. On a large vault or slow/iCloud disk the scan loses the race, `currentStreak` is stale, and the milestone banner + success haptic silently never fire — the user crosses a meaningful streak with no feedback. The fix makes `refreshRecentDays` awaitable so the celebration runs deterministically once fresh streak data is published.

### Acceptance
Build the DayPage scheme on the iPhone 17 simulator with no errors. Streak milestone banner + Haptics.success() now fire reliably on the first memo of a day that completes a milestone-length streak, regardless of vault scan latency (verify by seeding a vault of consecutive prior days via SampleDataSeeder so currentStreak == 7, then adding today's first memo). Existing sidebar streak display and all other refreshRecentDays() callers behave identically; no milestone re-fires once recorded in streakMilestonesShown; reduce-motion still suppresses the glow.