### PR TITLE
auto: Graph search: Return key jumps to next match & dismisses keyboard

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -61,6 +61,25 @@ struct GraphView: View {
                         TextField("搜索节点...", text: $viewModel.searchQuery)
                             .font(DSFonts.jetBrainsMono(size: 12))
                             .foregroundColor(DSColor.inkPrimary)
+                            .submitLabel(.search)
+                            .onSubmit {
+                                let matches = searchMatches
+                                guard !matches.isEmpty else {
+                                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                    return
+                                }
+                                if matches.count > 1 {
+                                    searchMatchIndex = (searchMatchIndex + 1) % matches.count
+                                    let node = matches[searchMatchIndex]
+                                    centerOn(node, in: simulationSize)
+                                    pulseNode(node)
+                                    Haptics.soft()
+                                } else {
+                                    centerOn(matches[0], in: simulationSize)
+                                    pulseNode(matches[0])
+                                    UIApplication.shared.sendAction(#selector(UIResponder.resignFirstResponder), to: nil, from: nil, for: nil)
+                                }
+                            }
                         if !viewModel.searchQuery.isEmpty {
                             Button {
                                 Haptics.soft()


### PR DESCRIPTION
## Graph search: Return key jumps to next match & dismisses keyboard

The Graph search field offers chevron buttons to cycle through matches but the keyboard's return key is a no-op, forcing users to tap tiny chevrons or manually dismiss the keyboard. Wire the search field's submit action so pressing Return advances to the next match (cycling, same as the down-chevron) and dismisses the keyboard when only one match exists, giving the field a proper search affordance.

### Acceptance
Build the DayPage scheme for iPhone 17. In Graph with several entities, type a query matching 2+ nodes; pressing Return on the keyboard advances to and centers the next match with a soft haptic and pulse ring, cycling back to the first after the last — identical to tapping the down chevron. With exactly one match, Return centers it and dismisses the keyboard. With zero matches, Return only dismisses the keyboard and does not crash. The keyboard return key displays the 'Search' label.