### PR TITLE
auto: Add a haptic 'tick' and accessibility countdown announcements to the Undo pill's final seconds

### DIFF
--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -5,9 +5,10 @@ import SwiftUI
 /// Pill shown for 5 seconds after a memo is submitted or deleted.
 /// Tapping it restores the submitted text / memo to its previous state.
 ///
-/// Escalating urgency cues over the final ~1.5s:
-///  - Ring stroke transitions from amber → error red and thickens (1.5 → 2 pt)
-///  - A single soft haptic fires at the 4s mark (1s remaining)
+/// Escalating urgency cues over the final ~3s:
+///  - Ring stroke transitions from amber → error red and thickens (1.5 → 2 pt) at 3.5s
+///  - Haptic ticks at 4s, 3s, 2s, 1s — intensifying in the last two (reduceMotion skips all)
+///  - VoiceOver announcement at the 3s mark
 struct UndoPillView: View {
     var label: String = NSLocalizedString("undo_pill.label.send", comment: "Undo send pill label")
     let onUndo: () -> Void
@@ -21,10 +22,6 @@ struct UndoPillView: View {
     @State private var crossedDismissThreshold: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-
-    // Work item for the haptic — cancelled on disappear so stale
-    // firings don't happen after the pill is removed from the hierarchy.
-    private let hapticWorkItem = HapticWorkItemHolder()
 
 
     var body: some View {
@@ -125,21 +122,20 @@ struct UndoPillView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) {
                 isUrgent = true
             }
-            // Fire a single soft haptic at 4s (1s remaining)
-            let workItem = DispatchWorkItem {
-                HapticFeedback.light()
-            }
-            hapticWorkItem.item = workItem
-            DispatchQueue.main.asyncAfter(deadline: .now() + 4, execute: workItem)
-        }
-        .onDisappear {
-            hapticWorkItem.item?.cancel()
-            hapticWorkItem.item = nil
         }
         .task {
             for remaining in stride(from: 4, through: 1, by: -1) {
                 try? await Task.sleep(for: .seconds(1))
                 secondsRemaining = remaining
+                if !reduceMotion {
+                    Haptics.rigid(intensity: remaining <= 2 ? 0.6 : 0.3)
+                }
+                if remaining == 3 {
+                    UIAccessibility.post(
+                        notification: .announcement,
+                        argument: NSLocalizedString("undo_pill.closing", comment: "VoiceOver announcement when undo window is about to close")
+                    )
+                }
             }
         }
     }
@@ -161,10 +157,3 @@ struct UndoPillView: View {
     }
 }
 
-// MARK: - HapticWorkItemHolder
-
-/// Reference-type box so the work item can be shared between onAppear and
-/// onDisappear closures without capturing a mutating struct.
-private final class HapticWorkItemHolder {
-    var item: DispatchWorkItem?
-}

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -94,6 +94,7 @@
 /* UndoPillView — US-009 */
 "undo_pill.label.send"       = "Undo send";
 "undo_pill.label.delete"     = "Deleted · Undo";
+"undo_pill.closing"          = "Undo window closing soon";
 
 /* Today header subline — note count */
 "today.subline.notes.zero"   = "%d notes";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -94,6 +94,7 @@
 /* UndoPillView — US-009 */
 "undo_pill.label.send"       = "撤销发送";
 "undo_pill.label.delete"     = "已删除 · 撤销";
+"undo_pill.closing"          = "撤销窗口即将关闭";
 
 /* Today header subline — note count */
 "today.subline.notes.zero"   = "%d 条记录";


### PR DESCRIPTION
## Add a haptic 'tick' and accessibility countdown announcements to the Undo pill's final seconds

The UndoPillView shows a 5-second countdown ring but only fires one haptic at the 4s mark and never announces the remaining time to VoiceOver users, so blind users can't tell the undo window is closing. This adds an escalating haptic tick at each of the final 3 seconds plus a VoiceOver announcement at the 3s mark, making the closing window perceivable without sight and giving sighted users tactile urgency that matches the existing amber→red ring escalation.

### Acceptance
Building the DayPage scheme succeeds. Submitting a memo shows the undo pill; with VoiceOver on, an announcement fires at the 3-second mark; with Reduce Motion off, a haptic tick fires each of the final ~3 seconds and feels stronger in the last two. With Reduce Motion on, no haptics fire and the ring stays amber. No stale haptic fires after the pill is dismissed early.