### PR TITLE
auto: Add VoiceOver-announced, haptic-confirmed 'memo saved' feedback when a memo is submitted from the composer

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1086,6 +1086,7 @@ struct TodayView: View {
                 draftText = ""
                 viewModel.submitCombinedMemo(body: body)
                 showUndoPill(for: body)
+                announceMemoSaved()
             },
             onPressToTalkTranscribe: { transcript in
                 if draftText.isEmpty {
@@ -1100,6 +1101,7 @@ struct TodayView: View {
                 draftText = ""
                 viewModel.submitCombinedMemo(body: body)
                 showUndoPill(for: body)
+                announceMemoSaved()
             },
             onAddPhotoAsset: nil,
             batchPhotoProgress: viewModel.batchPhotoProgress,
@@ -1126,6 +1128,7 @@ struct TodayView: View {
                     showWriteSheet = false
                     viewModel.submitCombinedMemo(body: body)
                     showUndoPill(for: body)
+                    announceMemoSaved()
                 },
                 onClose: { showWriteSheet = false }
             )
@@ -1722,6 +1725,12 @@ struct TodayView: View {
             guard !Task.isCancelled else { return }
             undoText = nil
         }
+    }
+
+    private func announceMemoSaved() {
+        Haptics.success()
+        UIAccessibility.post(notification: .announcement,
+                             argument: NSLocalizedString("today.memo.saved", comment: ""))
     }
 
     // US-006: Clear draft when it's more than 30 days old.

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -121,6 +121,9 @@
 /* AI summary card long-press copy confirmation */
 "today.summary.copied" = "Summary copied";
 
+/* VoiceOver announcement on successful memo save */
+"today.memo.saved" = "Memo saved";
+
 /* Archive Day Empty */
 "empty.archive_day.title" = "No page for this day.";
 "empty.archive_day.subtitle" = "This day hasn't been compiled yet. Head to Today to add memos first.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -121,6 +121,9 @@
 /* AI summary card long-press copy confirmation */
 "today.summary.copied" = "已复制今日一句";
 
+/* VoiceOver announcement on successful memo save */
+"today.memo.saved" = "备忘已保存";
+
 /* Archive Day Empty */
 "empty.archive_day.title" = "这一天还没有日记页。";
 "empty.archive_day.subtitle" = "这天尚未编译。先去「今天」添加备忘吧。";


### PR DESCRIPTION
## Add VoiceOver-announced, haptic-confirmed 'memo saved' feedback when a memo is submitted from the composer

Currently submitting a memo shows an undo pill and triggers a capture pulse, but there is no explicit success haptic or VoiceOver announcement confirming the save — VoiceOver users get no audible confirmation, and sighted users rely only on the visual pill. This adds a `Haptics.success()` and a `UIAccessibility.post(.announcement)` confirmation on each successful submit, matching the existing error-toast pattern (which already announces failures) so success and failure feedback are symmetric.

### Acceptance
Building the DayPage scheme succeeds. Submitting a memo via the inline composer, press-to-talk send, and the write sheet each fires a success haptic and posts a VoiceOver announcement. With VoiceOver enabled in the iPhone 17 simulator, saving a memo speaks 'Memo saved'. Existing undo-pill and capture-pulse behavior is unchanged.