### PR TITLE
auto: Discoverable long-press hint + haptic for the Today header export button

### DIFF
--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -158,6 +158,8 @@ extension AppSettings {
         static let memoSwipeHintShown = "memoswipeHintShown"
         // Streak milestone celebrations — comma-joined Int set, e.g. "3,7,14"
         static let streakMilestonesShown = "streakMilestonesShown"
+        // Export long-press hint — shown once when the button first appears with >=1 memo
+        static let exportLongPressHintShown = "today.exportLongPressHintShown"
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -86,6 +86,9 @@ struct TodayView: View {
     @State private var showExportSheet: Bool = false
     @State private var exportFileURL: URL? = nil
 
+    /// One-time discoverable pulse on the export button (fires when button first appears with >=1 memo).
+    @State private var exportHintPulse: Bool = false
+
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var orbBreathing: Bool = false
 
@@ -1179,6 +1182,9 @@ struct TodayView: View {
                         .background(.ultraThinMaterial, in: Circle())
                         .overlay(Circle().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
                         .clipShape(Circle())
+                        .scaleEffect(exportHintPulse ? 1.12 : 1)
+                        .shadow(color: DSColor.accentAmber.opacity(exportHintPulse ? 0.4 : 0), radius: exportHintPulse ? 8 : 0)
+                        .animation(reduceMotion ? nil : Motion.spring, value: exportHintPulse)
                 }
                 .accessibilityLabel(NSLocalizedString("export.action.title", comment: ""))
                 .accessibilityHint(NSLocalizedString("export.action.hint", comment: ""))
@@ -1186,12 +1192,26 @@ struct TodayView: View {
                 .frame(width: 44, height: 44)
                 .contentShape(Rectangle())
                 .alignmentGuide(.firstTextBaseline) { d in d[VerticalAlignment.center] + 6 }
+                .onAppear {
+                    guard !UserDefaults.standard.bool(forKey: AppSettings.Keys.exportLongPressHintShown),
+                          !reduceMotion,
+                          !viewModel.memos.isEmpty else { return }
+                    UserDefaults.standard.set(true, forKey: AppSettings.Keys.exportLongPressHintShown)
+                    Task { @MainActor in
+                        try? await Task.sleep(for: .seconds(0.8))
+                        Haptics.soft()
+                        withAnimation(Motion.spring) { exportHintPulse = true }
+                        try? await Task.sleep(for: .seconds(0.5))
+                        withAnimation(Motion.spring) { exportHintPulse = false }
+                    }
+                }
                 .onLongPressGesture(minimumDuration: 0.5) {
                     let content = MarkdownExportService.buildExportContent(
                         memos: viewModel.memos, date: Date(),
                         summary: viewModel.dailyPageSummary
                     )
                     UIPasteboard.general.string = content
+                    Haptics.medium()
                     Haptics.success()
                     bannerCenter.show(AppBannerModel(
                         kind: .info,


### PR DESCRIPTION
## Discoverable long-press hint + haptic for the Today header export button

The header export button (square.and.arrow.up) supports a hidden long-press-to-copy-markdown gesture, but nothing signals it exists, so users never discover the fast clipboard path. Add a one-time subtle pulse/tooltip the first time the button becomes available, and give the long-press a distinct medium-then-success haptic ladder so the copy action feels different from the tap-to-share action.

### Acceptance
On first launch with >=1 memo, the export icon performs a single subtle amber scale-pulse with one soft haptic, then never again (flag persists across launches). Tap still opens the share sheet; long-press copies markdown to the clipboard and now fires a medium-then-success haptic plus the existing 'copied' banner. Respects Reduce Motion (no pulse, gesture unchanged). `xcodebuild -scheme DayPage build` succeeds and the app launches in the iPhone 17 simulator.