### PR TITLE
auto: Add missing tap-confirm haptic to OnThisDayCard navigation

### DIFF
--- a/DayPage/Features/Today/OnThisDayCard.swift
+++ b/DayPage/Features/Today/OnThisDayCard.swift
@@ -12,6 +12,7 @@ struct OnThisDayCard: View {
 
     var body: some View {
         Button {
+            Haptics.tapConfirm()
             onTap(entry)
         } label: {
             cardContent


### PR DESCRIPTION
## Add missing tap-confirm haptic to OnThisDayCard navigation

The OnThisDayCard's primary tap (which navigates to that day's detail) fires no haptic feedback, even though its own dismiss button uses Haptics.soft() and every other navigational tap in the app (memo cards, daily-page card, AI summary, empty-state CTAs) fires Haptics.tapConfirm(). This is an inconsistency that makes the 'On This Day' resurfacing feature feel less responsive than the rest of Today. Adding the haptic restores tactile parity and reinforces the moment of reopening a past day.

### Acceptance
Tapping the On This Day card body produces a light tap-confirm haptic identical to tapping a memo card or the AI summary card, then navigates to that day. The dismiss (x) button still fires its existing soft haptic and does not navigate. No change to layout, animation, or VoiceOver labels. The DayPage scheme builds cleanly and existing tests pass.