### PR TITLE
auto: Voice recording timer: soft-cap visual warning for long recordings

### DIFF
--- a/DayPage/Features/Today/VoiceRecordingView.swift
+++ b/DayPage/Features/Today/VoiceRecordingView.swift
@@ -18,6 +18,25 @@ struct VoiceRecordingView: View {
     // MARK: Private State
 
     @StateObject private var voiceService = VoiceService.shared
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var didWarnLong = false
+
+    // MARK: - Duration Warning Thresholds
+
+    private static let amberThreshold = 300  // 5:00
+    private static let redThreshold   = 540  // 9:00
+
+    // MARK: - Timer Color
+
+    private var timerColor: Color {
+        if voiceService.elapsedSeconds >= Self.redThreshold {
+            return DSColor.error
+        } else if voiceService.elapsedSeconds >= Self.amberThreshold {
+            return DSColor.accentAmber
+        } else {
+            return DSColor.onSurface
+        }
+    }
 
     var body: some View {
         VStack(spacing: 0) {
@@ -67,6 +86,7 @@ struct VoiceRecordingView: View {
         .frame(maxWidth: .infinity)
         .background(DSColor.surface)
         .onAppear {
+            didWarnLong = false
             // Guard against re-entry: a fast double-tap on the mic-hero, or a
             // previously-stuck session from a press-to-talk gesture, can land
             // us here while VoiceService is still active. Starting again would
@@ -75,6 +95,12 @@ struct VoiceRecordingView: View {
             guard voiceService.state == .idle else { return }
             Task {
                 await voiceService.startRecording()
+            }
+        }
+        .onChange(of: voiceService.elapsedSeconds) { seconds in
+            if !didWarnLong && voiceService.state == .recording && seconds >= Self.amberThreshold {
+                didWarnLong = true
+                Haptics.soft()
             }
         }
         .onChange(of: voiceService.state) { newState in
@@ -120,8 +146,17 @@ struct VoiceRecordingView: View {
 
             Text(formattedTime(voiceService.elapsedSeconds))
                 .font(.system(size: 56, weight: .bold, design: .monospaced))
-                .foregroundColor(DSColor.onSurface)
+                .foregroundColor(timerColor)
                 .monospacedDigit()
+                .animation(reduceMotion ? nil : Motion.fade, value: timerColor)
+
+            if voiceService.elapsedSeconds >= Self.amberThreshold {
+                Text(NSLocalizedString("voice_recording_soft_cap_hint", comment: "建议 5 分钟内"))
+                    .font(DSFonts.jetBrainsMono(size: 12))
+                    .foregroundColor(DSColor.accentAmber)
+                    .transition(.opacity)
+                    .animation(reduceMotion ? nil : Motion.fade, value: voiceService.elapsedSeconds >= Self.amberThreshold)
+            }
         }
     }
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -279,6 +279,6 @@
 "today.streak.milestone.subtitle.30"  = "A whole month of daily logging. Remarkable.";
 "today.streak.milestone.subtitle.100" = "100 days. This journey is yours.";
 "today.streak.milestone.subtitle.365" = "One full year. A nomad's complete orbit.";
-
 "scroll_to_top.label.default"      = "Scroll to top";
 "scroll_to_top.label.new_content"   = "Scroll to top, new content";
+"voice_recording_soft_cap_hint"        = "Recommended under 5 min";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -307,6 +307,6 @@
 "today.streak.milestone.subtitle.30"  = "整整一个月的每日记录，了不起。";
 "today.streak.milestone.subtitle.100" = "100 天，这段旅程属于你。";
 "today.streak.milestone.subtitle.365" = "整整一年，游牧者完整的轨迹。";
-
 "scroll_to_top.label.default"      = "返回顶部";
 "scroll_to_top.label.new_content"   = "返回顶部，有新内容";
+"voice_recording_soft_cap_hint"        = "建议 5 分钟内";


### PR DESCRIPTION
## Voice recording timer: soft-cap visual warning for long recordings

The voice memo recorder shows elapsed time as a large mono counter but gives no signal as a recording grows long — yet long clips cost more in Whisper transcription and risk timeouts. Add a tiered color treatment to the timer (neutral → amber past 5:00 → red past 9:00) plus a one-shot haptic at the 5-minute mark, so users get gentle, glanceable feedback to wrap up without imposing a hard cut-off.

### Acceptance
Build the DayPage scheme succeeds. In Simulator (iPhone 17), open the voice recorder: the 56pt timer stays neutral under 5:00, crosses to amber at 5:00 with a single soft haptic, and turns red at 9:00; color transitions animate (and are suppressed under Reduce Motion). No hard stop is imposed — the user can still save or keep recording. Re-opening the recorder resets the warning state so the haptic can fire again.