### PR TITLE
auto: Human-readable date heading in Markdown export

### DIFF
--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -136,7 +136,7 @@ struct MarkdownExportServiceTests {
         let df = DateFormatter()
         df.dateFormat = "EEEE, MMMM d, yyyy"
         df.locale = Locale.current
-        df.timeZone = TimeZone(identifier: "UTC")!
+        df.timeZone = AppSettings.currentTimeZone()
         let expected = df.string(from: date)
         #expect(content.contains("# DayPage — \(expected)"))
 

--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -125,6 +125,27 @@ struct MarkdownExportServiceTests {
         #expect(content.contains("memo_count: 2"))
     }
 
+    // H1 heading uses long friendly date; YAML date: field keeps ISO form
+    @Test func h1Heading_usesLongDate_yamlDateKeepsISO() {
+        // June 8 2026 is a Monday
+        let date = makeDate(year: 2026, month: 6, day: 8)
+        let memo = makeMemo(body: "test")
+        let content = MarkdownExportService.buildExportContent(memos: [memo], date: date)
+
+        // H1 must contain a long-format date (EEEE, MMMM d, yyyy)
+        let df = DateFormatter()
+        df.dateFormat = "EEEE, MMMM d, yyyy"
+        df.locale = Locale.current
+        df.timeZone = TimeZone(identifier: "UTC")!
+        let expected = df.string(from: date)
+        #expect(content.contains("# DayPage — \(expected)"))
+
+        // YAML date: must still be ISO yyyy-MM-dd
+        #expect(content.contains("date: 2026-06-08"))
+        // H1 must NOT contain the raw ISO date
+        #expect(!content.contains("# DayPage — 2026-06-08"))
+    }
+
     // (2) Multiline mood produces a single-line, valid `mood:` value with no raw newline
     @Test func multilineMood_producesOneLineFrontmatterValue() {
         let memo = makeMemo(body: "test", mood: "happy\nthen sad")


### PR DESCRIPTION
## Human-readable date heading in Markdown export

The exported `.md` document's H1 currently reads `# DayPage — 2026-06-08`, a raw ISO date that looks machine-generated when opened in Obsidian, Notes, or Files. Render a friendly heading like `# DayPage — Sunday, June 8, 2026` while keeping the ISO `date:` in YAML frontmatter (which tooling parses) untouched, so both machines and humans get the right format.

### Acceptance
1) `xcodebuild -scheme DayPage build` succeeds. 2) `DayPageTests` (Swift Testing) all pass, including a new test verifying the exported content's `# DayPage —` heading uses the `EEEE, MMMM d, yyyy` long format while the YAML `date:` field still emits `yyyy-MM-dd`. 3) Exporting a day from Today (share button) produces a `.md` whose H1 reads e.g. `# DayPage — Sunday, June 8, 2026`, confirmed by inspecting the file written under the temp export directory.