### PR TITLE
auto: Idle re-pulse on the empty-state CTA to recapture attention

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -16,6 +16,7 @@ struct EmptyStateView: View {
     @State private var breathing = false
     @State private var ctaGlow = false
     @State private var revealTask: Task<Void, Never>?
+    @State private var idlePulseTask: Task<Void, Never>?
 
     var body: some View {
         VStack(spacing: 20) {
@@ -73,10 +74,14 @@ struct EmptyStateView: View {
                         try? await Task.sleep(nanoseconds: 70_000_000)
                         guard !Task.isCancelled else { return }
                         Haptics.soft()
-                        ctaGlow = true
-                        try? await Task.sleep(nanoseconds: 600_000_000)
-                        guard !Task.isCancelled else { return }
-                        ctaGlow = false
+                        await pulseCTA()
+                        idlePulseTask = Task { @MainActor in
+                            while !Task.isCancelled {
+                                try? await Task.sleep(nanoseconds: 6_000_000_000)
+                                guard !Task.isCancelled, !reduceMotion else { return }
+                                await pulseCTA()
+                            }
+                        }
                     }
                 }
             }
@@ -84,10 +89,18 @@ struct EmptyStateView: View {
         .onDisappear {
             revealTask?.cancel()
             revealTask = nil
+            idlePulseTask?.cancel()
+            idlePulseTask = nil
         }
     }
 
     // MARK: - Private
+
+    private func pulseCTA() async {
+        ctaGlow = true
+        try? await Task.sleep(nanoseconds: 600_000_000)
+        ctaGlow = false
+    }
 
     @ViewBuilder
     private var titleSection: some View {


### PR DESCRIPTION
## Idle re-pulse on the empty-state CTA to recapture attention

The Today empty-state CTA ("Capture" / 记录) is a static amber capsule that glows once on first appear, then sits visually inert. Add a gentle, accessibility-respecting idle re-pulse: after the initial reveal, the CTA's amber glow softly breathes back to life every ~6 seconds while the empty state remains on screen, drawing the eye back to the primary capture action without being distracting. Fully gated behind Reduce Motion and auto-cancelled on disappear.

### Acceptance
Build the DayPage scheme succeeds. On the Today tab with zero memos (first run), the CTA glows once on reveal, then softly re-pulses its amber shadow roughly every 6s. With Reduce Motion enabled (Settings → Accessibility), no idle pulse fires and the CTA is fully visible immediately. Navigating away from the empty state cancels the loop (no lingering Task, verified by the pulse stopping). Existing reveal sequence and haptics are unchanged.