### PR TITLE
auto: Add tactile + visual feedback to the Search field's clear (✕) button

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -203,6 +203,7 @@ struct SearchView: View {
     @State private var searchTask: Task<Void, Never>? = nil
     @State private var appearedIDs: Set<UUID> = []
     @State private var didBuzzEmpty: Bool = false
+    @State private var clearPressed: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
@@ -322,6 +323,17 @@ struct SearchView: View {
 
                 if !vm.query.isEmpty {
                     Button(action: {
+                        Haptics.soft()
+                        if !reduceMotion {
+                            withAnimation(.spring(response: 0.25, dampingFraction: 0.6)) {
+                                clearPressed = true
+                            }
+                            DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+                                withAnimation(.spring(response: 0.25, dampingFraction: 0.6)) {
+                                    clearPressed = false
+                                }
+                            }
+                        }
                         vm.query = ""
                         vm.results = []
                         vm.hasSearched = false
@@ -330,6 +342,7 @@ struct SearchView: View {
                         Image(systemName: "xmark.circle.fill")
                             .font(.system(size: 14))
                             .foregroundColor(DSColor.onSurfaceVariant)
+                            .scaleEffect(clearPressed ? 0.8 : 1.0)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel("清除搜索内容")


### PR DESCRIPTION
## Add tactile + visual feedback to the Search field's clear (✕) button

The search bar's inline clear button (xmark.circle.fill) wipes the query, results, and refocuses the field but is the only interactive control in SearchView with no haptic feedback — every other tap target (filter toggle, chips, rows, cancel) buzzes. This adds a Haptics.soft() tap plus a brief press-scale animation so clearing the field feels as responsive as the rest of the search surface.

### Acceptance
Tapping the ✕ in the search bar produces a soft haptic and a quick scale pulse on the icon, then clears the query, empties results, and re-focuses the field (keyboard stays up). With Reduce Motion on, the scale animation is suppressed but the haptic still fires. Build succeeds (xcodebuild -scheme DayPage build) and no other search behavior changes.