### PR TITLE
auto: Tint the empty-state orb accent by time of day, matching the Day Orb hero

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -18,6 +18,9 @@ struct EmptyStateView: View {
     @State private var revealTask: Task<Void, Never>?
     @State private var idlePulseTask: Task<Void, Never>?
 
+    /// Captured once on appear so the tint stays stable across the breathing animation.
+    @State private var orbTint: Color = TimeOfDay.from(Date()).tint
+
     var body: some View {
         VStack(spacing: 20) {
             VStack(spacing: 20) {
@@ -54,6 +57,7 @@ struct EmptyStateView: View {
         }
         .padding(.horizontal, 32)
         .onAppear {
+            orbTint = TimeOfDay.from(Date()).tint
             if reduceMotion {
                 revealStep = 4
                 breathing = false
@@ -121,15 +125,13 @@ struct EmptyStateView: View {
         }
     }
 
-    // amberAccent (#A8541B) at low opacity — a soft warm bloom behind the title
-    // rather than the old saturated peach blob. (#590)
     private var orbAccent: some View {
         Circle()
             .fill(
                 RadialGradient(
                     colors: [
-                        Color(hex: "A8541B").opacity(0.22),
-                        Color(hex: "A8541B").opacity(0.10),
+                        orbTint.opacity(0.22),
+                        orbTint.opacity(0.10),
                         Color.clear
                     ],
                     center: .center,


### PR DESCRIPTION
## Tint the empty-state orb accent by time of day, matching the Day Orb hero

The Day Orb hero in TodayView shifts its breathing glow through warm time-of-day hues (morning/afternoon/evening/night) via TimeOfDay.tint, but the EmptyStateView orb accent (shown on todayBlank, todayNoSignals, archiveMonthEmpty, graphEmpty) is hardcoded to a single amber (#A8541B). This makes the two most prominent 'orb' moments feel disconnected. Tinting the empty-state bloom with the same time-of-day color creates visual continuity and reinforces the app's ambient, time-aware identity.

### Acceptance
Build the DayPage scheme with no warnings. Launch on iPhone 17 simulator with an empty Today (no memos) at different system clock times (e.g. set simulator clock to morning vs evening): the soft bloom behind the empty-state title shows a warm hue that matches the Day Orb hero's tint at that time of day, instead of the fixed amber. Reduce Motion still renders a static tinted bloom. The same continuity is visible on the Graph empty state and Archive month-empty state. No layout shift, no regression to the staggered reveal or idle CTA pulse.