### PR TITLE
auto: Make the Today header word-count pill tappable to scroll to the latest memo

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1314,19 +1314,29 @@ struct TodayView: View {
                     let wcLabel = wc == 1
                         ? NSLocalizedString("writesheet.count.words.one", comment: "")
                         : String(format: NSLocalizedString("writesheet.count.words.other", comment: ""), wc)
-                    Text("\(wc)")
-                        .font(DSType.mono10)
-                        .tracking(1.0)
-                        .monospacedDigit()
-                        .foregroundColor(DSColor.inkSubtle)
-                        .modifier(NumericTextContentTransition(value: Double(wc), reduceMotion: reduceMotion))
-                        .animation(reduceMotion ? nil : Motion.spring, value: wc)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 5)
-                        .background(.ultraThinMaterial, in: Capsule())
-                        .transition(.opacity.combined(with: .scale(scale: 0.9)))
-                        .accessibilityLabel(wcLabel)
-                        .accessibilityIdentifier("today-wordcount-pill")
+                    Button {
+                        hasNewContentAboveFold = false
+                        Haptics.soft()
+                        withAnimation(reduceMotion ? nil : Motion.spring) {
+                            timelineScrollProxy?.scrollTo("timelineTop", anchor: .top)
+                        }
+                    } label: {
+                        Text("\(wc)")
+                            .font(DSType.mono10)
+                            .tracking(1.0)
+                            .monospacedDigit()
+                            .foregroundColor(DSColor.inkSubtle)
+                            .modifier(NumericTextContentTransition(value: Double(wc), reduceMotion: reduceMotion))
+                            .animation(reduceMotion ? nil : Motion.spring, value: wc)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(.ultraThinMaterial, in: Capsule())
+                            .transition(.opacity.combined(with: .scale(scale: 0.9)))
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel(wcLabel)
+                    .accessibilityHint(NSLocalizedString("today.wordcount.pill.hint", comment: ""))
+                    .accessibilityIdentifier("today-wordcount-pill")
                 }
 
                 Button {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 /* VoiceOver announcement on successful memo save */
 "today.memo.saved" = "Memo saved";
 "today.wordcount.milestone" = "You've written %d words today";
+"today.wordcount.pill.hint" = "Scroll to the latest entry";
 
 /* Archive Day Empty */
 "empty.archive_day.title" = "No page for this day.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 /* VoiceOver announcement on successful memo save */
 "today.memo.saved" = "备忘已保存";
 "today.wordcount.milestone" = "你今天已经写了 %d 个词";
+"today.wordcount.pill.hint" = "滚动到最新一条";
 
 /* Archive Day Empty */
 "empty.archive_day.title" = "这一天还没有日记页。";


### PR DESCRIPTION
## Make the Today header word-count pill tappable to scroll to the latest memo

The animated word-count pill in the Today header (TodayView.swift:1317) is currently the only inert chrome in an otherwise fully-interactive header — the date subline, export button, and gear are all tappable, but the pill has no gesture, haptic, or accessibility action. Wiring it to scroll the timeline back to the newest memo (reusing the existing `timelineScrollProxy.scrollTo("timelineTop")` path) gives the pill a purposeful, discoverable role and a satisfying haptic, matching the interaction language of the scroll-to-top chevron.

### Acceptance
1) `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` succeeds. 2) With >=1 memo and the timeline scrolled down, tapping the word-count pill scrolls smoothly back to the newest memo and plays a soft haptic. 3) The pill's appearance (size, mono font, material capsule, animated digit transition) is visually unchanged from before. 4) VoiceOver reads the word count and exposes the new hint; the accessibilityIdentifier remains `today-wordcount-pill`. 5) With Reduce Motion enabled, the scroll jumps without animation and no regressions occur. 6) No new compiler warnings; the change touches under ~40 lines across the three files.