### PR TITLE
auto: Add a capture-stats footer to Markdown export

### DIFF
--- a/DayPage/Services/MarkdownExportService.swift
+++ b/DayPage/Services/MarkdownExportService.swift
@@ -42,6 +42,8 @@ enum MarkdownExportService {
         lines.append("date: \(dateString)")
         lines.append("export_source: DayPage")
         lines.append("memo_count: \(memos.count)")
+        let totalWords = memos.reduce(0) { $0 + Self.wordCount($1.body) }
+        lines.append("export_word_count: \(totalWords)")
 
         if let mood = moods.first {
             lines.append("mood: \(yamlQuoted(mood))")
@@ -126,6 +128,25 @@ enum MarkdownExportService {
             }
         }
 
+        if !sorted.isEmpty {
+            let tf2 = DateFormatter()
+            tf2.dateFormat = "HH:mm"
+            tf2.locale = Locale(identifier: "en_US_POSIX")
+            tf2.timeZone = AppSettings.currentTimeZone()
+            let firstTime = tf2.string(from: sorted.first!.created)
+            let lastTime  = tf2.string(from: sorted.last!.created)
+            let wordTotal = sorted.reduce(0) { $0 + Self.wordCount($1.body) }
+
+            lines.append("")
+            lines.append("---")
+            lines.append("")
+            lines.append("## Summary")
+            lines.append("")
+            lines.append("> \(sorted.count) memos")
+            lines.append("> \(wordTotal) words")
+            lines.append("> \(firstTime) – \(lastTime)")
+        }
+
         return lines.joined(separator: "\n")
     }
 
@@ -174,6 +195,10 @@ enum MarkdownExportService {
     }
 
     // MARK: - Private Helpers
+
+    private static func wordCount(_ text: String) -> Int {
+        text.split(whereSeparator: \.isWhitespace).filter { !$0.isEmpty }.count
+    }
 
     private static func yamlQuoted(_ s: String) -> String {
         var escaped = s

--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -334,6 +334,47 @@ struct MarkdownExportServiceTests {
         #expect(url1.lastPathComponent == url2.lastPathComponent)
     }
 
+    // MARK: - Capture-stats footer
+
+    @Test func frontmatter_containsExportWordCount_summedFromTwoMemos() {
+        // "hello world" = 2 words, "foo bar baz" = 3 words → total 5
+        let m1 = makeMemo(body: "hello world", secondsOffset: 0)
+        let m2 = makeMemo(body: "foo bar baz", secondsOffset: 60)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m1, m2], date: makeDate()
+        )
+        #expect(content.contains("export_word_count: 5"))
+    }
+
+    @Test func summarySection_containsMemoCountWordCountAndTimeSpan() {
+        // Use a fixed UTC-based timezone so HH:mm is deterministic in tests.
+        // makeMemo uses timeIntervalSinceReferenceDate 800_000_000 (+offset).
+        // We only need first < last, and both within the same day.
+        let m1 = makeMemo(body: "hello world", secondsOffset: 0)
+        let m2 = makeMemo(body: "foo bar baz", secondsOffset: 3600)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m1, m2], date: makeDate()
+        )
+        #expect(content.contains("## Summary"))
+        #expect(content.contains("> 2 memos"))
+        #expect(content.contains("> 5 words"))
+        // Time span must contain " – " separator (first → last)
+        let summaryRange = content.range(of: "## Summary")
+        #expect(summaryRange != nil)
+        if let r = summaryRange {
+            let tail = String(content[r.lowerBound...])
+            #expect(tail.contains(" – "))
+        }
+    }
+
+    @Test func emptyMemos_producesNoSummaryFooter_andZeroWordCount() {
+        let content = MarkdownExportService.buildExportContent(
+            memos: [], date: makeDate()
+        )
+        #expect(content.contains("export_word_count: 0"))
+        #expect(!content.contains("## Summary"))
+    }
+
     // MARK: - 7. Memo bodies ordered by created ascending
 
     @Test func memoBodies_orderedByCreatedAscending() {


### PR DESCRIPTION
## Add a capture-stats footer to Markdown export

Today's Markdown export (MarkdownExportService.buildExportContent) ends abruptly on the last memo with no closing summary. Append a footer section that summarizes the day — total memos, combined word count, and the capture time span (first → last memo) — so the exported file reads as a complete daily record when filed into Obsidian or shared. This is visible on every single export and gives nomads a quick sense of their day's volume.

### Acceptance
Build the DayPage scheme cleanly. A new MarkdownExportServiceTests case asserts: (1) frontmatter contains `export_word_count: ` with the correct summed count for two memos of known length; (2) output contains a `## Summary` section with `2 memos`, the right word total, and a `HH:mm – HH:mm` span matching first/last memo times in the configured timezone; (3) exporting an empty memo array produces NO Summary footer and `export_word_count: 0`. Existing export tests still pass.