### PR TITLE
auto: Localize hardcoded Chinese error strings in TodayViewModel

### DIFF
--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -338,7 +338,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             memos = remaining
         }
         Haptics.warn()
-        persistMemos(remaining, capturedDate: date, previous: previous, failureMessagePrefix: "删除失败")
+        persistMemos(remaining, capturedDate: date, previous: previous, failureMessagePrefix: NSLocalizedString("error.memo.delete_failed", comment: ""))
 
         // Start 5-second undo window
         deleteUndoTask?.cancel()
@@ -374,7 +374,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             memos = restored
         }
         Haptics.soft()
-        persistMemos(restored, capturedDate: date, previous: previous, failureMessagePrefix: "撤销失败")
+        persistMemos(restored, capturedDate: date, previous: previous, failureMessagePrefix: NSLocalizedString("error.memo.undo_failed", comment: ""))
     }
 
     /// Replaces the body text of an existing memo and writes through to disk.
@@ -389,7 +389,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             memos = newMemos
         }
         Haptics.commit()
-        persistMemos(newMemos, capturedDate: date, previous: previous, failureMessagePrefix: "保存失败")
+        persistMemos(newMemos, capturedDate: date, previous: previous, failureMessagePrefix: NSLocalizedString("error.memo.save_failed", comment: ""))
     }
 
     /// Pins a memo to the top of today's list without changing its original timestamp.
@@ -405,7 +405,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         withAnimation(.easeInOut(duration: 0.25)) {
             memos = updated
         }
-        persistMemos(updated, capturedDate: date, previous: previous, failureMessagePrefix: "置顶失败")
+        persistMemos(updated, capturedDate: date, previous: previous, failureMessagePrefix: NSLocalizedString("error.memo.pin_failed", comment: ""))
     }
 
     /// Unpins a memo, restoring it to its natural position based on original `created` time.
@@ -421,7 +421,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         withAnimation(.easeInOut(duration: 0.25)) {
             memos = updated
         }
-        persistMemos(updated, capturedDate: date, previous: previous, failureMessagePrefix: "取消置顶失败")
+        persistMemos(updated, capturedDate: date, previous: previous, failureMessagePrefix: NSLocalizedString("error.memo.unpin_failed", comment: ""))
     }
 
     /// Dispatches a `RawStorage.rewrite` off the MainActor so disk I/O never
@@ -446,7 +446,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                     withAnimation(Motion.rise) {
                         self.memos = previous
                     }
-                    self.submitError = "\(failureMessagePrefix)：\(error.localizedDescription)"
+                    self.submitError = String(format: failureMessagePrefix, error.localizedDescription)
                 }
             }
         }
@@ -535,7 +535,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                     }
                     self.errorMessage = nil
                 case .failure(let error):
-                    self.errorMessage = "加载失败：\(error.localizedDescription)"
+                    self.errorMessage = String(format: NSLocalizedString("error.memo.load_failed", comment: ""), error.localizedDescription)
                     self.memos = []
                 }
 
@@ -598,7 +598,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             defer { isProcessingPhoto = false }
 
             guard let result = await photoService.processPickerItem(item) else {
-                submitError = "照片处理失败，请重试"
+                submitError = NSLocalizedString("error.memo.photo_failed", comment: "")
                 return
             }
 
@@ -656,7 +656,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             newMemos[memoIdx] = updated
             let previous = memos
             withAnimation { memos = newMemos }
-            persistMemos(newMemos, capturedDate: date, previous: previous, failureMessagePrefix: "重新转写失败")
+            persistMemos(newMemos, capturedDate: date, previous: previous, failureMessagePrefix: NSLocalizedString("error.memo.retranscribe_failed", comment: ""))
         }
     }
 
@@ -721,7 +721,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         do {
             try fm.copyItem(at: url, to: finalURL)
         } catch {
-            submitError = "文件复制失败：\(error.localizedDescription)"
+            submitError = String(format: NSLocalizedString("error.memo.file_copy_failed", comment: ""), error.localizedDescription)
             return
         }
 
