### PR TITLE
auto: Make the submit-error toast accessible and dismiss reliably

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -367,10 +367,21 @@ struct TodayView: View {
                                 .background(DSColor.error)
                                 .padding(.top, 8)
                                 .transition(.move(edge: .top).combined(with: .opacity))
+                                .accessibilityIdentifier("submit-error-toast")
+                                .accessibilityLabel(err)
+                                .accessibilityAddTraits(.isStaticText)
+                                .onTapGesture {
+                                    withAnimation(Motion.rise) { viewModel.submitError = nil }
+                                }
                                 .onAppear {
+                                    Haptics.warn()
+                                    UIAccessibility.post(notification: .announcement, argument: err)
+                                    let captured = err
                                     Task { @MainActor in
                                         try? await Task.sleep(for: .seconds(3))
-                                        viewModel.submitError = nil
+                                        if viewModel.submitError == captured {
+                                            viewModel.submitError = nil
+                                        }
                                     }
                                 }
                         }


### PR DESCRIPTION
## Make the submit-error toast accessible and dismiss reliably

The Today submit-error toast (TodayView, ~line 359-379) announces nothing to VoiceOver, fires no error haptic, and relies on a per-onAppear Task.sleep that can be re-triggered on re-render. Add a UIAccessibility announcement + warning haptic when the toast appears, give it an accessibility identifier/label so it's testable, and let users tap to dismiss immediately instead of waiting the full 3s.

### Acceptance
When a memo save fails (e.g. forced RawStorage error), the red toast appears, a warning haptic fires, and VoiceOver speaks the error message. Tapping the toast dismisses it immediately. A second error replacing the first is not cleared early by the first error's timer. App builds clean with `xcodebuild -scheme DayPage build` and existing tests pass.