### PR TITLE
auto: Live word-count footer on the inline composer (InputBarV4)

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -179,6 +179,12 @@ struct InputBarV4: View {
 
     // MARK: Derived
 
+    private var wordCount: Int {
+        text.split(whereSeparator: \.isWhitespace).count
+    }
+
+    private var charCount: Int { text.count }
+
     private var isComposing: Bool {
         composerState == .open || composerState == .expanding || !text.isEmpty || !pendingAttachments.isEmpty || pendingLocation != nil
     }
@@ -531,6 +537,27 @@ struct InputBarV4: View {
             .animation(.easeInOut(duration: 0.18), value: pressToTalkPhase)
     }
 
+    // MARK: - Word/Char Count Footer
+
+    private var countFooter: some View {
+        let wordsLabel = wordCount == 1
+            ? NSLocalizedString("writesheet.count.words.one", comment: "1 word")
+            : String(format: NSLocalizedString("writesheet.count.words.other", comment: "%d words"), wordCount)
+        return HStack {
+            Spacer()
+            Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+                .font(DSType.mono10)
+                .tracking(1.0)
+                .textCase(.uppercase)
+                .monospacedDigit()
+                .foregroundColor(DSColor.inkSubtle)
+                .accessibilityLabel("\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+                .accessibilityIdentifier("composer-word-count")
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 4)
+    }
+
     // MARK: - Composing Card Morph (US-008 / US-010)
     //
     // Full-width rounded-rect card that the idle capsule morphs into.
@@ -636,6 +663,13 @@ struct InputBarV4: View {
                 .transition(.opacity.combined(with: .move(edge: .top)))
             }
 
+            // Live word/char count — fades in only while text is non-empty.
+            if !text.isEmpty {
+                countFooter
+                    .transition(.opacity)
+                    .animation(Motion.fade, value: text.isEmpty)
+            }
+
             // Text field — full width, no border, generous padding.
             // The native caret (amber) tracks the real insertion point. An
             // earlier build hid it (.tint(.clear)) and drew a decorative
@@ -659,6 +693,14 @@ struct InputBarV4: View {
                             templateSuffix = ""
                             activeTemplate = nil
                         }
+                    }
+                    if newValue.isEmpty { lastMilestone = 0 }
+                }
+                .onChange(of: wordCount) { newCount in
+                    let milestone = newCount / 50
+                    if milestone > lastMilestone {
+                        lastMilestone = milestone
+                        if !reduceMotion { Haptics.soft() }
                     }
                 }
 
@@ -835,6 +877,7 @@ struct InputBarV4: View {
     }
 
     @State private var breathingOpacity: Double = 1.0
+    @State private var lastMilestone: Int = 0
 
     private var sendButton: some View {
         let affordance = sendAffordance


### PR DESCRIPTION
## Live word-count footer on the inline composer (InputBarV4)

The bottom-sheet WriteSheetView already shows a live 'N words · M chars' footer, but the inline composer (InputBarV4) — the primary capture surface — shows nothing, so users get inconsistent feedback depending on which composer they open. This adds a subtle, right-aligned word/char count that fades in only while text is non-empty, mirroring WriteSheetView's wording and localization keys, with a gentle haptic + amber tick at each 50-word milestone to reward longer entries.

### Acceptance
Build the DayPage scheme clean. Launch on iPhone 17 simulator: the inline composer shows no footer when empty; typing reveals a fading-in 'N words · M chars' line that updates live and matches WriteSheetView's wording; crossing 50/100 words fires a soft haptic; clearing the field hides the footer and resets the milestone counter. Footer is right-aligned, uses mono10/inkSubtle styling, respects Reduce Motion (no scale tick), and exposes the composer-word-count accessibility identifier. No regressions to submit, voice, or attachment flows.