### PR TITLE
auto: Add edge-of-limit haptic feedback to Graph zoom controls

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -647,8 +647,8 @@ struct GraphView: View {
                     .contentShape(Rectangle())
                     .opacity(scale >= 5.0 ? 0.4 : 1.0)
             }
-            .disabled(scale >= 5.0)
             .accessibilityLabel(NSLocalizedString("放大", comment: "Graph zoom in button"))
+            .accessibilityHint(scale >= 5.0 ? NSLocalizedString("已达到最大缩放比例", comment: "Graph zoom in limit hint") : "")
             .accessibilityAddTraits(.isButton)
 
             Rectangle()
@@ -666,8 +666,8 @@ struct GraphView: View {
                     .contentShape(Rectangle())
                     .opacity(scale <= 0.3 ? 0.4 : 1.0)
             }
-            .disabled(scale <= 0.3)
             .accessibilityLabel(NSLocalizedString("缩小", comment: "Graph zoom out button"))
+            .accessibilityHint(scale <= 0.3 ? NSLocalizedString("已达到最小缩放比例", comment: "Graph zoom out limit hint") : "")
             .accessibilityAddTraits(.isButton)
         }
         .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
@@ -677,9 +677,15 @@ struct GraphView: View {
     }
 
     private func zoom(by factor: CGFloat) {
-        withAnimation(Motion.spring) {
-            scale = max(0.3, min(5.0, scale * factor))
-            lastScale = scale
+        let target = max(0.3, min(5.0, scale * factor))
+        guard abs(target - scale) >= 0.0001 else {
+            Haptics.warn()
+            return
+        }
+        if !reduceMotion {
+            withAnimation(Motion.spring) { scale = target; lastScale = target }
+        } else {
+            scale = target; lastScale = target
         }
         Haptics.soft()
     }


### PR DESCRIPTION
## Add edge-of-limit haptic feedback to Graph zoom controls

The Graph view's +/- zoom buttons silently no-op once scale hits its 0.3–5.0 clamp: the button dims but a tap still fires `zoom(by:)`, which clamps to the same value and plays the normal `Haptics.soft()` as if zoom succeeded, giving false feedback. This adds a distinct warning haptic (and skips the misleading success haptic) when the user taps a zoom button that can no longer change the scale, so the limit is felt, not just faintly seen.

### Acceptance
Building the DayPage scheme succeeds. In the iPhone 17 simulator on the Graph tab: zooming in repeatedly to 500% then tapping + produces a warning haptic and no scale change or soft haptic; same for tapping - at 30%. Normal zoom steps within range still animate and play the soft haptic. The zoom indicator still reads 30%/500% at the bounds, and VoiceOver announces the buttons with their updated hints. Reduce Motion users get the haptic without animation.