### PR TITLE
auto: Localize the hardcoded '清除筛选' CTA in the Graph empty/no-match states

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -266,7 +266,7 @@ extension EmptyStateView {
         EmptyStateView(
             title: L10n.Empty.graphNoMatchesTitle,
             subtitle: L10n.Empty.graphNoMatchesSubtitle,
-            ctaLabel: "清除筛选",
+            ctaLabel: L10n.Empty.graphClearFilters,
             ctaAction: ctaAction,
             showOrbAccent: false
         )

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -372,7 +372,7 @@ struct GraphView: View {
                 .clipShape(Capsule())
         }
         .buttonStyle(ClearFiltersPressStyle(reduceMotion: reduceMotion))
-        .accessibilityLabel("清除筛选")
+        .accessibilityLabel(L10n.Empty.graphClearFilters)
         .accessibilityAddTraits(.isButton)
     }
 

--- a/DayPage/Resources/L10n.swift
+++ b/DayPage/Resources/L10n.swift
@@ -50,6 +50,7 @@ enum L10n {
         // Graph No Matches
         static let graphNoMatchesTitle    = LocalizedStringKey("empty.graph.no_matches.title")
         static let graphNoMatchesSubtitle = NSLocalizedString("empty.graph.no_matches.subtitle", comment: "")
+        static let graphClearFilters      = NSLocalizedString("empty.graph.clear_filters", comment: "")
     }
 
     enum Error {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -132,6 +132,7 @@
 /* Graph No Matches */
 "empty.graph.no_matches.title" = "No matching nodes.";
 "empty.graph.no_matches.subtitle" = "Adjust your search or filters to see nodes.";
+"empty.graph.clear_filters" = "Clear Filters";
 
 /* Mic Permission Denied */
 "empty.mic_denied.title" = "Microphone access needed.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -132,6 +132,7 @@
 /* Graph No Matches */
 "empty.graph.no_matches.title" = "无匹配节点。";
 "empty.graph.no_matches.subtitle" = "调整搜索或筛选条件以查看节点。";
+"empty.graph.clear_filters" = "清除筛选";
 
 /* Mic Permission Denied */
 "empty.mic_denied.title" = "需要麦克风权限。";


### PR DESCRIPTION
## Localize the hardcoded "清除筛选" CTA in the Graph empty/no-match states

The Graph tab's "no matches" empty state and the inline clear-filters control both hardcode the Chinese string "清除筛选" as their button label instead of routing through L10n like every other string in the app, so English-locale users see Chinese text on that one button. This adds a proper localized `graphClearFilters` key (EN + zh-Hans) and wires both call sites to it, making the Graph empty state correctly bilingual.

### Acceptance
Build the DayPage scheme cleanly. With the system language set to English, the Graph tab's no-matches empty state shows an English "Clear Filters" button (verified in Simulator on iPhone 17); with zh-Hans it still shows "清除筛选". The inline clear-filters control's VoiceOver label reads in the active language. No other empty-state copy changes.