### PR TITLE
auto: CJK-aware word count in WriteSheet composer

### DIFF
--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -64,9 +64,33 @@ struct WriteSheetView: View {
     /// Sheet-up easing — composer.jsx:219 `cubic-bezier(.2,.8,.2,1)` @ 320ms.
     private static let sheetUp = Animation.timingCurve(0.2, 0.8, 0.2, 1, duration: 0.32)
 
-    /// Actual word count — split on whitespace/newlines, filter empties.
+    /// CJK-aware word count: each CJK/Hiragana/Katakana ideograph = 1 word;
+    /// consecutive non-CJK non-whitespace scalars = 1 Latin word per run.
     private var wordCount: Int {
-        text.split(whereSeparator: \.isWhitespace).count
+        Self.wordCount(in: text)
+    }
+
+    static func wordCount(in text: String) -> Int {
+        var count = 0
+        var inLatinRun = false
+        for scalar in text.unicodeScalars {
+            switch scalar.value {
+            case 0x4E00...0x9FFF,  // CJK Unified Ideographs
+                 0x3400...0x4DBF,  // CJK Extension A
+                 0x3040...0x309F,  // Hiragana
+                 0x30A0...0x30FF:  // Katakana
+                if inLatinRun { inLatinRun = false }
+                count += 1
+            case _ where scalar.properties.isWhitespace:
+                inLatinRun = false
+            default:
+                if !inLatinRun {
+                    inLatinRun = true
+                    count += 1
+                }
+            }
+        }
+        return count
     }
 
     private var charCount: Int { text.count }

--- a/DayPageTests/WriteSheetCountTests.swift
+++ b/DayPageTests/WriteSheetCountTests.swift
@@ -1,0 +1,42 @@
+import Testing
+@testable import DayPage
+
+struct WriteSheetCountTests {
+
+    @Test func chineseSentence() {
+        // Each ideograph is one word
+        #expect(WriteSheetView.wordCount(in: "今天天气很好") == 6)
+    }
+
+    @Test func latinWords() {
+        #expect(WriteSheetView.wordCount(in: "hello world") == 2)
+    }
+
+    @Test func mixedCJKAndLatin() {
+        // "I love 北京 city" → I(1) love(2) 北(3) 京(4) city(5)
+        #expect(WriteSheetView.wordCount(in: "I love 北京 city") == 5)
+    }
+
+    @Test func emptyString() {
+        #expect(WriteSheetView.wordCount(in: "") == 0)
+    }
+
+    @Test func whitespaceOnly() {
+        #expect(WriteSheetView.wordCount(in: "   \t\n  ") == 0)
+    }
+
+    @Test func hiragana() {
+        // Each hiragana character counts as one word
+        #expect(WriteSheetView.wordCount(in: "あいう") == 3)
+    }
+
+    @Test func katakana() {
+        // Each katakana character counts as one word
+        #expect(WriteSheetView.wordCount(in: "アイウ") == 3)
+    }
+
+    @Test func mixedRunsAdjacentNoBoundary() {
+        // hello (1 Latin run) + 北 (1) + 京 (1) = 3, even without spaces
+        #expect(WriteSheetView.wordCount(in: "hello北京") == 3)
+    }
+}


### PR DESCRIPTION
## CJK-aware word count in WriteSheet composer

The WriteSheet composer's word counter splits only on whitespace, so any Chinese paragraph (the primary writing language — the app uses zh_cn locale and Chinese placeholders) counts as a single 'word'. This silently breaks the reading-time estimate, the 100-word milestone haptics, and the amber word-count color ramp for the target nomad user. Replace the splitter with a counter that tallies each CJK ideograph individually while still treating Latin runs as whitespace-delimited words.

### Acceptance
(1) Build succeeds: `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build`. (2) New Swift Testing cases in DayPageTests pass: '今天天气很好' → 6 words; 'hello world' → 2; mixed 'I love 北京 city' → 5 (I, love, 北, 京, city); empty string → 0; whitespace-only → 0. (3) In the Simulator, typing ~50 Chinese characters into the WriteSheet now shows '~1 min read' and fires the milestone haptic at 100 characters, whereas before the counter stayed at '1 word'. (4) reduceMotion and accessibility labels still read the corrected counts.