### PR TITLE
auto: Descriptive Markdown export filename + dedupe the export date logic

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1191,11 +1191,7 @@ struct TodayView: View {
                         memos: viewModel.memos, date: Date(),
                         summary: viewModel.dailyPageSummary
                     )
-                    let df = DateFormatter()
-                    df.dateFormat = "yyyy-MM-dd"
-                    df.locale = Locale(identifier: "en_US_POSIX")
-                    df.timeZone = AppSettings.currentTimeZone()
-                    let dateString = df.string(from: Date())
+                    let dateString = MarkdownExportService.exportDateString(for: Date())
                     do {
                         let url = try MarkdownExportService.writeExportFile(
                             content: content, dateString: dateString

--- a/DayPage/Services/MarkdownExportService.swift
+++ b/DayPage/Services/MarkdownExportService.swift
@@ -16,6 +16,15 @@ enum MarkdownExportService {
 
     // MARK: - Export
 
+    /// Returns a yyyy-MM-dd string for the given date in the user's configured timezone.
+    static func exportDateString(for date: Date) -> String {
+        let df = DateFormatter()
+        df.dateFormat = "yyyy-MM-dd"
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = AppSettings.currentTimeZone()
+        return df.string(from: date)
+    }
+
     /// Builds an Obsidian-compatible `.md` string from the given memos and date.
     static func buildExportContent(
         memos: [Memo],
@@ -23,11 +32,7 @@ enum MarkdownExportService {
         weather: String? = nil,
         summary: String? = nil
     ) -> String {
-        let df = DateFormatter()
-        df.dateFormat = "yyyy-MM-dd"
-        df.locale = Locale(identifier: "en_US_POSIX")
-        df.timeZone = AppSettings.currentTimeZone()
-        let dateString = df.string(from: date)
+        let dateString = exportDateString(for: date)
 
         let moods = memos.compactMap { $0.mood }.filter { !$0.isEmpty }
         let entities = Array(Set(memos.flatMap { $0.entityMentions })).sorted()
@@ -117,7 +122,7 @@ enum MarkdownExportService {
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent("DayPageExport", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-        let url = dir.appendingPathComponent("\(dateString).md")
+        let url = dir.appendingPathComponent("DayPage \(dateString).md")
         try content.write(to: url, atomically: true, encoding: .utf8)
         return url
     }
@@ -142,11 +147,7 @@ enum MarkdownExportService {
     /// Presents a share sheet for the exported markdown file.
     @MainActor
     static func share(memos: [Memo], date: Date, from viewController: UIViewController) {
-        let df = DateFormatter()
-        df.dateFormat = "yyyy-MM-dd"
-        df.locale = Locale(identifier: "en_US_POSIX")
-        df.timeZone = AppSettings.currentTimeZone()
-        let dateString = df.string(from: date)
+        let dateString = exportDateString(for: date)
 
         let content = buildExportContent(memos: memos, date: date)
         guard let url = try? writeExportFile(content: content, dateString: dateString) else {

--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -215,7 +215,19 @@ struct MarkdownExportServiceTests {
         #expect(content.contains("> AI · Productive day."))
     }
 
-    // MARK: - 4. Memo bodies ordered by created ascending
+    // MARK: - 4. writeExportFile produces a branded filename
+
+    @Test func writeExportFile_producesURLWithBrandedFilename() throws {
+        let date = makeDate(year: 2026, month: 6, day: 2)
+        let dateString = MarkdownExportService.exportDateString(for: date)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [makeMemo(body: "test")], date: date
+        )
+        let url = try MarkdownExportService.writeExportFile(content: content, dateString: dateString)
+        #expect(url.lastPathComponent == "DayPage \(dateString).md")
+    }
+
+    // MARK: - 5. Memo bodies ordered by created ascending
 
     @Test func memoBodies_orderedByCreatedAscending() {
         let m1 = makeMemo(body: "first", secondsOffset: 0)


### PR DESCRIPTION
## Descriptive Markdown export filename + dedupe the export date logic

Today's Markdown export writes the share file as a bare "2026-06-02.md", which is ambiguous in the share sheet and Files app next to other dated files, and TodayView duplicates the same DateFormatter date-string logic that MarkdownExportService.buildExportContent already computes internally. Give the export a branded, human-readable filename (e.g. "DayPage 2026-06-02.md") and collapse the redundant inline formatter so the export button has a single source of truth for the date.

### Acceptance
Build the DayPage scheme cleanly. Tapping the export button in Today with >=1 memo opens the share sheet showing a file titled "DayPage 2026-06-02.md" (today's date in the user's configured timezone). The on-disk file under the DayPageExport temp dir is named accordingly and its YAML front-matter `date:` field matches the filename's date. TodayView no longer contains an inline DateFormatter for the export date. Existing MarkdownExportService tests still pass; add one asserting writeExportFile produces a URL whose lastPathComponent equals "DayPage <date>.md".