### PR TITLE
auto: Add a long-press 'capture prompt' affordance to the Day Orb that seeds the composer with a time-aware writing prompt

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -910,10 +910,22 @@ struct TodayView: View {
                 radius: refreshGlow ? 18 : 0
             )
             .animation(.easeOut(duration: 0.6), value: refreshGlow)
+            .onLongPressGesture(minimumDuration: 0.5) {
+                Haptics.medium()
+                guard draftText.isEmpty else { return }
+                draftText = orbCapturePrompt(currentTime)
+                orbFocusToggle.toggle()
+            }
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(NSLocalizedString("today.orb.label", comment: ""))
             .accessibilityValue(orbValue)
             .accessibilityHint(NSLocalizedString("today.orb.hint", comment: ""))
+            .accessibilityAction(named: Text(NSLocalizedString("today.orb.prompt.action", comment: ""))) {
+                Haptics.medium()
+                guard draftText.isEmpty else { return }
+                draftText = orbCapturePrompt(currentTime)
+                orbFocusToggle.toggle()
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 12)
@@ -1004,6 +1016,17 @@ struct TodayView: View {
         case .afternoon: key = "empty.today.subtitle.afternoon"
         case .evening:   key = "empty.today.subtitle.evening"
         case .lateNight: key = "empty.today.subtitle.night"
+        }
+        return NSLocalizedString(key, comment: "")
+    }
+
+    private func orbCapturePrompt(_ date: Date) -> String {
+        let key: String
+        switch TimeOfDay.from(date) {
+        case .morning:   key = "today.orb.prompt.morning"
+        case .afternoon: key = "today.orb.prompt.afternoon"
+        case .evening:   key = "today.orb.prompt.evening"
+        case .lateNight: key = "today.orb.prompt.night"
         }
         return NSLocalizedString(key, comment: "")
     }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -125,7 +125,14 @@
 "today.orb.label"            = "Today's signal orb";
 "today.orb.value.one"        = "%d signal captured";
 "today.orb.value.other"      = "%d signals captured";
-"today.orb.hint"             = "Double tap to start a new note";
+"today.orb.hint"             = "Double tap to focus composer; long press for a writing prompt";
+"today.orb.prompt.action"    = "Get a writing prompt";
+
+/* Day Orb long-press capture prompts */
+"today.orb.prompt.morning"   = "What's the first thing on your mind?";
+"today.orb.prompt.afternoon" = "What's been on your mind this afternoon?";
+"today.orb.prompt.evening"   = "What made today worth remembering?";
+"today.orb.prompt.night"     = "How did today land?";
 
 /* DailyPage swipe action */
 "today.action.recompile"     = "Recompile";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -125,7 +125,14 @@
 "today.orb.label"            = "今日信号球";
 "today.orb.value.one"        = "已捕获 %d 条信号";
 "today.orb.value.other"      = "已捕获 %d 条信号";
-"today.orb.hint"             = "轻点两下开始新的记录";
+"today.orb.hint"             = "轻点两下聚焦输入框；长按获取写作提示";
+"today.orb.prompt.action"    = "获取写作提示";
+
+/* Day Orb long-press capture prompts */
+"today.orb.prompt.morning"   = "今天第一件想记下的事是什么？";
+"today.orb.prompt.afternoon" = "今天下午有什么在脑子里转？";
+"today.orb.prompt.evening"   = "今天有什么值得记住的瞬间？";
+"today.orb.prompt.night"     = "今天最终落在哪里了？";
 
 /* DailyPage swipe action */
 "today.action.recompile"     = "重新编译";


### PR DESCRIPTION
## Add a long-press 'capture prompt' affordance to the Day Orb that seeds the composer with a time-aware writing prompt

When today has zero memos, the 140pt Day Orb is the visual hero but only supports tap-to-focus the composer, leaving it empty. A long-press on the orb fires a haptic, picks a rotating time-of-day-aware prompt (e.g. morning: 'What's the first thing on your mind?'; late night: 'How did today land?'), and seeds it into the composer draft so the user has a concrete starting line instead of a blank field — reducing the blank-page friction that kills daily-capture habits.

### Acceptance
On an empty today, long-pressing the Day Orb (~0.5s) triggers a medium haptic, populates the composer with a time-appropriate prompt only when the field is empty, and focuses the input. Existing tap-to-focus behavior is unchanged. VoiceOver exposes the prompt action via an accessibility action and the hint text. Both en and zh-Hans render localized prompts (no raw keys). `xcodebuild -scheme DayPage build` succeeds and the app launches in the iPhone 17 simulator with the orb visible and interactive.