### PR TITLE
auto: Add accessibility identifiers & labels to SettingsView controls

### DIFF
--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -74,11 +74,14 @@ struct SettingsView: View {
                 dataSection
                 aboutSection
             }
+            .accessibilityIdentifier("settings-list")
             .navigationTitle("设置")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
                     Button("关闭") { dismiss() }
+                        .accessibilityLabel(NSLocalizedString("settings.close.label", comment: ""))
+                        .accessibilityIdentifier("settings-close-button")
                 }
             }
             .onAppear { computeVaultSize() }
@@ -127,6 +130,8 @@ struct SettingsView: View {
                         if let s = UIPasteboard.general.string { editingKeyValue = s }
                     }
                     .buttonStyle(.bordered)
+                    .accessibilityLabel(NSLocalizedString("settings.apikey.paste.label", comment: ""))
+                    .accessibilityIdentifier("api-key-paste-button")
 
                     Spacer()
 
@@ -135,6 +140,8 @@ struct SettingsView: View {
                     }
                     .buttonStyle(.bordered)
                     .tint(.red)
+                    .accessibilityLabel(NSLocalizedString("settings.apikey.clear.label", comment: ""))
+                    .accessibilityIdentifier("api-key-clear-button")
                 }
                 .padding(.horizontal)
 
@@ -164,6 +171,8 @@ struct SettingsView: View {
                         showApiKeyEditor = false
                     }
                     .fontWeight(.semibold)
+                    .accessibilityLabel(NSLocalizedString("settings.apikey.save.label", comment: ""))
+                    .accessibilityIdentifier("api-key-save-button")
                 }
             }
         }
@@ -215,7 +224,8 @@ struct SettingsView: View {
                 key: Secrets.resolvedDeepSeekApiKey,
                 isTesting: deepSeekTesting,
                 result: deepSeekResult,
-                onTest: { Task { await testDeepSeek() } }
+                onTest: { Task { await testDeepSeek() } },
+                providerID: "deepseek"
             )
             apiKeyRow(
                 name: "OpenAI Whisper",
@@ -223,7 +233,8 @@ struct SettingsView: View {
                 key: Secrets.resolvedOpenAIWhisperApiKey,
                 isTesting: whisperTesting,
                 result: whisperResult,
-                onTest: { Task { await testWhisper() } }
+                onTest: { Task { await testWhisper() } },
+                providerID: "whisper"
             )
             apiKeyRow(
                 name: "OpenWeatherMap",
@@ -231,7 +242,8 @@ struct SettingsView: View {
                 key: Secrets.resolvedOpenWeatherApiKey,
                 isTesting: weatherTesting,
                 result: weatherResult,
-                onTest: { Task { await testWeather() } }
+                onTest: { Task { await testWeather() } },
+                providerID: "openweather"
             )
         }
     }
