### PR TITLE
auto: Adaptive load skeleton matching the day's actual memo count

### DIFF
--- a/DayPage/Components/MemoListSkeleton.swift
+++ b/DayPage/Components/MemoListSkeleton.swift
@@ -3,16 +3,25 @@ import SwiftUI
 // MARK: - MemoListSkeleton
 
 /// Placeholder skeleton shown in TodayView while the initial vault load is in flight.
-/// Mirrors the approximate shape of 3 MemoCardView rows so the layout doesn't shift
-/// once real content appears. Uses a shimmer animation to signal activity.
+/// `count` controls how many placeholder cards are rendered (clamped to 1…6) so the
+/// skeleton height closely matches the incoming content and avoids a layout shift.
 struct MemoListSkeleton: View {
+    var count: Int = 3
+
+    private var clampedCount: Int { count.clamped(to: 1...6) }
+
     var body: some View {
         VStack(spacing: 8) {
-            SkeletonCard(lineCount: 3, wide: false)
-            SkeletonCard(lineCount: 2, wide: true)
-            SkeletonCard(lineCount: 4, wide: false)
+            ForEach(0..<clampedCount, id: \.self) { idx in
+                SkeletonCard(lineCount: lineCount(for: idx), wide: idx % 3 == 1)
+            }
         }
         .accessibilityHidden(true)
+    }
+
+    private func lineCount(for index: Int) -> Int {
+        let pattern = [3, 2, 4, 2, 3, 4]
+        return pattern[index % pattern.count]
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -46,6 +46,10 @@ struct TodayView: View {
     // If the draft is older than 30 days it is auto-cleared on next launch.
     @AppStorage("today.draftDate") private var draftDate: Double = 0
 
+    // Rolling count of the last successfully-loaded memo set for today.
+    // Drives MemoListSkeleton so placeholder height matches expected content height.
+    @AppStorage("today.skeletonCardCount") private var skeletonCardCount: Int = 3
+
     // US-009: Text to restore if undo is tapped within 5s of submit.
     @State private var undoText: String? = nil
     @State private var undoTask: Task<Void, Never>? = nil
@@ -1313,7 +1317,7 @@ struct TodayView: View {
                 }
 
                 if viewModel.loadState == .loading && viewModel.memos.isEmpty {
-                    MemoListSkeleton()
+                    MemoListSkeleton(count: skeletonCardCount)
                         .padding(.horizontal, 20)
                         .transition(.opacity)
                 }
@@ -1543,6 +1547,9 @@ struct TodayView: View {
                 }
             }
             lastMemoCount = count
+            if viewModel.loadState == .ready && count > 0 {
+                skeletonCardCount = count
+            }
         }
         .onChange(of: viewModel.isDailyPageCompiled) { compiled in
             if compiled && !didCelebrateCompile {


### PR DESCRIPTION
## Adaptive load skeleton matching the day's actual memo count

MemoListSkeleton always renders exactly 3 placeholder cards, so on days with many memos the timeline visibly jumps when real content replaces the skeleton. Persist the last-known memo count per day in UserDefaults and render that many skeleton cards (clamped 1–6) so the placeholder height closely matches the incoming content, eliminating the layout shift.

### Acceptance
On a day that previously had N memos (N between 1 and 6), reopening Today during the initial vault load shows N shimmer cards rather than always 3, and the timeline does not visibly jump in height when real memos replace the skeleton. With no cached count it falls back to 3 cards. Reduce Motion still disables the shimmer; the skeleton remains accessibilityHidden. The DayPage scheme builds clean.