### PR TITLE
auto: Add VoiceOver accessibility to GlassTabBar primary navigation

### DIFF
--- a/DayPage/Components/GlassTabBar.swift
+++ b/DayPage/Components/GlassTabBar.swift
@@ -91,6 +91,7 @@ struct GlassTabBar: View {
                 Image(systemName: active.icon)
                     .font(.system(size: 14, weight: .medium))
                     .foregroundColor(DSColor.amberDeep)
+                    .accessibilityHidden(true)
 
                 Text(active.label)
                     .font(DSType.labelSM)
@@ -99,6 +100,7 @@ struct GlassTabBar: View {
                 Image(systemName: "chevron.down")
                     .font(.system(size: 10, weight: .semibold))
                     .foregroundColor(DSColor.inkMuted)
+                    .accessibilityHidden(true)
             }
             .padding(.top, 6)
             .padding(.leading, 12)
@@ -107,6 +109,9 @@ struct GlassTabBar: View {
             .liquidGlassPill()
         }
         .buttonStyle(.plain)
+        .accessibilityLabel("Navigation, currently \(active.label)")
+        .accessibilityHint("Opens the section menu")
+        .accessibilityIdentifier("glass-tabbar-pill")
     }
 
     // MARK: - Expanded Menu
@@ -137,6 +142,7 @@ struct GlassTabBar: View {
                     .font(.system(size: 14, weight: isActive ? .semibold : .regular))
                     .foregroundColor(isActive ? Color.white.opacity(0.92) : DSColor.inkPrimary)
                     .frame(width: 18)
+                    .accessibilityHidden(true)
 
                 Text(section.label)
                     .font(isActive ? DSType.labelSM.weight(.semibold) : DSType.labelSM)
@@ -157,6 +163,10 @@ struct GlassTabBar: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityLabel(section.label)
+        .accessibilityHint("Switches to the \(section.label) section")
+        .accessibilityAddTraits(isActive ? [.isButton, .isSelected] : .isButton)
+        .accessibilityIdentifier("glass-tabbar-row-\(section.rawValue.lowercased())")
     }
 }
 


### PR DESCRIPTION
## Add VoiceOver accessibility to GlassTabBar primary navigation

The GlassTabBar (top-right glass pill that expands into the Today/Archive/Graph navigation menu) is the app's primary top-level navigation control yet has zero accessibility annotations — no labels, hints, or selected-state traits — while every other interactive surface in the app (TodayView buttons, GraphView, orb) is meticulously annotated. VoiceOver users currently hear the collapsed pill announced only as its raw icon/text with no role context, and the expanded menu rows give no indication of which section is active. This adds proper labels, hints, and the `.isSelected` trait so the nav is fully usable with VoiceOver.

### Acceptance
Build the DayPage scheme successfully (xcodebuild -scheme DayPage build). Launch on the iPhone 17 simulator with VoiceOver and confirm: the collapsed pill announces "Navigation, currently Today" with the "Opens the section menu" hint; expanding the menu announces each row by section name with a switch hint; and the currently-active row is announced as "selected". No visual change to the control in normal (non-VoiceOver) use.