### PR TITLE
auto: Add top-level 'locations' frontmatter to Markdown export for geospatial querying

### DIFF
--- a/DayPage/Services/MarkdownExportService.swift
+++ b/DayPage/Services/MarkdownExportService.swift
@@ -59,6 +59,18 @@ enum MarkdownExportService {
                 lines.append("  - \(yamlQuoted(e))")
             }
         }
+
+        let locations = memos.compactMap { $0.location?.name }.filter { !$0.isEmpty }
+        let dedupedLocations = Array(Set(locations)).sorted()
+        if dedupedLocations.isEmpty {
+            lines.append("locations: []")
+        } else {
+            lines.append("locations:")
+            for loc in dedupedLocations {
+                lines.append("  - \(yamlQuoted(loc))")
+            }
+        }
+
         lines.append("---")
         lines.append("")
         lines.append("# DayPage — \(dateString)")

--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -215,6 +215,67 @@ struct MarkdownExportServiceTests {
         #expect(content.contains("> AI · Productive day."))
     }
 
+    // MARK: - locations frontmatter
+
+    private func makeMemoWithLocation(
+        body: String,
+        locationName: String?,
+        secondsOffset: Double = 0
+    ) -> Memo {
+        let loc = locationName.map { Memo.Location(name: $0) }
+        return Memo(
+            id: UUID(),
+            type: .text,
+            created: Date(timeIntervalSinceReferenceDate: 800_000_000 + secondsOffset),
+            location: loc,
+            body: body
+        )
+    }
+
+    @Test func locations_deduped_whenTwoMemosShareSameLocation() {
+        let m1 = makeMemoWithLocation(body: "a", locationName: "Tokyo", secondsOffset: 0)
+        let m2 = makeMemoWithLocation(body: "b", locationName: "Tokyo", secondsOffset: 10)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m1, m2], date: makeDate()
+        )
+        // "Tokyo" must appear exactly once in the locations block
+        let locationSection = content.components(separatedBy: "locations:").last ?? ""
+        let tokyoCount = locationSection.components(separatedBy: "\"Tokyo\"").count - 1
+        #expect(tokyoCount == 1)
+        #expect(!content.contains("locations: []"))
+    }
+
+    @Test func locations_sorted_whenMultipleDistinctLocations() {
+        let m1 = makeMemoWithLocation(body: "a", locationName: "Zurich", secondsOffset: 0)
+        let m2 = makeMemoWithLocation(body: "b", locationName: "Amsterdam", secondsOffset: 10)
+        let m3 = makeMemoWithLocation(body: "c", locationName: "Berlin", secondsOffset: 20)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m1, m2, m3], date: makeDate()
+        )
+        let aRange = content.range(of: "\"Amsterdam\"")!
+        let bRange = content.range(of: "\"Berlin\"")!
+        let zRange = content.range(of: "\"Zurich\"")!
+        #expect(aRange.lowerBound < bRange.lowerBound)
+        #expect(bRange.lowerBound < zRange.lowerBound)
+    }
+
+    @Test func locations_yamlSpecialChars_areEscaped() {
+        let m = makeMemoWithLocation(body: "a", locationName: "O'ahu \"Hawaii\"")
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m], date: makeDate()
+        )
+        #expect(content.contains("\"O'ahu \\\"Hawaii\\\"\""))
+    }
+
+    @Test func locations_emptyArray_whenNoGeotaggedMemos() {
+        let m1 = makeMemo(body: "no location")
+        let m2 = makeMemoWithLocation(body: "explicit nil", locationName: nil)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m1, m2], date: makeDate()
+        )
+        #expect(content.contains("locations: []"))
+    }
+
     // MARK: - 4. writeExportFile produces a branded filename
 
     @Test func writeExportFile_producesURLWithBrandedFilename() throws {


### PR DESCRIPTION
## Add top-level `locations` frontmatter to Markdown export for geospatial querying

The Obsidian Markdown export embeds per-memo `> 📍 <name>` lines but exposes no top-level location field in the YAML frontmatter, so nomad users can't query or map a day's places across their vault. This adds a deduplicated, ordered `locations:` list to the frontmatter (mirroring the existing `entity_mentions:` shape), making each day's geography first-class and Dataview-queryable.

### Acceptance
1) Build passes (`xcodebuild -scheme DayPage build`). 2) New tests in MarkdownExportServiceTests assert: a day with two memos sharing a location yields a single deduped `locations:` entry; multiple distinct locations are sorted; YAML-special chars in a place name are escaped via yamlQuoted; and a day with no locations emits `locations: []`. 3) Existing export tests still pass. 4) Frontmatter remains valid YAML (verify by inspecting a generated `.md` under the export temp dir).