### PR TITLE
auto: Announce centered node to VoiceOver when cycling Graph search matches

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -74,6 +74,7 @@ struct GraphView: View {
                                     let node = matches[searchMatchIndex]
                                     centerOn(node, in: simulationSize)
                                     pulseNode(node)
+                                    announceSearchMatch(node, index: searchMatchIndex, total: matches.count)
                                     Haptics.soft()
                                 } else {
                                     centerOn(matches[0], in: simulationSize)
@@ -165,6 +166,7 @@ struct GraphView: View {
                                     let node = matches[searchMatchIndex]
                                     centerOn(node, in: simulationSize)
                                     pulseNode(node)
+                                    announceSearchMatch(node, index: searchMatchIndex, total: matches.count)
                                 } label: {
                                     Image(systemName: "chevron.up")
                                         .font(.system(size: 12, weight: .medium))
@@ -182,6 +184,7 @@ struct GraphView: View {
                                     let node = matches[searchMatchIndex]
                                     centerOn(node, in: simulationSize)
                                     pulseNode(node)
+                                    announceSearchMatch(node, index: searchMatchIndex, total: matches.count)
                                 } label: {
                                     Image(systemName: "chevron.down")
                                         .font(.system(size: 12, weight: .medium))
@@ -390,6 +393,17 @@ struct GraphView: View {
     }
 
     // MARK: - Accessibility Helpers
+
+    private func announceSearchMatch(_ node: GraphNode, index: Int, total: Int) {
+        guard UIAccessibility.isVoiceOverRunning else { return }
+        let message: String
+        if total == 1 {
+            message = String(format: NSLocalizedString("graph.search.match.announcement.single", comment: "VoiceOver: single search match"), node.name)
+        } else {
+            message = String(format: NSLocalizedString("graph.search.match.announcement", comment: "VoiceOver: search match position"), node.name, index + 1, total)
+        }
+        UIAccessibility.post(notification: .announcement, argument: message)
+    }
 
     private func localizedEntityTypeName(_ entityType: String) -> String {
         switch entityType {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -161,6 +161,10 @@
 "empty.graph.subtitle" = "Compiled entries will surface entity nodes here — write something to start building your network.";
 "empty.graph.cta" = "Write something";
 
+/* Graph search match VoiceOver announcements */
+"graph.search.match.announcement" = "%1$@, match %2$d of %3$d";
+"graph.search.match.announcement.single" = "%1$@";
+
 /* Graph No Matches */
 "empty.graph.no_matches.title" = "No matching nodes.";
 "empty.graph.no_matches.subtitle" = "Adjust your search or filters to see nodes.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -161,6 +161,10 @@
 "empty.graph.subtitle" = "编译日记后，实体节点将在此出现，写点什么开始构建你的知识网络。";
 "empty.graph.cta" = "去写点什么";
 
+/* Graph search match VoiceOver announcements */
+"graph.search.match.announcement" = "%1$@，第 %2$d 个，共 %3$d 个";
+"graph.search.match.announcement.single" = "%1$@";
+
 /* Graph No Matches */
 "empty.graph.no_matches.title" = "无匹配节点。";
 "empty.graph.no_matches.subtitle" = "调整搜索或筛选条件以查看节点。";


### PR DESCRIPTION
## Announce centered node to VoiceOver when cycling Graph search matches

When navigating between Graph search matches (via the up/down chevron buttons or repeated keyboard Search submits), the graph silently recenters and pulses the target node but posts no VoiceOver announcement — so VoiceOver users get only an undifferentiated soft haptic and never learn which node they jumped to or their position in the result set. This adds a spoken announcement (e.g. "Tokyo, 2 of 5 matches") at every match-cycle call site, mirroring the visual `2/5 个匹配` pill that sighted users already see.

### Acceptance
With VoiceOver enabled on iPhone 17 simulator: typing a Graph search query that matches >=2 nodes and tapping the down/up chevrons (or pressing Search repeatedly) speaks an announcement naming the centered node and its position ("<name>, match N of M") on each cycle, staying in sync with the visual N/M pill; a single-match query speaks just the node name; reduce-motion and existing haptics/visual behavior are unchanged; the DayPage scheme builds clean.