### PR TITLE
auto: Restore lost draft text when a memo submit fails

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -467,6 +467,16 @@ struct TodayView: View {
                     viewModel.shouldShowSettings = false
                 }
             }
+            // Restore failed draft body into the composer so the user can retry.
+            // Only restores when the composer is empty — never clobbers a new draft.
+            .onChange(of: viewModel.lastFailedBody) { failedBody in
+                guard let body = failedBody else { return }
+                viewModel.lastFailedBody = nil
+                guard draftText.isEmpty else { return }
+                draftText = body
+                orbFocusToggle.toggle()
+                Haptics.warn()
+            }
             // Daily Page full-screen sheet
             .fullScreenCover(isPresented: $showDailyPage) {
                 let dateStr: String = {

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -150,6 +150,9 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
     /// Transient submit error shown as a toast/alert.
     @Published var submitError: String? = nil
 
+    /// Body text of the most recently failed submission; non-nil until the view consumes it.
+    @Published var lastFailedBody: String? = nil
+
     /// Whether location fetch is in progress.
     @Published var isLocating: Bool = false
 
@@ -889,6 +892,9 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 UserDefaults.standard.set(count + 1, forKey: AppSettings.Keys.memoSaveCount)
             } catch {
                 submitError = String(format: NSLocalizedString("error.memo.save_failed", comment: ""), error.localizedDescription)
+                if !finalBody.isEmpty {
+                    lastFailedBody = finalBody
+                }
             }
         }
     }


### PR DESCRIPTION
## Restore lost draft text when a memo submit fails

Currently TodayView clears draftText to "" before calling submitCombinedMemo, so when submission fails the user's typed content is gone — the only recovery is the transient 5s undo pill, which competes with and is visually overridden by the error toast. This change restores the failed body back into the composer and focuses it, turning a silent data-loss moment into a graceful retry.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator. Simulate a submit failure (e.g. by forcing the storage write to throw): after the failure, the previously-typed text reappears in the composer, the input is focused, a warning haptic fires, and the error toast still shows. When draftText is non-empty (user already typing again), the failed body is not restored. Existing MemoSerializationTests and TodayViewModelTests still pass.