### PR TITLE
auto: Pause idle CTA glow pulse & announce empty-state reveal for VoiceOver users

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -10,6 +10,7 @@ struct EmptyStateView: View {
     var showOrbAccent: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.accessibilityVoiceOverEnabled) private var voiceOverEnabled
 
     /// 0 = all hidden, 1 = orb visible, 2 = title, 3 = subtitle, 4 = CTA
     @State private var revealStep: Int = 0
@@ -75,14 +76,18 @@ struct EmptyStateView: View {
                     guard !Task.isCancelled else { return }
                     revealStep = 4  // CTA
                     if ctaAction != nil {
+                        if let label = ctaLabel {
+                            UIAccessibility.post(notification: .announcement, argument: label)
+                        }
                         try? await Task.sleep(nanoseconds: 70_000_000)
                         guard !Task.isCancelled else { return }
                         Haptics.soft()
                         await pulseCTA()
+                        guard !voiceOverEnabled else { return }
                         idlePulseTask = Task { @MainActor in
                             while !Task.isCancelled {
                                 try? await Task.sleep(nanoseconds: 6_000_000_000)
-                                guard !Task.isCancelled, !reduceMotion else { return }
+                                guard !Task.isCancelled, !reduceMotion, !voiceOverEnabled else { return }
                                 await pulseCTA()
                             }
                         }


### PR DESCRIPTION
## Pause idle CTA glow pulse & announce empty-state reveal for VoiceOver users

EmptyStateView runs a forever-repeating amber CTA glow pulse every 6 seconds, but this is purely decorative and provides no value to VoiceOver users while wasting render cycles; it also never posts an accessibility announcement when the staged reveal finishes, so screen-reader users get no cue that an actionable CTA has appeared. This change gates the idle pulse loop behind a VoiceOver-running check and posts a single .announcement when the CTA becomes available, making the empty state both quieter under assistive tech and properly announced.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator with no warnings. With VoiceOver off: the empty-state CTA still glows once on reveal and re-pulses every 6s (unchanged). With VoiceOver on (or Reduce Motion on): the repeating idle glow does not run, and on the blank Today empty state VoiceOver speaks the CTA label once shortly after the view appears. Verify the reveal still completes through all stages and onDisappear cancels both tasks.