### PR TITLE
auto: Graph header: live knowledge-network size pill with animated count-up

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -41,6 +41,9 @@ struct GraphView: View {
     // Wrap-around flash state for the match-count pill
     @State private var matchPillFlash: Bool = false
 
+    // Network-size milestone tracking — fires soft haptic + VoiceOver every 10 nodes
+    @State private var lastNetworkMilestone: Int = 0
+
     // Legend type-visibility filter — persisted across tab switches and relaunches
     @AppStorage(AppSettings.Keys.graphHiddenTypes) private var hiddenTypesRaw: String = ""
 
@@ -140,6 +143,13 @@ struct GraphView: View {
                 }
                 .padding(.horizontal, DSSpacing.lg)
                 .padding(.vertical, DSSpacing.sm)
+
+                if !viewModel.nodes.isEmpty && !hasActiveFilter {
+                    networkSizePill
+                        .padding(.horizontal, DSSpacing.lg)
+                        .padding(.bottom, DSSpacing.sm)
+                        .transition(.opacity)
+                }
 
                 if !viewModel.searchQuery.isEmpty {
                     HStack(spacing: DSSpacing.xs) {
@@ -331,8 +341,19 @@ struct GraphView: View {
         .onAppear {
             viewModel.load()
         }
-        .onChange(of: viewModel.nodes.count) { _ in
+        .onChange(of: viewModel.nodes.count) { count in
             if !viewModel.nodes.isEmpty { startSimulation() }
+            let milestone = count / 10
+            guard count > 0, milestone > lastNetworkMilestone else { return }
+            lastNetworkMilestone = milestone
+            Haptics.soft()
+            if UIAccessibility.isVoiceOverRunning {
+                let msg = String(
+                    format: NSLocalizedString("graph.network.milestone.announcement", comment: "VoiceOver: network crossed a 10-node milestone"),
+                    count, viewModel.edges.count
+                )
+                UIAccessibility.post(notification: .announcement, argument: msg)
+            }
         }
         .onDisappear {
             stopSimulation()
@@ -423,6 +444,54 @@ struct GraphView: View {
         .buttonStyle(ClearFiltersPressStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(L10n.Empty.graphClearFilters)
         .accessibilityAddTraits(.isButton)
+    }
+
+    // MARK: - Network Size Pill
+
+    private var networkSizePill: some View {
+        let nodeCount = viewModel.nodes.count
+        let edgeCount = viewModel.edges.count
+        return HStack(spacing: 0) {
+            Text(NSLocalizedString("graph.pill.nodes.prefix", comment: "Graph network pill — before node count"))
+                .font(DSType.mono10)
+                .foregroundColor(DSColor.inkMuted)
+                .textCase(.uppercase)
+                .tracking(0.5)
+            Text("\(nodeCount)")
+                .font(DSType.mono10)
+                .foregroundColor(DSColor.inkMuted)
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .modifier(NumericTextContentTransition(value: Double(nodeCount), reduceMotion: reduceMotion))
+                .animation(reduceMotion ? nil : Motion.spring, value: nodeCount)
+            Text(NSLocalizedString("graph.pill.nodes.suffix", comment: "Graph network pill — between node and edge count"))
+                .font(DSType.mono10)
+                .foregroundColor(DSColor.inkMuted)
+                .textCase(.uppercase)
+                .tracking(0.5)
+            Text("\(edgeCount)")
+                .font(DSType.mono10)
+                .foregroundColor(DSColor.inkMuted)
+                .textCase(.uppercase)
+                .tracking(0.5)
+                .modifier(NumericTextContentTransition(value: Double(edgeCount), reduceMotion: reduceMotion))
+                .animation(reduceMotion ? nil : Motion.spring, value: edgeCount)
+            Text(NSLocalizedString("graph.pill.edges.suffix", comment: "Graph network pill — after edge count"))
+                .font(DSType.mono10)
+                .foregroundColor(DSColor.inkMuted)
+                .textCase(.uppercase)
+                .tracking(0.5)
+        }
+        .padding(.horizontal, DSSpacing.md)
+        .padding(.vertical, 5)
+        .background(DSColor.glassLo)
+        .background(.ultraThinMaterial, in: Capsule())
+        .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(
+            format: NSLocalizedString("graph.pill.accessibility", comment: "VoiceOver: network size combined label"),
+            nodeCount, edgeCount
+        ))
     }
 
     // MARK: - Accessibility Helpers
@@ -987,6 +1056,23 @@ struct GraphView: View {
     private func stopSimulation() {
         simulationTimer?.invalidate()
         simulationTimer = nil
+    }
+}
+
+// MARK: - NumericTextContentTransition
+
+private struct NumericTextContentTransition: ViewModifier {
+    let value: Double
+    let reduceMotion: Bool
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *) {
+            content
+                .contentTransition(reduceMotion ? .identity : .numericText(value: value))
+        } else {
+            content
+                .contentTransition(.identity)
+        }
     }
 }
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -178,6 +178,13 @@
 "empty.graph.no_matches.subtitle" = "Adjust your search or filters to see nodes.";
 "empty.graph.clear_filters" = "Clear Filters";
 
+/* Graph Network Size Pill */
+"graph.pill.nodes.prefix" = "";
+"graph.pill.nodes.suffix" = " nodes · ";
+"graph.pill.edges.suffix" = " connections";
+"graph.pill.accessibility" = "Knowledge network: %d nodes, %d connections";
+"graph.network.milestone.announcement" = "Knowledge network: %d nodes, %d connections";
+
 /* Mic Permission Denied */
 "empty.mic_denied.title" = "Microphone access needed.";
 "empty.mic_denied.subtitle" = "Allow microphone access in Settings to record voice memos.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -178,6 +178,13 @@
 "empty.graph.no_matches.subtitle" = "调整搜索或筛选条件以查看节点。";
 "empty.graph.clear_filters" = "清除筛选";
 
+/* Graph Network Size Pill */
+"graph.pill.nodes.prefix" = "";
+"graph.pill.nodes.suffix" = " 节点 · ";
+"graph.pill.edges.suffix" = " 连接";
+"graph.pill.accessibility" = "知识网络：%d 个节点，%d 条连接";
+"graph.network.milestone.announcement" = "知识网络：%d 个节点，%d 条连接";
+
 /* Mic Permission Denied */
 "empty.mic_denied.title" = "需要麦克风权限。";
 "empty.mic_denied.subtitle" = "请在「设置」中允许访问麦克风，以便录制语音备忘。";


### PR DESCRIPTION
## Graph header: live knowledge-network size pill with animated count-up

The Graph view shows per-search match counts but never surfaces the overall size of the user's knowledge network, missing a chance to reinforce the 'your network is growing' product narrative. Add a compact mono-style glass pill in the Graph header showing the total node and connection counts, animating the numbers with the same NumericTextContentTransition treatment Today's signal counter already uses, with a soft haptic + VoiceOver announcement when the network crosses growth milestones (every 10 nodes).

### Acceptance
Build the DayPage scheme for iPhone 17. With >=1 entity, the Graph header shows a glass pill reading the live node/connection counts; adding memos that grow the graph past a multiple of 10 nodes animates the count and fires one soft haptic. The pill is hidden while a search/date/type filter is active and in the empty state. VoiceOver reads a single combined network-size label. Reduce Motion disables the count-up animation. No regression to existing search-match pill or graph simulation.