### PR TITLE
auto: Daily word-count progress pill in the Today header

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1307,6 +1307,28 @@ struct TodayView: View {
 
             // US-019: Export as Markdown (tap → share sheet; long-press → copy to clipboard)
             if !viewModel.memos.isEmpty {
+                // Word-count pill: animated mono readout of today's total word count.
+                // Only rendered when there is at least one word to show.
+                let wc = viewModel.todayWordCount
+                if wc > 0 {
+                    let wcLabel = wc == 1
+                        ? NSLocalizedString("writesheet.count.words.one", comment: "")
+                        : String(format: NSLocalizedString("writesheet.count.words.other", comment: ""), wc)
+                    Text("\(wc)")
+                        .font(DSType.mono10)
+                        .tracking(1.0)
+                        .monospacedDigit()
+                        .foregroundColor(DSColor.inkSubtle)
+                        .modifier(NumericTextContentTransition(value: Double(wc), reduceMotion: reduceMotion))
+                        .animation(reduceMotion ? nil : Motion.spring, value: wc)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 5)
+                        .background(.ultraThinMaterial, in: Capsule())
+                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                        .accessibilityLabel(wcLabel)
+                        .accessibilityIdentifier("today-wordcount-pill")
+                }
+
                 Button {
                     let content = MarkdownExportService.buildExportContent(
                         memos: viewModel.memos, date: Date(),


### PR DESCRIPTION
## Daily word-count progress pill in the Today header

Once today has memos, show a compact, tappable mono pill in the Today header (next to the export/settings buttons) displaying the aggregate CJK-aware word count across all of today's memos — e.g. "342 字" — animated with the existing NumericTextContentTransition so it ticks up satisfyingly as new memos land. This reuses TodayViewModel.totalWordCount (already computed) and surfaces a progress signal that today is otherwise invisible, reinforcing the capture-reward loop the orb pulse already hints at.

### Acceptance
Build the DayPage scheme for iPhone 17. With ≥1 memo today, the header shows a mono word-count pill that matches the sum reported by TodayViewModel.totalWordCount; adding a new memo animates the number upward via numericText transition; the pill is hidden on an empty day (word count 0) and when reduceMotion is on the value updates without animation. VoiceOver reads the pill as today's total word count.