### PR TITLE
auto: Add accessibility-friendly word-count milestone announcements to Today timeline

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -101,6 +101,10 @@ struct TodayView: View {
     @State private var dailyPageHintOffset: CGFloat = 0
     @State private var memoCardHintOffset: CGFloat = 0
 
+    /// Tracks the highest word-count milestone (100/250/500) already announced this session.
+    /// Reset to 0 when all memos are deleted so milestones re-arm on a fresh day.
+    @State private var lastWordMilestone: Int = 0
+
     /// Session-only: true once the 3-memo unlock celebration has fired this session.
     /// Resets to false when memo count drops back below 3 so delete+readd re-fires it.
     @State private var didCelebrateUnlock: Bool = false
@@ -1718,6 +1722,22 @@ struct TodayView: View {
             } else if !compiled {
                 didCelebrateCompile = false
             }
+        }
+        .onChange(of: viewModel.todayWordCount) { count in
+            if viewModel.memos.isEmpty {
+                lastWordMilestone = 0
+                return
+            }
+            let milestones = [100, 250, 500]
+            let crossed = milestones.filter { count >= $0 }.max() ?? 0
+            guard crossed > lastWordMilestone else { return }
+            lastWordMilestone = crossed
+            Haptics.success()
+            let message = String(format: NSLocalizedString("today.wordcount.milestone", comment: ""), crossed)
+            UIAccessibility.post(notification: .announcement, argument: message)
+        }
+        .onChange(of: viewModel.memos.isEmpty) { isEmpty in
+            if isEmpty { lastWordMilestone = 0 }
         }
 
         inputBarV4

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -147,6 +147,7 @@
 
 /* VoiceOver announcement on successful memo save */
 "today.memo.saved" = "Memo saved";
+"today.wordcount.milestone" = "You've written %d words today";
 
 /* Archive Day Empty */
 "empty.archive_day.title" = "No page for this day.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -147,6 +147,7 @@
 
 /* VoiceOver announcement on successful memo save */
 "today.memo.saved" = "备忘已保存";
+"today.wordcount.milestone" = "你今天已经写了 %d 个词";
 
 /* Archive Day Empty */
 "empty.archive_day.title" = "这一天还没有日记页。";


### PR DESCRIPTION
## Add accessibility-friendly word-count milestone announcements to Today timeline

TodayViewModel already computes `todayWordCount`, but it is only displayed visually with no VoiceOver feedback when a meaningful writing milestone is reached. This adds a one-shot UIAccessibility announcement plus a subtle success haptic each time today's cumulative word count crosses a milestone (100, 250, 500 words), giving both sighted and VoiceOver users a sense of momentum without any new persistent UI.

### Acceptance
Building the DayPage scheme succeeds. With VoiceOver on in the iPhone 17 simulator, adding memos that push today's word count past 100 triggers a spoken 'You've written 100 words today' announcement exactly once; crossing 250 and 500 each announce once. Deleting all memos and re-adding re-arms the milestones. No visible layout change occurs and reduce-motion users get the announcement without any glow/animation.