### PR TITLE
auto: Time-of-day-aware orb accent on every empty state (parity with Today)

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -276,10 +276,10 @@ extension EmptyStateView {
     }
 
     /// Archive — selected month has no entries.
-    static func archiveMonthEmpty(ctaAction: @escaping () -> Void) -> EmptyStateView {
+    static func archiveMonthEmpty(ctaAction: @escaping () -> Void, subtitleOverride: String? = nil) -> EmptyStateView {
         EmptyStateView(
             title: L10n.Empty.archiveMonthEmptyTitle,
-            subtitle: L10n.Empty.archiveMonthEmptySubtitle,
+            subtitle: subtitleOverride ?? L10n.Empty.archiveMonthEmptySubtitle,
             ctaLabel: L10n.Empty.archiveMonthEmptyCta,
             ctaAction: ctaAction,
             showOrbAccent: true
@@ -309,10 +309,10 @@ extension EmptyStateView {
     }
 
     /// Graph tab — no compiled entities exist yet.
-    static func graphEmpty(ctaAction: @escaping () -> Void) -> EmptyStateView {
+    static func graphEmpty(ctaAction: @escaping () -> Void, subtitleOverride: String? = nil) -> EmptyStateView {
         EmptyStateView(
             title: L10n.Empty.graphEmptyTitle,
-            subtitle: L10n.Empty.graphEmptySubtitle,
+            subtitle: subtitleOverride ?? L10n.Empty.graphEmptySubtitle,
             ctaLabel: L10n.Empty.graphEmptyCta,
             ctaAction: ctaAction,
             showOrbAccent: true

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -62,6 +62,9 @@ struct GraphView: View {
     private let nodeRadius: CGFloat = 16
     private let maxSimSteps = 200
 
+    @State private var currentTime: Date = Date()
+    private let headerTimer = Timer.publish(every: 60, on: .main, in: .common).autoconnect()
+
     var body: some View {
         VStack(spacing: 0) {
             // MARK: Header bar — Liquid Glass strip on the warm canvas
@@ -322,6 +325,9 @@ struct GraphView: View {
             }
         }
         .navigationBarHidden(true)
+        .onReceive(headerTimer) { date in
+            currentTime = date
+        }
         .onAppear {
             viewModel.load()
         }
@@ -367,9 +373,9 @@ struct GraphView: View {
     @ViewBuilder
     private var emptyState: some View {
         if viewModel.nodes.isEmpty {
-            EmptyStateView.graphEmpty {
+            EmptyStateView.graphEmpty(ctaAction: {
                 nav.navigate(to: .today)
-            }
+            }, subtitleOverride: graphEmptySubtitle(currentTime))
         } else {
             EmptyStateView.graphNoMatches {
                 Haptics.tapConfirm()
@@ -381,6 +387,17 @@ struct GraphView: View {
                 }
             }
         }
+    }
+
+    private func graphEmptySubtitle(_ date: Date) -> String {
+        let key: String
+        switch TimeOfDay.from(date) {
+        case .morning:   key = "empty.graph.subtitle.morning"
+        case .afternoon: key = "empty.graph.subtitle.afternoon"
+        case .evening:   key = "empty.graph.subtitle.evening"
+        case .lateNight: key = "empty.graph.subtitle.night"
+        }
+        return NSLocalizedString(key, comment: "")
     }
 
     private var clearFiltersButton: some View {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -163,6 +163,12 @@
 "empty.graph.subtitle" = "Compiled entries will surface entity nodes here — write something to start building your network.";
 "empty.graph.cta" = "Write something";
 
+/* Graph empty-state time-of-day subtitles */
+"empty.graph.subtitle.morning" = "A fresh morning — start writing and your knowledge graph will take shape.";
+"empty.graph.subtitle.afternoon" = "Afternoon's a good time to log — compiled entries will appear here as nodes.";
+"empty.graph.subtitle.evening" = "End the day by capturing thoughts — they'll surface as your knowledge graph.";
+"empty.graph.subtitle.night" = "Before you sleep, jot something down — your graph grows one entry at a time.";
+
 /* Graph search match VoiceOver announcements */
 "graph.search.match.announcement" = "%1$@, match %2$d of %3$d";
 "graph.search.match.announcement.single" = "%1$@";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -163,6 +163,12 @@
 "empty.graph.subtitle" = "编译日记后，实体节点将在此出现，写点什么开始构建你的知识网络。";
 "empty.graph.cta" = "去写点什么";
 
+/* Graph empty-state time-of-day subtitles */
+"empty.graph.subtitle.morning" = "清晨是新的开始 — 开始记录，知识图谱将在这里生长。";
+"empty.graph.subtitle.afternoon" = "下午也是好时机 — 编译后的记录会以节点形式出现在这里。";
+"empty.graph.subtitle.evening" = "用傍晚的思绪收尾 — 写下来，它们会成为你知识图谱的一部分。";
+"empty.graph.subtitle.night" = "睡前记一笔 — 每一条记录都让图谱更丰富。";
+
 /* Graph search match VoiceOver announcements */
 "graph.search.match.announcement" = "%1$@，第 %2$d 个，共 %3$d 个";
 "graph.search.match.announcement.single" = "%1$@";


### PR DESCRIPTION
## Time-of-day-aware orb accent on every empty state (parity with Today)

The Today empty state already crossfades its orb accent tint across morning/afternoon/evening/late-night and gives a live time-aware subtitle, but the Archive-month and Graph empty states (which also set showOrbAccent: true) only capture the tint once on appear and never refresh it across a day boundary, and their subtitles are static. This adds the same live tint timer behavior already present in EmptyStateView to ensure the orb glow tracks time-of-day everywhere, plus an optional time-of-day subtitle override for the graphEmpty and archiveMonthEmpty factories so a user who opens an empty tab at dusk gets the same warm, alive feedback as on Today.

### Acceptance
Build the DayPage scheme for iPhone 17 simulator with no warnings. Launch with zero compiled entities and open the Graph tab: the orb accent glow is visible and its tint matches the current time of day (warm amber at dusk, cool at late night), and the subtitle text reflects the time of day. Advance the simulator clock across a time-of-day boundary while the empty state is visible and confirm the orb tint crossfades (does not freeze). Verify VoiceOver still reads title+subtitle as one combined element and the CTA still announces on reveal. Confirm reduce-motion disables the breathing/crossfade as before.