### PR TITLE
auto: Auto-fit the knowledge graph to screen when the force-layout simulation settles

### DIFF
--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -35,6 +35,9 @@ struct GraphView: View {
     @State private var lastCenteredMatchID: String? = nil
     @State private var searchMatchIndex: Int = 0
 
+    // Auto-fit state — fires once when simulation settles; re-arms on node-set change
+    @State private var didAutoFit: Bool = false
+
     // Zero-match haptic guard — fires warn() exactly once per zero-crossing
     @State private var lastZeroQuery: String? = nil
 
@@ -342,7 +345,11 @@ struct GraphView: View {
             viewModel.load()
         }
         .onChange(of: viewModel.nodes.count) { count in
-            if !viewModel.nodes.isEmpty { startSimulation() }
+            didAutoFit = false
+            if !viewModel.nodes.isEmpty {
+                startSimulation()
+                if simulationSteps >= maxSimSteps { attemptAutoFit() }
+            }
             let milestone = count / 10
             guard count > 0, milestone > lastNetworkMilestone else { return }
             lastNetworkMilestone = milestone
@@ -1044,6 +1051,12 @@ struct GraphView: View {
 
     // MARK: - Simulation
 
+    private func attemptAutoFit() {
+        guard !didAutoFit, !isTransformed, visibleNodes.count >= 2 else { return }
+        didAutoFit = true
+        fitToScreen(in: simulationSize)
+    }
+
     private func startSimulation(reset: Bool = true) {
         if reset { simulationSteps = 0 }
         simulationTimer?.invalidate()
@@ -1055,6 +1068,9 @@ struct GraphView: View {
                 }
                 self.viewModel.simulationStep(size: self.simulationSize)
                 self.simulationSteps += 1
+                if self.simulationSteps == self.maxSimSteps {
+                    self.attemptAutoFit()
+                }
             }
         }
     }


### PR DESCRIPTION
## Auto-fit the knowledge graph to screen when the force-layout simulation settles

When the Graph view loads, nodes spawn at the layout origin and the force-directed simulation pushes them outward, but the camera never moves — so users frequently land on a graph that's clipped at the edges or sitting off-center and must manually find the 'fit to screen' button on every visit. This adds a one-time auto-fit that runs once the simulation converges (or after a sticky settle delay), framing the whole network within the viewport on first appearance. It only fires when the user hasn't already panned/zoomed, respects reduceMotion, and re-arms when the node set changes (e.g. new entities compiled).

### Acceptance
Open the Graph tab with >=2 entities and a cold layout: after the simulation visibly settles, the camera animates once to frame the entire network within the viewport (matching the existing 'fit to screen' button result), and the recenter/zoom-% controls appear. If the user pans or pinches before settling, no auto-fit occurs. Switching away and back, or compiling new entities that change the node count, re-arms a single auto-fit. With Reduce Motion enabled the fit is instant (no spring). Build succeeds via `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` and existing DayPageTests pass.