### PR TITLE
auto: Show local UTC offset (GMT+7) in the Today header subline for timezone-hopping nomads

### DIFF
--- a/DayPage/Features/Today/TimeOfDay.swift
+++ b/DayPage/Features/Today/TimeOfDay.swift
@@ -1,5 +1,23 @@
 import SwiftUI
 
+/// Formats the device's current UTC offset as a compact GMT token for the Today header.
+/// e.g. GMT+7, GMT-3:30, GMT+5:45, GMT (zero offset)
+enum TimeZoneBadge {
+    static func gmtOffset(for tz: TimeZone, at date: Date) -> String {
+        let totalSeconds = tz.secondsFromGMT(for: date)
+        guard totalSeconds != 0 else { return "GMT" }
+        let sign = totalSeconds > 0 ? "+" : "-"
+        let abs = Swift.abs(totalSeconds)
+        let hours = abs / 3600
+        let minutes = (abs % 3600) / 60
+        if minutes == 0 {
+            return "GMT\(sign)\(hours)"
+        } else {
+            return String(format: "GMT\(sign)\(hours):%02d", minutes)
+        }
+    }
+}
+
 /// Pure time-of-day bucketing shared by the Day Orb and the kicker.
 enum TimeOfDay: Int {
     case morning    = 0

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1863,6 +1863,7 @@ struct TodayView: View {
         if let place = todayPlaceShort() {
             parts.append(place)
         }
+        parts.append(todayTimeZoneShort())
         return parts.joined(separator: "  ·  ")
     }
 
@@ -1886,6 +1887,7 @@ struct TodayView: View {
         }
         if let weather = todayWeatherShort() { parts.append(weather) }
         if let place = todayPlaceShort() { parts.append(place) }
+        parts.append(todayTimeZoneShort())
         return parts.joined(separator: ", ")
     }
 
@@ -1910,6 +1912,10 @@ struct TodayView: View {
             }
         }
         return nil
+    }
+
+    private func todayTimeZoneShort() -> String {
+        TimeZoneBadge.gmtOffset(for: .current, at: currentTime)
     }
 }
 

--- a/DayPageTests/TimeOfDayTests.swift
+++ b/DayPageTests/TimeOfDayTests.swift
@@ -59,6 +59,38 @@ struct TimeOfDayTests {
         #expect(Set(descriptions).count == 4)
     }
 
+    // MARK: - TimeZoneBadge
+
+    @Test func gmtZeroOffset() {
+        let tz = TimeZone(secondsFromGMT: 0)!
+        #expect(TimeZoneBadge.gmtOffset(for: tz, at: Date()) == "GMT")
+    }
+
+    @Test func gmtPositiveWholeHour() {
+        let tz = TimeZone(secondsFromGMT: 7 * 3600)!
+        #expect(TimeZoneBadge.gmtOffset(for: tz, at: Date()) == "GMT+7")
+    }
+
+    @Test func gmtNegativeWholeHour() {
+        let tz = TimeZone(secondsFromGMT: -5 * 3600)!
+        #expect(TimeZoneBadge.gmtOffset(for: tz, at: Date()) == "GMT-5")
+    }
+
+    @Test func gmtIndiaHalfHour() {
+        let tz = TimeZone(secondsFromGMT: 5 * 3600 + 30 * 60)!
+        #expect(TimeZoneBadge.gmtOffset(for: tz, at: Date()) == "GMT+5:30")
+    }
+
+    @Test func gmtNepalQuarterHour() {
+        let tz = TimeZone(secondsFromGMT: 5 * 3600 + 45 * 60)!
+        #expect(TimeZoneBadge.gmtOffset(for: tz, at: Date()) == "GMT+5:45")
+    }
+
+    @Test func gmtNewfoundlandNegativeHalfHour() {
+        let tz = TimeZone(secondsFromGMT: -(3 * 3600 + 30 * 60))!
+        #expect(TimeZoneBadge.gmtOffset(for: tz, at: Date()) == "GMT-3:30")
+    }
+
     // MARK: - from(_:calendar:) round-trip
 
     @Test func fromDateUsesCalendarHour() {


### PR DESCRIPTION
## Show local UTC offset (GMT+7) in the Today header subline for timezone-hopping nomads

The Today header subline already shows date · notes · words · weather · place, but never the timezone — the one piece of context that changes most for digital nomads bouncing between zones (the app's stated target user). Add a pure, unit-tested TimeZoneBadge helper that formats the current local zone as a compact 'GMT+7' / 'GMT-3:30' token and append it to the subline (and its VoiceOver label), mirroring the existing weather/place segments.

### Acceptance
Build succeeds for the DayPage scheme on iPhone 17. New TimeZoneBadge tests pass (covering whole-hour, half-hour +5:30/-3:30, quarter-hour +5:45, and zero offsets). Launching in the Simulator shows the GMT offset as the last segment of the Today header subline for both the empty-day and with-memos states, and VoiceOver reads it as part of the comma-separated subline label. No changes to any @Model/persistence file; total diff under 100 lines across 3 files.