### PR TITLE
auto: Smooth time-of-day orb tint instead of hard 4-bucket color snaps

### DIFF
--- a/DayPage/Features/Today/TimeOfDay.swift
+++ b/DayPage/Features/Today/TimeOfDay.swift
@@ -58,4 +58,55 @@ enum TimeOfDay: Int {
         case .lateNight: return Color(red: 0.28, green: 0.22, blue: 0.60)  // deep indigo late-night
         }
     }
+
+    /// Continuously interpolated tint that drifts smoothly between bucket anchors.
+    /// Anchor hours are bucket midpoints: morning≈08:00, afternoon≈14:30, evening≈20:00, late-night≈01:30.
+    /// The original discrete `tint` is unchanged for back-compat.
+    static func continuousTint(at date: Date, calendar: Calendar = .current) -> Color {
+        struct Anchor {
+            let minuteOfDay: Double  // 0 = 00:00, 1439 = 23:59
+            let r, g, b: Double
+        }
+        // Anchor colors match the four discrete tints, centred on bucket midpoints.
+        // accentAmber resolves to (1.0, 0.75, 0.0) — the canonical midday amber.
+        let anchors: [Anchor] = [
+            Anchor(minuteOfDay:  90, r: 0.28, g: 0.22, b: 0.60), // 01:30 late-night
+            Anchor(minuteOfDay: 480, r: 0.45, g: 0.55, b: 0.88), // 08:00 morning
+            Anchor(minuteOfDay: 870, r: 1.00, g: 0.75, b: 0.00), // 14:30 afternoon
+            Anchor(minuteOfDay: 1200, r: 0.85, g: 0.40, b: 0.15), // 20:00 evening
+        ]
+        let hour   = Double(calendar.component(.hour,   from: date))
+        let minute = Double(calendar.component(.minute, from: date))
+        let current = hour * 60 + minute  // 0…1439
+
+        // Find the two nearest anchors by circular clock distance.
+        // We extend the anchor list with wrap-around copies to handle midnight crossings.
+        let dayMinutes = 24.0 * 60.0
+        // Compute forward (clockwise) distance from current to each anchor.
+        func forwardDist(_ anchor: Anchor) -> Double {
+            let d = anchor.minuteOfDay - current
+            return d < 0 ? d + dayMinutes : d
+        }
+        // Sort anchors by forward distance; the first is the "next" anchor, the last is "prev".
+        let sorted = anchors.sorted { forwardDist($0) < forwardDist($1) }
+        let next = sorted[0]
+        let prev = sorted[anchors.count - 1]
+
+        // Distance from prev to current (going forward).
+        let distFromPrev: Double = {
+            let d = current - prev.minuteOfDay
+            return d < 0 ? d + dayMinutes : d
+        }()
+        // Arc between prev and next.
+        let arcPrevNext: Double = {
+            let d = next.minuteOfDay - prev.minuteOfDay
+            return d <= 0 ? d + dayMinutes : d
+        }()
+        let t = arcPrevNext > 0 ? min(1, max(0, distFromPrev / arcPrevNext)) : 0
+
+        let r = prev.r + t * (next.r - prev.r)
+        let g = prev.g + t * (next.g - prev.g)
+        let b = prev.b + t * (next.b - prev.b)
+        return Color(red: r, green: g, blue: b)
+    }
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1047,9 +1047,9 @@ struct TodayView: View {
         TimeOfDay.from(date).bucketIndex
     }
 
