### PR TITLE
auto: Fix UndoPillView countdown off-by-one so displayed seconds match the depleting ring

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -137,9 +137,9 @@ struct UndoPillView: View {
             hapticWorkItem.item = nil
         }
         .task {
-            for tick in stride(from: 4, through: 0, by: -1) {
+            for remaining in stride(from: 4, through: 1, by: -1) {
                 try? await Task.sleep(for: .seconds(1))
-                secondsRemaining = tick
+                secondsRemaining = remaining
             }
         }
     }


### PR DESCRIPTION
## Fix UndoPillView countdown off-by-one so displayed seconds match the depleting ring

UndoPillView initializes secondsRemaining to 5 and the ring to a 5s linear depletion, but its countdown task starts at 4 — so the label shows '5s' for the first ~1s while the ring is already draining, and the final second shows '0s' before the pill is removed. This makes the numeric countdown visibly lag the ring animation by a full second. The fix realigns the task's tick schedule and starting value so the digit, ring, and the parent's actual dismissal window all agree.

### Acceptance
Build the DayPage scheme successfully (xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'). Launch in the iPhone 17 simulator, submit a memo, and confirm the undo pill's numeric label counts 5→4→3→2→1 in sync with the depleting amber ring, never displaying '0s', and that the ring turns red + thickens in the final ~1.5s and the soft haptic still fires near 1s remaining. Reduce-motion path still shows a static pill with no countdown regressions.