### PR TITLE
auto: Extract and test WeeklyRecapService's date-range logic into a pure helper

### DIFF
--- a/DayPage/Services/WeeklyRecapService.swift
+++ b/DayPage/Services/WeeklyRecapService.swift
@@ -1,5 +1,35 @@
 import Foundation
 
+// MARK: - WeeklyRecapRange
+
+/// Pure date-range helper for the Weekly Recap section.
+///
+/// Extracts the date-math from `WeeklyRecapService` so it can be unit-tested
+/// independently with an injected calendar.
+enum WeeklyRecapRange {
+
+    /// Returns local-midnight dates in [min(weekStart, yesterday), today),
+    /// oldest-first. The `min` rule prevents the range from being empty on
+    /// Mondays — without it, Monday's weekStart == today and the section vanishes.
+    static func dates(referenceDate: Date, calendar: Calendar) -> [Date] {
+        let today = calendar.startOfDay(for: referenceDate)
+        guard let monday = calendar.dateInterval(of: .weekOfYear, for: today)?.start,
+              let yesterday = calendar.date(byAdding: .day, value: -1, to: today)
+        else { return [] }
+
+        let lowerBound = min(monday, yesterday)
+
+        var cursor = lowerBound
+        var result: [Date] = []
+        while cursor < today {
+            result.append(cursor)
+            guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
+            cursor = next
+        }
+        return result
+    }
+}
+
 // MARK: - WeeklyRecapEntry
 
 /// One compiled day appearing in Today's "Weekly Recap" section.
