### PR TITLE
auto: Restore keyboard focus after clearing an empty-result search

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -806,6 +806,7 @@ struct SearchView: View {
                         vm.hasSearched = false
                         didBuzzEmpty = false
                         setupDebounce()
+                        isInputFocused = true
                     }) {
                         Text("清除搜索")
                             .monoLabelStyle(size: 11)


### PR DESCRIPTION
## Restore keyboard focus after clearing an empty-result search

In SearchView's empty-result state, the '清除搜索' (Clear search) button resets the query but leaves the keyboard dismissed, forcing the user to tap the search field again before typing a new term. This contradicts the inline clear button in the search bar, which re-focuses the field. Refocusing on clear lets the user immediately retype, matching the existing pattern and removing a dead-end tap.

### Acceptance
1) Build DayPage scheme succeeds. 2) In Simulator (iPhone 17): open Archive → Search, type a query that yields no results, tap '清除搜索' — the keyboard stays up and the cursor is in the empty search field, ready for immediate typing. 3) Behavior now matches the inline 'xmark.circle.fill' clear button in the search bar. 4) Existing tests still pass.