### PR TITLE
auto: Extract testable TimeOfDay helper for orb greeting & ambient tint

### DIFF
--- a/DayPage/Features/Today/TimeOfDay.swift
+++ b/DayPage/Features/Today/TimeOfDay.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// Pure time-of-day bucketing shared by the Day Orb and the kicker.
+enum TimeOfDay: Int {
+    case morning    = 0
+    case afternoon  = 1
+    case evening    = 2
+    case lateNight  = 3
+
+    static func bucket(hour: Int) -> TimeOfDay {
+        switch hour {
+        case 5...11:  return .morning
+        case 12...17: return .afternoon
+        case 18...22: return .evening
+        default:      return .lateNight
+        }
+    }
+
+    static func from(_ date: Date, calendar: Calendar = .current) -> TimeOfDay {
+        let hour = calendar.component(.hour, from: date)
+        return bucket(hour: hour)
+    }
+
+    var greetingKey: String {
+        switch self {
+        case .morning:   return "today.greeting.morning"
+        case .afternoon: return "today.greeting.afternoon"
+        case .evening:   return "today.greeting.evening"
+        case .lateNight: return "today.greeting.latenight"
+        }
+    }
+
+    var bucketIndex: Int { rawValue }
+
+    var tint: Color {
+        switch self {
+        case .morning:   return Color(red: 0.45, green: 0.55, blue: 0.88)  // cool periwinkle dawn
+        case .afternoon: return DSColor.accentAmber                         // midday amber (canonical)
+        case .evening:   return Color(red: 0.85, green: 0.40, blue: 0.15)  // warm orange-ember evening
+        case .lateNight: return Color(red: 0.28, green: 0.22, blue: 0.60)  // deep indigo late-night
+        }
+    }
+}

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -948,41 +948,18 @@ struct TodayView: View {
     }
 
     private func orbGreeting(_ date: Date) -> String {
-        let hour = Calendar.current.component(.hour, from: date)
-        switch hour {
-        case 5...11:  return NSLocalizedString("today.greeting.morning",   comment: "")
-        case 12...17: return NSLocalizedString("today.greeting.afternoon", comment: "")
-        case 18...22: return NSLocalizedString("today.greeting.evening",   comment: "")
-        default:      return NSLocalizedString("today.greeting.latenight", comment: "")
-        }
+        NSLocalizedString(TimeOfDay.from(date).greetingKey, comment: "")
     }
 
-    /// Returns an integer bucket index (0–3) for the current time-of-day bucket,
-    /// matching the same hour ranges used by `orbGreeting`. Used to key the tint
-    /// animation so crossfades fire only at bucket boundaries, not every minute.
+    /// Returns an integer bucket index (0–3) for the current time-of-day bucket.
+    /// Used to key the tint animation so crossfades fire only at bucket boundaries.
     private func orbTintBucket(_ date: Date) -> Int {
-        let hour = Calendar.current.component(.hour, from: date)
-        switch hour {
-        case 5...11:  return 0  // morning
-        case 12...17: return 1  // afternoon
-        case 18...22: return 2  // evening
-        default:      return 3  // late-night
-        }
+        TimeOfDay.from(date).bucketIndex
     }
 