-    /// Derives a subtle ambient hue for the orb breathing glow from the time-of-day bucket.
+    /// Derives a continuously-interpolated ambient hue for the orb breathing glow.
     private func orbTint(_ date: Date) -> Color {
-        TimeOfDay.from(date).tint
+        TimeOfDay.continuousTint(at: date)
     }
 
     private func orbKicker(_ date: Date) -> String {

--- a/DayPageTests/TimeOfDayTests.swift
+++ b/DayPageTests/TimeOfDayTests.swift
@@ -91,6 +91,79 @@ struct TimeOfDayTests {
         #expect(TimeZoneBadge.gmtOffset(for: tz, at: Date()) == "GMT-3:30")
     }
 
+    // MARK: - continuousTint
+
+    /// Helper: resolve a Color(red:green:blue:) to its (r,g,b) components in sRGB.
+    private func components(_ color: Color) -> (r: Double, g: Double, b: Double) {
+        var r: CGFloat = 0, g: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        UIColor(color).getRed(&r, green: &g, blue: &b, alpha: &a)
+        return (Double(r), Double(g), Double(b))
+    }
+
+    private func makeDate(hour: Int, minute: Int = 0) -> (Date, Calendar) {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 1; comps.day = 1
+        comps.hour = hour; comps.minute = minute
+        return (cal.date(from: comps)!, cal)
+    }
+
+    @Test func continuousTintAtMorningAnchorApproximatesDiscrete() {
+        let (date, cal) = makeDate(hour: 8, minute: 0)
+        let continuous = TimeOfDay.continuousTint(at: date, calendar: cal)
+        let discrete = TimeOfDay.morning.tint
+        let c = components(continuous)
+        let d = components(discrete)
+        // Within 15% of the anchor — it's an interpolated midpoint, not exact equality
+        #expect(abs(c.r - d.r) < 0.15)
+        #expect(abs(c.g - d.g) < 0.15)
+        #expect(abs(c.b - d.b) < 0.15)
+    }
+
+    @Test func continuousTintAtEveningAnchorApproximatesDiscrete() {
+        let (date, cal) = makeDate(hour: 20, minute: 0)
+        let continuous = TimeOfDay.continuousTint(at: date, calendar: cal)
+        let discrete = TimeOfDay.evening.tint
+        let c = components(continuous)
+        let d = components(discrete)
+        #expect(abs(c.r - d.r) < 0.15)
+        #expect(abs(c.g - d.g) < 0.15)
+        #expect(abs(c.b - d.b) < 0.15)
+    }
+
+    @Test func continuousTintBetweenMorningAndAfternoonFallsBetweenAnchors() {
+        let (date, cal) = makeDate(hour: 11, minute: 15)
+        let mid = TimeOfDay.continuousTint(at: date, calendar: cal)
+        let morning = components(TimeOfDay.morning.tint)
+        let afternoon = components(Color(red: 1.0, green: 0.75, blue: 0.0))
+        let m = components(mid)
+        // Each component should lie between the two anchor components (monotonic interpolation)
+        func between(_ v: Double, _ a: Double, _ b: Double) -> Bool {
+            let lo = min(a, b), hi = max(a, b)
+            return v >= lo - 0.01 && v <= hi + 0.01
+        }
+        #expect(between(m.r, morning.r, afternoon.r))
+        #expect(between(m.g, morning.g, afternoon.g))
+        #expect(between(m.b, morning.b, afternoon.b))
+    }
+
+    @Test func continuousTintHasNoNaNComponents() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(secondsFromGMT: 0)!
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 1; comps.day = 1
+        for hour in 0..<24 {
+            comps.hour = hour; comps.minute = 0
+            let date = cal.date(from: comps)!
+            let c = components(TimeOfDay.continuousTint(at: date, calendar: cal))
+            #expect(!c.r.isNaN && !c.g.isNaN && !c.b.isNaN,
+                    "NaN component at hour \(hour)")
+            #expect((0...1).contains(c.r) && (0...1).contains(c.g) && (0...1).contains(c.b),
+                    "Component out of [0,1] at hour \(hour)")
+        }
+    }
+
     // MARK: - from(_:calendar:) round-trip
 
     @Test func fromDateUsesCalendarHour() {


### PR DESCRIPTION
## Smooth time-of-day orb tint instead of hard 4-bucket color snaps

The Day Orb's ambient glow color is currently driven by TimeOfDay.tint, a discrete 4-bucket value (morning/afternoon/evening/late-night) that snaps abruptly at 5:00, 12:00, 18:00 and 23:00 — even though the orb already animates on tint changes and tracks day progress. Add a continuous tint that interpolates between adjacent buckets by hour so the orb's hue drifts smoothly across the day, matching the existing 'breathing orb' ambient language. The original discrete tint is kept for back-compat and existing tests.

### Acceptance
Build the DayPage scheme succeeds (xcodebuild -scheme DayPage build). Existing TimeOfDayTests still pass (the discrete `tint` and bucketing are unchanged). Add a lightweight test asserting continuousTint at a bucket midpoint hour is approximately equal to that bucket's anchor tint and that values between two buckets fall component-wise between the two anchor colors (monotonic, no NaN). In Simulator (iPhone 17) the empty-state Day Orb glow shows no visible color 'snap' when crossing an hour boundary; the hue visibly differs between e.g. an 08:00 vs 20:00 device clock. reduceMotion users see the static interpolated color with no animation.