### PR TITLE
auto: Stop firing a warning haptic on every keystroke in Search's empty-result state

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -204,6 +204,7 @@ struct SearchView: View {
     @State private var searchTask: Task<Void, Never>? = nil
     @State private var appearedIDs: Set<UUID> = []
     @State private var didBuzzEmpty: Bool = false
+    @State private var lastBuzzedEmptyQuery: String? = nil
     @State private var clearPressed: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
@@ -295,11 +296,17 @@ struct SearchView: View {
             await MainActor.run {
                 vm.isSearching = false
                 appearedIDs = []
-                didBuzzEmpty = false
                 vm.results = hits
                 vm.hasSearched = !trimmed.isEmpty || capturedFilters.isActive
                 if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
-                if hits.isEmpty { didBuzzEmpty = false }
+                if hits.isEmpty && vm.hasSearched {
+                    if trimmed != lastBuzzedEmptyQuery {
+                        if !reduceMotion { Haptics.warn() }
+                        lastBuzzedEmptyQuery = trimmed
+                    }
+                } else if !hits.isEmpty {
+                    lastBuzzedEmptyQuery = nil
+                }
                 if UIAccessibility.isVoiceOverRunning && vm.hasSearched {
                     let message = hits.isEmpty ? "无匹配结果" : "\(hits.count) 条结果"
                     UIAccessibility.post(notification: .announcement, argument: message)
@@ -833,7 +840,6 @@ struct SearchView: View {
         .onAppear {
             if !didBuzzEmpty {
                 didBuzzEmpty = true
-                if !reduceMotion { Haptics.warn() }
             }
         }
     }


### PR DESCRIPTION
## Stop firing a warning haptic on every keystroke in Search's empty-result state

In SearchView, the empty-result view fires Haptics.warn() in .onAppear, but didBuzzEmpty is reset to false on every debounced search in runSearch(). As a user types a query that matches nothing, each keystroke re-renders the empty state and re-triggers a jarring warning buzz, turning 'no results' into a stutter of vibrations. This change debounces the haptic so it fires at most once per distinct no-result query and never repeats while the user keeps typing within the same empty session.

### Acceptance
Build the DayPage scheme for iPhone 17 and run in Simulator. Type a query that matches nothing (e.g. 'zzzz') character by character: a single warning haptic fires when results first become empty, and no further haptics fire while continuing to type within the empty state. Clearing and entering a different no-result query fires exactly one new haptic. A query that returns results fires the existing soft 'found' haptic and resets state so a subsequent empty query buzzes again. Reduce Motion off/on both behave correctly (no warn haptic under Reduce Motion). The empty-state scale-in entrance animation still plays.