### PR TITLE
auto: Empty-state orb accent tracks time-of-day instead of freezing on first appear

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -23,6 +23,10 @@ struct EmptyStateView: View {
 
     /// Captured once on appear so the tint stays stable across the breathing animation.
     @State private var orbTint: Color = TimeOfDay.from(Date()).tint
+    /// Tracks which TimeOfDay bucket is currently displayed; avoids float-equality churn.
+    @State private var tintBucket: Int = TimeOfDay.from(Date()).bucketIndex
+
+    private let tintTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
 
     var body: some View {
         VStack(spacing: 20) {
@@ -59,6 +63,15 @@ struct EmptyStateView: View {
             }
         }
         .padding(.horizontal, 32)
+        .onReceive(tintTimer) { now in
+            guard showOrbAccent else { return }
+            let tod = TimeOfDay.from(now)
+            guard tod.bucketIndex != tintBucket else { return }
+            tintBucket = tod.bucketIndex
+            withAnimation(reduceMotion ? nil : .easeInOut(duration: 0.8)) {
+                orbTint = tod.tint
+            }
+        }
         .onAppear {
             orbTint = TimeOfDay.from(Date()).tint
             if reduceMotion {


### PR DESCRIPTION
## Empty-state orb accent tracks time-of-day instead of freezing on first appear

The EmptyStateView orb-accent tint is captured once in onAppear and never updates, so a user who leaves Today open across a time-of-day boundary (e.g. morning→afternoon) sees a stale ambient hue that no longer matches the live Day Orb hero, which already crossfades its tint. This adds a low-frequency timer that refreshes orbTint when the TimeOfDay bucket changes, with a smooth crossfade, keeping the empty-state ambience coherent with the rest of Today.

### Acceptance
Build the DayPage scheme clean for iPhone 17. In Simulator, open Today with zero memos so EmptyStateView.todayBlank renders; advance the simulator clock across a TimeOfDay boundary (e.g. set to 11:58, wait past 12:00) and confirm the orb-accent hue crossfades to the new bucket's tint within ~60s without a view reload, matching the live orb hero. With Reduce Motion on, the tint still updates but without animation. Non-orb empty states (showOrbAccent == false) are unaffected and incur no timer cost.