### PR TITLE
auto: Tap status bar / header date to scroll Today timeline to top

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1248,6 +1248,24 @@ struct TodayView: View {
             .accessibilityLabel("Open navigation")
             .accessibilityHint("Opens the sidebar navigation drawer")
             .accessibilityIdentifier("sidebar-menu-button")
+            .simultaneousGesture(
+                TapGesture(count: 2).onEnded {
+                    guard !viewModel.memos.isEmpty, timelineScrollOffset < -8 else { return }
+                    hasNewContentAboveFold = false
+                    Haptics.soft()
+                    withAnimation(reduceMotion ? nil : Motion.spring) {
+                        timelineScrollProxy?.scrollTo("timelineTop", anchor: .top)
+                    }
+                }
+            )
+            .accessibilityAction(named: Text(NSLocalizedString("today.header.scroll_to_top", comment: "Scroll to top accessibility action"))) {
+                guard !viewModel.memos.isEmpty else { return }
+                hasNewContentAboveFold = false
+                Haptics.soft()
+                withAnimation(reduceMotion ? nil : Motion.spring) {
+                    timelineScrollProxy?.scrollTo("timelineTop", anchor: .top)
+                }
+            }
             .onLongPressGesture(minimumDuration: 1.5) {
                 HapticFeedback.medium()
                 if let entry = OnThisDayScheduler.shared.forceRefresh() {


### PR DESCRIPTION
## Tap status bar / header date to scroll Today timeline to top

Today's timeline has a scroll-to-top button that only appears after scrolling 240pt, but iOS users expect tapping the top of the screen to jump to the top. Add a double-tap gesture on the always-visible header date that scrolls the timeline back to the 'timelineTop' anchor with the same spring animation and soft haptic the existing button uses, making return-to-top discoverable before the floating button appears.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator. Add 10+ memos so the timeline scrolls, scroll down, then double-tap the header date row: the timeline springs back to the top, the new-content amber dot clears, and a soft haptic fires. Single-tapping the header still opens the sidebar; long-press still triggers On This Day. With Reduce Motion on, the scroll jumps without animation. VoiceOver exposes a 'Scroll to top' action on the header.