### PR TITLE
auto: Fix: highlighted search keyword ignores Dynamic Type (a11y regression)

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -1095,7 +1095,8 @@ struct SearchView: View {
 
             attributed[attrRange].backgroundColor = UIColor(DSColor.amberAccent).withAlphaComponent(0.28)
             attributed[attrRange].foregroundColor = UIColor(DSColor.onSurface)
-            attributed[attrRange].font = .system(size: 13, weight: .semibold)
+            // Scaled font keeps highlight emphasis in lockstep with the snippet's Dynamic Type size.
+            attributed[attrRange].font = UIFontMetrics(forTextStyle: .footnote).scaledFont(for: .systemFont(ofSize: 13, weight: .semibold))
 
             searchStart = range.upperBound
         }


### PR DESCRIPTION
## Fix: highlighted search keyword ignores Dynamic Type (a11y regression)

In SearchView, matched keyword spans in result snippets are hardcoded to `.system(size: 13, weight: .semibold)`, so when a user enlarges text via Dynamic Type the highlight stays fixed at 13pt while the surrounding `.bodySMStyle()` text scales — producing mismatched, smaller-looking emphasis exactly for the users who need larger text. Replace the fixed font with a Dynamic-Type-aware bold variant so the highlight scales in lockstep with the snippet body.

### Acceptance
Build the DayPage scheme cleanly. In Simulator (iPhone 17), open Search, query a term that matches a snippet, and confirm the keyword is bold + amber-highlighted at the default text size. Then raise the system text size (Settings → Accessibility → Display & Text Size → Larger Text, or the Control Center text-size slider): the highlighted keyword must grow proportionally with the surrounding snippet text — no longer rendering smaller than its neighbors. Highlight color/background and multi-occurrence highlighting remain intact.