### PR TITLE
auto: Archive: 'Today' jump-to-current-month pill

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -716,17 +716,15 @@ struct ArchiveView: View {
                         .padding(.horizontal, 10)
                         .padding(.vertical, 6)
                         .background(DSColor.amberDeep, in: Capsule())
-                        .background(.ultraThinMaterial, in: Capsule())
                         .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel("回到本月")
                 .accessibilityHint("跳转到当前月份")
                 .transition(.scale.combined(with: .opacity))
-                .animation(reduceMotion ? nil : Motion.spring, value: viewModel.isViewingCurrentMonth)
-
-                Spacer()
             }
+
+            Spacer()
 
             Button(action: {
                 Haptics.rigid(intensity: 0.4)
@@ -744,6 +742,7 @@ struct ArchiveView: View {
             .accessibilityLabel("下个月")
             .accessibilityHint("切换到下一个月")
         }
+        .animation(reduceMotion ? nil : Motion.spring, value: viewModel.isViewingCurrentMonth)
     }
 
     private func toggleButton(_ label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -341,6 +341,15 @@ final class ArchiveViewModel: ObservableObject {
         return now.year == currentYear && now.month == currentMonth
     }
 
+    var isViewingCurrentMonth: Bool { isCurrentMonthAndYear }
+
+    func goToCurrentMonth() {
+        let now = Calendar.current.dateComponents([.year, .month], from: Date())
+        currentYear = now.year ?? currentYear
+        currentMonth = now.month ?? currentMonth
+        loadMonth()
+    }
+
     var today: Int {
         Calendar.current.component(.day, from: Date())
     }
@@ -689,6 +698,35 @@ struct ArchiveView: View {
             .clipShape(Capsule())
 
             Spacer()
+
+            if !viewModel.isViewingCurrentMonth {
+                Button(action: {
+                    Haptics.tapConfirm()
+                    let now = Calendar.current.dateComponents([.year, .month], from: Date())
+                    let targetYear = now.year ?? viewModel.currentYear
+                    let targetMonth = now.month ?? viewModel.currentMonth
+                    let isFuture = (viewModel.currentYear, viewModel.currentMonth) > (targetYear, targetMonth)
+                    monthNavDirection = isFuture ? .leading : .trailing
+                    withAnimation(reduceMotion ? nil : Motion.spring) { viewModel.goToCurrentMonth() }
+                    UIAccessibility.post(notification: .announcement, argument: viewModel.currentMonthTitle)
+                }) {
+                    Text("TODAY")
+                        .monoLabelStyle(size: 10)
+                        .foregroundColor(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 6)
+                        .background(DSColor.amberDeep, in: Capsule())
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("回到本月")
+                .accessibilityHint("跳转到当前月份")
+                .transition(.scale.combined(with: .opacity))
+                .animation(reduceMotion ? nil : Motion.spring, value: viewModel.isViewingCurrentMonth)
+
+                Spacer()
+            }
 
             Button(action: {
                 Haptics.rigid(intensity: 0.4)


### PR DESCRIPTION
## Archive: "Today" jump-to-current-month pill

When the user pages the Archive calendar away from the current month, there is no quick way back — they must tap the chevron repeatedly. Add a small "TODAY" pill in the month navigation row that appears only when the displayed month differs from the real current month, snapping the calendar back with a spring animation and haptic.

### Acceptance
Building the DayPage scheme succeeds. In the Simulator (iPhone 17), opening Archive on the current month shows no TODAY pill; paging to any other month makes the pill fade/scale in; tapping it springs the calendar back to the current month with a confirm haptic and the current-month title, and the pill disappears. VoiceOver reads the pill as "回到本月" and announces the month on activation. Reduce Motion disables the transition animation but the jump still works.