### PR TITLE
auto: Auto-dismiss the 'recent searches cleared' undo pill after 5s

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -22,6 +22,7 @@ final class SearchViewModel: ObservableObject {
     private let maxRecent = 10
 
     @Published var lastClearedSearches: [String]? = nil
+    private var clearUndoTask: Task<Void, Never>? = nil
 
     var recentSearches: [String] {
         get { UserDefaults.standard.stringArray(forKey: recentKey) ?? [] }
@@ -122,13 +123,26 @@ final class SearchViewModel: ObservableObject {
         lastClearedSearches = current
         recentSearches = []
         objectWillChange.send()
+        clearUndoTask?.cancel()
+        clearUndoTask = Task { @MainActor in
+            try? await Task.sleep(for: .seconds(5))
+            guard !Task.isCancelled, lastClearedSearches != nil else { return }
+            lastClearedSearches = nil
+        }
     }
 
     func undoClearRecentSearches() {
         guard let snapshot = lastClearedSearches else { return }
+        clearUndoTask?.cancel()
+        clearUndoTask = nil
         recentSearches = snapshot
         lastClearedSearches = nil
         objectWillChange.send()
+    }
+
+    func cancelClearUndo() {
+        clearUndoTask?.cancel()
+        clearUndoTask = nil
     }
 
     // MARK: Result grouping
@@ -244,6 +258,7 @@ struct SearchView: View {
                             Haptics.soft()
                             vm.undoClearRecentSearches()
                         } onDismiss: {
+                            vm.cancelClearUndo()
                             vm.lastClearedSearches = nil
                         }
                         .padding(.bottom, 40)


### PR DESCRIPTION
## Auto-dismiss the 'recent searches cleared' undo pill after 5s

The undo pill shown after clearing recent searches in SearchView has no time-based auto-dismiss — unlike the submit-error toast (3s) and the implicit undo windows elsewhere in the app, it lingers indefinitely until the user manually dismisses it or navigates away, semantically promising an undo that stays available forever and occupying the bottom of the screen. Add a 5-second auto-dismiss timer (cancellable, restarted on each clear) so the pill behaves consistently with the rest of the app's transient feedback affordances.

### Acceptance
Build the DayPage scheme (xcodebuild -scheme DayPage build) succeeds. In Simulator (iPhone 17): open Search, perform a couple searches to populate recent history, tap '清除' to clear them — the undo pill appears and slides away on its own ~5s later if untouched. Tapping the pill within 5s still restores the searches (timer cancelled, no late nil-ing). Tapping '清除' again restarts a fresh 5s window rather than inheriting the prior timer. Manually dismissing the pill cancels the pending timer (no flicker). No regression to the delete-undo or submit-error toasts.