### PR TITLE
auto: Fix data-loss bug: newlines in memo front-matter values (transcripts, mood, location) corrupt the file on save

### DIFF
--- a/DayPage/Models/Memo.swift
+++ b/DayPage/Models/Memo.swift
@@ -266,11 +266,13 @@ extension Memo {
 
     // MARK: Private helpers
 
-    /// 将字符串用双引号包裹，转义内部引号和反斜杠。
+    /// 将字符串用双引号包裹，转义内部引号、反斜杠和换行符，确保值保持在单行上。
     private func yamlQuote(_ s: String) -> String {
         let escaped = s
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\n", with: "\\n")
         return "\"\(escaped)\""
     }
 }
@@ -430,15 +432,36 @@ struct YAMLParser {
         return nil
     }
 
-    /// 去除外围双引号并反转义 \" 和 \\。
+    /// 去除外围双引号并反转义 \"、\\n、\\r 和 \\。
+    /// 使用字符扫描而非顺序字符串替换，避免 \\\\ 被误解析为转义序列前缀。
     private func yamlUnquote(_ s: String) -> String {
-        var v = s
-        if v.hasPrefix("\"") && v.hasSuffix("\"") && v.count >= 2 {
-            v = String(v.dropFirst().dropLast())
-            v = v
-                .replacingOccurrences(of: "\\\"", with: "\"")
-                .replacingOccurrences(of: "\\\\", with: "\\")
+        guard s.hasPrefix("\""), s.hasSuffix("\""), s.count >= 2 else { return s }
+        let inner = s.dropFirst().dropLast()
+        var result = ""
+        result.reserveCapacity(inner.count)
+        var idx = inner.startIndex
+        while idx < inner.endIndex {
+            let ch = inner[idx]
+            if ch == "\\" {
+                let next = inner.index(after: idx)
+                if next < inner.endIndex {
+                    switch inner[next] {
+                    case "\"": result.append("\"")
+                    case "n":  result.append("\n")
+                    case "r":  result.append("\r")
+                    case "\\": result.append("\\")
+                    default:   result.append(ch); result.append(inner[next])
+                    }
+                    idx = inner.index(after: next)
+                } else {
+                    result.append(ch)
+                    idx = next
+                }
+            } else {
+                result.append(ch)
+                idx = inner.index(after: idx)
+            }
         }
-        return v
+        return result
     }
 }

--- a/DayPageTests/MemoSerializationTests.swift
+++ b/DayPageTests/MemoSerializationTests.swift
@@ -127,6 +127,67 @@ struct MemoSerializationTests {
         assertRoundTrip(memo)
     }
 
+    // MARK: - Newline-in-front-matter tests (data-loss regression)
+
+    @Test func transcript_with_embedded_newlines_roundTrips() {
+        let multiLineTranscript = "Line one.\nLine two.\n\nPara two"
+        let memo = Memo(
+            id: UUID(),
+            type: .voice,
+            created: fixedDate,
+            attachments: [
+                Memo.Attachment(
+                    file: "voice.m4a",
+                    kind: "audio",
+                    duration: 8.0,
+                    transcript: multiLineTranscript,
+                    transcriptionStatus: .done
+                )
+            ],
+            body: "Voice memo"
+        )
+        assertRoundTrip(memo)
+
+        // The serialized front-matter must contain exactly one "transcript:" line —
+        // no raw newline may appear inside the quoted YAML scalar.
+        let md = memo.toMarkdown()
+        let transcriptLineCount = md.components(separatedBy: "\n").filter { $0.contains("transcript:") }.count
+        #expect(transcriptLineCount == 1)
+    }
+
+    @Test func mood_with_embedded_newline_roundTrips() {
+        let memo = Memo(
+            id: UUID(),
+            type: .text,
+            created: fixedDate,
+            mood: "happy\nexcited",
+            body: "Mood test"
+        )
+        assertRoundTrip(memo)
+    }
+
+    @Test func locationName_with_embedded_newline_roundTrips() {
+        let memo = Memo(
+            id: UUID(),
+            type: .location,
+            created: fixedDate,
+            location: Memo.Location(name: "Coffee\nShop", lat: 35.6762, lng: 139.6503),
+            body: "Location test"
+        )
+        assertRoundTrip(memo)
+    }
+
+    @Test func entityMention_with_embedded_newline_roundTrips() {
+        let memo = Memo(
+            id: UUID(),
+            type: .text,
+            created: fixedDate,
+            entityMentions: ["Alice\nBob", "Project\nPhoenix"],
+            body: "Entity test"
+        )
+        assertRoundTrip(memo)
+    }
+
     @Test func explicit_empty_entityMentions_and_attachments() {
         let memo = Memo(
             id: UUID(),


### PR DESCRIPTION
## Fix data-loss bug: newlines in memo front-matter values (transcripts, mood, location) corrupt the file on save

Memo.yamlQuote() escapes backslashes and double-quotes but NOT newline characters, so any front-matter string containing a '\n' (most commonly a Whisper transcript, but also mood, weather, device, location.name, or an entity_mention) is written as a multi-line quoted YAML value. The line-based YAMLParser cannot read that back: it treats the continuation line as a separate malformed key, truncating the value and desyncing the rest of the front-matter — the same data-loss class fixed for memo bodies in commit 27eb1cc, still open for front-matter values. The fix escapes \n and \r in yamlQuote and reverses it symmetrically in yamlUnquote, completing the JSON-style escaping the function already performs.

### Acceptance
1) A Memo whose transcript/mood/location.name/entity_mention contains '\n' survives toMarkdown -> fromMarkdown unchanged (parsed == memo). 2) The serialized front-matter for such a memo keeps each value on a single physical line (no raw newline inside the quoted YAML scalar). 3) All pre-existing MemoSerializationTests and ParserTests still pass. 4) The DayPage scheme builds clean for iPhone 17.