### PR TITLE
auto: Fix missing search highlights for accented & full-width matches

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -1125,6 +1125,12 @@ struct SearchView: View {
 
     // MARK: - Keyword highlight via AttributedString
 
+    /// Mirrors SearchService's folding so the highlighter matches exactly what the service matched.
+    private func foldedForSearch(_ s: String) -> String {
+        s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+                  locale: Locale(identifier: "en_US_POSIX"))
+    }
+
     @ViewBuilder
     private func highlightedSnippet(_ snippet: String, keyword: String) -> some View {
         let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1139,17 +1145,22 @@ struct SearchView: View {
         }
     }
 
-    /// Returns a ~80-char window of `snippet` centered just before the first
-    /// case-insensitive match of `keyword`, so the highlight is always visible.
+    /// Returns a ~80-char window of `snippet` centered just before the first folded match of
+    /// `keyword`, so the highlight is always visible even for diacritic/width/case differences.
     /// Prepends/appends '…' when the window doesn't reach the string boundaries.
     /// Falls back to the original snippet when `keyword` is not found.
     private func snippetWindow(_ snippet: String, keyword: String, context: Int = 24) -> String {
         let kw = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !kw.isEmpty else { return snippet }
 
-        guard let matchRange = snippet.range(of: kw, options: .caseInsensitive) else { return snippet }
+        let foldedSnippet = foldedForSearch(snippet)
+        let foldedKw = foldedForSearch(kw)
 
-        let matchOffset = snippet.distance(from: snippet.startIndex, to: matchRange.lowerBound)
+        // Locate the match in the folded string, then map the character offset back to original.
+        // Folding with these options is 1:1 per character, so character-distance mapping is safe.
+        guard let foldedRange = foldedSnippet.range(of: foldedKw) else { return snippet }
+
+        let matchOffset = foldedSnippet.distance(from: foldedSnippet.startIndex, to: foldedRange.lowerBound)
         let windowStartOffset = max(0, matchOffset - context)
 
         let windowStart = snippet.index(snippet.startIndex, offsetBy: windowStartOffset)
@@ -1167,15 +1178,16 @@ struct SearchView: View {
         var attributed = AttributedString(text)
         attributed.foregroundColor = UIColor(DSColor.onSurface)
 
-        let loweredText = text.lowercased()
-        let loweredKeyword = keyword.lowercased()
+        let foldedText = foldedForSearch(text)
+        let foldedKeyword = foldedForSearch(keyword)
+        guard !foldedKeyword.isEmpty else { return attributed }
 
-        var searchStart = loweredText.startIndex
-        while searchStart < loweredText.endIndex,
-              let range = loweredText.range(of: loweredKeyword, range: searchStart..<loweredText.endIndex) {
-            // Map the range from lowercased string to the original text
-            let offset = loweredText.distance(from: loweredText.startIndex, to: range.lowerBound)
-            let length = loweredText.distance(from: range.lowerBound, to: range.upperBound)
+        var searchStart = foldedText.startIndex
+        while searchStart < foldedText.endIndex,
+              let range = foldedText.range(of: foldedKeyword, range: searchStart..<foldedText.endIndex) {
+            // Folding is 1:1 per character for these options — character offset is safe to map back.
+            let offset = foldedText.distance(from: foldedText.startIndex, to: range.lowerBound)
+            let length = foldedText.distance(from: range.lowerBound, to: range.upperBound)
 
             let attrStart = attributed.index(attributed.startIndex, offsetByCharacters: offset)
             let attrEnd = attributed.index(attrStart, offsetByCharacters: length)
@@ -1492,6 +1504,16 @@ private struct SwipeableRecentRow: View {
 
 extension SearchViewModel.GroupedResults: Identifiable {
     var id: SearchViewModel.Section { section }
+}
+
+// MARK: - Testable folding helper
+
+extension SearchView {
+    /// Exposed for unit testing only — mirrors SearchService's folding options.
+    static func foldedForSearchTesting(_ s: String) -> String {
+        s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+                  locale: Locale(identifier: "en_US_POSIX"))
+    }
 }
 
 // MARK: - Memo.MemoType + UI helpers

--- a/DayPageTests/SearchHighlightTests.swift
+++ b/DayPageTests/SearchHighlightTests.swift
@@ -1,0 +1,87 @@
+import Testing
+import Foundation
+@testable import DayPage
+
+@Suite("SearchHighlight")
+struct SearchHighlightTests {
+
+    // MARK: - foldedForSearch helper
+
+    @Test("folding 'cafe' matches 'Café'")
+    func foldCafeMatchesCafe() {
+        let folded = SearchView.foldedForSearchTesting("Café")
+        let keyword = SearchView.foldedForSearchTesting("cafe")
+        #expect(folded.contains(keyword))
+    }
+
+    @Test("folding is case-insensitive")
+    func foldCaseInsensitive() {
+        let folded = SearchView.foldedForSearchTesting("Hello World")
+        let keyword = SearchView.foldedForSearchTesting("hello world")
+        #expect(folded.contains(keyword))
+    }
+
+    @Test("folding is diacritic-insensitive")
+    func foldDiacriticInsensitive() {
+        let folded = SearchView.foldedForSearchTesting("naïve résumé")
+        let keyword = SearchView.foldedForSearchTesting("naive resume")
+        #expect(folded.contains(keyword))
+    }
+
+    @Test("folding is width-insensitive for full-width ASCII")
+    func foldWidthInsensitive() {
+        // Full-width 'Ａ' (U+FF21) should fold to 'a'
+        let fullWidth = "\u{FF21}\u{FF22}\u{FF23}" // ＡＢＣ
+        let folded = SearchView.foldedForSearchTesting(fullWidth)
+        let keyword = SearchView.foldedForSearchTesting("abc")
+        #expect(folded.contains(keyword))
+    }
+
+    // MARK: - Highlight range for accented match
+
+    @Test("'cafe' produces a highlight range in 'Visited the Café'")
+    func highlightCafeInCafe() {
+        let text = "Visited the Café"
+        let keyword = "cafe"
+
+        let foldedText = SearchView.foldedForSearchTesting(text)
+        let foldedKeyword = SearchView.foldedForSearchTesting(keyword)
+
+        // The folded text should contain the folded keyword
+        #expect(foldedText.contains(foldedKeyword))
+
+        // And the match range should resolve to a non-nil range (highlight will be applied)
+        let matchRange = foldedText.range(of: foldedKeyword)
+        #expect(matchRange != nil)
+
+        // The character offset should be 12 (after "Visited the ")
+        if let range = matchRange {
+            let offset = foldedText.distance(from: foldedText.startIndex, to: range.lowerBound)
+            #expect(offset == 12)
+        }
+    }
+
+    @Test("ASCII keyword still produces a highlight range")
+    func highlightAsciiKeyword() {
+        let text = "Took the train to Berlin"
+        let keyword = "berlin"
+
+        let foldedText = SearchView.foldedForSearchTesting(text)
+        let foldedKeyword = SearchView.foldedForSearchTesting(keyword)
+
+        let matchRange = foldedText.range(of: foldedKeyword)
+        #expect(matchRange != nil)
+    }
+
+    @Test("no match returns nil range — fallback intact")
+    func noMatchReturnsNil() {
+        let text = "Nothing relevant here"
+        let keyword = "café"
+
+        let foldedText = SearchView.foldedForSearchTesting(text)
+        let foldedKeyword = SearchView.foldedForSearchTesting(keyword)
+
+        let matchRange = foldedText.range(of: foldedKeyword)
+        #expect(matchRange == nil)
+    }
+}


### PR DESCRIPTION
## Fix missing search highlights for accented & full-width matches

SearchService matches keywords with case-, diacritic-, and width-insensitive folding, so searching 'cafe' returns a memo containing 'Café'. But SearchView's snippet highlighter only matches case-insensitively, so those rows render with NO visible highlight and the snippet window scrolls past the actual match. This aligns the highlighter's matching with the service's folding so every returned result visibly highlights its match.

### Acceptance
Build the DayPage scheme cleanly. New tests pass. In Simulator (iPhone 17), seed a memo containing 'Café' (or a full-width term), search the diacritic-free form ('cafe'), and confirm the result row shows the amber highlight over the matched substring and the snippet window is centered on it — not the snippet's start. Existing ASCII-keyword highlighting is unchanged.