@@ -737,7 +737,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         cameraPhotoTask = Task { @MainActor in
             defer { isProcessingPhoto = false }
             guard let result = await photoService.processImageDataAsync(data) else {
-                submitError = "照片处理失败，请重试"
+                submitError = NSLocalizedString("error.memo.photo_failed", comment: "")
                 return
             }
             pendingAttachments.append(.photo(result))
@@ -751,7 +751,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
         cameraPhotoTask = Task { @MainActor in
             defer { isProcessingPhoto = false }
             guard let result = await photoService.processImageDataAsync(data) else {
-                submitError = "照片处理失败，请重试"
+                submitError = NSLocalizedString("error.memo.photo_failed", comment: "")
                 return
             }
             pendingAttachments.append(.photo(result))
@@ -888,7 +888,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 let count = UserDefaults.standard.integer(forKey: AppSettings.Keys.memoSaveCount)
                 UserDefaults.standard.set(count + 1, forKey: AppSettings.Keys.memoSaveCount)
             } catch {
-                submitError = "保存失败：\(error.localizedDescription)"
+                submitError = String(format: NSLocalizedString("error.memo.save_failed", comment: ""), error.localizedDescription)
             }
         }
     }
@@ -928,7 +928,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 }
                 // Don't show error for timeout — coords-only is acceptable
             } catch {
-                submitError = "位置获取失败：\(error.localizedDescription)"
+                submitError = String(format: NSLocalizedString("error.memo.location_failed", comment: ""), error.localizedDescription)
             }
         }
     }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -301,6 +301,18 @@
 "scroll_to_top.label.new_content"   = "Scroll to top, new content";
 "voice_recording_soft_cap_hint"        = "Recommended under 5 min";
 
+// MARK: Memo errors
+"error.memo.delete_failed"       = "Delete failed: %@";
+"error.memo.undo_failed"         = "Undo failed: %@";
+"error.memo.save_failed"         = "Failed to save: %@";
+"error.memo.pin_failed"          = "Pin failed: %@";
+"error.memo.unpin_failed"        = "Unpin failed: %@";
+"error.memo.retranscribe_failed" = "Re-transcription failed: %@";
+"error.memo.load_failed"         = "Failed to load: %@";
+"error.memo.photo_failed"        = "Photo processing failed, please try again";
+"error.memo.file_copy_failed"    = "File copy failed: %@";
+"error.memo.location_failed"     = "Location fetch failed: %@";
+
 /* TodayViewModel compile() banners */
 "today.compile.success"           = "Today's Daily Page is ready";
 "today.compile.offline"           = "You're offline — added to queue";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -329,6 +329,18 @@
 "scroll_to_top.label.new_content"   = "返回顶部，有新内容";
 "voice_recording_soft_cap_hint"        = "建议 5 分钟内";
 
+// MARK: Memo errors
+"error.memo.delete_failed"       = "删除失败：%@";
+"error.memo.undo_failed"         = "撤销失败：%@";
+"error.memo.save_failed"         = "保存失败：%@";
+"error.memo.pin_failed"          = "置顶失败：%@";
+"error.memo.unpin_failed"        = "取消置顶失败：%@";
+"error.memo.retranscribe_failed" = "重新转写失败：%@";
+"error.memo.load_failed"         = "加载失败：%@";
+"error.memo.photo_failed"        = "照片处理失败，请重试";
+"error.memo.file_copy_failed"    = "文件复制失败：%@";
+"error.memo.location_failed"     = "位置获取失败：%@";
+
 /* TodayViewModel compile() banners */
 "today.compile.success"           = "今日 Daily Page 已生成";
 "today.compile.offline"           = "当前离线，已加入队列";


### PR DESCRIPTION
## Localize hardcoded Chinese error strings in TodayViewModel

TodayViewModel surfaces user-facing error messages as hardcoded Chinese literals (e.g. "删除失败", "保存失败：", "照片处理失败，请重试", "位置获取失败：", "文件复制失败：", "重新转写失败", "撤销失败", "置顶失败", "取消置顶失败", "加载失败：") while the rest of the app routes through NSLocalizedString. This leaves these toasts untranslated for en/other locales and inconsistent with the just-merged i18n cleanup (#667). Replace each literal with an NSLocalizedString key and add the keys to Localizable.strings.

### Acceptance
DayPage scheme builds clean (xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'). No remaining hardcoded CJK string literals passed to submitError or persistMemos in TodayViewModel.swift (grep for failure literals returns none). Every new key exists in both en.lproj and zh-Hans.lproj Localizable.strings with matching key sets. Triggering a save/delete failure shows the correctly localized toast in both an English and a Chinese simulator locale; %@ placeholders correctly interpolate error.localizedDescription.