### PR TITLE
auto: Add press-scale animation + tap haptic to Weekly Recap day cards

### DIFF
--- a/DayPage/Features/Today/WeeklyRecapSection.swift
+++ b/DayPage/Features/Today/WeeklyRecapSection.swift
@@ -69,8 +69,13 @@ private struct WeeklyRecapDayCard: View {
     let entry: WeeklyRecapEntry
     let onTap: () -> Void
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
     var body: some View {
-        Button(action: onTap) {
+        Button(action: {
+            Haptics.tapConfirm()
+            onTap()
+        }) {
             HStack(alignment: .top, spacing: 14) {
                 dateRail
                 summaryColumn
@@ -85,8 +90,10 @@ private struct WeeklyRecapDayCard: View {
             .background(DSColor.surfaceContainer)
             .cornerRadius(DSSpacing.radiusCard)
         }
-        .buttonStyle(.plain)
+        .buttonStyle(RecapCardButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(accessibilityLabel)
+        .accessibilityHint(NSLocalizedString("recap.card.accessibility_hint", value: "Double tap to open this day's page", comment: "Accessibility hint for weekly recap day cards"))
+        .accessibilityAddTraits(.isButton)
     }
 
     private var dateRail: some View {
@@ -140,5 +147,21 @@ private struct WeeklyRecapDayCard: View {
     private var accessibilityLabel: String {
         let summaryText = entry.summary.flatMap { $0.isEmpty ? nil : $0 } ?? "已编译"
         return "\(entry.dateString)，\(summaryText)"
+    }
+}
+
+// MARK: - RecapCardButtonStyle
+
+private struct RecapCardButtonStyle: ButtonStyle {
+    let reduceMotion: Bool
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect((!reduceMotion && configuration.isPressed) ? 0.97 : 1)
+            .opacity(configuration.isPressed ? 0.94 : 1)
+            .animation(
+                reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.7),
+                value: configuration.isPressed
+            )
     }
 }


### PR DESCRIPTION
## Add press-scale animation + tap haptic to Weekly Recap day cards

The 'THIS WEEK' recap cards at the bottom of the Today timeline are tappable Buttons that navigate to DayDetailView, but unlike every other interactive surface on the Today screen (memo cards, daily-page card, CTA buttons) they fire no haptic and have no press-down scale feedback. This makes them feel dead on touch and breaks the app's consistent tactile language. Add a light tap haptic and reuse a pressable-scale button style so the recap cards respond like the rest of the timeline.

### Acceptance
Build succeeds with `xcodebuild -scheme DayPage build`. In the iPhone 17 simulator, scrolling to the 'THIS WEEK' section and pressing a day card produces a subtle scale-down + light haptic on touch and navigates to DayDetailView on release. With Reduce Motion enabled the scale animation is suppressed but the haptic and navigation still work. VoiceOver reads the card label plus the new hint, and the element is exposed as a button.