### PR TITLE
auto: Tint the Day Orb's glow by time of day (dawn → dusk → night)

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -16,6 +16,8 @@ struct DayOrbView: View {
     var pulseToggle: Bool = false
     /// Fraction of the current day elapsed (0 at local midnight, 1.0 at next midnight).
     var dayProgress: CGFloat = 0
+    /// Time-of-day accent color driving the halo and orb fill (dawn → midday → dusk → night).
+    var timeTint: Color = DSColor.accentAmber
 
     @State private var breatheScale: CGFloat = 1.0
     @State private var pulse: Bool = false
@@ -168,7 +170,7 @@ struct DayOrbView: View {
             .fill(
                 RadialGradient(
                     colors: [
-                        Color(red: 168/255, green: 84/255, blue: 27/255).opacity(invitePulse ? 0.18 : 0.08),
+                        timeTint.opacity(invitePulse ? 0.18 : 0.08),
                         Color.clear
                     ],
                     center: .center,
@@ -192,7 +194,7 @@ struct DayOrbView: View {
             .fill(
                 RadialGradient(
                     colors: [
-                        Color(red: 168/255, green: 84/255, blue: 27/255).opacity(haloOpacity),
+                        timeTint.opacity(haloOpacity),
                         Color.clear
                     ],
                     center: .center,
@@ -225,8 +227,8 @@ struct DayOrbView: View {
                     stops: [
                         .init(color: Color.white.opacity(0.425), location: 0),
                         .init(color: Color(red: 255/255, green: 206/255, blue: 140/255).opacity(0.2), location: 0.4),
-                        .init(color: Color(red: 168/255, green: 84/255, blue: 27/255).opacity(0.1), location: 0.8),
-                        .init(color: Color(red: 168/255, green: 84/255, blue: 27/255).opacity(0.025), location: 1)
+                        .init(color: timeTint.opacity(0.1), location: 0.8),
+                        .init(color: timeTint.opacity(0.025), location: 1)
                     ],
                     center: UnitPoint(x: 0.35, y: 0.30),
                     startRadius: 0,

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -843,10 +843,12 @@ struct TodayView: View {
             let signalCount = viewModel.signalCount
             let orbValueKey = signalCount == 1 ? "today.orb.value.one" : "today.orb.value.other"
             let orbValue = String(format: NSLocalizedString(orbValueKey, comment: ""), signalCount)
+            let tint = orbTimeTint(currentTime)
             DayOrbView(signalCount: signalCount, size: 140, onTap: {
                 Haptics.tapConfirm()
                 orbFocusToggle.toggle()
-            }, pulseToggle: orbCapturePulse, dayProgress: dayProgress)
+            }, pulseToggle: orbCapturePulse, dayProgress: dayProgress, timeTint: tint)
+            .animation(reduceMotion ? nil : .easeInOut(duration: 0.8), value: tint)
             .scaleEffect(reduceMotion ? 1.0 : (orbBreathing ? 1.03 : 0.985))
             .shadow(
                 color: DSColor.accentAmber.opacity(orbBreathing ? 0.28 + glowBoost : 0.12 + glowBoost),
@@ -951,6 +953,17 @@ struct TodayView: View {
         case 12...17: return NSLocalizedString("today.greeting.afternoon", comment: "")
         case 18...22: return NSLocalizedString("today.greeting.evening",   comment: "")
         default:      return NSLocalizedString("today.greeting.latenight", comment: "")
+        }
+    }
+
+    // Dawn gold → midday amber → dusk rust → night indigo, matching the four greeting buckets.
+    private func orbTimeTint(_ date: Date) -> Color {
+        let hour = Calendar.current.component(.hour, from: date)
+        switch hour {
+        case 5...11:  return Color(red: 224/255, green: 162/255, blue:  77/255) // dawn gold   #E0A24D
+        case 12...17: return Color(red: 168/255, green:  84/255, blue:  27/255) // midday amber #A8541B
+        case 18...22: return Color(red: 154/255, green:  74/255, blue:  42/255) // dusk rust   #9A4A2A
+        default:      return Color(red:  62/255, green:  74/255, blue: 107/255) // night indigo #3E4A6B
         }
     }
 


### PR DESCRIPTION
## Tint the Day Orb's glow by time of day (dawn → dusk → night)

The signature Day Orb on the empty Today screen renders a static amber halo/fill regardless of the hour, even though the app already classifies the day into morning/afternoon/evening/latenight for its greeting. Drive the orb's halo and accent gradient from the current hour so it shifts from cool dawn gold → warm midday amber → rust dusk → deep indigo-night, reinforcing DayPage's 'capture your day' metaphor and giving nomads an ambient sense of where they are in the day.

### Acceptance
1) DayPage builds clean for the DayPage scheme on iPhone 17. 2) On the empty Today screen the orb halo/fill color visibly differs between morning, afternoon, evening, and late-night (verify by temporarily forcing each hour bucket in a preview). 3) Existing breathing, capture pulse, day-progress arc, and signal-count odometer animations are unchanged. 4) With Reduce Motion on, the orb shows the correct static time tint and no added animation. 5) No new SwiftData/@Model files touched; change is under ~60 lines across 2 files.