### PR TITLE
auto: Make SearchView suggestion chips accessible & add tap-feedback scale

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -698,7 +698,10 @@ struct SearchView: View {
                 .background(DSColor.surfaceContainer)
                 .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
         }
-        .buttonStyle(.plain)
+        .buttonStyle(ChipButtonStyle(reduceMotion: reduceMotion))
+        .accessibilityLabel("搜索 \(entity)")
+        .accessibilityHint("双击以该关键词搜索归档")
+        .accessibilityAddTraits(.isButton)
     }
 
     private func entityChipWithCount(_ entity: EntityFrequency, maxCount: Int, index: Int) -> some View {
@@ -1159,6 +1162,17 @@ private struct EntityFrequencyChip: View {
                 }
             }
         }
+    }
+}
+
+// MARK: - ChipButtonStyle
+
+private struct ChipButtonStyle: ButtonStyle {
+    let reduceMotion: Bool
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.94 : 1)
+            .animation(reduceMotion ? nil : Motion.spring, value: configuration.isPressed)
     }
 }
 


### PR DESCRIPTION
## Make SearchView suggestion chips accessible & add tap-feedback scale

The reusable `entityChip` helper in SearchView (used for starter suggestions, recent-search re-tries, and high-frequency entity suggestions in the empty-result state) renders a bare tappable Text with no accessibility label or hint, so VoiceOver users hear only the word with no cue that tapping runs a search. Add a descriptive accessibility label/hint plus a brief press-scale animation so the chips match the polish of the already-accessible `EntityFrequencyChip`.

### Acceptance
Build the DayPage scheme for iPhone 17 simulator succeeds. With VoiceOver, focusing a starter/recent/entity suggestion chip announces '搜索 <term>, button' and the hint '双击以该关键词搜索归档'. Tapping a chip still fills the query, runs the search, and fires tapConfirm haptics. Chips show a subtle press-scale (suppressed under Reduce Motion). No regression to the EntityFrequencyChip frequency bars.