### PR TITLE
auto: Localize and humanize Search result dates (relative + locale-aware)

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -1207,14 +1207,28 @@ struct SearchView: View {
 
     private static let dateFormatter: DateFormatter = {
         let f = DateFormatter()
-        f.dateFormat = "MMMM d, yyyy"
-        f.locale = Locale(identifier: "en_US_POSIX")
+        f.locale = .current
+        f.dateStyle = .long
         return f
     }()
 
     private func formatDate(_ dateString: String) -> String {
         guard let date = SearchView.dateParser.date(from: dateString) else { return dateString }
-        return SearchView.dateFormatter.string(from: date).uppercased()
+        let cal = Calendar.current
+        let now = Date()
+        let startOfDate = cal.startOfDay(for: date)
+        let startOfToday = cal.startOfDay(for: now)
+        let days = cal.dateComponents([.day], from: startOfDate, to: startOfToday).day ?? 0
+        switch days {
+        case 0:
+            return NSLocalizedString("search.result.today", comment: "Search result date label for today")
+        case 1:
+            return NSLocalizedString("search.result.yesterday", comment: "Search result date label for yesterday")
+        case 2...6:
+            return String(format: NSLocalizedString("search.result.daysAgo", comment: "Search result date label for N days ago"), days)
+        default:
+            return SearchView.dateFormatter.string(from: date)
+        }
     }
 
     private func matchIcon(for kind: SearchResult.MatchKind) -> String {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -324,6 +324,15 @@
 
 "search.undo.cleared" = "Recent searches cleared";
 
+/* Search result row — relative date labels */
+"search.result.today"     = "Today";
+"search.result.yesterday" = "Yesterday";
+"search.result.daysAgo"   = "%d days ago";
+
+/* Search entity chips */
+"search.entity.mostFrequent"       = "Top";
+"search.entity.relativeFrequency"  = "%d%%";
+
 /* CompileFooterButton — time-of-day hints */
 "compile.hint.morning"   = "Your day is just getting started";
 "compile.hint.afternoon" = "Keep the day flowing";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -352,6 +352,15 @@
 
 "search.undo.cleared" = "已清除搜索记录";
 
+/* Search result row — relative date labels */
+"search.result.today"     = "今天";
+"search.result.yesterday" = "昨天";
+"search.result.daysAgo"   = "%d 天前";
+
+/* Search entity chips */
+"search.entity.mostFrequent"       = "最高频";
+"search.entity.relativeFrequency"  = "%d%%";
+
 /* CompileFooterButton — time-of-day hints */
 "compile.hint.morning"   = "今天才刚开始";
 "compile.hint.afternoon" = "记录还在继续";


### PR DESCRIPTION
## Localize and humanize Search result dates (relative + locale-aware)

Search result rows currently render dates as English 'JUNE 8, 2025' via an en_US_POSIX 'MMMM d, yyyy' formatter, which clashes with the otherwise fully-Chinese search UI (今天/本周/筛选) and forces the user to mentally parse an absolute date. Replace it with locale-aware formatting plus relative labels ('今天', '昨天', 'N 天前') for recent results so the date is instantly scannable and visually consistent with the section headers above it.

### Acceptance
Build the DayPage scheme on iPhone 17 sim. Open Archive → Search, run a query that matches today, yesterday, 3 days ago, and 2 months ago. Verify: today's result reads '今天', yesterday '昨天', three-days-ago '3 天前', and the old entry shows a locale-formatted date (e.g. '2026年4月3日') with no stray uppercasing and no English month names. Confirm the VoiceOver result-row label announces the same humanized date, and that the result rows still tap through to the correct day page.