### PR TITLE
auto: Add swipe-to-dismiss gesture to the submit-error toast

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -369,10 +369,20 @@ struct TodayView: View {
                                 .transition(.move(edge: .top).combined(with: .opacity))
                                 .accessibilityIdentifier("submit-error-toast")
                                 .accessibilityLabel(err)
+                                .accessibilityHint(NSLocalizedString("Tap or swipe to dismiss", comment: "submit error toast dismiss hint"))
                                 .accessibilityAddTraits(.isStaticText)
                                 .onTapGesture {
                                     withAnimation(Motion.rise) { viewModel.submitError = nil }
                                 }
+                                .gesture(
+                                    DragGesture(minimumDistance: 20)
+                                        .onEnded { value in
+                                            if value.translation.height < -10 || abs(value.translation.width) > 40 {
+                                                Haptics.soft()
+                                                withAnimation(Motion.rise) { viewModel.submitError = nil }
+                                            }
+                                        }
+                                )
                                 .onAppear {
                                     Haptics.warn()
                                     UIAccessibility.post(notification: .announcement, argument: err)


### PR DESCRIPTION
## Add swipe-to-dismiss gesture to the submit-error toast

The submit-error toast in TodayView is tappable and auto-dismisses after 3s, but unlike the app's syncBanner and undo pills it cannot be flicked away with a gesture — an inconsistency since every other transient surface in Today supports swipe dismissal. This adds an upward drag-to-dismiss gesture (matching syncBanner's pattern) plus a soft haptic, giving users an immediate way to clear the error without waiting or precisely tapping the small toast.

### Acceptance
Trigger a submit error (e.g. submit while offline/failing). The red toast appears at top; flicking it upward or sideways immediately dismisses it with a soft haptic and Motion.rise animation. Tapping still dismisses it, and if untouched it still auto-clears after 3s. Build succeeds via xcodebuild -scheme DayPage and the app runs in the iPhone 17 simulator with no regressions to the toast's appearance or accessibility announcement.