### PR TITLE
auto: Time-of-day adaptive empty-state subtitle on the Today screen

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -200,10 +200,10 @@ private struct PressableScaleStyle: ButtonStyle {
 
 extension EmptyStateView {
     /// Today tab — no memos yet.
-    static func todayBlank(ctaAction: @escaping () -> Void) -> EmptyStateView {
+    static func todayBlank(ctaAction: @escaping () -> Void, subtitleOverride: String? = nil) -> EmptyStateView {
         EmptyStateView(
             title: L10n.Empty.todayBlankTitle,
-            subtitle: L10n.Empty.todayBlankSubtitle,
+            subtitle: subtitleOverride ?? L10n.Empty.todayBlankSubtitle,
             ctaLabel: L10n.Empty.todayBlankCta,
             ctaAction: ctaAction,
             showOrbAccent: true
@@ -211,10 +211,10 @@ extension EmptyStateView {
     }
 
     /// Today tab — memos exist but no signal cards generated.
-    static func todayNoSignals(ctaAction: (() -> Void)? = nil) -> EmptyStateView {
+    static func todayNoSignals(ctaAction: (() -> Void)? = nil, subtitleOverride: String? = nil) -> EmptyStateView {
         EmptyStateView(
             title: L10n.Empty.todayNoSignalsTitle,
-            subtitle: L10n.Empty.todayNoSignalsSubtitle,
+            subtitle: subtitleOverride ?? L10n.Empty.todayNoSignalsSubtitle,
             ctaLabel: ctaAction != nil ? L10n.Empty.todayBlankCta : nil,
             ctaAction: ctaAction,
             showOrbAccent: true

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -608,7 +608,7 @@ struct TodayView: View {
                 onThisDayDateString = dateString
             }
         case .pureEmpty:
-            EmptyStateView.todayNoSignals(ctaAction: { orbFocusToggle.toggle() })
+            EmptyStateView.todayNoSignals(ctaAction: { orbFocusToggle.toggle() }, subtitleOverride: todayEmptySubtitle(currentTime))
                 .padding(.horizontal, 20)
         }
     }
@@ -946,6 +946,17 @@ struct TodayView: View {
 
     private func orbGreeting(_ date: Date) -> String {
         NSLocalizedString(TimeOfDay.from(date).greetingKey, comment: "")
+    }
+
+    private func todayEmptySubtitle(_ date: Date) -> String {
+        let key: String
+        switch TimeOfDay.from(date) {
+        case .morning:   key = "empty.today.subtitle.morning"
+        case .afternoon: key = "empty.today.subtitle.afternoon"
+        case .evening:   key = "empty.today.subtitle.evening"
+        case .lateNight: key = "empty.today.subtitle.night"
+        }
+        return NSLocalizedString(key, comment: "")
     }
 
     /// Returns an integer bucket index (0–3) for the current time-of-day bucket.
@@ -1350,7 +1361,7 @@ struct TodayView: View {
                 if viewModel.memos.isEmpty && viewModel.loadState == .ready {
                     let hasOnboarded = UserDefaults.standard.bool(forKey: AppSettings.Keys.hasOnboarded)
                     if !hasOnboarded {
-                        EmptyStateView.todayBlank { orbFocusToggle.toggle() }
+                        EmptyStateView.todayBlank(ctaAction: { orbFocusToggle.toggle() }, subtitleOverride: todayEmptySubtitle(currentTime))
                             .padding(.top, 48)
                             .padding(.horizontal, 20)
                     } else {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -9,6 +9,12 @@
 "empty.today.no_signals.title" = "Nothing surfaced yet.";
 "empty.today.no_signals.subtitle" = "Keep logging — signals appear once you've captured a few memos.";
 
+/* Today empty-state time-of-day subtitles */
+"empty.today.subtitle.morning" = "What's the first thing on your mind today?";
+"empty.today.subtitle.afternoon" = "How's your afternoon shaping up?";
+"empty.today.subtitle.evening" = "What made today worth remembering?";
+"empty.today.subtitle.night" = "Anything to set down before the day closes?";
+
 /* Compile Locked */
 "empty.compile_locked.title" = "Not enough to compile.";
 "empty.compile_locked.subtitle" = "%d of 3 memos captured. Keep going to unlock daily compilation.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -9,6 +9,12 @@
 "empty.today.no_signals.title" = "暂时没有信号浮现。";
 "empty.today.no_signals.subtitle" = "继续记录吧——积累几条备忘后，信号卡就会出现。";
 
+/* Today empty-state time-of-day subtitles */
+"empty.today.subtitle.morning" = "今天第一件想记下的事是什么？";
+"empty.today.subtitle.afternoon" = "下午过得怎么样？";
+"empty.today.subtitle.evening" = "今天有什么值得记住的瞬间？";
+"empty.today.subtitle.night" = "睡前，有什么想落下来的？";
+
 /* Compile Locked */
 "empty.compile_locked.title" = "备忘不够，还无法编译。";
 "empty.compile_locked.subtitle" = "当前 %d 条备忘，累计 3 条后可解锁每日编译。";


### PR DESCRIPTION
## Time-of-day adaptive empty-state subtitle on the Today screen

The Today empty state (EmptyStateView.todayBlank) shows a static subtitle regardless of when the user opens the app, while the orb hero already adapts its greeting and tint to morning/afternoon/evening/night. This adds a matching time-aware subtitle so the empty state feels alive and personal at every hour, reusing the existing TimeOfDay bucket logic for zero new state.

### Acceptance
Opening Today with zero memos shows a subtitle that differs by morning/afternoon/evening/night, refreshes when currentTime advances past a bucket boundary, the existing staggered reveal + idle CTA pulse still fire, VoiceOver reads the new subtitle, the DayPage scheme builds clean, and the rendered .md vault files are unaffected.