### PR TITLE
auto: Cap the empty-state CTA idle pulse so it nudges then rests

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -11,6 +11,8 @@ struct EmptyStateView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
+    private let maxIdlePulses = 3
+
     /// 0 = all hidden, 1 = orb visible, 2 = title, 3 = subtitle, 4 = CTA
     @State private var revealStep: Int = 0
     @State private var breathing = false
@@ -80,7 +82,7 @@ struct EmptyStateView: View {
                         Haptics.soft()
                         await pulseCTA()
                         idlePulseTask = Task { @MainActor in
-                            while !Task.isCancelled {
+                            for _ in 0..<maxIdlePulses {
                                 try? await Task.sleep(nanoseconds: 6_000_000_000)
                                 guard !Task.isCancelled, !reduceMotion else { return }
                                 await pulseCTA()


### PR DESCRIPTION
## Cap the empty-state CTA idle pulse so it nudges then rests

EmptyStateView's idle glow pulse on the call-to-action button repeats forever every 6 seconds, creating a persistently distracting (and battery-draining) flicker on the empty Today/Archive/Graph screens. Cap it to a small number of pulses (3) so the affordance gently invites the first interaction, then settles into a calm resting state — matching the app's restrained, museum-like aesthetic.

### Acceptance
On the empty Today screen (no memos, onboarded), the CTA button glows once on reveal, then pulses at most 3 more times at ~6s intervals, after which it stops pulsing and remains static. With Reduce Motion enabled, no idle pulses fire. The `DayPage` scheme builds cleanly (`xcodebuild -scheme DayPage build`) and the screen is verified visually in the iPhone 17 Simulator: glow ceases after the capped pulses and tapping the CTA still focuses the composer with a haptic.