### PR TITLE
fix(i18n): add missing localization keys and fix untranslated en strings

### DIFF
--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -20,8 +20,8 @@
 "compile.dock.unlocked" = "Daily compilation unlocked";
 
 /* InputBarV4 — press-to-talk hint states */
-"input.hint.placeholder"     = "记下此刻";
-"input.hint.idle"            = "轻点书写 · 长按录音";
+"input.hint.placeholder"     = "Capture this moment";
+"input.hint.idle"            = "Tap to write · Hold to record";
 "input.hint.pre_recording"   = "Hold a moment longer";
 "input.hint.recording"       = "Swipe up to cancel · Left to transcribe · Release to send";
 "input.hint.cancel_armed"    = "Release to cancel";
@@ -50,6 +50,8 @@
 "write.sheet.icon.photo"     = "Photos";
 "write.sheet.icon.location"  = "Location";
 "write.sheet.icon.tag"       = "Tag";
+"write.sheet.icon.disabled.hint" = "Add from the main input bar";
+"write.sheet.rail.hint"      = "Tap the dock to attach photos, location and more";
 
 /* WriteSheet — word/char counter */
 "writesheet.count.words.one"   = "1 word";
@@ -63,6 +65,15 @@
 "input.a11y.mic"             = "Microphone";
 "input.a11y.mic_hint_full"   = "Tap to open the recorder; press-and-hold to send a voice memo";
 "input.a11y.write_text"      = "Write text";
+"input.a11y.mic_transcribe"  = "Record and transcribe";
+"input.a11y.mic_stop_transcribe" = "Stop recording and transcribe";
+"input.a11y.camera"          = "Take photo";
+"input.a11y.photo_library"   = "Choose from library";
+"input.a11y.add_location"    = "Add current location";
+"input.a11y.clear_location"  = "Clear location";
+"input.a11y.collapse"        = "Collapse input bar";
+"input.a11y.drag_handle"     = "Drag handle";
+"input.a11y.drag_handle_hint" = "Drag up or down to expand or collapse the input bar";
 
 /* Dock button labels — shown next to each icon */
 "input.dock.more"            = "More";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -50,6 +50,8 @@
 "write.sheet.icon.photo"     = "相册";
 "write.sheet.icon.location"  = "位置";
 "write.sheet.icon.tag"       = "标签";
+"write.sheet.icon.disabled.hint" = "请在主输入栏添加";
+"write.sheet.rail.hint"      = "轻点底部工具栏可添加照片、位置等";
 
 /* WriteSheet — word/char counter */
 "writesheet.count.words.one"   = "1 个词";
@@ -63,6 +65,15 @@
 "input.a11y.mic"             = "麦克风";
 "input.a11y.mic_hint_full"   = "单击进入录音页；长按说话松手发送";
 "input.a11y.write_text"      = "写文字";
+"input.a11y.mic_transcribe"  = "录音转文字";
+"input.a11y.mic_stop_transcribe" = "停止录音并转文字";
+"input.a11y.camera"          = "拍照";
+"input.a11y.photo_library"   = "从相册选择";
+"input.a11y.add_location"    = "添加当前位置";
+"input.a11y.clear_location"  = "清除位置";
+"input.a11y.collapse"        = "收起输入栏";
+"input.a11y.drag_handle"     = "拖动手柄";
+"input.a11y.drag_handle_hint" = "上下拖动可展开或收起输入栏";
 
 /* Dock button labels — shown next to each icon */
 "input.dock.more"            = "更多";


### PR DESCRIPTION
## 背景

自主巡检 Today / WriteSheet 界面时发现:部分 `NSLocalizedString` key 在代码里被引用,但在两个 `Localizable.strings` 表里都缺失,运行时直接漏出原始 key(如截图里的 `WRITE.SHEET.RAIL.HINT`),并在 VoiceOver 中读出 key 名。此外 en 表里有两条值仍是中文,导致英文 locale 下显示 CJK。

## 改动

**zh-Hans + en — 补齐 11 个缺失 key**
- `write.sheet.rail.hint`、`write.sheet.icon.disabled.hint`
- 9 个 `input.a11y.*` 无障碍标签:`mic_transcribe` / `mic_stop_transcribe` / `camera` / `photo_library` / `add_location` / `clear_location` / `collapse` / `drag_handle` / `drag_handle_hint`

**en — 修正 2 条漏翻译(值仍是中文)**
- `input.hint.placeholder`:`记下此刻` → `Capture this moment`
- `input.hint.idle`:`轻点书写 · 长按录音` → `Tap to write · Hold to record`

英文 mono 风格小标签(`EARLIER` / `BY DAY` / `1 WORDS`)按设计保留,不在本次范围。

## 验证

- `plutil -lint` 两个 strings 表均通过
- `xcodebuild -scheme DayPage` 构建成功(exit 0)
- 将模拟器首选语言改为 `zh-Hans-CN`,写入今日 memo 复现场景 → 实机截图确认 Today 界面中文渲染正常(`下午好。` / `记下此刻` / `再记 N 条解锁今日成稿` / `EARLIER` 分隔线不再漏 key)

## 备注(未在本 PR 处理)

- 侧边栏导航项(`Today` / `Archive` / `Graph` / `Feedback` / `Settings`)当前为英文,需确认是设计风格还是漏翻译