### PR TITLE
auto: Add a brief skeleton placeholder for the frequent-entities section while the background scan runs

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -35,12 +35,14 @@ final class SearchViewModel: ObservableObject {
     // MARK: Frequent entities — cached, loaded off the main thread
 
     @Published private(set) var topEntities: [EntityFrequency] = []
+    @Published private(set) var isLoadingEntities: Bool = false
 
     // Cache key: (file count, newest mtime since reference date)
     private var entitiesCacheKey: (Int, TimeInterval)? = nil
     private var entitiesCache: [EntityFrequency] = []
 
     func loadTopEntities(limit: Int = 5) {
+        isLoadingEntities = true
         let currentKey = entitiesCacheKey
         let currentCache = entitiesCache
         Task.detached(priority: .utility) {
@@ -54,6 +56,7 @@ final class SearchViewModel: ObservableObject {
                 self.entitiesCacheKey = key
                 self.entitiesCache = entities
                 self.topEntities = entities
+                self.isLoadingEntities = false
             }
         }
     }
@@ -601,22 +604,31 @@ struct SearchView: View {
                     }
                 }
 
-                if !entities.isEmpty {
+                if !entities.isEmpty || vm.isLoadingEntities {
                     sectionHeader(title: "高频实体", trailing: AnyView(EmptyView()))
 
-                    let maxCount = entities.map(\.count).max() ?? 1
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: 8) {
-                            ForEach(Array(entities.enumerated()), id: \.element) { idx, entity in
-                                entityChipWithCount(entity, maxCount: maxCount, index: idx)
+                    Group {
+                        if vm.isLoadingEntities && entities.isEmpty {
+                            EntityChipSkeleton(reduceMotion: reduceMotion)
+                                .transition(.opacity)
+                        } else {
+                            let maxCount = entities.map(\.count).max() ?? 1
+                            ScrollView(.horizontal, showsIndicators: false) {
+                                HStack(spacing: 8) {
+                                    ForEach(Array(entities.enumerated()), id: \.element) { idx, entity in
+                                        entityChipWithCount(entity, maxCount: maxCount, index: idx)
+                                    }
+                                }
+                                .padding(.horizontal, 20)
+                                .padding(.vertical, 10)
                             }
+                            .transition(.opacity)
                         }
-                        .padding(.horizontal, 20)
-                        .padding(.vertical, 10)
                     }
+                    .animation(Motion.fade, value: vm.isLoadingEntities)
                 }
 
-                if recent.isEmpty && entities.isEmpty {
+                if recent.isEmpty && entities.isEmpty && !vm.isLoadingEntities {
                     VStack(spacing: 20) {
                         VStack(spacing: 12) {
                             Image(systemName: "magnifyingglass")
@@ -1173,6 +1185,41 @@ private struct ChipButtonStyle: ButtonStyle {
         configuration.label
             .scaleEffect(configuration.isPressed && !reduceMotion ? 0.94 : 1)
             .animation(reduceMotion ? nil : Motion.spring, value: configuration.isPressed)
+    }
+}
+
+// MARK: - EntityChipSkeleton
+
+private struct EntityChipSkeleton: View {
+
+    let reduceMotion: Bool
+
+    @State private var pulsing: Bool = false
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(0..<4, id: \.self) { _ in
+                    Capsule()
+                        .fill(DSColor.surfaceContainer)
+                        .frame(width: 80, height: 28)
+                        .opacity(pulsing ? 0.45 : 0.85)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 10)
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(
+                .easeInOut(duration: 0.85)
+                    .repeatForever(autoreverses: true)
+            ) {
+                pulsing = true
+            }
+        }
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1814,11 +1814,16 @@ struct TodayView: View {
             let notesKey = count == 1 ? "today.subline.notes.one" : "today.subline.notes.other"
             let notesStr = String(format: NSLocalizedString(notesKey, comment: ""), count)
             parts = [dateStr, notesStr]
+            let words = viewModel.todayWordCount
+            if words > 0 {
+                let wordsKey = words == 1 ? "today.subline.words.one" : "today.subline.words.other"
+                parts.append(String(format: NSLocalizedString(wordsKey, comment: ""), words))
+            }
         }
 
         // Museum-aesthetic subline: append today's weather + place when known.
         // Sourced from existing memos — no extra network/location fetch (M1 is UI-only).
-        // e.g. "MAY 28 · 2 NOTES · 28° · VIENTIANE"
+        // e.g. "MAY 28 · 2 NOTES · 340 WORDS · 28° · VIENTIANE"
         if let weather = todayWeatherShort() {
             parts.append(weather)
         }
@@ -1829,7 +1834,7 @@ struct TodayView: View {
     }
 
     /// Comma-separated version of the header subline for VoiceOver.
-    /// e.g. "May 28, 2 notes, 28°, Vientiane"
+    /// e.g. "May 28, 2 notes, 340 words, 28°, Vientiane"
     private func headerSublineAccessibilityLabel(_ date: Date) -> String {
         let count = viewModel.memos.count
         let dateStr = Self.headerDateFmt.string(from: date)
@@ -1840,6 +1845,11 @@ struct TodayView: View {
             let notesKey = count == 1 ? "today.subline.notes.one" : "today.subline.notes.other"
             let notesStr = String(format: NSLocalizedString(notesKey, comment: ""), count)
             parts = [dateStr, notesStr]
+            let words = viewModel.todayWordCount
+            if words > 0 {
+                let wordsKey = words == 1 ? "today.subline.words.one" : "today.subline.words.other"
+                parts.append(String(format: NSLocalizedString(wordsKey, comment: ""), words))
+            }
         }
         if let weather = todayWeatherShort() { parts.append(weather) }
         if let place = todayPlaceShort() { parts.append(place) }

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -87,6 +87,40 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
     /// Number of signals (memos) captured today — drives the Day Orb readout.
     var signalCount: Int { memos.count }
 
+    /// Total word count across all of today's memo bodies.
+    var todayWordCount: Int {
+        memos.reduce(0) { $0 + TodayViewModel.wordCount(in: $1.body) }
+    }
+
+    /// CJK-aware word counter: each CJK ideograph = 1 word; runs of non-CJK
+    /// non-whitespace characters = 1 word each.
+    static func wordCount(in text: String) -> Int {
+        var count = 0
+        var inLatinRun = false
+        for scalar in text.unicodeScalars {
+            let v = scalar.value
+            let isCJK = (v >= 0x4E00 && v <= 0x9FFF)
+                     || (v >= 0x3400 && v <= 0x4DBF)
+                     || (v >= 0x20000 && v <= 0x2A6DF)
+                     || (v >= 0xF900 && v <= 0xFAFF)
+                     || (v >= 0x2E80 && v <= 0x2EFF)
+                     || (v >= 0x3000 && v <= 0x303F)
+            let isWhitespace = CharacterSet.whitespacesAndNewlines.contains(scalar)
+            if isCJK {
+                if inLatinRun { inLatinRun = false }
+                count += 1
+            } else if isWhitespace {
+                inLatinRun = false
+            } else {
+                if !inLatinRun {
+                    inLatinRun = true
+                    count += 1
+                }
+            }
+        }
+        return count
+    }
+
     /// Whether the Daily Page for today has been compiled.
     @Published var isDailyPageCompiled: Bool = false
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -89,6 +89,10 @@
 "today.subline.notes.one"    = "%d note";
 "today.subline.notes.other"  = "%d notes";
 
+/* Today header subline — word count */
+"today.subline.words.one"    = "%d WORD";
+"today.subline.words.other"  = "%d WORDS";
+
 /* Today orb greeting — time-of-day serif greeting above kicker */
 "today.greeting.morning"     = "Good morning.";
 "today.greeting.afternoon"   = "Good afternoon.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -89,6 +89,10 @@
 "today.subline.notes.one"    = "%d 条记录";
 "today.subline.notes.other"  = "%d 条记录";
 
+/* Today header subline — word count */
+"today.subline.words.one"    = "%d 字";
+"today.subline.words.other"  = "%d 字";
+
 /* Today orb greeting — time-of-day serif greeting above kicker */
 "today.greeting.morning"     = "早上好。";
 "today.greeting.afternoon"   = "下午好。";


### PR DESCRIPTION
## Add a brief skeleton placeholder for the frequent-entities section while the background scan runs

SearchView's '高频实体' (frequent entities) section is populated by an off-main-thread vault scan in loadTopEntities(), so on the empty-query screen it pops in abruptly a beat after appearance with a spring of bars. Add a lightweight shimmer/placeholder row that occupies the section's slot while topEntities is still empty-and-loading, so the layout doesn't jump and the wait reads as intentional. This mirrors the existing MemoListSkeleton pattern used in TodayView.

### Acceptance
Build the DayPage scheme cleanly. Open Search with an empty query on a vault that has >=5 linked entities: the '高频实体' section shows 4 shimmering placeholder capsules immediately, then crossfades to the real frequency chips when the scan completes (no layout jump/pop). With Reduce Motion enabled, placeholders show as static (non-pulsing) capsules and the swap is a plain fade. When the vault has no entities, no skeleton lingers — the section simply doesn't appear after loading finishes.

Recreation of PR #663 after merge queue closed original without merging.