### PR TITLE
auto: Animate the Day Orb's signal-count number with a rolling odometer transition on each new memo

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -297,7 +297,7 @@ struct DayOrbView: View {
                         .font(DSFonts.spaceGrotesk(size: size * 0.36, weight: .semibold))
                         .tracking(-2)
                         .foregroundColor(DSColor.amberDeep)
-                        .contentTransition(.numericText())
+                        .modifier(OrbNumericTextTransition(value: Double(signalCount), reduceMotion: reduceMotion))
                         .animation(.snappy, value: signalCount)
                         .scaleEffect(countPop)
 
@@ -310,6 +310,23 @@ struct DayOrbView: View {
                         .animation(.easeInOut(duration: 0.25), value: readoutLabel)
                 }
             }
+        }
+    }
+}
+
+// MARK: - OrbNumericTextTransition
+
+private struct OrbNumericTextTransition: ViewModifier {
+    let value: Double
+    let reduceMotion: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content
+                .contentTransition(reduceMotion ? .identity : .numericText(value: value))
+        } else {
+            content
+                .contentTransition(.identity)
         }
     }
 }


### PR DESCRIPTION
## Animate the Day Orb's signal-count number with a rolling odometer transition on each new memo

When a new memo is captured, the Day Orb's center count currently snaps to the new value via a plain `.animation(.snappy)`. Replace it with a `.numericText` content transition (matching the pattern already used in the orb kicker and SearchView's result count) so the digit rolls like an odometer, giving the capture a more rewarding, premium feel that reinforces the existing capture-pulse glow. This is a small, self-contained polish to an already-instrumented value.

### Acceptance
Build the DayPage scheme for iPhone 17. Launch in Simulator, add memos on the empty Today screen, and confirm the orb's center number rolls digit-by-digit (odometer style) rather than hard-cutting when the count increments. Toggle Settings > Accessibility > Reduce Motion ON and confirm the number changes instantly with no rolling animation. No regression to the existing capture-pulse glow or breathing animation.