-    /// Derives a subtle ambient hue for the orb breathing glow from the
-    /// time-of-day bucket. Purely presentational — no storage changes.
-    ///   0 morning    → cool periwinkle-blue dawn
-    ///   1 afternoon  → canonical accentAmber (warm midday)
-    ///   2 evening    → warm orange-ember
-    ///   3 late-night → deep indigo
+    /// Derives a subtle ambient hue for the orb breathing glow from the time-of-day bucket.
     private func orbTint(_ date: Date) -> Color {
-        switch orbTintBucket(date) {
-        case 0: return Color(red: 0.45, green: 0.55, blue: 0.88)   // cool periwinkle dawn
-        case 1: return DSColor.accentAmber                          // midday amber (canonical)
-        case 2: return Color(red: 0.85, green: 0.40, blue: 0.15)   // warm orange-ember evening
-        default: return Color(red: 0.28, green: 0.22, blue: 0.60)  // deep indigo late-night
-        }
+        TimeOfDay.from(date).tint
     }
 
     private func orbKicker(_ date: Date) -> String {

--- a/DayPageTests/TimeOfDayTests.swift
+++ b/DayPageTests/TimeOfDayTests.swift
@@ -1,0 +1,83 @@
+import Testing
+import SwiftUI
+@testable import DayPage
+
+@Suite("TimeOfDay")
+struct TimeOfDayTests {
+
+    // MARK: - bucket(hour:) boundary coverage
+
+    @Test func hour4IsLateNight()   { #expect(TimeOfDay.bucket(hour: 4)  == .lateNight) }
+    @Test func hour5IsMorning()     { #expect(TimeOfDay.bucket(hour: 5)  == .morning) }
+    @Test func hour11IsMorning()    { #expect(TimeOfDay.bucket(hour: 11) == .morning) }
+    @Test func hour12IsAfternoon()  { #expect(TimeOfDay.bucket(hour: 12) == .afternoon) }
+    @Test func hour17IsAfternoon()  { #expect(TimeOfDay.bucket(hour: 17) == .afternoon) }
+    @Test func hour18IsEvening()    { #expect(TimeOfDay.bucket(hour: 18) == .evening) }
+    @Test func hour22IsEvening()    { #expect(TimeOfDay.bucket(hour: 22) == .evening) }
+    @Test func hour23IsLateNight()  { #expect(TimeOfDay.bucket(hour: 23) == .lateNight) }
+    @Test func hour0IsLateNight()   { #expect(TimeOfDay.bucket(hour: 0)  == .lateNight) }
+
+    // MARK: - bucketIndex consistency
+
+    @Test func bucketIndexMatchesRawValue() {
+        #expect(TimeOfDay.morning.bucketIndex   == 0)
+        #expect(TimeOfDay.afternoon.bucketIndex == 1)
+        #expect(TimeOfDay.evening.bucketIndex   == 2)
+        #expect(TimeOfDay.lateNight.bucketIndex == 3)
+    }
+
+    // MARK: - greetingKey consistency
+
+    @Test func greetingKeysAreDistinct() {
+        let keys = [
+            TimeOfDay.morning.greetingKey,
+            TimeOfDay.afternoon.greetingKey,
+            TimeOfDay.evening.greetingKey,
+            TimeOfDay.lateNight.greetingKey,
+        ]
+        #expect(Set(keys).count == 4)
+    }
+
+    @Test func greetingKeyValues() {
+        #expect(TimeOfDay.morning.greetingKey   == "today.greeting.morning")
+        #expect(TimeOfDay.afternoon.greetingKey == "today.greeting.afternoon")
+        #expect(TimeOfDay.evening.greetingKey   == "today.greeting.evening")
+        #expect(TimeOfDay.lateNight.greetingKey == "today.greeting.latenight")
+    }
+
+    // MARK: - tint consistency (four distinct colors)
+
+    @Test func tintsAreDistinct() {
+        let tints = [
+            TimeOfDay.morning.tint,
+            TimeOfDay.afternoon.tint,
+            TimeOfDay.evening.tint,
+            TimeOfDay.lateNight.tint,
+        ]
+        // Convert to string description for equality comparison since Color isn't Equatable in older SDKs
+        let descriptions = tints.map { "\($0)" }
+        #expect(Set(descriptions).count == 4)
+    }
+
+    // MARK: - from(_:calendar:) round-trip
+
+    @Test func fromDateUsesCalendarHour() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 1; comps.day = 1
+
+        comps.hour = 7
+        #expect(TimeOfDay.from(cal.date(from: comps)!, calendar: cal) == .morning)
+
+        comps.hour = 14
+        #expect(TimeOfDay.from(cal.date(from: comps)!, calendar: cal) == .afternoon)
+
+        comps.hour = 20
+        #expect(TimeOfDay.from(cal.date(from: comps)!, calendar: cal) == .evening)
+
+        comps.hour = 2
+        #expect(TimeOfDay.from(cal.date(from: comps)!, calendar: cal) == .lateNight)
+    }
+}


### PR DESCRIPTION
## Extract testable TimeOfDay helper for orb greeting & ambient tint

The Day Orb's greeting text and time-of-day ambient tint are driven by three private hour-bucketing functions in TodayView (orbGreeting, orbTintBucket, orbTint) that are duplicated, untestable, and have fragile boundary logic (5/11/12/17/18/22 cutoffs). Extract this pure mapping into a small TimeOfDay enum/helper so the bucket-to-greeting and bucket-to-tint logic is reused by both the orb and the kicker, and back it with Swift Testing boundary tests. Purely a refactor + test addition with no behavioral change to the UI.

### Acceptance
DayPage scheme builds clean; new TimeOfDayTests pass via Swift Testing; the orb greeting and ambient tint render identically to before (visually verify empty-state Today on iPhone 17 simulator across at least two time buckets by temporarily injecting hours in a preview or test); no remaining duplicated hour-switch literals in TodayView for greeting/tint.