### PR TITLE
auto: Double-tap-to-zoom-in on the knowledge Graph

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -586,9 +586,15 @@ struct GraphView: View {
                 zoomControls
             }
             .onTapGesture(count: 2) {
-                guard isTransformed else { return }
                 Haptics.tapConfirm()
-                resetTransform()
+                if isTransformed {
+                    resetTransform()
+                } else {
+                    withAnimation(reduceMotion ? nil : Motion.spring) {
+                        scale = max(0.3, min(5.0, 2.2))
+                        lastScale = scale
+                    }
+                }
             }
             .gesture(
                 SimultaneousGesture(


### PR DESCRIPTION
## Double-tap-to-zoom-in on the knowledge Graph

The Graph's double-tap gesture currently only resets the view when already zoomed/panned — at the default 1.0 scale it does nothing, so users have no quick way to zoom in besides a two-finger pinch. Add a toggle: double-tapping an un-transformed graph zooms in to ~2.2x (centered on the canvas), while double-tapping a transformed graph still resets, matching the Maps/Photos convention users expect.

### Acceptance
Build succeeds (`xcodebuild -scheme DayPage build`). In the Simulator (iPhone 17), open Graph: double-tapping the un-zoomed graph springs it to ~2.2x with a confirm haptic, the zoom-percentage indicator and recenter button appear; double-tapping again (now transformed) resets to 1.0x and they disappear. With Reduce Motion enabled, the zoom change applies instantly with no animation. Pinch-zoom still works and shares the same 0.3–5.0 clamp.