### PR TITLE
auto: Add a soft haptic ladder to the EmptyStateView staggered reveal

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -68,12 +68,15 @@ struct EmptyStateView: View {
                 breathing = true
                 revealTask = Task { @MainActor in
                     revealStep = 1  // orb blooms
+                    if !voiceOverEnabled { Haptics.rigid(intensity: 0.25) }
                     try? await Task.sleep(nanoseconds: 70_000_000)
                     guard !Task.isCancelled else { return }
                     revealStep = 2  // title rises
+                    if !voiceOverEnabled { Haptics.rigid(intensity: 0.35) }
                     try? await Task.sleep(nanoseconds: 70_000_000)
                     guard !Task.isCancelled else { return }
                     revealStep = 3  // subtitle
+                    if !voiceOverEnabled { Haptics.rigid(intensity: 0.45) }
                     try? await Task.sleep(nanoseconds: 70_000_000)
                     guard !Task.isCancelled else { return }
                     revealStep = 4  // CTA


### PR DESCRIPTION
## Add a soft haptic ladder to the EmptyStateView staggered reveal

EmptyStateView animates its orb → title → subtitle → CTA in a beautiful 70ms staggered cascade, but the reveal is silent until the very end (only the CTA fires Haptics.soft()). Adding a gentle, escalating haptic tick synchronized to each reveal step makes the first-run empty state feel physically alive and intentional, reinforcing DayPage's tactile design language already present throughout TodayView (scroll-ring ticks, capture pulses).

### Acceptance
On a cold launch into the empty Today screen (no memos), the orb/title/subtitle bloom in with three faint escalating haptic ticks followed by the existing CTA soft tap. With Reduce Motion or VoiceOver enabled, no reveal-ladder haptics fire and the layout still resolves to the fully-revealed state. `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` succeeds and existing DayPageTests still pass.