### PR TITLE
auto: Haptic + scale feedback when entering/exiting multi-select mode and toggling memo selection

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1007,6 +1007,8 @@ struct TodayView: View {
                 .tracking(1.5)
                 .textCase(.uppercase)
                 .foregroundColor(DSColor.inkPrimary)
+                .modifier(NumericTextContentTransition(value: Double(count), reduceMotion: reduceMotion))
+                .animation(reduceMotion ? nil : Motion.spring, value: count)
 
             Spacer()
 
@@ -1535,6 +1537,7 @@ struct TodayView: View {
                             },
                             onEnterSelectionMode: {
                                 Haptics.tapConfirm()
+                                if !reduceMotion { Haptics.soft() }
                                 selectedMemoIds = [memo.id]
                             },
                             isSelectionMode: isInSelectionMode,
@@ -1550,6 +1553,14 @@ struct TodayView: View {
                                     return
                                 }
                                 selectedMemoIds = set
+                                if !reduceMotion {
+                                    if set.count == 2 {
+                                        // Crossed shareable threshold — signal 'now you can share'
+                                        Haptics.rigid(intensity: 0.4)
+                                    } else {
+                                        Haptics.soft()
+                                    }
+                                }
                             },
                             onOpen: { openedMemoID = memo.id }
                         )


### PR DESCRIPTION
## Haptic + scale feedback when entering/exiting multi-select mode and toggling memo selection

The multi-select mode in TodayView (issue #309 W2) lets users tap memos to build a collage selection, but selecting/deselecting an individual card and the count changing in the selection toolbar produce no tactile or animated feedback — every other interaction in this view (orb tap, compile unlock, scroll milestones, undo) has carefully tuned haptics. This adds a light selection-change haptic and a subtle count-bump animation to the toolbar's '已选 N' label so building a collage feels as responsive and rewarding as the rest of Today.

### Acceptance
Build the DayPage scheme for iPhone 17 succeeds. In the Simulator: long-pressing a memo to enter multi-select fires a soft haptic; tapping cards to select/deselect fires a selection haptic each time and the toolbar's '已选 N' count animates with a numeric bump; reaching 2 selected items fires a distinct stronger haptic as the Share button enables. With Reduce Motion on, the count updates without animation and selection haptics still fire only per the existing VoiceOver/reduceMotion guards. No regression to existing collage-share flow (sharePayload still set with the correct memos).