### PR TITLE
auto: Surface persistent quick-search chips + clean up dead locals in SearchView

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -618,6 +618,20 @@ struct SearchView: View {
                 let recent = vm.recentSearches
                 let entities = vm.topEntities
 
+                if !recent.isEmpty || !entities.isEmpty {
+                    sectionHeader(title: "快捷检索", trailing: AnyView(EmptyView()))
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            ForEach(SearchView.starterSuggestions, id: \.self) { suggestion in
+                                entityChip(suggestion)
+                            }
+                        }
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 4)
+                    }
+                }
+
                 if !recent.isEmpty {
                     sectionHeader(title: "最近搜索", trailing: AnyView(
                         Button(action: {
@@ -977,9 +991,7 @@ struct SearchView: View {
     }
 
     private func resultRow(_ result: SearchResult) -> some View {
-        let status = result.isDailyPageCompiled ? "VERIFIED" : "METADATA"
-        let snippet = String(result.snippet.prefix(80))
-        let a11yLabel = "\(formatDate(result.dateString)), \(matchLabel(for: result.matchKind)) match, \(status), \(snippet)"
+        let a11yLabel = "\(formatDate(result.dateString)), \(matchLabel(for: result.matchKind)) match, \(result.isDailyPageCompiled ? "VERIFIED" : "METADATA"), \(String(result.snippet.prefix(80)))"
         return Button(action: {
             Haptics.tapConfirm()
             vm.recordSearch(vm.query)


### PR DESCRIPTION
## Surface persistent quick-search chips + clean up dead locals in SearchView

The handy starter chips (今天/本周/本月/位置/照片/语音) currently only appear in the empty-query state when the user has NO recent searches AND no indexed entities — so returning users with history never see these one-tap quick filters. This adds a persistent '快捷检索' chip row at the top of the empty-query state and removes two unused locals (`status`, `snippet`) in `resultRow`.

### Acceptance
Build `xcodebuild -scheme DayPage build` succeeds with no new warnings (the two removed locals eliminate any 'unused' warnings). Launch in iPhone 17 Simulator, open Search from Archive: with existing recent searches present, a '快捷检索' chip row now appears at the top showing 今天/本周/本月/位置/照片/语音; tapping a chip fills the query, records it to recent, and runs the search. The no-history empty block still renders its own '试试搜索' chips for first-run users without duplication. VoiceOver reads each chip as '搜索 <term>'.