### PR TITLE
auto: Localize the multi-select toolbar (Today): replace hardcoded Chinese strings with NSLocalizedString

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -991,7 +991,7 @@ struct TodayView: View {
         let count = selected.count
         let canShare = count >= 2 && count <= CollageSnapshot.maxItems
         HStack(spacing: 12) {
-            Button("取消") {
+            Button(NSLocalizedString("today.select.cancel", comment: "")) {
                 Haptics.soft()
                 selectedMemoIds = nil
             }
@@ -1002,7 +1002,9 @@ struct TodayView: View {
 
             Spacer()
 
-            Text(count == 0 ? "选择 memo" : "已选 \(count)")
+            Text(count == 0
+                 ? NSLocalizedString("today.select.prompt", comment: "")
+                 : String(format: NSLocalizedString("today.select.count", comment: ""), count))
                 .font(DSType.mono10)
                 .tracking(1.5)
                 .textCase(.uppercase)
@@ -1010,6 +1012,9 @@ struct TodayView: View {
 
             Spacer()
 
+            let shareLabel = count >= 2
+                ? String(format: NSLocalizedString("today.select.share", comment: ""), count)
+                : NSLocalizedString("today.select.share.min", comment: "")
             Button {
                 guard canShare else { return }
                 Haptics.tapConfirm()
@@ -1019,7 +1024,7 @@ struct TodayView: View {
                 // foreground; keeping the toolbar around would feel orphaned.
                 selectedMemoIds = nil
             } label: {
-                Text(count >= 2 ? "分享 \(count) 项" : "至少 2 项")
+                Text(shareLabel)
                     .font(DSType.mono10)
                     .tracking(1.0)
                     .textCase(.uppercase)
@@ -1033,6 +1038,7 @@ struct TodayView: View {
             }
             .buttonStyle(.plain)
             .disabled(!canShare)
+            .accessibilityLabel(shareLabel)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -97,6 +97,13 @@
 "undo_pill.label.delete"     = "Deleted · Undo";
 "undo_pill.closing"          = "Undo window closing soon";
 
+/* Today multi-select toolbar (issue #309) */
+"today.select.cancel"    = "Cancel";
+"today.select.prompt"    = "Select memos";
+"today.select.count"     = "%d selected";
+"today.select.share"     = "Share %d";
+"today.select.share.min" = "Pick at least 2";
+
 /* Today header subline — note count */
 "today.subline.notes.zero"   = "%d notes";
 "today.subline.notes.one"    = "%d note";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -97,6 +97,13 @@
 "undo_pill.label.delete"     = "已删除 · 撤销";
 "undo_pill.closing"          = "撤销窗口即将关闭";
 
+/* Today multi-select toolbar (issue #309) */
+"today.select.cancel"    = "取消";
+"today.select.prompt"    = "选择 memo";
+"today.select.count"     = "已选 %d";
+"today.select.share"     = "分享 %d 项";
+"today.select.share.min" = "至少 2 项";
+
 /* Today header subline — note count */
 "today.subline.notes.zero"   = "%d 条记录";
 "today.subline.notes.one"    = "%d 条记录";


### PR DESCRIPTION
## Localize the multi-select toolbar (Today): replace hardcoded Chinese strings with NSLocalizedString

In TodayView's `selectionToolbar` (issue #309 multi-select / collage share mode), the three controls render hardcoded Chinese literals — "取消", "选择 memo" / "已选 N", and "分享 N 项" / "至少 2 项" — instead of going through the app's bilingual L10n pipeline. English users entering selection mode see Chinese UI. This routes all four label variants through NSLocalizedString with new keys added to both en and zh-Hans Localizable.strings, matching every other string in the view.

### Acceptance
Build the DayPage scheme cleanly. Launch on iPhone 17 simulator with device language English: add 3+ memos, long-press a memo to enter multi-select mode, and verify the toolbar reads "Cancel" / "Select memos" (0 selected) / "%d selected" / "Share %d" / "Pick at least 2" — no Chinese characters. Switch device language to Simplified Chinese and confirm the original Chinese strings still render identically. No remaining hardcoded CJK string literals in `selectionToolbar`.