### PR TITLE
auto: Localize the hardcoded Chinese swipe-action labels in SwipeableMemoCard

### DIFF
--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -240,14 +240,16 @@ struct SwipeableMemoCard: View {
         var items: [SwipeAction] = []
         items.append(SwipeAction(
             id: .pin,
-            label: memo.pinnedAt != nil ? "取消置顶" : "置顶",
+            label: memo.pinnedAt != nil
+                ? NSLocalizedString("memo.swipe.unpin", comment: "Swipe action: unpin memo")
+                : NSLocalizedString("memo.swipe.pin",   comment: "Swipe action: pin memo"),
             systemImage: memo.pinnedAt != nil ? "pin.slash" : "pin",
             tone: .neutral,
             run: { runAction { onPin?() } }
         ))
         items.append(SwipeAction(
             id: .more,
-            label: "更多",
+            label: NSLocalizedString("memo.swipe.more", comment: "Swipe action: more options"),
             systemImage: "ellipsis",
             tone: .neutral,
             run: { runAction(haptic: .soft) { onMore?() } }
@@ -260,14 +262,14 @@ struct SwipeableMemoCard: View {
         [
             SwipeAction(
                 id: .share,
-                label: "分享",
+                label: NSLocalizedString("memo.swipe.share", comment: "Swipe action: share memo"),
                 systemImage: "square.and.arrow.up",
                 tone: .accent,
                 run: { runAction(haptic: .confirm) { onShare?() } }
             ),
             SwipeAction(
                 id: .delete,
-                label: "删除",
+                label: NSLocalizedString("memo.swipe.delete", comment: "Swipe action: delete memo"),
                 systemImage: "trash",
                 tone: .destructive,
                 run: { runAction(haptic: .confirm) { onDelete?() } }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -143,6 +143,13 @@
 "today.orb.prompt.evening"   = "What made today worth remembering?";
 "today.orb.prompt.night"     = "How did today land?";
 
+/* SwipeableMemoCard swipe-action labels */
+"memo.swipe.pin"    = "Pin";
+"memo.swipe.unpin"  = "Unpin";
+"memo.swipe.more"   = "More";
+"memo.swipe.share"  = "Share";
+"memo.swipe.delete" = "Delete";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "Recompile";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -143,6 +143,13 @@
 "today.orb.prompt.evening"   = "今天有什么值得记住的瞬间？";
 "today.orb.prompt.night"     = "今天最终落在哪里了？";
 
+/* SwipeableMemoCard swipe-action labels */
+"memo.swipe.pin"    = "置顶";
+"memo.swipe.unpin"  = "取消置顶";
+"memo.swipe.more"   = "更多";
+"memo.swipe.share"  = "分享";
+"memo.swipe.delete" = "删除";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "重新编译";
 


### PR DESCRIPTION
## Localize the hardcoded Chinese swipe-action labels in SwipeableMemoCard

The swipe-to-reveal action drawer in SwipeableMemoCard.swift hardcodes Chinese strings ("置顶"/"取消置顶", "更多", "分享", "删除") for the Pin/More/Share/Delete buttons, while the rest of the app routes every user-facing string through NSLocalizedString against en.lproj and zh-Hans.lproj. As a result, an English-locale user sees Chinese text on the card swipe actions — a visible i18n defect. Replace the literals with NSLocalizedString keys and add the matching entries to both .strings files.

### Acceptance
Build the DayPage scheme on iPhone 17 simulator with no errors. With device language set to English, swiping a memo card left shows "Share"/"Delete" and swiping right shows "Pin"/"More" (or "Unpin" for a pinned memo); with language set to 简体中文 the labels remain 分享/删除/置顶/取消置顶/更多. No remaining hardcoded CJK string literals in SwipeableMemoCard.swift (grep for non-ASCII finds none in code paths). VoiceOver accessibilityLabel on each action matches the visible localized label.