### PR TITLE
auto: Per-memo capture feedback on the CompileUnlockCard progress dots

### DIFF
--- a/DayPage/Features/Today/CompileUnlockCard.swift
+++ b/DayPage/Features/Today/CompileUnlockCard.swift
@@ -129,14 +129,29 @@ struct CompileUnlockCard: View {
             }
         }
         .onChange(of: memoCount) { newCount in
-            guard newCount > lastFilled, !reduceMotion else {
+            guard newCount > lastFilled else {
                 lastFilled = newCount
                 return
             }
-            poppedIndex = newCount - 1
-            Task { @MainActor in
-                try? await Task.sleep(nanoseconds: 250_000_000)
-                poppedIndex = nil
+            // Haptic and VoiceOver announcement fire on every increment,
+            // regardless of Reduce Motion.
+            Haptics.soft()
+            let stillNeeded = max(0, 3 - newCount)
+            if stillNeeded > 0 {
+                let msg = NSLocalizedString(
+                    "compile.unlock.progress",
+                    value: "还需 \(stillNeeded) 条",
+                    comment: "VoiceOver progress after adding a memo while unlock card is visible"
+                )
+                UIAccessibility.post(notification: .announcement, argument: msg)
+            }
+            // Dot-pop scale animation is suppressed under Reduce Motion.
+            if !reduceMotion {
+                poppedIndex = newCount - 1
+                Task { @MainActor in
+                    try? await Task.sleep(nanoseconds: 250_000_000)
+                    poppedIndex = nil
+                }
             }
             lastFilled = newCount
         }


### PR DESCRIPTION
## Per-memo capture feedback on the CompileUnlockCard progress dots

When a memo is added while the CompileUnlockCard is visible (memo count 1→2, 2→3), only a silent visual dot-pop fires today, and nothing at all fires under Reduce Motion. Add a light haptic tick on every increment plus a VoiceOver announcement of remaining count, so each capture feels acknowledged and progress is conveyed non-visually.

### Acceptance
Adding a memo (1→2, 2→3) while the unlock card is on screen produces a soft haptic each time; with VoiceOver on, an announcement states the remaining count; with Reduce Motion on, the haptic and announcement still fire while the dot-pop scale animation is suppressed; build of the DayPage scheme succeeds and no force-unwraps are introduced.