### PR TITLE
auto: Surface frequent-entity chips in Search's empty-result state

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -799,6 +799,27 @@ struct SearchView: View {
                         }
                     }
                 }
+
+                let entitySuggestions = vm.topEntities.prefix(6).map(\.name).filter { $0 != vm.query }
+                if !entitySuggestions.isEmpty {
+                    VStack(alignment: .leading, spacing: 10) {
+                        Text("高频实体")
+                            .monoLabelStyle(size: 10)
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 20)
+
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(entitySuggestions, id: \.self) { name in
+                                    entityChip(name)
+                                }
+                            }
+                            .padding(.horizontal, 20)
+                            .padding(.vertical, 4)
+                        }
+                    }
+                }
             }
             .frame(maxWidth: .infinity)
             .padding(.top, 80)


### PR DESCRIPTION
## Surface frequent-entity chips in Search's empty-result state

When a search returns zero matches, SearchView currently only offers recent-query chips as alternatives — and only if recent history exists. This adds the user's top indexed entities (already loaded via vm.topEntities) as tappable jump-chips in the empty-result state, turning a dead-end screen into an actionable one, with a confirming haptic and VoiceOver announcement when a suggestion is tapped.

### Acceptance
1) Search a term with no matches while ≥1 indexed [[entity]] exists → a '高频实体' row of tappable chips appears below the empty-result message. 2) Tapping a chip fires a confirm haptic, sets vm.query to that entity, and runs the search immediately. 3) The current query string is never shown as its own suggestion chip. 4) When no entities are indexed, the row is absent (no empty header). 5) Build succeeds: `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build`. 6) Reduce-motion and VoiceOver behavior is unaffected (reuses existing entityChip path).