### PR TITLE
auto: Polish the Entity Page loading & navigation: skeleton placeholder + tap haptics

### DIFF
--- a/DayPage/Features/Entity/EntityPageView.swift
+++ b/DayPage/Features/Entity/EntityPageView.swift
@@ -15,6 +15,7 @@ struct EntityPageView: View {
     var sourceDateString: String? = nil
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var model: EntityModel? = nil
     @State private var notFound: Bool = false
     @State private var selectedDate: String? = nil
@@ -22,6 +23,7 @@ struct EntityPageView: View {
     @State private var selectedEntityType: String = "themes"
     /// Memos from raw vault files that mention this entity slug.
     @State private var linkedMemos: [(dateStr: String, memo: Memo)] = []
+    @State private var skeletonBreathe = false
 
     var body: some View {
         NavigationStack {
@@ -48,8 +50,7 @@ struct EntityPageView: View {
                         }
                     }
                 } else {
-                    ProgressView()
-                        .tint(DSColor.onSurfaceVariant)
+                    entitySkeleton
                 }
             }
             .navigationBarTitleDisplayMode(.inline)
@@ -98,6 +99,66 @@ struct EntityPageView: View {
                 EntityPageView(entityType: selectedEntityType, entitySlug: slug)
             }
         }
+    }
+
+    // MARK: - Skeleton
+
+    @ViewBuilder
+    private var entitySkeleton: some View {
+        let opacity = reduceMotion ? 1.0 : (skeletonBreathe ? 0.45 : 0.25)
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                // Badge chip
+                Capsule()
+                    .fill(DSColor.glassStd)
+                    .frame(width: 60, height: 18)
+
+                // Title bar
+                RoundedRectangle(cornerRadius: 2)
+                    .fill(DSColor.glassStd)
+                    .frame(maxWidth: .infinity * 0.7)
+                    .frame(width: UIScreen.main.bounds.width * 0.7 - 40, height: 32)
+
+                // Two mock sections
+                ForEach(0..<2, id: \.self) { _ in
+                    VStack(alignment: .leading, spacing: 10) {
+                        // Section label rule
+                        HStack(spacing: 12) {
+                            RoundedRectangle(cornerRadius: 1)
+                                .fill(DSColor.glassStd)
+                                .frame(width: 80, height: 11)
+                            Rectangle()
+                                .fill(DSColor.inkFaint)
+                                .frame(height: 1)
+                        }
+                        // Body lines at 94 / 80 / 55 %
+                        ForEach([0.94, 0.80, 0.55], id: \.self) { frac in
+                            RoundedRectangle(cornerRadius: 2)
+                                .fill(DSColor.glassStd)
+                                .frame(width: (UIScreen.main.bounds.width - 40) * frac, height: 14)
+                        }
+                    }
+                }
+
+                // Two related-entry row rectangles
+                ForEach(0..<2, id: \.self) { _ in
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(DSColor.glassStd)
+                        .frame(maxWidth: .infinity)
+                        .frame(height: 52)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+        }
+        .opacity(opacity)
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true)) {
+                skeletonBreathe = true
+            }
+        }
+        .accessibilityHidden(true)
     }
 
     // MARK: - Not Found
@@ -209,7 +270,7 @@ struct EntityPageView: View {
                 // Show individual memo snippets with navigation
                 ForEach(linkedMemos.indices, id: \.self) { idx in
                     let item = linkedMemos[idx]
-                    Button(action: { selectedDate = item.dateStr }) {
+                    Button(action: { Haptics.tapConfirm(); selectedDate = item.dateStr }) {
                         VStack(alignment: .leading, spacing: 4) {
                             Text(relativeDateLabel(item.dateStr))
                                 .monoLabelStyle(size: 9)
@@ -239,7 +300,7 @@ struct EntityPageView: View {
             } else {
                 // Fallback: daily page dates only (entity mentioned in compiled page but not raw)
                 ForEach(model.relatedDates, id: \.self) { dateStr in
-                    Button(action: { selectedDate = dateStr }) {
+                    Button(action: { Haptics.tapConfirm(); selectedDate = dateStr }) {
                         HStack {
                             Text(relativeDateLabel(dateStr))
                                 .monoLabelStyle(size: 11)


### PR DESCRIPTION
## Polish the Entity Page loading & navigation: skeleton placeholder + tap haptics

EntityPageView is a core pipeline output (Graph → Entity Page) but is visibly less finished than the Today/Graph screens: it shows a bare centered ProgressView() while loading and fires no haptic when a related-memo or related-date row is tapped, unlike every other navigation surface in the app. This replaces the spinner with a layout-matched skeleton (header chip + title bar + section lines + related-entry rows, mirroring GraphSkeleton's shimmer style) and adds Haptics.tapConfirm() to row taps so opening a daily page feels consistent with the rest of the app.

### Acceptance
Build the DayPage scheme for iPhone 17 succeeds with no warnings. Launching the app and tapping a Graph node to open an Entity Page shows the shimmer skeleton (not a bare spinner) for the brief load, which then crossfades into real content; with Reduce Motion enabled the skeleton renders static. Tapping a related-entry/related-date row produces a light confirmation haptic and navigates to the Daily Page. The notFound and populated states are visually unchanged.