### PR TITLE
auto: Progressive haptic ticks on the scroll-to-top progress ring

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -124,6 +124,8 @@ struct TodayView: View {
     /// Milestone feedback when the scroll-to-top progress ring fills to 100%.
     @State private var didReachScrollEnd: Bool = false
     @State private var scrollRingGlow: Bool = false
+    /// Tracks which 1/3-ring milestone bucket (0/1/2) has already fired a haptic tick this scroll gesture.
+    @State private var lastScrollMilestone: Int = 0
 
     /// Scroll proxy captured from the timeline ScrollViewReader; used by composeSection
     /// to scroll to the top anchor after a new memo is added.
@@ -329,6 +331,12 @@ struct TodayView: View {
                 }
                 .animation(reduceMotion ? nil : Motion.rise, value: timelineScrollOffset < -240)
                 .onChange(of: scrollProgress) { progress in
+                    // Intermediate milestone ticks at 33% and 66% fill.
+                    let milestone = Int(progress * 3) // 0/1/2/3
+                    if milestone > lastScrollMilestone && milestone < 3 && !reduceMotion {
+                        Haptics.rigid(intensity: 0.3 + 0.2 * CGFloat(milestone))
+                        lastScrollMilestone = milestone
+                    }
                     if progress >= 1.0 && !didReachScrollEnd {
                         didReachScrollEnd = true
                         hasNewContentAboveFold = false
@@ -342,6 +350,7 @@ struct TodayView: View {
                         }
                     } else if progress < 0.95 {
                         didReachScrollEnd = false
+                        lastScrollMilestone = 0
                     }
                 }
                 // Submit error toast — scoped animation lives on the overlay


### PR DESCRIPTION
## Progressive haptic ticks on the scroll-to-top progress ring

The scroll-to-top button's amber progress ring fills as the user scrolls deeper (0→100% over 1200pt past the 240pt threshold), but only emits a single soft haptic when it hits 100%. Add a light, escalating 'tick' at the 33% and 66% quarter-milestones so the ring's fill is felt, not just seen — giving the deep-scroll gesture the same tactile texture as the rest of the composer's haptic ladder, while staying fully reduce-motion / accessibility aware.

### Acceptance
Build the DayPage scheme on iPhone 17. Scroll today's timeline (needs enough memos to scroll >240pt + 1200pt). As the amber progress ring fills, a crisp escalating haptic tick fires once at ~33% and once at ~66%, with the existing soft haptic + glow at 100%. Scrolling back up below 95% rearms the milestones so re-scrolling re-fires them. With Reduce Motion enabled, no intermediate ticks fire. No regression to the existing scroll-to-top button visuals or the 100% glow.