### PR TITLE
auto: Tap-to-reset zoom on the Graph zoom-level pill

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -605,7 +605,7 @@ struct GraphView: View {
                 }
 
                 if isTransformed { recenterButton }
-                if scale != 1.0 { zoomIndicator }
+                if isTransformed { zoomIndicator }
                 zoomControls
             }
             .onTapGesture(count: 2) {
@@ -693,19 +693,25 @@ struct GraphView: View {
     }
 
     private var zoomIndicator: some View {
-        Text("\(Int(scale * 100))%")
-            .font(DSFonts.jetBrainsMono(size: 10))
-            .foregroundColor(DSColor.inkPrimary)
-            .padding(.horizontal, DSSpacing.sm)
-            .padding(.vertical, 6)
-            .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
-            .padding(DSSpacing.lg)
-            .padding(.bottom, 56)
-            .accessibilityLabel("Zoom level")
-            .accessibilityValue("\(Int(scale * 100)) percent")
-            .transition(.opacity.combined(with: .scale))
-            .animation(reduceMotion ? .default.speed(0) : Motion.spring, value: scale)
+        Button {
+            Haptics.tapConfirm()
+            resetTransform()
+        } label: {
+            Text("\(Int(scale * 100))%")
+                .font(DSFonts.jetBrainsMono(size: 10))
+                .foregroundColor(DSColor.inkPrimary)
+                .padding(.horizontal, DSSpacing.sm)
+                .padding(.vertical, 6)
+        }
+        .liquidGlassCard(cornerRadius: DSRadius.md, tone: .hi)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+        .padding(DSSpacing.lg)
+        .padding(.bottom, 56)
+        .accessibilityLabel("Zoom level, tap to reset")
+        .accessibilityValue("\(Int(scale * 100)) percent")
+        .accessibilityAddTraits(.isButton)
+        .transition(.opacity.combined(with: .scale))
+        .animation(reduceMotion ? .default.speed(0) : Motion.spring, value: isTransformed)
     }
 
     private var zoomControls: some View {


### PR DESCRIPTION
## Tap-to-reset zoom on the Graph zoom-level pill

The Graph's '%' zoom indicator pill is currently a static, non-interactive label that only appears when zoomed. Make it a button that resets the graph transform (scale + pan) on tap, with a confirm haptic and proper accessibility, giving users a direct map-app-style 'tap the zoom percentage to reset' affordance alongside the existing floating recenter button.

### Acceptance
Build the DayPage scheme for iPhone 17 with no warnings. In the Simulator: pinch to zoom the graph — the '%' pill appears and tapping it animates scale+offset back to 1.0/.zero with a confirm haptic. Pan at 100% zoom — the pill now appears (previously hidden) and tapping it recenters. VoiceOver reads the pill as a button labeled 'Zoom level, tap to reset' with the percent value, and the existing floating recenter (scope) button still works unchanged.