@@ -243,7 +255,8 @@ struct SettingsView: View {
         key: String,
         isTesting: Bool,
         result: APITestResult?,
-        onTest: @escaping () -> Void
+        onTest: @escaping () -> Void,
+        providerID: String = ""
     ) -> some View {
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 12) {
@@ -296,6 +309,8 @@ struct SettingsView: View {
                     .buttonStyle(.bordered)
                     .controlSize(.small)
                     .disabled(isTesting)
+                    .accessibilityLabel(NSLocalizedString("settings.apikey.test.label", comment: ""))
+                    .accessibilityIdentifier("api-key-test-button-\(providerID)")
                 }
             }
             if let result {
@@ -433,6 +448,7 @@ struct SettingsView: View {
             Toggle(isOn: $onThisDayEnabled) {
                 Label("On This Day", systemImage: "calendar.badge.clock")
             }
+            .accessibilityIdentifier("onthisday-enabled-toggle")
             .onChange(of: onThisDayEnabled) { val in
                 OnThisDayScheduler.shared.isEnabled = val
             }
@@ -443,6 +459,7 @@ struct SettingsView: View {
                     Text("清晨 06:00").tag(6)
                     Text("上午 09:00").tag(9)
                 }
+                .accessibilityIdentifier("onthisday-refresh-hour-picker")
                 .onChange(of: onThisDayRefreshHour) { val in
                     OnThisDayScheduler.shared.refreshHour = val
                 }
@@ -609,6 +626,9 @@ struct SettingsView: View {
             Button(role: .destructive, action: rollbackToLocal) {
                 Label("切换回本地存储", systemImage: "arrow.counterclockwise")
             }
+            .accessibilityLabel(NSLocalizedString("settings.rollback.label", comment: ""))
+            .accessibilityHint(NSLocalizedString("settings.rollback.hint", comment: ""))
+            .accessibilityIdentifier("settings-rollback-button")
         }
     }
 
@@ -632,6 +652,9 @@ struct SettingsView: View {
             Button(role: .destructive, action: { showCleanupConfirm = true }) {
                 Label("清理本地备份", systemImage: "trash")
             }
+            .accessibilityLabel(NSLocalizedString("settings.cleanup_backup.label", comment: ""))
+            .accessibilityHint(NSLocalizedString("settings.cleanup_backup.hint", comment: ""))
+            .accessibilityIdentifier("settings-cleanup-backup-button")
             .confirmationDialog(
                 "确认清理本地备份？",
                 isPresented: $showCleanupConfirm,
@@ -708,6 +731,9 @@ struct SettingsView: View {
                 Button(role: .destructive, action: { showClearSampleConfirm = true }) {
                     Label("清除示例数据", systemImage: "trash")
                 }
+                .accessibilityLabel(NSLocalizedString("settings.clear_sample.label", comment: ""))
+                .accessibilityHint(NSLocalizedString("settings.clear_sample.hint", comment: ""))
+                .accessibilityIdentifier("settings-clear-sample-button")
                 .confirmationDialog(
                     "确认清除示例数据？",
                     isPresented: $showClearSampleConfirm,

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -259,6 +259,19 @@
 /* Archive — async month loading (US-015) */
 "archive.loading_month" = "Loading…";
 
+/* Settings — Accessibility labels/hints */
+"settings.close.label" = "Close Settings";
+"settings.apikey.paste.label" = "Paste API key from clipboard";
+"settings.apikey.clear.label" = "Clear API key";
+"settings.apikey.save.label" = "Save API key";
+"settings.apikey.test.label" = "Test connection";
+"settings.rollback.label" = "Switch back to local storage";
+"settings.rollback.hint" = "Destructive. Reverts vault location from iCloud to local device storage.";
+"settings.cleanup_backup.label" = "Delete local backup";
+"settings.cleanup_backup.hint" = "Destructive. Permanently deletes the local backup. This cannot be undone.";
+"settings.clear_sample.label" = "Clear sample data";
+"settings.clear_sample.hint" = "Destructive. Permanently deletes all sample data. This cannot be undone.";
+
 /* Settings — AI Engine (US-014) */
 "settings.ai.section_title" = "AI Engine";
 "settings.ai.model" = "Model";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -287,6 +287,19 @@
 /* Archive — async month loading (US-015) */
 "archive.loading_month" = "加载中…";
 
+/* Settings — Accessibility labels/hints */
+"settings.close.label" = "关闭设置";
+"settings.apikey.paste.label" = "从剪贴板粘贴 API Key";
+"settings.apikey.clear.label" = "清除 API Key";
+"settings.apikey.save.label" = "保存 API Key";
+"settings.apikey.test.label" = "测试连接";
+"settings.rollback.label" = "切换回本地存储";
+"settings.rollback.hint" = "危险操作，将把 Vault 位置从 iCloud 切换回设备本地存储。";
+"settings.cleanup_backup.label" = "清理本地备份";
+"settings.cleanup_backup.hint" = "危险操作，将永久删除本地备份，无法撤销。";
+"settings.clear_sample.label" = "清除示例数据";
+"settings.clear_sample.hint" = "危险操作，将永久删除所有示例数据，无法撤销。";
+
 /* Settings — AI Engine (US-014) */
 "settings.ai.section_title" = "AI 引擎";
 "settings.ai.model" = "模型";


### PR DESCRIPTION
## Add accessibility identifiers & labels to SettingsView controls

SettingsView.swift and TimeZonePickerView.swift contain zero accessibility identifiers or labels (verified via grep), while sibling surfaces like TodayView are thoroughly instrumented. This leaves the Settings screen — which is full of destructive actions (rollback to local, cleanup backup, clear sample data) and toggles — opaque to VoiceOver and untestable via XCUITest. Add concise identifiers/labels so Settings matches the codebase's existing accessibility standard.

### Acceptance
`xcodebuild -scheme DayPage build` succeeds; grep for 'accessibilityIdentifier' in SettingsView.swift now returns the new identifiers (previously 0); running the app in the iPhone 17 simulator with VoiceOver, each settings button announces a clear label and destructive actions announce their warning hint; the change is purely additive modifiers with no logic or layout changes (< 100 lines, 1 file).