### PR TITLE
auto: Localize the Day Orb readout labels (remove hardcoded English status strings)

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -323,11 +323,11 @@ struct DayOrbView: View {
 
     private var readoutLabel: String {
         switch signalCount {
-        case 0:        return "TAP TO BEGIN"
-        case 1:        return "SIGNAL TODAY"
-        case 2...4:    return "BUILDING"
-        case 5...9:    return "RICH DAY"
-        default:       return "PACKED"
+        case 0:        return NSLocalizedString("orb.readout.tapToBegin", comment: "")
+        case 1:        return NSLocalizedString("orb.readout.signalToday", comment: "")
+        case 2...4:    return NSLocalizedString("orb.readout.building", comment: "")
+        case 5...9:    return NSLocalizedString("orb.readout.richDay", comment: "")
+        default:       return NSLocalizedString("orb.readout.packed", comment: "")
         }
     }
 
@@ -342,7 +342,7 @@ struct DayOrbView: View {
                         .opacity(invitePulse ? 1.0 : 0.7)
                         .animation(.easeInOut(duration: 2.2).repeatForever(autoreverses: true), value: invitePulse)
 
-                    Text("TAP TO BEGIN")
+                    Text(readoutLabel)
                         .font(DSFonts.jetBrainsMono(size: 9, weight: .medium))
                         .tracking(1.4)
                         .foregroundColor(DSColor.amberDeep)

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -93,6 +93,13 @@
 "today.kicker.signal.one"    = "SIGNAL";
 "today.kicker.signal.other"  = "SIGNALS";
 
+/* Day Orb readout labels */
+"orb.readout.tapToBegin"  = "TAP TO BEGIN";
+"orb.readout.signalToday" = "SIGNAL TODAY";
+"orb.readout.building"    = "BUILDING";
+"orb.readout.richDay"     = "RICH DAY";
+"orb.readout.packed"      = "PACKED";
+
 /* Day Orb accessibility */
 "today.orb.label"            = "Today's signal orb";
 "today.orb.value.one"        = "%d signal captured";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -93,6 +93,13 @@
 "today.kicker.signal.one"    = "信号";
 "today.kicker.signal.other"  = "信号";
 
+/* Day Orb readout labels */
+"orb.readout.tapToBegin"  = "轻点开始";
+"orb.readout.signalToday" = "今日首条";
+"orb.readout.building"    = "记录中";
+"orb.readout.richDay"     = "充实一天";
+"orb.readout.packed"      = "满载";
+
 /* Day Orb accessibility */
 "today.orb.label"            = "今日信号球";
 "today.orb.value.one"        = "已捕获 %d 条信号";


### PR DESCRIPTION
## Localize the Day Orb readout labels (remove hardcoded English status strings)

DayOrbView renders its status readout — 'TAP TO BEGIN', 'SIGNAL TODAY', 'BUILDING', 'RICH DAY', 'PACKED' — as hardcoded English string literals, bypassing the app's NSLocalizedString infrastructure. Every other user-facing string in TodayView is localized (zh-Hans + en), so these labels stay in English even when the device is in Chinese, breaking the visual consistency of the signature orb. This wires them through Localizable.strings with localized values in both locales.

### Acceptance
DayPage scheme builds clean for iPhone 17. With device language set to Simplified Chinese, the orb shows localized readout labels (e.g. 记录中) instead of English; with English it shows the original strings. No remaining hardcoded readout literals in DayOrbView.swift. Existing orb animations, haptics, and tier behavior are unchanged.