### PR TITLE
auto: Show an inline searching indicator in the Search bar while results load

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -15,6 +15,7 @@ final class SearchViewModel: ObservableObject {
     @Published var query: String = ""
     @Published var results: [SearchResult] = []
     @Published var hasSearched: Bool = false
+    @Published var isSearching: Bool = false
 
     // MARK: Recent searches — persisted via UserDefaults
     private let recentKey = "search.recentQueries"
@@ -280,12 +281,19 @@ struct SearchView: View {
         let capturedFilters = filters
         let wasEmpty = vm.results.isEmpty
         searchTask?.cancel()
+        if !trimmed.isEmpty || capturedFilters.isActive {
+            vm.isSearching = true
+        }
         searchTask = Task {
             let hits = await Task.detached(priority: .userInitiated) {
                 SearchService.search(keyword: trimmed, filters: capturedFilters)
             }.value
-            guard !Task.isCancelled else { return }
+            guard !Task.isCancelled else {
+                await MainActor.run { vm.isSearching = false }
+                return
+            }
             await MainActor.run {
+                vm.isSearching = false
                 appearedIDs = []
                 didBuzzEmpty = false
                 vm.results = hits
@@ -321,7 +329,12 @@ struct SearchView: View {
                     }
                     .accessibilityLabel("搜索框")
 
-                if !vm.query.isEmpty {
+                if vm.isSearching {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                        .tint(DSColor.onSurfaceVariant)
+                        .accessibilityLabel("正在搜索")
+                } else if !vm.query.isEmpty {
                     Button(action: {
                         Haptics.soft()
                         if !reduceMotion {


### PR DESCRIPTION
## Show an inline searching indicator in the Search bar while results load

SearchView runs each query on a detached background task with a 200ms debounce, but the search field gives no visual feedback while that task is in flight — on a large vault the list can sit empty for a beat, reading as 'no results'. Add a small spinner that replaces the clear button while a search is actively running, so users see the app is working before results (or the empty state) appear.

### Acceptance
Typing a multi-character query into Search shows a small spinner in the search field within ~200ms and it disappears the moment results (or the empty state) render; clearing the field with the x button or 取消 never leaves a stuck spinner; rapid typing that cancels in-flight tasks does not leave the spinner spinning; field height/layout is unchanged; VoiceOver announces the spinner as '正在搜索'; project builds clean via `xcodebuild -scheme DayPage build` and existing DayPageTests still pass.