### PR TITLE
auto: Bump re-used recent searches to the top of history when tapped

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -685,9 +685,7 @@ struct SearchView: View {
     @ViewBuilder
     private func recentSearchRow(_ q: String) -> some View {
         SwipeableRecentRow(query: q, onSelect: { query in
-            Haptics.tapConfirm()
-            vm.query = query
-            runSearch(keyword: query)
+            selectSuggestion(query)
         }, onDelete: {
             vm.removeRecentSearch(q)
         })
@@ -696,11 +694,16 @@ struct SearchView: View {
             .background(DSColor.outlineVariant.opacity(0.5))
     }
 
+    private func selectSuggestion(_ term: String) {
+        Haptics.tapConfirm()
+        vm.query = term
+        vm.recordSearch(term)
+        runSearch(keyword: term)
+    }
+
     private func entityChip(_ entity: String) -> some View {
         Button(action: {
-            Haptics.tapConfirm()
-            vm.query = entity
-            runSearch(keyword: entity)
+            selectSuggestion(entity)
         }) {
             Text(entity)
                 .font(.custom("Inter-Regular", size: 13))
@@ -731,9 +734,7 @@ struct SearchView: View {
             reduceMotion: reduceMotion,
             a11yLabel: a11yLabel
         ) {
-            Haptics.tapConfirm()
-            vm.query = entity.name
-            runSearch(keyword: entity.name)
+            selectSuggestion(entity.name)
         }
     }
 


### PR DESCRIPTION
## Bump re-used recent searches to the top of history when tapped

Tapping a row in Search's "最近搜索" list re-runs that query but never calls recordSearch, so a frequently re-used term keeps its stale position and can silently fall off the 10-item cap while less-used queries survive. This makes the recent list feel unresponsive to actual usage. The fix records the tapped (and submitted-result) query so most-recently-used always floats to the top, matching the dedup+prepend behavior the model already implements.

### Acceptance
1) Build DayPage scheme succeeds on iPhone 17 simulator. 2) Perform searches A, B, C (recent list shows C, B, A). 3) Tap recent row 'A' → it re-runs the search AND moves to the top (list becomes A, C, B). 4) Re-tapping an existing term creates no duplicate row. 5) Tapping a high-frequency-entity chip or a no-result suggestion chip also records that term to the top of recent searches. 6) Existing clear/undo behavior and the 10-item cap are unaffected.