### PR TITLE
auto: Body text stats in Memo Detail metadata (words · characters · reading time)

### DIFF
--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -550,7 +550,49 @@ private struct DetailMetadataSection: View {
         return "vault/raw/\(f.string(from: memo.created)).md"
     }
 
+    // MARK: - Body stats
+
+    private struct BodyStats {
+        let wordCount: Int
+        let charCount: Int
+        let readingMinutes: Int  // 0 means "< 1 min"
+    }
+
+    private func bodyStats(for text: String) -> BodyStats {
+        func isCJK(_ scalar: Unicode.Scalar) -> Bool {
+            (0x4E00...0x9FFF).contains(scalar.value) ||
+            (0x3400...0x4DBF).contains(scalar.value) ||
+            (0x3040...0x30FF).contains(scalar.value)
+        }
+
+        var cjkCount = 0
+        var latinWords = 0
+        var inLatinRun = false
+
+        for scalar in text.unicodeScalars {
+            if isCJK(scalar) {
+                cjkCount += 1
+                inLatinRun = false
+            } else if scalar.properties.isWhitespace {
+                inLatinRun = false
+            } else {
+                if !inLatinRun { latinWords += 1 }
+                inLatinRun = true
+            }
+        }
+
+        // Reading time: CJK at 300 cpm, Latin at 220 wpm — sum independent estimates
+        let totalMinutes = Double(cjkCount) / 300.0 + Double(latinWords) / 220.0
+        return BodyStats(
+            wordCount: cjkCount + latinWords,
+            charCount: text.count,
+            readingMinutes: Int(totalMinutes.rounded())
+        )
+    }
+
     var body: some View {
+        let bodyTrimmed = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
+
         VStack(alignment: .leading, spacing: 12) {
             Text("Metadata")
                 .font(DSType.mono10)
@@ -562,6 +604,26 @@ private struct DetailMetadataSection: View {
             metaRow(label: "Created", value: createdFull)
             metaRow(label: "File", value: vaultFilePath)
             metaRow(label: "Kind", value: memo.type.rawValue.capitalized)
+
+            // Body stats — only shown when there is actual body text
+            if !bodyTrimmed.isEmpty {
+                let stats = bodyStats(for: bodyTrimmed)
+                metaRow(
+                    label: NSLocalizedString("memo.detail.meta.words", comment: ""),
+                    value: "\(stats.wordCount)"
+                )
+                metaRow(
+                    label: NSLocalizedString("memo.detail.meta.characters", comment: ""),
+                    value: "\(stats.charCount)"
+                )
+                let readingValue: String = stats.readingMinutes < 1
+                    ? NSLocalizedString("memo.detail.meta.reading.less_than_1", comment: "")
+                    : String(format: NSLocalizedString("memo.detail.meta.reading.min", comment: ""), stats.readingMinutes)
+                metaRow(
+                    label: NSLocalizedString("memo.detail.meta.reading", comment: ""),
+                    value: readingValue
+                )
+            }
 
             // Kind-specific fields
             kindSpecificRows

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -199,6 +199,11 @@
 "memo.detail.meta.created" = "Created";
 "memo.detail.meta.file" = "File";
 "memo.detail.meta.kind" = "Kind";
+"memo.detail.meta.words" = "Words";
+"memo.detail.meta.characters" = "Characters";
+"memo.detail.meta.reading" = "Reading";
+"memo.detail.meta.reading.min" = "%d min read";
+"memo.detail.meta.reading.less_than_1" = "< 1 min";
 "memo.detail.meta.duration" = "Duration";
 "memo.detail.meta.transcription" = "Transcription";
 "memo.detail.meta.aperture" = "Aperture";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -227,6 +227,11 @@
 "memo.detail.meta.created" = "创建于";
 "memo.detail.meta.file" = "文件";
 "memo.detail.meta.kind" = "类型";
+"memo.detail.meta.words" = "字词数";
+"memo.detail.meta.characters" = "字符数";
+"memo.detail.meta.reading" = "阅读时间";
+"memo.detail.meta.reading.min" = "%d 分钟";
+"memo.detail.meta.reading.less_than_1" = "< 1 分钟";
 "memo.detail.meta.duration" = "时长";
 "memo.detail.meta.transcription" = "转写";
 "memo.detail.meta.aperture" = "光圈";


### PR DESCRIPTION
## Body text stats in Memo Detail metadata (words · characters · reading time)

The MemoDetailView metadata rail surfaces rich context (created, file, kind, EXIF, weather) but says nothing about the written body itself — the core artifact of a journaling app. Add CJK-aware Words / Characters / Reading-time rows to DetailMetadataSection, rendered in the existing JetBrains Mono metadata style so they feel native to the museum-tag aesthetic.

### Acceptance
Open any memo with a non-empty body from the Today timeline → detail view shows Words, Characters, and Reading rows in the Metadata section matching the existing mono metadata style. A Chinese-only memo counts each ideograph as a word (e.g. 「今天很好」 = 4 words); a mixed memo counts both. A voice/photo-only memo with empty body shows no body-stat rows. Reading time never shows 0 (floors to '< 1 min'). `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` succeeds and existing tests pass.