### PR TITLE
auto: Pre-warm and cache haptic generators to eliminate first-tap Taptic Engine latency

### DIFF
--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -156,6 +156,8 @@ struct DayPageApp: App {
         // Eagerly initialize WatchReceiveService so WCSession activates on launch.
         // Without this the lazy singleton never starts and Watch audio transfers are lost.
         _ = WatchReceiveService.shared
+        // Pre-warm Taptic Engine generators so first-tap haptics fire without latency.
+        Task { @MainActor in HapticFeedback.warmUp() }
     }
 
     var body: some Scene {
@@ -221,6 +223,8 @@ struct DayPageApp: App {
                     // actually changed (issue #345).
                     if phase == .active {
                         TimelineIndex.shared.refreshIfExternallyModified()
+                        // Re-warm generators after backgrounding so they're ready immediately.
+                        HapticFeedback.warmUp()
                     }
                 }
         }

--- a/DayPage/Services/HapticFeedback.swift
+++ b/DayPage/Services/HapticFeedback.swift
@@ -1,60 +1,85 @@
 import UIKit
 
+@MainActor
 enum HapticFeedback {
+
+    // MARK: - Cached Generators
+
+    private static var impactGenerators: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = [:]
+    private static var notificationGenerator = UINotificationFeedbackGenerator()
+    private static var warmedUp = false
+
+    // MARK: - Warm-up
+
+    /// Pre-warms the Taptic Engine so the first haptic fires without latency.
+    /// Call once at launch and again on scenePhase → .active.
+    static func warmUp() {
+        let styles: [UIImpactFeedbackGenerator.FeedbackStyle] = [.soft, .light, .medium, .rigid]
+        for style in styles {
+            generator(for: style).prepare()
+        }
+        notificationGenerator.prepare()
+    }
 
     // MARK: - Impact
 
     static func light() {
-        impact(.light)
+        fire(style: .light)
     }
 
     static func medium() {
-        impact(.medium)
+        fire(style: .medium)
     }
 
     static func heavy() {
-        impact(.heavy)
+        fire(style: .heavy)
     }
 
     static func soft() {
-        impact(.soft)
+        fire(style: .soft)
     }
 
     static func rigid(intensity: CGFloat = 1.0) {
-        let generator = UIImpactFeedbackGenerator(style: .rigid)
-        generator.prepare()
-        generator.impactOccurred(intensity: intensity)
+        let gen = generator(for: .rigid)
+        gen.impactOccurred(intensity: intensity)
+        gen.prepare()
     }
 
     static func impact(style: UIImpactFeedbackGenerator.FeedbackStyle) {
-        impact(style)
+        fire(style: style)
     }
 
     // MARK: - Notification
 
     static func success() {
-        notification(.success)
+        notificationGenerator.notificationOccurred(.success)
+        notificationGenerator.prepare()
     }
 
     static func warning() {
-        notification(.warning)
+        notificationGenerator.notificationOccurred(.warning)
+        notificationGenerator.prepare()
     }
 
     static func error() {
-        notification(.error)
+        notificationGenerator.notificationOccurred(.error)
+        notificationGenerator.prepare()
     }
 
     // MARK: - Private
 
-    private static func impact(_ style: UIImpactFeedbackGenerator.FeedbackStyle) {
-        let generator = UIImpactFeedbackGenerator(style: style)
-        generator.prepare()
-        generator.impactOccurred()
+    private static func generator(for style: UIImpactFeedbackGenerator.FeedbackStyle) -> UIImpactFeedbackGenerator {
+        if let existing = impactGenerators[style] {
+            return existing
+        }
+        let gen = UIImpactFeedbackGenerator(style: style)
+        impactGenerators[style] = gen
+        return gen
     }
 
-    private static func notification(_ type: UINotificationFeedbackGenerator.FeedbackType) {
-        let generator = UINotificationFeedbackGenerator()
-        generator.prepare()
-        generator.notificationOccurred(type)
+    private static func fire(style: UIImpactFeedbackGenerator.FeedbackStyle) {
+        let gen = generator(for: style)
+        gen.impactOccurred()
+        gen.prepare()
     }
 }


### PR DESCRIPTION
## Pre-warm and cache haptic generators to eliminate first-tap Taptic Engine latency

Every haptic in the app currently allocates a fresh UIImpactFeedbackGenerator/UINotificationFeedbackGenerator and calls prepare() immediately before firing in the same synchronous frame. Because prepare() is asynchronous (it ramps the Taptic Engine from cold), the engine is rarely warm in time, causing dropped or delayed first haptics — most visible in the app's rapid escalating ladders (scroll-ring milestone ticks at 33/66/100%, composer key feedback, capture-reward pulses). Retain cached generators per style and re-prepare() after each fire so the engine stays warm for the next call.

### Acceptance
Build succeeds with `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'`. All existing Haptics.* / HapticFeedback.* call sites compile unchanged. On a physical device, the first haptic after launch fires without the prior delay/miss, and rapid escalating ladders (scroll to top past the milestone thresholds, fast composer typing) feel crisp with no dropped pulses. No new generator is allocated per call (verified by inspection: generators are cached, not constructed inside the fire methods). Reduce-motion/accessibility behavior is unchanged.