### PR TITLE
auto: Purge stale Markdown export temp files to prevent unbounded temp-dir growth

### DIFF
--- a/DayPage/Services/MarkdownExportService.swift
+++ b/DayPage/Services/MarkdownExportService.swift
@@ -117,11 +117,45 @@ enum MarkdownExportService {
         return lines.joined(separator: "\n")
     }
 
+    // MARK: - Export Directory
+
+    static var exportDirectory: URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("DayPageExport", isDirectory: true)
+    }
+
+    // MARK: - Stale Export Cleanup
+
+    /// Removes `.md` files in `exportDirectory` whose modification date is older than `now - interval`.
+    /// Best-effort: per-file errors are logged and skipped.
+    static func purgeStaleExports(olderThan interval: TimeInterval = 86_400, now: Date = Date()) {
+        let fm = FileManager.default
+        let dir = exportDirectory
+        guard let contents = try? fm.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: .skipsHiddenFiles
+        ) else { return }
+
+        let cutoff = now.addingTimeInterval(-interval)
+        for fileURL in contents where fileURL.pathExtension == "md" {
+            guard let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey]),
+                  let modDate = values.contentModificationDate else { continue }
+            if modDate < cutoff {
+                do {
+                    try fm.removeItem(at: fileURL)
+                } catch {
+                    DayPageLogger.log(level: "ERROR", message: "MarkdownExportService: failed to remove stale export \(fileURL.lastPathComponent): \(error)")
+                }
+            }
+        }
+    }
+
     /// Writes the export content to a temp file and returns the URL.
     static func writeExportFile(content: String, dateString: String) throws -> URL {
-        let dir = FileManager.default.temporaryDirectory
-            .appendingPathComponent("DayPageExport", isDirectory: true)
+        let dir = exportDirectory
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        purgeStaleExports()
         let url = dir.appendingPathComponent("DayPage \(dateString).md")
         try content.write(to: url, atomically: true, encoding: .utf8)
         return url

--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -227,7 +227,53 @@ struct MarkdownExportServiceTests {
         #expect(url.lastPathComponent == "DayPage \(dateString).md")
     }
 
-    // MARK: - 5. Memo bodies ordered by created ascending
+    // MARK: - 5. purgeStaleExports removes old files, keeps fresh ones
+
+    @Test func purgeStaleExports_removesOldFile_keepsNewFile() throws {
+        let fm = FileManager.default
+        let dir = MarkdownExportService.exportDirectory
+        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+
+        let staleURL = dir.appendingPathComponent("DayPage 2026-01-01.md")
+        let freshURL = dir.appendingPathComponent("DayPage 2026-06-01.md")
+
+        try "stale content".write(to: staleURL, atomically: true, encoding: .utf8)
+        try "fresh content".write(to: freshURL, atomically: true, encoding: .utf8)
+
+        // Backdate the stale file to 48 hours ago
+        let now = Date()
+        let staleDate = now.addingTimeInterval(-48 * 3600)
+        try fm.setAttributes([.modificationDate: staleDate], ofItemAtPath: staleURL.path)
+        // Keep the fresh file's modification date at now (default after write)
+
+        MarkdownExportService.purgeStaleExports(olderThan: 86_400, now: now)
+
+        #expect(!fm.fileExists(atPath: staleURL.path), "Stale file should have been removed")
+        #expect(fm.fileExists(atPath: freshURL.path), "Fresh file should still exist")
+
+        // Cleanup
+        try? fm.removeItem(at: freshURL)
+    }
+
+    // MARK: - 6. writeExportFile twice returns valid URL for current date
+
+    @Test func writeExportFileTwice_returnsValidURL() throws {
+        let date = makeDate(year: 2026, month: 6, day: 2)
+        let dateString = MarkdownExportService.exportDateString(for: date)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [makeMemo(body: "round1")], date: date
+        )
+        let url1 = try MarkdownExportService.writeExportFile(content: content, dateString: dateString)
+        let content2 = MarkdownExportService.buildExportContent(
+            memos: [makeMemo(body: "round2")], date: date
+        )
+        let url2 = try MarkdownExportService.writeExportFile(content: content2, dateString: dateString)
+        let text = try String(contentsOf: url2, encoding: .utf8)
+        #expect(text.contains("round2"))
+        #expect(url1.lastPathComponent == url2.lastPathComponent)
+    }
+
+    // MARK: - 7. Memo bodies ordered by created ascending
 
     @Test func memoBodies_orderedByCreatedAscending() {
         let m1 = makeMemo(body: "first", secondsOffset: 0)


### PR DESCRIPTION
## Purge stale Markdown export temp files to prevent unbounded temp-dir growth

Each Markdown export writes a file named `DayPage <date>.md` into a persistent `DayPageExport` temp subdirectory, but these files are never cleaned up — every export and re-export leaves a file behind, so the directory grows without bound across the app's lifetime. Add a cleanup pass that removes export files older than 24 hours whenever a new export is written, keeping the share flow intact while bounding disk usage.

### Acceptance
1) `xcodebuild -scheme DayPage build` succeeds. 2) A new test in MarkdownExportServiceTests writes two files into the export directory — one with a backdated contentModificationDate (e.g. 48h old) and one fresh — calls `purgeStaleExports(olderThan: 86_400, now: Date())`, and asserts the stale file is removed while the fresh file remains. 3) Existing MarkdownExportServiceTests still pass. 4) Calling `writeExportFile` twice in succession still returns a valid, readable URL for the current date's export (cleanup never deletes the just-written file).