### PR TITLE
auto: Fix CJK-broken live word count in the composer input bar

### DIFF
--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -559,18 +559,13 @@ private struct DetailMetadataSection: View {
     }
 
     private func bodyStats(for text: String) -> BodyStats {
-        func isCJK(_ scalar: Unicode.Scalar) -> Bool {
-            (0x4E00...0x9FFF).contains(scalar.value) ||
-            (0x3400...0x4DBF).contains(scalar.value) ||
-            (0x3040...0x30FF).contains(scalar.value)
-        }
-
         var cjkCount = 0
         var latinWords = 0
         var inLatinRun = false
-
         for scalar in text.unicodeScalars {
-            if isCJK(scalar) {
+            if (0x4E00...0x9FFF).contains(scalar.value) ||
+               (0x3400...0x4DBF).contains(scalar.value) ||
+               (0x3040...0x30FF).contains(scalar.value) {
                 cjkCount += 1
                 inLatinRun = false
             } else if scalar.properties.isWhitespace {
@@ -580,11 +575,10 @@ private struct DetailMetadataSection: View {
                 inLatinRun = true
             }
         }
-
         // Reading time: CJK at 300 cpm, Latin at 220 wpm — sum independent estimates
         let totalMinutes = Double(cjkCount) / 300.0 + Double(latinWords) / 220.0
         return BodyStats(
-            wordCount: cjkCount + latinWords,
+            wordCount: TextCount.words(text),
             charCount: text.count,
             readingMinutes: Int(totalMinutes.rounded())
         )

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -180,7 +180,7 @@ struct InputBarV4: View {
     // MARK: Derived
 
     private var wordCount: Int {
-        text.split(whereSeparator: \.isWhitespace).count
+        TextCount.words(text)
     }
 
     private var charCount: Int { text.count }

--- a/DayPage/Models/Memo.swift
+++ b/DayPage/Models/Memo.swift
@@ -279,6 +279,30 @@ extension Memo {
     }
 }
 
+// MARK: - CJK-aware word count
+
+enum TextCount {
+    static func words(_ text: String) -> Int {
+        var cjkCount = 0
+        var latinWords = 0
+        var inLatinRun = false
+        for scalar in text.unicodeScalars {
+            if (0x4E00...0x9FFF).contains(scalar.value) ||
+               (0x3400...0x4DBF).contains(scalar.value) ||
+               (0x3040...0x30FF).contains(scalar.value) {
+                cjkCount += 1
+                inLatinRun = false
+            } else if scalar.properties.isWhitespace {
+                inLatinRun = false
+            } else {
+                if !inLatinRun { latinWords += 1 }
+                inLatinRun = true
+            }
+        }
+        return cjkCount + latinWords
+    }
+}
+
 // MARK: - ISO8601DateFormatter extension
 
 extension ISO8601DateFormatter {


### PR DESCRIPTION
## Fix CJK-broken live word count in the composer input bar

The Today composer's live count footer (InputBarV4.wordCount) counts words via `text.split(whereSeparator: \.isWhitespace)`, which is wrong for Chinese/Japanese text — an entire CJK sentence with no spaces counts as a single 'word', so the bilingual (zh-Hans-primary) target audience sees '1 word' for a full paragraph. The codebase already ships a correct CJK-aware counter in MemoDetailView.bodyStats (CJK scalars counted individually + Latin whitespace runs); this change extracts that proven algorithm into a shared helper and points the live footer at it so the in-composer count matches the post-save MemoDetail count.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator. Type a CJK-only paragraph (e.g. '今天在清迈喝了很好喝的咖啡') into the Today composer: the live footer now shows a word count equal to the number of CJK characters (12) instead of 1, while charCount is unchanged. Type a Latin sentence: count is unchanged from before. Save the memo, open MemoDetail, and confirm the 'Words' value there exactly matches the live composer count for the same text. Existing tests still pass.