### PR TITLE
auto: Surface the weather condition glyph in the Today header subline

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1903,23 +1903,56 @@ struct TodayView: View {
                 parts.append(String(format: NSLocalizedString(wordsKey, comment: ""), words))
             }
         }
-        if let weather = todayWeatherShort() { parts.append(weather) }
+        if let weather = todayWeatherAccessibility() { parts.append(weather) }
         if let place = todayPlaceShort() { parts.append(place) }
         parts.append(todayTimeZoneShort())
         return parts.joined(separator: ", ")
     }
 
-    /// Today's weather temperature, taken from the most recent memo that carries
-    /// a weather string (e.g. "28° · 多云" → "28°"). Returns nil when unknown.
+    /// Condition glyphs emitted by WeatherService.glyph(forConditionCode:icon:).
+    private static let conditionGlyphs: [String] = ["⛈", "🌦", "🌧", "❄️", "🌫", "🌙", "☀️", "☁️", "🌤"]
+
+    /// Maps a condition glyph to a VoiceOver-friendly word.
+    private static let glyphAccessibilityLabel: [String: String] = [
+        "☀️": NSLocalizedString("weather.glyph.sunny",   comment: ""),
+        "☁️": NSLocalizedString("weather.glyph.cloudy",  comment: ""),
+        "🌧": NSLocalizedString("weather.glyph.rainy",   comment: ""),
+        "❄️": NSLocalizedString("weather.glyph.snowy",   comment: ""),
+        "⛈": NSLocalizedString("weather.glyph.stormy",  comment: ""),
+        "🌦": NSLocalizedString("weather.glyph.showery", comment: ""),
+        "🌫": NSLocalizedString("weather.glyph.foggy",   comment: ""),
+        "🌙": NSLocalizedString("weather.glyph.night",   comment: ""),
+        "🌤": NSLocalizedString("weather.glyph.partlycloudy", comment: ""),
+    ]
+
+    /// Today's weather, taken from the most recent memo that carries a weather string.
+    /// Returns "<glyph> <temp>" (e.g. "☀️ 28°") when a condition glyph is present,
+    /// or just "<temp>" when none is found. Returns nil when no weather is available.
     private func todayWeatherShort() -> String? {
         for memo in viewModel.memos {  // memos is already newest-first
             if let w = memo.weather?.trimmingCharacters(in: .whitespaces), !w.isEmpty {
-                // Keep only the temperature token ("28° · 多云" → "28°").
+                // Extract the temperature token (text before "·", or whole string).
                 let temp = w.split(separator: "·").first.map { $0.trimmingCharacters(in: .whitespaces) } ?? w
-                return temp.isEmpty ? nil : temp
+                guard !temp.isEmpty else { continue }
+                // Scan the full weather string for a known condition glyph.
+                if let glyph = Self.conditionGlyphs.first(where: { w.contains($0) }) {
+                    return "\(glyph) \(temp)"
+                }
+                return temp
             }
         }
         return nil
+    }
+
+    /// Like `todayWeatherShort()` but substitutes glyphs with spoken words for VoiceOver.
+    private func todayWeatherAccessibility() -> String? {
+        guard let short = todayWeatherShort() else { return nil }
+        for (glyph, label) in Self.glyphAccessibilityLabel {
+            if short.hasPrefix(glyph) {
+                return short.replacingOccurrences(of: glyph, with: label).trimmingCharacters(in: .whitespaces)
+            }
+        }
+        return short
     }
 
     /// Today's place name, taken from the most recent memo carrying a location.

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1931,11 +1931,18 @@ struct TodayView: View {
     private func todayWeatherShort() -> String? {
         for memo in viewModel.memos {  // memos is already newest-first
             if let w = memo.weather?.trimmingCharacters(in: .whitespaces), !w.isEmpty {
-                // Extract the temperature token (text before "·", or whole string).
-                let temp = w.split(separator: "·").first.map { $0.trimmingCharacters(in: .whitespaces) } ?? w
+                // Detect whether the string leads with a known condition glyph.
+                let foundGlyph = Self.conditionGlyphs.first(where: { w.hasPrefix($0) })
+                // Strip any leading glyph + thin-space before extracting the temperature.
+                let withoutGlyph = foundGlyph.map { w.dropFirst($0.count).trimmingCharacters(in: .whitespaces) } ?? w
+                // Keep only the first token (before "·" or ",") — the temperature.
+                let temp = withoutGlyph.split(omittingEmptySubsequences: true,
+                                              whereSeparator: { $0 == "·" || $0 == "," })
+                                       .first
+                                       .map { $0.trimmingCharacters(in: .whitespaces) }
+                                       ?? withoutGlyph
                 guard !temp.isEmpty else { continue }
-                // Scan the full weather string for a known condition glyph.
-                if let glyph = Self.conditionGlyphs.first(where: { w.contains($0) }) {
+                if let glyph = foundGlyph {
                     return "\(glyph) \(temp)"
                 }
                 return temp

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -106,6 +106,17 @@
 "today.subline.words.one"    = "%d WORD";
 "today.subline.words.other"  = "%d WORDS";
 
+/* Today header subline — weather condition glyphs (VoiceOver) */
+"weather.glyph.sunny"        = "Sunny";
+"weather.glyph.cloudy"       = "Cloudy";
+"weather.glyph.rainy"        = "Rainy";
+"weather.glyph.snowy"        = "Snowy";
+"weather.glyph.stormy"       = "Stormy";
+"weather.glyph.showery"      = "Showery";
+"weather.glyph.foggy"        = "Foggy";
+"weather.glyph.night"        = "Clear night";
+"weather.glyph.partlycloudy" = "Partly cloudy";
+
 /* Today orb greeting — time-of-day serif greeting above kicker */
 "today.greeting.morning"     = "Good morning.";
 "today.greeting.afternoon"   = "Good afternoon.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -106,6 +106,17 @@
 "today.subline.words.one"    = "%d 字";
 "today.subline.words.other"  = "%d 字";
 
+/* Today header subline — weather condition glyphs (VoiceOver) */
+"weather.glyph.sunny"        = "晴天";
+"weather.glyph.cloudy"       = "多云";
+"weather.glyph.rainy"        = "雨天";
+"weather.glyph.snowy"        = "雪天";
+"weather.glyph.stormy"       = "雷暴";
+"weather.glyph.showery"      = "阵雨";
+"weather.glyph.foggy"        = "雾天";
+"weather.glyph.night"        = "夜晴";
+"weather.glyph.partlycloudy" = "晴间多云";
+
 /* Today orb greeting — time-of-day serif greeting above kicker */
 "today.greeting.morning"     = "早上好。";
 "today.greeting.afternoon"   = "下午好。";


### PR DESCRIPTION
## Surface the weather condition glyph in the Today header subline

The recent commit (9701dbb) added a condition glyph (☀️/☁️/🌧/❄️) to weather strings, but `todayWeatherShort()` in TodayView strips it out — keeping only the temperature token ("28° · ☀️ 多云" → "28°"). The museum-aesthetic header subline therefore shows the bare temperature while the just-added glyph is thrown away. Extract the leading emoji glyph and prepend it to the temperature so the header reads "☀️ 28°", completing that feature where users actually see it.

### Acceptance
Build succeeds with `xcodebuild -scheme DayPage build`. On a day whose memos carry a weather string containing a condition glyph (e.g. "28° · ☀️ 多云"), the Today header subline renders "☀️ 28°" (glyph + temperature) instead of bare "28°". When the weather string has no glyph, the subline shows just the temperature exactly as before. When no memo carries weather, the weather token is omitted entirely (no regression). VoiceOver reads a sensible label rather than a raw emoji. Verify visually in the iPhone 17 Simulator with at least one weather-bearing memo present.