### PR TITLE
auto: Pause Graph force-simulation timer when app backgrounds; resume on foreground

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -45,6 +45,7 @@ struct GraphView: View {
     // both `emptyState` and `clearFiltersButton` read `reduceMotion`; deleting it
     // breaks the build — see incident around PR #466).
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.scenePhase) private var scenePhase
     private let nodeRadius: CGFloat = 16
     private let maxSimSteps = 200
 
@@ -311,6 +312,18 @@ struct GraphView: View {
         }
         .onDisappear {
             stopSimulation()
+        }
+        .onChange(of: scenePhase) { phase in
+            switch phase {
+            case .active:
+                if !viewModel.nodes.isEmpty && simulationSteps < maxSimSteps {
+                    startSimulation(reset: false)
+                }
+            case .inactive, .background:
+                stopSimulation()
+            @unknown default:
+                break
+            }
         }
         .sheet(isPresented: $showEntityPage) {
             if let node = selectedNode {
@@ -862,8 +875,8 @@ struct GraphView: View {
 
     // MARK: - Simulation
 
-    private func startSimulation() {
-        simulationSteps = 0
+    private func startSimulation(reset: Bool = true) {
+        if reset { simulationSteps = 0 }
         simulationTimer?.invalidate()
         simulationTimer = Timer.scheduledTimer(withTimeInterval: 1.0 / 30.0, repeats: true) { _ in
             Task { @MainActor in


### PR DESCRIPTION
## Pause Graph force-simulation timer when app backgrounds; resume on foreground

GraphView runs a 30fps Timer-based force-directed layout simulation that keeps firing even when the app is backgrounded, wasting CPU and battery, because there is no scenePhase observation. Add scenePhase handling to stop the simulation timer on .background/.inactive and restart it on .active (only while nodes exist and the layout hasn't fully settled), and gate the timer body so it no-ops if the view has disappeared. This is a low-risk performance/correctness fix in a single file with a visible benefit: smoother return-to-Graph behavior and no off-screen battery drain.

### Acceptance
Build the DayPage scheme for iPhone 17 simulator with no warnings. Launch, open the Graph tab with >=2 nodes, confirm nodes lay out as before. Background the app (Home) and confirm via Instruments/Time Profiler or a log in the timer body that simulationStep stops firing; foreground and confirm the simulation resumes only if not yet settled and the layout does not visibly re-scramble from scratch. Reduce-motion and existing search/zoom interactions remain unaffected.