### PR TITLE
auto: Persist Graph legend type-visibility toggles across sessions

### DIFF
--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -160,6 +160,8 @@ extension AppSettings {
         static let streakMilestonesShown = "streakMilestonesShown"
         // Export long-press hint — shown once when the button first appears with >=1 memo
         static let exportLongPressHintShown = "today.exportLongPressHintShown"
+        // Graph legend — comma-joined hidden entity types, e.g. "places,people"
+        static let graphHiddenTypes = "graph.hiddenTypes"
     }
 }
 

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -38,8 +38,18 @@ struct GraphView: View {
     // Zero-match haptic guard — fires warn() exactly once per zero-crossing
     @State private var lastZeroQuery: String? = nil
 
-    // Legend type-visibility filter
-    @State private var hiddenTypes: Set<String> = []
+    // Legend type-visibility filter — persisted across tab switches and relaunches
+    @AppStorage(AppSettings.Keys.graphHiddenTypes) private var hiddenTypesRaw: String = ""
+
+    private var hiddenTypes: Set<String> {
+        get {
+            let parts = hiddenTypesRaw.split(separator: ",").map(String.init).filter { !$0.isEmpty }
+            return Set(parts)
+        }
+        set {
+            hiddenTypesRaw = newValue.sorted().joined(separator: ",")
+        }
+    }
 
     // Empty state animation + ClearFiltersPressStyle (do not remove this @Environment:
     // both `emptyState` and `clearFiltersButton` read `reduceMotion`; deleting it
@@ -362,7 +372,7 @@ struct GraphView: View {
                     viewModel.searchQuery = ""
                     viewModel.filterStartDate = nil
                     viewModel.filterEndDate = nil
-                    hiddenTypes = []
+                    hiddenTypes = Set()
                 }
             }
         }
@@ -375,6 +385,7 @@ struct GraphView: View {
                 viewModel.searchQuery = ""
                 viewModel.filterStartDate = nil
                 viewModel.filterEndDate = nil
+                hiddenTypes = Set()
             }
         } label: {
             Text("清除筛选")
@@ -793,11 +804,13 @@ struct GraphView: View {
         Button {
             Haptics.soft()
             withAnimation(Motion.spring) {
+                var updated = hiddenTypes
                 if isHidden {
-                    hiddenTypes.remove(type)
+                    updated.remove(type)
                 } else {
-                    hiddenTypes.insert(type)
+                    updated.insert(type)
                 }
+                hiddenTypes = updated
             }
         } label: {
             HStack(spacing: 6) {


### PR DESCRIPTION
## Persist Graph legend type-visibility toggles across sessions

The Graph legend lets users hide entity types (places/people/themes) by tapping legend rows, but this state lives in a session-only `@State private var hiddenTypes: Set<String>` that silently resets every time the user switches away from the Graph tab — unlike date filters, which persist. Back `hiddenTypes` with `@AppStorage` (stored as a comma-joined string since `Set` isn't directly AppStorage-codable) so legend visibility survives tab switches and app relaunches, making the filter behavior consistent.

### Acceptance
Hide one or more entity types via the Graph legend, navigate to Today and back to Graph (and cold-relaunch the app) — the previously hidden types stay hidden and their legend rows remain struck-through/dimmed. Tapping a hidden row re-shows it and the change persists. The 'clear filters' empty-state button still resets all hidden types to visible. `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` succeeds and existing GraphViewModel tests still pass.