### PR TITLE
auto: Harmonize the Day Orb's progress arc with the time-of-day tint + add a leading-edge progress dot

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -152,18 +152,33 @@ struct DayOrbView: View {
 
     // MARK: - Day Progress Arc
 
-    // Thin amber arc around the orb outer edge filling from 0 (midnight) to 1.0 (next midnight).
+    // Thin arc around the orb outer edge filling from 0 (midnight) to 1.0 (next midnight).
+    // Stroke tracks timeTint so the arc always harmonizes with the halo and orb fill.
+    // A small glowing dot sits at the arc's leading edge for at-a-glance time remaining.
     private var dayProgressArc: some View {
-        Circle()
-            .trim(from: 0, to: dayProgress)
-            .stroke(
-                DSColor.accentAmber.opacity(0.55),
-                style: StrokeStyle(lineWidth: 2, lineCap: .round)
-            )
-            .rotationEffect(.degrees(-90))
-            .frame(width: size + 6, height: size + 6)
-            .animation(reduceMotion ? nil : .linear(duration: 1), value: dayProgress)
-            .allowsHitTesting(false)
+        ZStack {
+            Circle()
+                .trim(from: 0, to: dayProgress)
+                .stroke(
+                    timeTint.opacity(0.65),
+                    style: StrokeStyle(lineWidth: 2, lineCap: .round)
+                )
+                .rotationEffect(.degrees(-90))
+                .frame(width: size + 6, height: size + 6)
+                .animation(reduceMotion ? nil : .linear(duration: 1), value: dayProgress)
+                .allowsHitTesting(false)
+
+            if dayProgress > 0.01 {
+                Circle()
+                    .fill(timeTint)
+                    .frame(width: 5, height: 5)
+                    .shadow(color: timeTint.opacity(0.8), radius: 3, x: 0, y: 0)
+                    .offset(y: -(size + 6) / 2)
+                    .rotationEffect(.degrees(360 * dayProgress - 90))
+                    .animation(reduceMotion ? nil : .linear(duration: 1), value: dayProgress)
+                    .allowsHitTesting(false)
+            }
+        }
     }
 
     // MARK: - Pulse Halo


### PR DESCRIPTION
## Harmonize the Day Orb's progress arc with the time-of-day tint + add a leading-edge progress dot

The Day Orb's halo and fill smoothly drift through the dawn→midday→dusk→night palette via `timeTint`, but its day-progress arc is hardcoded to static `DSColor.accentAmber`, so the ring visually clashes with the orb at every hour except midday. This change feeds `timeTint` into the arc stroke and adds a small glowing dot at the arc's leading edge so the user can read 'how much of today is left' at a glance — a subtle, always-visible UX refinement that completes the existing time-tinting system.

### Acceptance
Build the DayPage scheme cleanly (`xcodebuild -scheme DayPage build`). In the iPhone 17 Simulator with an empty day, the orb's progress arc color matches the orb halo and shifts across morning/afternoon/evening/night (verify by temporarily passing different `timeTint` values or via the existing time-of-day tinting). A small tinted dot sits at the arc's leading edge and advances with `dayProgress`; it is hidden at exactly 0% and present otherwise. With Reduce Motion enabled the dot/arc snap without animating. Existing `DayProgressTests` and `TimeOfDayTests` still pass.