### PR TITLE
auto: Localize AI-compilation banner strings in TodayViewModel.compile()

### DIFF
--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -230,7 +230,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             .publisher(for: .compilationDidFail)
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in
-                self?.compilationFailedError = "后台编译失败，请检查网络或 API Key 后重试"
+                self?.compilationFailedError = NSLocalizedString("today.compile.background.failed", comment: "")
             }
             .store(in: &cancellables)
 
@@ -937,21 +937,21 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 HapticFeedback.success()
                 BannerCenter.shared.show(AppBannerModel(
                     kind: .success,
-                    title: "今日 Daily Page 已生成",
+                    title: NSLocalizedString("today.compile.success", comment: ""),
                     autoDismiss: true
                 ))
             } catch CompilationError.offline {
                 BannerCenter.shared.show(AppBannerModel(
                     kind: .info,
-                    title: "当前离线，已加入队列",
+                    title: NSLocalizedString("today.compile.offline", comment: ""),
                     autoDismiss: true
                 ))
             } catch CompilationError.missingApiKey {
                 HapticFeedback.error()
                 BannerCenter.shared.show(AppBannerModel(
                     kind: .error,
-                    title: "DashScope API Key 未配置",
-                    primaryAction: BannerAction(label: "前往设置") { [weak self] in
+                    title: NSLocalizedString("today.compile.missingKey", comment: ""),
+                    primaryAction: BannerAction(label: NSLocalizedString("today.compile.action.settings", comment: "")) { [weak self] in
                         self?.shouldShowSettings = true
                     }
                 ))
@@ -959,8 +959,8 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 HapticFeedback.error()
                 BannerCenter.shared.show(AppBannerModel(
                     kind: .error,
-                    title: "API Key 无效或已过期",
-                    primaryAction: BannerAction(label: "前往设置") { [weak self] in
+                    title: NSLocalizedString("today.compile.invalidKey", comment: ""),
+                    primaryAction: BannerAction(label: NSLocalizedString("today.compile.action.settings", comment: "")) { [weak self] in
                         self?.shouldShowSettings = true
                     }
                 ))
@@ -968,8 +968,8 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 HapticFeedback.error()
                 BannerCenter.shared.show(AppBannerModel(
                     kind: .error,
-                    title: "AI 返回格式异常",
-                    primaryAction: BannerAction(label: "查看日志") { }
+                    title: NSLocalizedString("today.compile.parseError", comment: ""),
+                    primaryAction: BannerAction(label: NSLocalizedString("today.compile.action.viewLog", comment: "")) { }
                 ))
             } catch {
                 HapticFeedback.error()

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -282,3 +282,13 @@
 "scroll_to_top.label.default"      = "Scroll to top";
 "scroll_to_top.label.new_content"   = "Scroll to top, new content";
 "voice_recording_soft_cap_hint"        = "Recommended under 5 min";
+
+/* TodayViewModel compile() banners */
+"today.compile.success"           = "Today's Daily Page is ready";
+"today.compile.offline"           = "You're offline — added to queue";
+"today.compile.missingKey"        = "DashScope API Key not configured";
+"today.compile.invalidKey"        = "API Key is invalid or expired";
+"today.compile.parseError"        = "Unexpected AI response format";
+"today.compile.action.settings"   = "Go to Settings";
+"today.compile.action.viewLog"    = "View Log";
+"today.compile.background.failed" = "Background compilation failed — check your network or API Key and try again";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -310,3 +310,13 @@
 "scroll_to_top.label.default"      = "返回顶部";
 "scroll_to_top.label.new_content"   = "返回顶部，有新内容";
 "voice_recording_soft_cap_hint"        = "建议 5 分钟内";
+
+/* TodayViewModel compile() banners */
+"today.compile.success"           = "今日 Daily Page 已生成";
+"today.compile.offline"           = "当前离线，已加入队列";
+"today.compile.missingKey"        = "DashScope API Key 未配置";
+"today.compile.invalidKey"        = "API Key 无效或已过期";
+"today.compile.parseError"        = "AI 返回格式异常";
+"today.compile.action.settings"   = "前往设置";
+"today.compile.action.viewLog"    = "查看日志";
+"today.compile.background.failed" = "后台编译失败，请检查网络或 API Key 后重试";


### PR DESCRIPTION
## Localize AI-compilation banner strings in TodayViewModel.compile()

The compile() success/offline/error banners in TodayViewModel emit hardcoded Chinese strings (e.g. "今日 Daily Page 已生成", "当前离线，已加入队列", "DashScope API Key 未配置"), breaking the NSLocalizedString convention used everywhere else in the app and leaving these user-visible messages untranslatable. This routes all six banner titles and their action labels through NSLocalizedString with new keys, restoring i18n consistency for the most frequently-seen feedback in the app.

### Acceptance
App builds clean with `xcodebuild -scheme DayPage build`. Triggering a compile (success and forced-failure paths) shows banners whose text comes from Localizable.strings; switching the simulator language to English surfaces English banner text. No hardcoded CJK string literals remain in TodayViewModel.compile() or observeCompilationFailure(). Existing tests pass.