### PR TITLE
auto: Hoist WriteSheetView's per-keystroke DateFormatter allocations into static cached formatters

### DIFF
--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -100,32 +100,38 @@ struct WriteSheetView: View {
 
     // MARK: - Date / time strings (museum-tag style)
 
+    private static let weekdayFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "EEEE"
+        return f
+    }()
+
+    private static let stampFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "MMM d · HH:mm"
+        return f
+    }()
+
+    private static let isoFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        return f
+    }()
+
     /// Captured once so the stamp doesn't reshuffle while the sheet is open.
     private let now = Date()
 
     /// Full weekday, e.g. "Thursday" (design composer.jsx:236).
-    private var weekday: String {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US")
-        f.dateFormat = "EEEE"
-        return f.string(from: now)
-    }
+    private var weekday: String { Self.weekdayFmt.string(from: now) }
 
     /// Mono stamp "MAY 28 · 15:47" (design composer.jsx:239).
-    private var stamp: String {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US")
-        f.dateFormat = "MMM d · HH:mm"
-        return f.string(from: now).uppercased()
-    }
+    private var stamp: String { Self.stampFmt.string(from: now).uppercased() }
 
     /// ISO date for the vault caption "YYYY-MM-DD" (design composer.jsx:340).
-    private var isoDate: String {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = "yyyy-MM-dd"
-        return f.string(from: now)
-    }
+    private var isoDate: String { Self.isoFmt.string(from: now) }
 
     // MARK: - Body
 


### PR DESCRIPTION
## Hoist WriteSheetView's per-keystroke DateFormatter allocations into static cached formatters

WriteSheetView's `weekday`, `stamp`, and `isoDate` computed properties each allocate a brand-new DateFormatter every time they're read — and they're read from `body`, which re-renders on every character typed into the composer (text is a @Binding). DateFormatter creation is one of the most expensive routine allocations in Cocoa, so the app's most interactive surface churns three of them per keystroke. This matches the established convention already used in MemoCardView, TodayView, SidebarView, and ArchiveView, which all hoist formatters into `private static let`.

### Acceptance
DayPage scheme builds clean (xcodebuild -scheme DayPage build). The WriteSheetView opens from the Today dock's text affordance and the header shows the identical weekday + 'MMM D · HH:MM' stamp and the 'VAULT / YYYY-MM-DD.md' caption as before. Typing into the composer no longer allocates DateFormatters (verify by inspection: no `DateFormatter()` remains inside any computed property or `body`-reachable code path — all three live in `private static let`). Existing DayPageTests still pass.