### PR TITLE
auto: Surface the active writing-streak in the Today empty-state to motivate daily capture

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -666,8 +666,24 @@ struct TodayView: View {
                 onThisDayDateString = dateString
             }
         case .pureEmpty:
-            EmptyStateView.todayNoSignals(ctaAction: { orbFocusToggle.toggle() }, subtitleOverride: todayEmptySubtitle(currentTime))
-                .padding(.horizontal, 20)
+            VStack(spacing: 12) {
+                EmptyStateView.todayNoSignals(ctaAction: { orbFocusToggle.toggle() }, subtitleOverride: todayEmptySubtitle(currentTime))
+                let streak = sidebarVM.currentStreak
+                if streak >= 1 {
+                    let kickerText: String = streak == 1
+                        ? String(format: NSLocalizedString("today.empty.streak.kicker.one", comment: ""), streak)
+                        : String(format: NSLocalizedString("today.empty.streak.kicker", comment: ""), streak)
+                    Text(kickerText)
+                        .font(DSType.mono10)
+                        .tracking(1.0)
+                        .foregroundColor(DSColor.inkSubtle)
+                        .textCase(.uppercase)
+                        .dynamicTypeSize(.xSmall ... .accessibility5)
+                        .accessibilityLabel(kickerText)
+                        .transition(.opacity)
+                }
+            }
+            .padding(.horizontal, 20)
         }
     }
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -328,6 +328,10 @@
 "compile.hint.evening"   = "Wind down — look back on today";
 "compile.hint.night"     = "Put a period on today";
 
+/* Today empty-state streak kicker */
+"today.empty.streak.kicker.one" = "%d-DAY STREAK · KEEP IT ALIVE";
+"today.empty.streak.kicker" = "%d-DAY STREAK · KEEP IT ALIVE";
+
 /* Streak milestone celebration (TodayView) */
 "today.streak.milestone.title"        = "%d day streak! 🔥";
 "today.streak.milestone.subtitle.3"   = "Three days in a row — the habit is forming.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -356,6 +356,10 @@
 "compile.hint.evening"   = "夜深了，回顾今天吧";
 "compile.hint.night"     = "为今天画上句号";
 
+/* Today empty-state streak kicker */
+"today.empty.streak.kicker.one" = "连续 %d 天 · 别断了";
+"today.empty.streak.kicker" = "连续 %d 天 · 别断了";
+
 /* Streak milestone celebration (TodayView) */
 "today.streak.milestone.title"        = "连续 %d 天！🔥";
 "today.streak.milestone.subtitle.3"   = "连续三天，习惯正在形成。";


### PR DESCRIPTION
## Surface the active writing-streak in the Today empty-state to motivate daily capture

The streak count is already computed in SidebarViewModel and shown in the sidebar heatmap, but the Today empty-state (EmptyStateView.todayNoSignals) — the first thing a returning user sees on a fresh day — gives no hint that they have a chain to keep alive. Adding a subtle 'N-day streak · keep it alive' mono kicker above or below the empty-state CTA leverages existing data to nudge the nomad target audience to log before midnight, with zero new computation or storage.

### Acceptance
Build the DayPage scheme on the iPhone 17 simulator with no errors. On a day with zero memos and a prior consecutive logging streak >= 1, the Today empty-state shows the streak kicker line; with a streak of 0 (or first-ever day) no line appears. The line uses correct singular/plural localized strings in both en and zh-Hans, reads correctly under VoiceOver, respects reduce-motion, and disappears the moment the first memo of the day is captured (since orbHero/empty-state is replaced). No regression to existing empty-state CTA behavior.