### PR TITLE
auto: Enrich Markdown export with a human-readable title date and a frontmatter time_range field

### DIFF
--- a/DayPage/Services/MarkdownExportService.swift
+++ b/DayPage/Services/MarkdownExportService.swift
@@ -25,6 +25,15 @@ enum MarkdownExportService {
         return df.string(from: date)
     }
 
+    /// Returns a long-form human-readable date string, e.g. "Monday, 8 June 2026".
+    static func longDateString(for date: Date) -> String {
+        let df = DateFormatter()
+        df.dateFormat = "EEEE, d MMMM yyyy"
+        df.locale = Locale(identifier: "en_US_POSIX")
+        df.timeZone = AppSettings.currentTimeZone()
+        return df.string(from: date)
+    }
+
     /// Builds an Obsidian-compatible `.md` string from the given memos and date.
     static func buildExportContent(
         memos: [Memo],
@@ -38,12 +47,25 @@ enum MarkdownExportService {
         let entities = Array(Set(memos.flatMap { $0.entityMentions })).sorted()
         let resolvedWeather = weather ?? memos.first(where: { $0.weather != nil && !($0.weather!.isEmpty) })?.weather
 
+        // Compute time range once for use in both frontmatter and body
+        let sorted = memos.sorted { $0.created < $1.created }
+        let timeFmt = DateFormatter()
+        timeFmt.dateFormat = "HH:mm"
+        timeFmt.locale = Locale(identifier: "en_US_POSIX")
+        timeFmt.timeZone = AppSettings.currentTimeZone()
+
         var lines: [String] = ["---"]
         lines.append("date: \(dateString)")
         lines.append("export_source: DayPage")
         lines.append("memo_count: \(memos.count)")
         let totalWords = memos.reduce(0) { $0 + Self.wordCount($1.body) }
         lines.append("export_word_count: \(totalWords)")
+
+        if !sorted.isEmpty {
+            let firstTime = timeFmt.string(from: sorted.first!.created)
+            let lastTime  = timeFmt.string(from: sorted.last!.created)
+            lines.append("time_range: \"\(firstTime) – \(lastTime)\"")
+        }
 
         if let mood = moods.first {
             lines.append("mood: \(yamlQuoted(mood))")
@@ -75,7 +97,7 @@ enum MarkdownExportService {
 
         lines.append("---")
         lines.append("")
-        lines.append("# DayPage — \(dateString)")
+        lines.append("# DayPage — \(longDateString(for: date))")
         lines.append("")
 
         if let s = summary, !s.isEmpty {
@@ -83,7 +105,6 @@ enum MarkdownExportService {
             lines.append("")
         }
 
-        let sorted = memos.sorted { $0.created < $1.created }
         for (idx, memo) in sorted.enumerated() {
             if idx > 0 {
                 lines.append("")
@@ -92,11 +113,7 @@ enum MarkdownExportService {
             }
 
             // Timestamp header
-            let tf = DateFormatter()
-            tf.dateFormat = "HH:mm"
-            tf.locale = Locale(identifier: "en_US_POSIX")
-            tf.timeZone = AppSettings.currentTimeZone()
-            lines.append("## \(tf.string(from: memo.created))")
+            lines.append("## \(timeFmt.string(from: memo.created))")
             lines.append("")
 
             if !memo.body.isEmpty {
@@ -129,12 +146,8 @@ enum MarkdownExportService {
         }
 
         if !sorted.isEmpty {
-            let tf2 = DateFormatter()
-            tf2.dateFormat = "HH:mm"
-            tf2.locale = Locale(identifier: "en_US_POSIX")
-            tf2.timeZone = AppSettings.currentTimeZone()
-            let firstTime = tf2.string(from: sorted.first!.created)
-            let lastTime  = tf2.string(from: sorted.last!.created)
+            let firstTime = timeFmt.string(from: sorted.first!.created)
+            let lastTime  = timeFmt.string(from: sorted.last!.created)
             let wordTotal = sorted.reduce(0) { $0 + Self.wordCount($1.body) }
 
             lines.append("")

--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -375,6 +375,59 @@ struct MarkdownExportServiceTests {
         #expect(!content.contains("## Summary"))
     }
 
+    // MARK: - Long date title and time_range frontmatter
+
+    @Test func titleLine_containsWeekdayName() {
+        // 2026-06-01 is a Monday
+        let memo = makeMemo(body: "test", secondsOffset: 0)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate(year: 2026, month: 6, day: 1)
+        )
+        // H1 must contain the weekday word
+        #expect(content.contains("# DayPage — Monday"))
+    }
+
+    @Test func titleLine_containsFullLongDate() {
+        // 2026-06-08 is a Monday
+        let memo = makeMemo(body: "test", secondsOffset: 0)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate(year: 2026, month: 6, day: 8)
+        )
+        #expect(content.contains("# DayPage — Monday, 8 June 2026"))
+    }
+
+    @Test func frontmatter_containsTimeRange_forMultipleMemos() {
+        let m1 = makeMemo(body: "first", secondsOffset: 0)
+        let m2 = makeMemo(body: "last", secondsOffset: 3600)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [m1, m2], date: makeDate()
+        )
+        // time_range must appear in frontmatter (before the closing ---)
+        let frontmatterEnd = content.range(of: "\n---\n", range: content.range(of: "---\n")!.upperBound..<content.endIndex)
+        #expect(frontmatterEnd != nil)
+        if let fmEnd = frontmatterEnd {
+            let frontmatter = String(content[content.startIndex..<fmEnd.upperBound])
+            #expect(frontmatter.contains("time_range:"))
+            #expect(frontmatter.contains(" – "))
+        }
+    }
+
+    @Test func frontmatter_omitsTimeRange_forEmptyMemos() {
+        let content = MarkdownExportService.buildExportContent(
+            memos: [], date: makeDate()
+        )
+        #expect(!content.contains("time_range:"))
+    }
+
+    @Test func frontmatter_isoDateUnchanged_withLongTitle() {
+        // ISO date: frontmatter must still have `date: 2026-06-08`
+        let memo = makeMemo(body: "test", secondsOffset: 0)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate(year: 2026, month: 6, day: 8)
+        )
+        #expect(content.contains("date: 2026-06-08"))
+    }
+
     // MARK: - 7. Memo bodies ordered by created ascending
 
     @Test func memoBodies_orderedByCreatedAscending() {


### PR DESCRIPTION
## Enrich Markdown export with a human-readable title date and a frontmatter time_range field

The exported `.md` currently titles the document with only the ISO date (`# DayPage — 2026-06-08`) and emits the capture span only inside the body Summary, so neither the title nor the YAML frontmatter is human-friendly when opened in Obsidian/Files. This adds a long-form weekday title (`# DayPage — Monday, 8 June 2026`) and a `time_range:` frontmatter key, making exported entries scannable and queryable in note tools.

### Acceptance
Build the DayPage scheme cleanly. Exported markdown (verified via the Today export button → share sheet → Files) shows a weekday-prefixed H1 title and a `time_range` frontmatter key bracketing the day's first and last memo times; empty-day export omits `time_range`. New Swift Testing cases in DayPageTests pass and existing tests remain green.