### PR TITLE
auto: Multi-entry geo-bucketed weather cache for nomads bouncing between locations

### DIFF
--- a/DayPage/Services/WeatherService.swift
+++ b/DayPage/Services/WeatherService.swift
@@ -28,7 +28,8 @@ final class WeatherService {
 
     // MARK: Private
 
-    private var cache: CacheEntry?
+    /// Bounded LRU cache: up to `cacheMaxEntries` geo-bucketed entries (most-recent last).
+    private var cache: [CacheEntry] = []
 
     /// 缓存 TTL：10 分钟
     private let cacheTTL: TimeInterval = 10 * 60
@@ -36,12 +37,31 @@ final class WeatherService {
     /// 缓存条目对新位置被认为过时的最大距离（米）
     private let cacheLocationRadius: CLLocationDistance = 1000
 
+    /// Maximum number of distinct geo-buckets kept in memory.
+    private let cacheMaxEntries = 6
+
     private init() {}
+
+    // MARK: - Test Hooks
+
+#if DEBUG
+    /// Creates a fresh, isolated instance for unit tests (bypasses the singleton).
+    convenience init(testing: Bool) { self.init() }
+
+    /// Seeds a cache entry directly, bypassing network, for unit-test use only.
+    func seedCacheEntry(weather: String, lat: Double, lng: Double, age: TimeInterval) {
+        let fetchedAt = Date(timeIntervalSinceNow: -age)
+        insertEntry(CacheEntry(weather: weather, fetchedAt: fetchedAt, lat: lat, lng: lng))
+    }
+#endif
 
     // MARK: - Public API
 
     /// 最近一次成功获取的天气字符串（同步，供 UI 快速读取）。
-    var cachedWeatherString: String? { cache?.weather }
+    var cachedWeatherString: String? { cache.last?.weather }
+
+    /// Number of entries currently held in the LRU cache (test hook).
+    var cacheCount: Int { cache.count }
 
     /// 返回给定位置的格式化天气字符串，如 "32°C, Overcast Clouds"。
     ///
@@ -54,14 +74,9 @@ final class WeatherService {
             return nil
         }
 
-        // 如果缓存仍然新鲜且位置足够近，返回缓存结果
-        if let entry = cache,
-           Date().timeIntervalSince(entry.fetchedAt) < cacheTTL {
-            let cachedCoord = CLLocation(latitude: entry.lat, longitude: entry.lng)
-            let requestCoord = CLLocation(latitude: lat, longitude: lng)
-            if cachedCoord.distance(from: requestCoord) <= cacheLocationRadius {
-                return entry.weather
-            }
+        // Return a fresh, nearby cached entry if one exists.
+        if let entry = cachedEntry(for: CLLocation(latitude: lat, longitude: lng)) {
+            return entry.weather
         }
 
         // 从 OpenWeatherMap 获取
@@ -91,11 +106,37 @@ final class WeatherService {
                 return nil
             }
             let formatted = try parseWeather(from: data)
-            cache = CacheEntry(weather: formatted, fetchedAt: Date(), lat: lat, lng: lng)
+            insertEntry(CacheEntry(weather: formatted, fetchedAt: Date(), lat: lat, lng: lng))
             return formatted
         } catch {
             // 网络/解析失败不阻塞 —— 调用方在没有天气数据的情况下继续执行
             return nil
+        }
+    }
+
+    // MARK: - Cache Helpers
+
+    /// Returns the first fresh entry whose location is within `cacheLocationRadius` of `coord`.
+    private func cachedEntry(for coord: CLLocation) -> CacheEntry? {
+        cache.first { entry in
+            guard Date().timeIntervalSince(entry.fetchedAt) < cacheTTL else { return false }
+            let entryCoord = CLLocation(latitude: entry.lat, longitude: entry.lng)
+            return entryCoord.distance(from: coord) <= cacheLocationRadius
+        }
+    }
+
+    /// Inserts `entry`, pruning any stale same-location entry first, then trims to `cacheMaxEntries`.
+    private func insertEntry(_ entry: CacheEntry) {
+        let coord = CLLocation(latitude: entry.lat, longitude: entry.lng)
+        // Remove any existing (possibly stale) entry for the same geo-bucket.
+        cache.removeAll { existing in
+            let existingCoord = CLLocation(latitude: existing.lat, longitude: existing.lng)
+            return existingCoord.distance(from: coord) <= cacheLocationRadius
+        }
+        cache.append(entry)
+        // Trim oldest entries beyond the max capacity.
+        if cache.count > cacheMaxEntries {
+            cache.removeFirst(cache.count - cacheMaxEntries)
         }
     }
 

--- a/DayPageTests/WeatherServiceCacheTests.swift
+++ b/DayPageTests/WeatherServiceCacheTests.swift
@@ -1,0 +1,140 @@
+import Testing
+import CoreLocation
+@testable import DayPage
+
+// MARK: - WeatherServiceCacheTests
+
+/// Tests for the geo-bucketed LRU weather cache introduced to serve nomads who
+/// alternate between nearby locations (café ↔ co-working ↔ home).
+///
+/// Network is never hit — entries are injected directly via the internal test API.
+@MainActor
+struct WeatherServiceCacheTests {
+
+    // MARK: - Helpers
+
+    /// Injects a CacheEntry-equivalent by calling the service's internal warm-up path.
+    /// We do this by populating `cache` indirectly through `seedEntry`.
+    private func makeService() -> WeatherService {
+        WeatherService(testing: true)
+    }
+
+    /// Seeds a geo-entry into the service's LRU cache without a network call.
+    private func seed(
+        _ service: WeatherService,
+        weather: String,
+        lat: Double,
+        lng: Double,
+        age: TimeInterval = 0
+    ) {
+        service.seedCacheEntry(weather: weather, lat: lat, lng: lng, age: age)
+    }
+
+    // MARK: - Cache hit: same location within TTL
+
+    @Test func sameLocationWithinTTL_returnsCachedValue() async {
+        let svc = makeService()
+        seed(svc, weather: "20°C, Sunny", lat: 37.33, lng: -122.03)
+
+        let location = makeLocation(lat: 37.33, lng: -122.03)
+        // cachedEntry should match — exposed via cachedWeatherString for same coords.
+        #expect(svc.cachedWeatherString == "20°C, Sunny")
+        _ = location  // used to document intent
+    }
+
+    // MARK: - Cache miss: different location > 1km
+
+    @Test func differentLocationBeyond1km_isCacheMiss() async {
+        let svc = makeService()
+        // Seed location A (San Jose)
+        seed(svc, weather: "18°C, Clear", lat: 37.3382, lng: -121.8863)
+
+        // Location B is ~5 km away (Santa Clara)
+        // The service has no API key in test, so currentWeather returns nil — that proves
+        // it did NOT return the cached entry for location A.
+        let locationB = makeLocation(lat: 37.3541, lng: -121.9552)
+        let result = await svc.currentWeather(at: locationB)
+        #expect(result == nil, "No API key in tests — a cache miss must return nil, not location A's weather")
+    }
+
+    // MARK: - Re-lookup at first location hits cache
+
+    @Test func reLookupAtFirstLocationWithinTTL_returnsCachedEntry() async {
+        let svc = makeService()
+        // Seed both A and B so B is present as a separate bucket.
+        seed(svc, weather: "18°C, Clear",    lat: 37.3382, lng: -121.8863)  // A
+        seed(svc, weather: "22°C, Overcast", lat: 37.3541, lng: -121.9552)  // B (~5 km away)
+
+        // Re-lookup at A (within TTL) — must return A's cached value.
+        let locationA = makeLocation(lat: 37.3382, lng: -121.8863)
+        let result = await svc.currentWeather(at: locationA)
+        #expect(result == "18°C, Clear", "Re-lookup at location A must hit the cache and return A's weather")
+    }
+
+    // MARK: - LRU bound: never exceeds 6 entries
+
+    @Test func eightDistinctLocations_cacheLimitedToSix() async {
+        let svc = makeService()
+        // 8 locations spaced ~1° apart (~111 km each) — all distinct geo-buckets.
+        for i in 0..<8 {
+            seed(svc, weather: "Loc\(i)", lat: Double(10 + i), lng: 120.0)
+        }
+        #expect(svc.cacheCount == 6, "Cache must not exceed 6 entries; got \(svc.cacheCount)")
+    }
+
+    // MARK: - Stale entry (> 10 min) is treated as a miss
+
+    @Test func staleEntry_olderThanTTL_isCacheMiss() async {
+        let svc = makeService()
+        // Seed with an entry that is 11 minutes old.
+        seed(svc, weather: "Old weather", lat: 37.33, lng: -122.03, age: 11 * 60)
+
+        // currentWeather should miss the stale entry; no API key → returns nil.
+        let location = makeLocation(lat: 37.33, lng: -122.03)
+        let result = await svc.currentWeather(at: location)
+        #expect(result == nil, "An entry older than TTL must be a cache miss")
+    }
+
+    // MARK: - Missing API key returns nil (unchanged behaviour)
+
+    @Test func missingAPIKey_returnsNil() async {
+        let svc = makeService()
+        let location = makeLocation(lat: 37.33, lng: -122.03)
+        // No seed → no cache hit; no API key in test environment → nil.
+        let result = await svc.currentWeather(at: location)
+        #expect(result == nil)
+    }
+
+    // MARK: - Nil location returns nil (unchanged behaviour)
+
+    @Test func nilLocation_returnsNil() async {
+        let svc = makeService()
+        let result = await svc.currentWeather(at: nil)
+        #expect(result == nil)
+    }
+
+    // MARK: - cachedWeatherString reflects most-recently-fetched entry
+
+    @Test func cachedWeatherString_returnsMostRecentEntry() {
+        let svc = makeService()
+        seed(svc, weather: "First",  lat: 10.0, lng: 120.0)
+        seed(svc, weather: "Second", lat: 20.0, lng: 120.0)
+        seed(svc, weather: "Third",  lat: 30.0, lng: 120.0)
+        #expect(svc.cachedWeatherString == "Third")
+    }
+
+    // MARK: - Same location re-seed updates rather than duplicates
+
+    @Test func reSeedSameLocation_doesNotGrowCache() {
+        let svc = makeService()
+        seed(svc, weather: "First",   lat: 37.33, lng: -122.03)
+        seed(svc, weather: "Updated", lat: 37.33, lng: -122.03)
+        #expect(svc.cacheCount == 1, "Re-seeding same location must replace, not append")
+    }
+
+    // MARK: - Private helpers
+
+    private func makeLocation(lat: Double, lng: Double) -> Memo.Location {
+        Memo.Location(name: nil, lat: lat, lng: lng)
+    }
+}


### PR DESCRIPTION
## Multi-entry geo-bucketed weather cache for nomads bouncing between locations

WeatherService currently caches only the single most-recent weather lookup, so a nomad alternating between two locations more than 1km apart (café ↔ co-working ↔ home) gets zero cache hits and re-fetches on every memo — wasting OpenWeatherMap free-tier quota and adding network latency to each capture. Replace the single CacheEntry with a small bounded LRU of geo-bucketed entries so recently-visited locations stay warm, directly serving the stated nomad audience.

### Acceptance
1) Build succeeds: `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build`. 2) New test file WeatherServiceCacheTests.swift (Swift Testing) covers: a second lookup at a location ~5km from the first, then a re-lookup back at the first location within TTL, returns the first location's cached value without a network call (inject/stub via a known cached entry); the cache never exceeds 6 entries after 8 distinct far-apart lookups; an entry older than 10 min is treated as a miss. 3) Existing behavior unchanged: same-location-within-1km lookups still hit cache; missing API key or HTTP != 200 still returns nil. 4) `swift test`/DayPageTests pass.