### PR TITLE
auto: Add a contextual orb-accent + retry shimmer to the Graph and Mic-denied empty states

### DIFF
--- a/DayPage/Components/EmptyStateView.swift
+++ b/DayPage/Components/EmptyStateView.swift
@@ -246,24 +246,6 @@ extension EmptyStateView {
         )
     }
 
-    /// Compilation locked — not enough memos.
-    ///
-    /// **Orphaned.** Today screen no longer renders this as a card. The
-    /// compile-locked hint now lives as a single-line mono `Text` directly
-    /// above the input bar (see `TodayView` Compile Area). Kept temporarily
-    /// for the SwiftUI preview at the bottom of this file. Remove (along
-    /// with the preview and the `compileLockedTitle`/`compileLockedSubtitle`
-    /// L10n accessors) one release cycle after 2026-05-12 if no new caller
-    /// appears.
-    @available(*, deprecated, message: "Replaced by inline `compile.dock.locked` Text in TodayView. Pending removal — see doc comment.")
-    static func compileLocked(currentCount: Int) -> EmptyStateView {
-        EmptyStateView(
-            title: L10n.Empty.compileLockedTitle,
-            subtitle: L10n.Empty.compileLockedSubtitle(count: currentCount),
-            showOrbAccent: false
-        )
-    }
-
     /// Archive — selected day has no compiled page.
     static func archiveDayEmpty(ctaAction: @escaping () -> Void) -> EmptyStateView {
         EmptyStateView(
@@ -293,7 +275,7 @@ extension EmptyStateView {
             subtitle: L10n.Empty.graphNoMatchesSubtitle,
             ctaLabel: L10n.Empty.graphClearFilters,
             ctaAction: ctaAction,
-            showOrbAccent: false
+            showOrbAccent: true
         )
     }
 
@@ -304,7 +286,7 @@ extension EmptyStateView {
             subtitle: L10n.Empty.micDeniedSubtitle,
             ctaLabel: L10n.Empty.micDeniedCta,
             ctaAction: ctaAction,
-            showOrbAccent: false
+            showOrbAccent: true
         )
     }
 


### PR DESCRIPTION
## Add a contextual orb-accent + retry shimmer to the Graph and Mic-denied empty states

The graphNoMatches and micPermissionDenied empty states render flat (showOrbAccent: false) while every other empty state blooms with the warm time-of-day orb, making error/no-match states feel jarringly cold and unbranded. This enables the existing orb accent for both and adds a one-shot amber CTA glow on appear so the recovery action (clear filters / open Settings) is immediately discoverable — reusing the component's existing pulseCTA machinery with zero new visual language.

### Acceptance
Build the DayPage scheme cleanly. Launch in iPhone 17 simulator: trigger Graph with a search query matching nothing → the no-match empty state shows the warm breathing orb accent above the title and the 'Clear filters' CTA pulses amber once on appear. Deny mic permission and open the recorder → the denied state shows the orb accent and the Settings CTA pulses. With Reduce Motion on, the orb appears static (no breathing) and no haptics fire. grep confirms no remaining references to EmptyStateView.compileLocked.