### PR TITLE
auto: Show a visible toast when a daily word-count milestone is crossed

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1783,6 +1783,8 @@ struct TodayView: View {
             Haptics.success()
             let message = String(format: NSLocalizedString("today.wordcount.milestone", comment: ""), crossed)
             UIAccessibility.post(notification: .announcement, argument: message)
+            let bannerTitle = String(format: NSLocalizedString("today.wordcount.milestone.banner", comment: ""), crossed)
+            bannerCenter.show(AppBannerModel(kind: .success, title: bannerTitle, autoDismiss: true))
         }
         .onChange(of: viewModel.memos.isEmpty) { isEmpty in
             if isEmpty { lastWordMilestone = 0 }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 /* VoiceOver announcement on successful memo save */
 "today.memo.saved" = "Memo saved";
 "today.wordcount.milestone" = "You've written %d words today";
+"today.wordcount.milestone.banner" = "Nice — %d words today ✍️";
 "today.wordcount.pill.hint" = "Scroll to the latest entry";
 
 /* Archive Day Empty */

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -148,6 +148,7 @@
 /* VoiceOver announcement on successful memo save */
 "today.memo.saved" = "备忘已保存";
 "today.wordcount.milestone" = "你今天已经写了 %d 个词";
+"today.wordcount.milestone.banner" = "不错 — 今天已写 %d 个词 ✍️";
 "today.wordcount.pill.hint" = "滚动到最新一条";
 
 /* Archive Day Empty */


### PR DESCRIPTION
## Show a visible toast when a daily word-count milestone is crossed

When today's word count crosses 100/250/500, the app already fires a success haptic and posts a VoiceOver announcement, but sighted users get no visible reward — the milestone passes silently. This adds a celebratory banner (via the existing BannerCenter) so the milestone is actually felt by everyone, closing the gap between the haptic/announcement path and the visual one.

### Acceptance
Build the DayPage scheme for iPhone 17 simulator with no warnings. Launch the app, add memos on Today until the running word count crosses 100: a banner appears at the same moment the success haptic fires, auto-dismisses, and reads the milestone copy. Deleting memos back below 100 and re-crossing it re-fires the banner (milestone re-arms via lastWordMilestone reset). With VoiceOver on, both the spoken announcement and the visible banner occur. Crossing 250 and 500 each fire once. The existing haptic and announcement behavior is unchanged; only a visible banner is added.