### PR TITLE
auto: Fix empty-result animation replay + add 'no results' VoiceOver-friendly retry chip in Search

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -333,7 +333,17 @@ struct SearchView: View {
                 if willBeEmpty { appearedRecents = [] }
                 vm.results = hits
                 vm.hasSearched = !trimmed.isEmpty || capturedFilters.isActive
-                if !hits.isEmpty && !trimmed.isEmpty && wasEmpty { Haptics.soft() }
+                if hits.isEmpty && vm.hasSearched {
+                    if trimmed != lastBuzzedEmptyQuery {
+                        if !reduceMotion { Haptics.warn() }
+                        lastBuzzedEmptyQuery = trimmed
+                        didBuzzEmpty = false
+                    }
+                } else if !hits.isEmpty {
+                    lastBuzzedEmptyQuery = nil
+                    didBuzzEmpty = false
+                }
+                if wasEmpty && !hits.isEmpty && !trimmed.isEmpty { Haptics.soft() }
                 // Scroll to top when a different query yields results
                 let scrollKey = trimmed + (capturedFilters.isActive ? "|filtered" : "")
                 if !hits.isEmpty && scrollKey != lastScrolledQuery {
@@ -341,14 +351,6 @@ struct SearchView: View {
                     withAnimation(reduceMotion ? nil : Motion.spring) {
                         searchScrollProxy?.scrollTo("searchTop", anchor: .top)
                     }
-                }
-                if hits.isEmpty && vm.hasSearched {
-                    if trimmed != lastBuzzedEmptyQuery {
-                        if !reduceMotion { Haptics.warn() }
-                        lastBuzzedEmptyQuery = trimmed
-                    }
-                } else if !hits.isEmpty {
-                    lastBuzzedEmptyQuery = nil
                 }
                 if UIAccessibility.isVoiceOverRunning && vm.hasSearched {
                     let message = hits.isEmpty


### PR DESCRIPTION
## Fix empty-result animation replay + add 'no results' VoiceOver-friendly retry chip in Search

In SearchView, the empty-result state plays its spring scale-in only once per view lifetime because `didBuzzEmpty` is set true on first appear and never reset, so later empty searches pop in with no feedback. Reset the flag whenever results transition back to non-empty (and on query clear) so each genuinely-new empty result re-animates, giving consistent tactile/visual feedback that a search returned nothing.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator. In Search: type a query with zero matches → empty state springs in with a warn haptic; type a second distinct zero-match query → empty state re-animates (previously it appeared with no motion); type a query that has results then another zero-match query → empty state animates again. With Reduce Motion ON, no scale animation plays but the layout and VoiceOver '无匹配结果' announcement still fire. Existing tests still pass.