### PR TITLE
auto: Anchor +/− zoom buttons (and pinch) to the viewport center on the Knowledge Graph

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -605,8 +605,14 @@ struct GraphView: View {
             .gesture(
                 SimultaneousGesture(
                     MagnificationGesture()
-                        .onChanged { value in scale = max(0.3, min(5.0, lastScale * value)) }
-                        .onEnded { _ in lastScale = scale },
+                        .onChanged { value in
+                            let newScale = max(0.3, min(5.0, lastScale * value))
+                            let ratio = newScale / scale
+                            offset.width *= ratio
+                            offset.height *= ratio
+                            scale = newScale
+                        }
+                        .onEnded { _ in lastScale = scale; lastOffset = offset },
                     DragGesture()
                         .onChanged { value in
                             offset = CGSize(
@@ -804,10 +810,16 @@ struct GraphView: View {
             Haptics.warn()
             return
         }
+        let ratio = target / scale
+        let newOffset = CGSize(width: offset.width * ratio, height: offset.height * ratio)
         if !reduceMotion {
-            withAnimation(Motion.spring) { scale = target; lastScale = target }
+            withAnimation(Motion.spring) {
+                scale = target; lastScale = target
+                offset = newOffset; lastOffset = newOffset
+            }
         } else {
             scale = target; lastScale = target
+            offset = newOffset; lastOffset = newOffset
         }
         Haptics.soft()
     }


### PR DESCRIPTION
## Anchor +/− zoom buttons (and pinch) to the viewport center on the Knowledge Graph

The Graph's zoom-in/out buttons and pinch gesture scale around the content origin (0,0) instead of what's currently centered on screen, so after panning the graph visibly slides away under the user's finger when they zoom. This fixes the zoom to keep the point at the viewport center stationary — the standard, expected map-zoom behavior — making +/− feel precise instead of disorienting.

### Acceptance
Build the DayPage scheme for iPhone 17 and open the Graph tab. Pan the graph so a recognizable node sits at the screen center, then tap + and −: that node stays at the center instead of drifting toward a corner. Pinch-zoom centered on a node keeps it anchored. At default (un-panned, offset == .zero) behavior is unchanged. Zoom limits (0.3–5.0), the warn() haptic at the limit, the recenter button, and double-tap reset all still work. VoiceOver labels are unaffected.