### PR TITLE
auto: Live reading-time estimate in the WriteSheet footer counter

### DIFF
--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -71,6 +71,12 @@ struct WriteSheetView: View {
 
     private var charCount: Int { text.count }
 
+    private var readingMinutes: Int {
+        max(1, Int(ceil(Double(wordCount) / 200.0)))
+    }
+
+    private var showReadingTime: Bool { wordCount >= 50 }
+
     private var canSave: Bool {
         !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
@@ -356,26 +362,39 @@ struct WriteSheetView: View {
             let wordsLabel = wordCount == 1
                 ? NSLocalizedString("writesheet.count.words.one", comment: "1 word")
                 : String(format: NSLocalizedString("writesheet.count.words.other", comment: "%d words"), wordCount)
-            Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
-                .font(DSType.mono10)
-                .tracking(1.0)
-                .textCase(.uppercase)
-                .monospacedDigit()
-                .foregroundColor(wordCountColor)
-                .modifier(NumericTextContentTransition(value: Double(wordCount), reduceMotion: reduceMotion))
-                .animation(reduceMotion ? nil : Motion.fade, value: wordCount)
-                .animation(reduceMotion ? nil : Motion.spring, value: wordCount)
-                .padding(.trailing, 10)
-                .accessibilityLabel("\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
-                .onChange(of: wordCount) { newCount in
-                    let milestone = newCount / 100
-                    if milestone > lastMilestone {
-                        lastMilestone = milestone
-                        if newCount > 0 { Haptics.soft() }
-                    } else if milestone < lastMilestone {
-                        lastMilestone = milestone
-                    }
+            let readLabel = String(format: NSLocalizedString("writesheet.count.read", comment: "~%d min read"), readingMinutes)
+            HStack(spacing: 0) {
+                Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+                    .modifier(NumericTextContentTransition(value: Double(wordCount), reduceMotion: reduceMotion))
+                    .animation(reduceMotion ? nil : Motion.fade, value: wordCount)
+                    .animation(reduceMotion ? nil : Motion.spring, value: wordCount)
+                if showReadingTime {
+                    Text(" · \(readLabel)")
+                        .modifier(NumericTextContentTransition(value: Double(readingMinutes), reduceMotion: reduceMotion))
+                        .animation(reduceMotion ? nil : Motion.fade, value: readingMinutes)
+                        .animation(reduceMotion ? nil : Motion.spring, value: readingMinutes)
+                        .transition(.opacity)
                 }
+            }
+            .font(DSType.mono10)
+            .tracking(1.0)
+            .textCase(.uppercase)
+            .monospacedDigit()
+            .foregroundColor(wordCountColor)
+            .animation(reduceMotion ? nil : Motion.spring, value: showReadingTime)
+            .padding(.trailing, 10)
+            .accessibilityLabel(showReadingTime
+                ? "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars")), \(readLabel)"
+                : "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+            .onChange(of: wordCount) { newCount in
+                let milestone = newCount / 100
+                if milestone > lastMilestone {
+                    lastMilestone = milestone
+                    if newCount > 0 { Haptics.soft() }
+                } else if milestone < lastMilestone {
+                    lastMilestone = milestone
+                }
+            }
 
             savePill
         }
@@ -563,15 +582,27 @@ struct WriteSheetView: View {
         let wordsLabel = wordCount == 1
             ? NSLocalizedString("writesheet.count.words.one", comment: "1 word")
             : String(format: NSLocalizedString("writesheet.count.words.other", comment: "%d words"), wordCount)
-        Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
-            .font(DSType.mono10)
-            .tracking(1.0)
-            .textCase(.uppercase)
-            .monospacedDigit()
-            .foregroundColor(wordCountColor)
-            .modifier(NumericTextContentTransition(value: Double(wordCount), reduceMotion: reduceMotion))
-            .animation(reduceMotion ? nil : Motion.spring, value: wordCount)
-            .accessibilityLabel("\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+        let readLabel = String(format: NSLocalizedString("writesheet.count.read", comment: "~%d min read"), readingMinutes)
+        HStack(spacing: 0) {
+            Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+                .modifier(NumericTextContentTransition(value: Double(wordCount), reduceMotion: reduceMotion))
+                .animation(reduceMotion ? nil : Motion.spring, value: wordCount)
+            if showReadingTime {
+                Text(" · \(readLabel)")
+                    .modifier(NumericTextContentTransition(value: Double(readingMinutes), reduceMotion: reduceMotion))
+                    .animation(reduceMotion ? nil : Motion.spring, value: readingMinutes)
+                    .transition(.opacity)
+            }
+        }
+        .font(DSType.mono10)
+        .tracking(1.0)
+        .textCase(.uppercase)
+        .monospacedDigit()
+        .foregroundColor(wordCountColor)
+        .animation(reduceMotion ? nil : Motion.spring, value: showReadingTime)
+        .accessibilityLabel(showReadingTime
+            ? "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars")), \(readLabel)"
+            : "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
 
         Spacer()
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -68,6 +68,7 @@
 "writesheet.count.words.one"   = "1 word";
 "writesheet.count.words.other" = "%d words";
 "writesheet.count.chars"       = "chars";
+"writesheet.count.read"        = "~%d min read";
 
 /* InputBarV4 — accessibility */
 "input.a11y.too_short"       = "Recording too short. Hold the mic and keep speaking.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -68,6 +68,7 @@
 "writesheet.count.words.one"   = "1 个词";
 "writesheet.count.words.other" = "%d 个词";
 "writesheet.count.chars"       = "字符";
+"writesheet.count.read"        = "~%d 分钟阅读";
 
 /* InputBarV4 — accessibility */
 "input.a11y.too_short"       = "录音太短，请按住麦克风继续说";


### PR DESCRIPTION
## Live reading-time estimate in the WriteSheet footer counter

The WriteSheet composer footer shows a live word·char counter but no sense of entry length in human terms. Add a subtle reading-time estimate (e.g. "~2 MIN READ") that appears once the draft passes a meaningful threshold, giving journal writers a tangible feel for how substantial their entry has become. It reuses the existing mono10 styling, numeric content transition, and amber-lerp color so it feels native to the surface.

### Acceptance
Building the DayPage scheme succeeds. Opening the WriteSheet from the Today dock and typing fewer than 50 words shows only the existing word·char counter. Crossing 50 words fades in a "~1 MIN READ" segment that updates with numeric transition as the draft grows (~2 MIN at 250+ words), styled identically to the counter, hidden again if text drops below threshold. The keyboard accessory counter shows the same segment. VoiceOver reads the counter including the reading-time phrase. reduceMotion suppresses the numeric/scale animation. No changes to persistence or @Model files.