### PR TITLE
auto: Localize the compile-button time-of-day hint (fix hardcoded Chinese strings)

### DIFF
--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -148,10 +148,10 @@ struct CompileFooterButton: View {
     /// Contextual nudge based on time of day.
     private var timeHint: String {
         switch currentHour {
-        case 5..<12:  return "今天才刚开始"
-        case 12..<18: return "记录还在继续"
-        case 18..<24: return "夜深了，回顾今天吧"
-        default:      return "为今天画上句号"
+        case 5..<12:  return NSLocalizedString("compile.hint.morning", comment: "")
+        case 12..<18: return NSLocalizedString("compile.hint.afternoon", comment: "")
+        case 18..<24: return NSLocalizedString("compile.hint.evening", comment: "")
+        default:      return NSLocalizedString("compile.hint.night", comment: "")
         }
     }
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -251,6 +251,12 @@
 
 "search.undo.cleared" = "Recent searches cleared";
 
+/* CompileFooterButton — time-of-day hints */
+"compile.hint.morning"   = "Your day is just getting started";
+"compile.hint.afternoon" = "Keep the day flowing";
+"compile.hint.evening"   = "Wind down — look back on today";
+"compile.hint.night"     = "Put a period on today";
+
 /* Streak milestone celebration (TodayView) */
 "today.streak.milestone.title"        = "%d day streak! 🔥";
 "today.streak.milestone.subtitle.3"   = "Three days in a row — the habit is forming.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -279,6 +279,12 @@
 
 "search.undo.cleared" = "已清除搜索记录";
 
+/* CompileFooterButton — time-of-day hints */
+"compile.hint.morning"   = "今天才刚开始";
+"compile.hint.afternoon" = "记录还在继续";
+"compile.hint.evening"   = "夜深了，回顾今天吧";
+"compile.hint.night"     = "为今天画上句号";
+
 /* Streak milestone celebration (TodayView) */
 "today.streak.milestone.title"        = "连续 %d 天！🔥";
 "today.streak.milestone.subtitle.3"   = "连续三天，习惯正在形成。";


### PR DESCRIPTION
## Localize the compile-button time-of-day hint (fix hardcoded Chinese strings)

The contextual nudge shown under the 'Compile Today' button (CompileFooterButton.timeHint) is hardcoded in Chinese ('今天才刚开始', '夜深了，回顾今天吧', etc.), bypassing the NSLocalizedString/L10n system the rest of the app uses — so English-locale users see Chinese text. This routes the four time-of-day hints through Localizable.strings with proper en/zh-Hans entries, matching the existing localization convention.

### Acceptance
Build the DayPage scheme succeeds. On an English-locale simulator (iPhone 17), the hint under the compile button renders the English string for the current time bucket; on a zh-Hans simulator it renders the original Chinese wording unchanged. No remaining hardcoded CJK literals in CompileFooterButton.timeHint. Hint still updates across hour boundaries via the existing minute timer.