### PR TITLE
auto: Add a subtle tap-scale + haptic to the Smart Template row

### DIFF
--- a/DayPage/Features/Today/SmartTemplateRow.swift
+++ b/DayPage/Features/Today/SmartTemplateRow.swift
@@ -67,6 +67,7 @@ struct SmartTemplateRow: View {
 
     var body: some View {
         Button {
+            Haptics.soft()
             onTap(template)
         } label: {
             HStack(spacing: 0) {
@@ -88,8 +89,20 @@ struct SmartTemplateRow: View {
             .padding(.vertical, 10)
             .contentShape(Rectangle())
         }
-        .buttonStyle(.plain)
+        .buttonStyle(SmartTemplateButtonStyle())
         .accessibilityLabel("模板：\(template.display)")
         .accessibilityHint("点击将模板填入输入框")
+    }
+}
+
+// MARK: - SmartTemplateButtonStyle
+
+private struct SmartTemplateButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(reduceMotion ? 1 : (configuration.isPressed ? 0.97 : 1))
+            .animation(reduceMotion ? nil : Motion.spring, value: configuration.isPressed)
     }
 }


### PR DESCRIPTION
## Add a subtle tap-scale + haptic to the Smart Template row

The composer's SmartTemplateRow (shown when the composer is empty) currently fills the input on tap with no tactile or visual feedback, making it feel inert compared to every other interactive surface in Today, which all use Haptics + spring scale. This adds a press-state scale-down and a soft haptic on tap, matching the app's established interaction language and making the template feel like a first-class affordance.

### Acceptance
Tapping the Smart Template row in an empty composer plays a soft haptic and shows a brief 0.97 scale-down press animation before the prefix fills the input; with Reduce Motion enabled the scale animation is suppressed but the haptic and fill still work; existing accessibility label/hint are unchanged; DayPage scheme builds clean on the iPhone 17 simulator.