### PR TITLE
auto: Make Daily Page mention chips tappable to open their Entity Page

### DIFF
--- a/DayPage/Features/Daily/DailyPageSummarySection.swift
+++ b/DayPage/Features/Daily/DailyPageSummarySection.swift
@@ -7,6 +7,7 @@ import SwiftUI
 struct DailyPageSummarySection: View {
 
     let model: DailyPageModel
+    var onMentionTap: ((String) -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -79,17 +80,33 @@ struct DailyPageSummarySection: View {
                 .tracking(1.6)
             FlowLayout(spacing: 8) {
                 ForEach(mentions, id: \.self) { mention in
-                    Text(mention)
-                        .font(DSFonts.inter(size: 12, weight: .medium))
-                        .foregroundColor(DSColor.amberDeep)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(DSColor.amberSoft)
-                        .overlay(Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
-                        .clipShape(Capsule())
+                    if let handler = onMentionTap {
+                        Button(action: {
+                            HapticFeedback.soft()
+                            handler(mention)
+                        }) {
+                            mentionCapsule(mention)
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("打开 \(mention) 的实体页")
+                        .accessibilityHint("双击以打开 \(mention) 的实体页")
+                    } else {
+                        mentionCapsule(mention)
+                    }
                 }
             }
         }
+    }
+
+    private func mentionCapsule(_ mention: String) -> some View {
+        Text(mention)
+            .font(DSFonts.inter(size: 12, weight: .medium))
+            .foregroundColor(DSColor.amberDeep)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 5)
+            .background(DSColor.amberSoft)
+            .overlay(Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
+            .clipShape(Capsule())
     }
 
     // MARK: - Stubs

--- a/DayPage/Features/Daily/DailyPageView.swift
+++ b/DayPage/Features/Daily/DailyPageView.swift
@@ -490,7 +490,12 @@ struct DailyPageView: View {
                 .lineSpacing(2)
                 .padding(.bottom, 22)
 
-            DailyPageSummarySection(model: model)
+            DailyPageSummarySection(model: model, onMentionTap: { mention in
+                let slug = mention.hasPrefix("@") ? String(mention.dropFirst()) : mention
+                let (type, resolved) = resolveEntityTypeAndSlug(slug)
+                selectedEntityType = type
+                selectedEntitySlug = resolved
+            })
         }
         .padding(28)
         .liquidGlassCard(cornerRadius: 24, tone: .hi)


### PR DESCRIPTION
## Make Daily Page mention chips tappable to open their Entity Page

The Daily Page summary renders 'MENTIONS' as static amber capsule chips, but tapping one does nothing — even though DailyPageView already owns an entity-navigation path (selectedEntitySlug → EntityPageView sheet) used by inline wikilinks. This change wires each mention chip to that existing path so tapping a mention opens its Entity Page, completing the raw→diary→entity→graph knowledge-network loop from a second surface.

### Acceptance
Build the DayPage scheme for iPhone 17 succeeds. In the Simulator, open a compiled Daily Page: tapping a MENTIONS chip triggers a soft haptic and presents the EntityPageView sheet for that mention's slug (existing 'page not generated yet' placeholder shown for unknown slugs). Inline wikilink navigation still works unchanged. VoiceOver reads each mention chip as a button with the '打开 …的实体页' hint. Stub mentions (when model.mentions is empty) remain visually identical and non-crashing.