@@ -61,26 +91,11 @@ final class WeeklyRecapService {
 
     /// Compiled day entries from this week's Monday up to (but not including)
     /// `referenceDate`'s local-midnight, newest first.
-    /// Returns empty when `referenceDate` falls on Monday.
+    /// On Monday, returns exactly yesterday (Sunday) — see `WeeklyRecapRange`.
     func entries(referenceDate: Date = Date()) -> [WeeklyRecapEntry] {
         let dailyDir = VaultInitializer.vaultURL.appendingPathComponent("wiki/daily")
         let fm = FileManager.default
-
-        let today = calendar.startOfDay(for: referenceDate)
-        guard let monday = startOfWeek(for: today),
-              let yesterday = calendar.date(byAdding: .day, value: -1, to: today)
-        else { return [] }
-        // Whichever is earlier — usually Monday, but on Monday itself the
-        // Monday-only range would be empty, so yesterday (Sunday) takes over.
-        let lowerBound = min(monday, yesterday)
-
-        var cursor = lowerBound
-        var dates: [Date] = []
-        while cursor < today {
-            dates.append(cursor)
-            guard let next = calendar.date(byAdding: .day, value: 1, to: cursor) else { break }
-            cursor = next
-        }
+        let dates = WeeklyRecapRange.dates(referenceDate: referenceDate, calendar: calendar)
 
         var entries: [WeeklyRecapEntry] = []
         for date in dates {
@@ -103,15 +118,6 @@ final class WeeklyRecapService {
         }
 
         return entries.reversed()
-    }
-
-    // MARK: - Private
-
-    /// Monday 00:00 of the week containing `date`.
-    /// `dateInterval(of: .weekOfYear, for:)` honors `calendar.firstWeekday`,
-    /// which we forced to Monday in init.
-    private func startOfWeek(for date: Date) -> Date? {
-        return calendar.dateInterval(of: .weekOfYear, for: date)?.start
     }
 
 }

--- a/DayPageTests/WeeklyRecapRangeTests.swift
+++ b/DayPageTests/WeeklyRecapRangeTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import Foundation
+@testable import DayPage
+
+@Suite("WeeklyRecapRange")
+struct WeeklyRecapRangeTests {
+
+    /// Monday-first Gregorian calendar in UTC — stable, no DST.
+    private var cal: Calendar {
+        var c = Calendar(identifier: .gregorian)
+        c.timeZone = TimeZone(identifier: "UTC")!
+        c.firstWeekday = 2  // Monday
+        return c
+    }
+
+    /// Build a UTC midnight Date from components.
+    private func date(year: Int, month: Int, day: Int) -> Date {
+        var comps = DateComponents()
+        comps.year = year; comps.month = month; comps.day = day
+        comps.hour = 0; comps.minute = 0; comps.second = 0
+        comps.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: comps)!
+    }
+
+    // MARK: - Mid-week (Wednesday)
+
+    /// Wednesday 2026-06-03: range should be Mon 06-01 and Tue 06-02 (today excluded).
+    @Test func midWeekWednesday_returnsMondayAndTuesday() {
+        let wednesday = date(year: 2026, month: 6, day: 3)
+        let result = WeeklyRecapRange.dates(referenceDate: wednesday, calendar: cal)
+
+        let monday = date(year: 2026, month: 6, day: 1)
+        let tuesday = date(year: 2026, month: 6, day: 2)
+        #expect(result == [monday, tuesday])
+    }
+
+    @Test func midWeekWednesday_todayExcluded() {
+        let wednesday = date(year: 2026, month: 6, day: 3)
+        let result = WeeklyRecapRange.dates(referenceDate: wednesday, calendar: cal)
+        #expect(!result.contains(wednesday))
+    }
+
+    // MARK: - Monday edge case
+
+    /// Monday 2026-06-01: the week's Monday == today, so the lower bound falls
+    /// back to yesterday (Sunday 2026-05-31). Result must be exactly [yesterday].
+    @Test func monday_returnsExactlyYesterday_neverEmpty() {
+        let monday = date(year: 2026, month: 6, day: 1)
+        let result = WeeklyRecapRange.dates(referenceDate: monday, calendar: cal)
+
+        let sunday = date(year: 2026, month: 5, day: 31)
+        #expect(result == [sunday])
+        #expect(result.count == 1)
+    }
+
+    // MARK: - Sunday
+
+    /// Sunday 2026-06-07: range should be Mon 06-01 through Sat 06-06 (6 dates).
+    @Test func sunday_returnsMonThroughSat() {
+        let sunday = date(year: 2026, month: 6, day: 7)
+        let result = WeeklyRecapRange.dates(referenceDate: sunday, calendar: cal)
+
+        let expected = (1...6).map { day in date(year: 2026, month: 6, day: day) }
+        #expect(result == expected)
+    }
+
+    // MARK: - Ordering and bounds
+
+    /// Dates must be oldest-first and all strictly before today's midnight.
+    @Test func dates_areOldestFirst_allBeforeToday() {
+        let wednesday = date(year: 2026, month: 6, day: 3)
+        let result = WeeklyRecapRange.dates(referenceDate: wednesday, calendar: cal)
+
+        let today = cal.startOfDay(for: wednesday)
+        #expect(result == result.sorted())
+        for d in result {
+            #expect(d < today)
+        }
+    }
+}


### PR DESCRIPTION
## Extract and test WeeklyRecapService's date-range logic into a pure helper

WeeklyRecapService.entries() contains non-trivial, untested date math: the `min(monday, yesterday)` lower-bound rule (which prevents the Recap section from vanishing on Mondays) and a cursor loop that enumerates [lowerBound, today). This logic has zero test coverage despite every sibling helper (DayProgress, TimeOfDay, TimelineIndex) having a dedicated test file. Extract it into a pure, calendar-injectable `WeeklyRecapRange.dates(referenceDate:calendar:)` helper and add a test file, locking in the Monday edge-case behavior so a future refactor can't silently regress it.

### Acceptance
`xcodebuild -scheme DayPage build` succeeds; the new WeeklyRecapRangeTests pass under the DayPageTests target on iPhone 17; WeeklyRecapService.entries() produces byte-identical output to before (same files loaded, same newest-first order); the Monday case asserts a non-empty single-element [yesterday] result, guarding the documented edge case; no @Model/SwiftData files touched and total change is under 100 lines.