### PR TITLE
auto: Add swipe-to-dismiss gesture and VoiceOver support to GlassErrorBanner

### DIFF
--- a/DayPage/Components/GlassErrorBanner.swift
+++ b/DayPage/Components/GlassErrorBanner.swift
@@ -113,16 +113,21 @@ struct GlassErrorBanner: View {
                 .frame(width: 24, height: 24)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(title)
-                    .font(DSType.bodySM)
-                    .fontWeight(.semibold)
-                    .foregroundColor(DSColor.inkPrimary)
-
-                if let subtitle {
-                    Text(subtitle)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(title)
                         .font(DSType.bodySM)
-                        .foregroundColor(DSColor.inkMuted)
+                        .fontWeight(.semibold)
+                        .foregroundColor(DSColor.inkPrimary)
+
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(DSType.bodySM)
+                            .foregroundColor(DSColor.inkMuted)
+                    }
                 }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(title)
+                .accessibilityHint(subtitle != nil ? subtitle! : "")
 
                 if let label = retryLabel, let action = retryAction {
                     Button {
@@ -137,6 +142,7 @@ struct GlassErrorBanner: View {
                     }
                     .buttonStyle(.plain)
                     .padding(.top, 2)
+                    .accessibilityLabel(label)
                 }
             }
 
@@ -151,7 +157,19 @@ struct GlassErrorBanner: View {
                     .frame(width: 20, height: 20)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+            .accessibilityIdentifier("error-banner-dismiss")
         }
+        .accessibilityHint("Swipe up to dismiss")
+        .gesture(
+            DragGesture()
+                .onEnded { value in
+                    if value.translation.height < -10 {
+                        Haptics.soft()
+                        onDismiss?()
+                    }
+                }
+        )
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
         .background(


### PR DESCRIPTION
## Add swipe-to-dismiss gesture and VoiceOver support to GlassErrorBanner

The app's primary error banner (GlassErrorBanner) can only be dismissed via the small X button or a tap-outside, while every other banner in the app (e.g. syncBanner in TodayView) supports an upward swipe to dismiss. It also has zero VoiceOver annotations, so the error title, retry button, and dismiss control are read as disconnected fragments. This adds a swipe-up-to-dismiss DragGesture and proper accessibility labels/hints, making error recovery faster and reachable for VoiceOver users.

### Acceptance
Build the DayPage scheme (xcodebuild -scheme DayPage build) succeeds. In Simulator (iPhone 17), triggering an error banner and swiping up dismisses it with a soft haptic, matching syncBanner behavior. With VoiceOver on, the banner reads its title+subtitle as one element, the retry and dismiss buttons are individually labeled, and the dismiss button is reachable via the 'error-banner-dismiss' identifier. The X-button tap and tap-outside dismissal still work unchanged.