### PR TITLE
auto: Day Orb empty-state: tap-to-cycle time-of-day capture prompt with a gentle bounce

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -95,6 +95,7 @@ struct TodayView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var orbBreathing: Bool = false
+    @State private var orbTapBounce: Bool = false
 
     /// Hint offset for the one-time swipe-left nudge on the Daily Page card.
     @State private var dailyPageHintOffset: CGFloat = 0
@@ -902,10 +903,19 @@ struct TodayView: View {
             let tint = orbTint(currentTime)
             DayOrbView(signalCount: signalCount, size: 140, onTap: {
                 Haptics.tapConfirm()
+                if viewModel.memos.isEmpty && draftText.isEmpty {
+                    draftText = orbCapturePrompt(currentTime)
+                    if !reduceMotion {
+                        withAnimation(Motion.spring) { orbTapBounce = true }
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                            withAnimation(Motion.spring) { orbTapBounce = false }
+                        }
+                    }
+                }
                 orbFocusToggle.toggle()
             }, pulseToggle: orbCapturePulse, dayProgress: dayProgress, timeTint: tint)
             .animation(reduceMotion ? nil : .easeInOut(duration: 0.8), value: tint)
-            .scaleEffect(reduceMotion ? 1.0 : (orbBreathing ? 1.03 : 0.985))
+            .scaleEffect(reduceMotion ? 1.0 : (orbTapBounce ? 0.9 : (orbBreathing ? 1.03 : 0.985)))
             .shadow(
                 color: tint.opacity(orbBreathing ? 0.28 + glowBoost : 0.12 + glowBoost),
                 radius: orbBreathing ? 22 + glowBoost * 40 : 12


### PR DESCRIPTION
## Day Orb empty-state: tap-to-cycle time-of-day capture prompt with a gentle bounce

The empty-state Day Orb currently only injects a single fixed capture prompt on long-press, which most users never discover. Add a discoverable single-tap behavior that injects the time-of-day prompt directly into the composer (with a soft haptic and a brief orb scale bounce), so first-run and zero-memo days get an obvious, low-friction way to start writing. This reuses the existing orbCapturePrompt(_:) and orbFocusToggle plumbing.

### Acceptance
On a zero-memo day, single-tapping the orb pre-fills the composer with the current time-of-day prompt and focuses it, accompanied by a soft haptic and a brief scale bounce; with reduceMotion on, the prompt still fills but no bounce plays; tapping when draftText is non-empty only focuses the composer without overwriting the draft. DayPage scheme builds clean and existing tests pass.