### PR TITLE
auto: Fix YAML data-loss: escape newlines in quoted scalars in Memo serialization

### DIFF
--- a/DayPage/Models/Memo.swift
+++ b/DayPage/Models/Memo.swift
@@ -266,13 +266,15 @@ extension Memo {
 
     // MARK: Private helpers
 
-    /// 将字符串用双引号包裹，转义内部引号、反斜杠和换行符，确保值保持在单行上。
+    /// 将字符串用双引号包裹，转义内部引号、反斜杠及换行符，确保标量值始终占一行。
     private func yamlQuote(_ s: String) -> String {
         let escaped = s
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")
-            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\r\n", with: "\\n")
             .replacingOccurrences(of: "\n", with: "\\n")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\t", with: "\\t")
         return "\"\(escaped)\""
     }
 }
@@ -432,10 +434,10 @@ struct YAMLParser {
         return nil
     }
 
-    /// 去除外围双引号并反转义 \"、\\n、\\r 和 \\。
-    /// 使用字符扫描而非顺序字符串替换，避免 \\\\ 被误解析为转义序列前缀。
+    /// 去除外围双引号并反转义所有转义序列（\ \" \n \r \t）。
+    /// 使用逐字符扫描确保 \n 被解码为字面反斜杠+n，而非换行符。
     private func yamlUnquote(_ s: String) -> String {
-        guard s.hasPrefix("\""), s.hasSuffix("\""), s.count >= 2 else { return s }
+        guard s.hasPrefix("\"") && s.hasSuffix("\"") && s.count >= 2 else { return s }
         let inner = s.dropFirst().dropLast()
         var result = ""
         result.reserveCapacity(inner.count)
@@ -446,9 +448,10 @@ struct YAMLParser {
                 let next = inner.index(after: idx)
                 if next < inner.endIndex {
                     switch inner[next] {
-                    case "\"": result.append("\"")
                     case "n":  result.append("\n")
                     case "r":  result.append("\r")
+                    case "t":  result.append("\t")
+                    case "\"": result.append("\"")
                     case "\\": result.append("\\")
                     default:   result.append(ch); result.append(inner[next])
                     }

--- a/DayPageTests/MemoSerializationTests.swift
+++ b/DayPageTests/MemoSerializationTests.swift
@@ -188,6 +188,35 @@ struct MemoSerializationTests {
         assertRoundTrip(memo)
     }
 
+    @Test func newlineAndTab_inTranscriptAndMood_roundTrip() {
+        let memo = Memo(
+            id: UUID(),
+            type: .voice,
+            created: fixedDate,
+            mood: "happy\nexcited",
+            attachments: [
+                Memo.Attachment(
+                    file: "audio.m4a",
+                    kind: "audio",
+                    duration: 5.0,
+                    transcript: "line one\nline two\ttabbed",
+                    transcriptionStatus: .done
+                )
+            ],
+            body: "Body text"
+        )
+        assertRoundTrip(memo)
+        // Literal backslash-n in source must NOT become a newline on round-trip.
+        let literalBackslashN = Memo(
+            id: UUID(),
+            type: .text,
+            created: fixedDate,
+            mood: "has \\n literal",
+            body: "ok"
+        )
+        assertRoundTrip(literalBackslashN)
+    }
+
     @Test func explicit_empty_entityMentions_and_attachments() {
         let memo = Memo(
             id: UUID(),


### PR DESCRIPTION
## Fix YAML data-loss: escape newlines in quoted scalars in Memo serialization

Memo.toMarkdown()'s yamlQuote helper escapes backslashes and double-quotes but NOT newlines. A Whisper transcript, mood, weather, or location name containing a line break is written as a literal multi-line double-quoted scalar, which the hand-written YAMLParser cannot parse back — silently losing the field on the next load (and potentially mis-parsing the rest of the front-matter). This escapes \n, \r, and \t on write and unescapes them on read so any single-line scalar value round-trips losslessly.

### Acceptance
Add a MemoSerializationTests case building a Memo whose transcript = "line one\nline two\ttabbed" and whose mood contains an embedded newline; assertRoundTrip passes (parsed == memo). All existing MemoSerializationTests and ParserTests still pass. xcodebuild -scheme DayPage build succeeds and the full DayPageTests suite is green. A literal backslash-n in the source text (e.g. user types the two characters \ and n) is NOT converted to a newline on round-trip.