### PR TITLE
auto: Add success confirmation banner when Markdown export succeeds

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1358,6 +1358,11 @@ struct TodayView: View {
                         exportFileURL = url
                         showExportSheet = true
                         Haptics.tapConfirm()
+                        bannerCenter.show(AppBannerModel(
+                            kind: .success,
+                            title: NSLocalizedString("export.success.title", comment: ""),
+                            autoDismiss: true
+                        ))
                     } catch {
                         Haptics.warn()
                         bannerCenter.show(AppBannerModel(

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -326,6 +326,7 @@
 "export.action.title"  = "Export as Markdown";
 "export.action.label"  = "Export";
 "export.action.hint"   = "Double tap to share, long press to copy";
+"export.success.title" = "Exported as Markdown";
 "export.error.title"   = "Export failed, please try again";
 "export.copied.title"  = "Markdown copied";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -354,6 +354,7 @@
 "export.action.title"  = "导出为 Markdown";
 "export.action.label"  = "导出";
 "export.action.hint"   = "双击分享，长按复制";
+"export.success.title" = "已导出为 Markdown";
 "export.error.title"   = "导出失败，请重试";
 "export.copied.title"  = "已复制今日 Markdown";
 


### PR DESCRIPTION
## Add success confirmation banner when Markdown export succeeds

The Today header's export button shows an error banner when the export file fails to write, but on success it gives only a subtle haptic before the share sheet appears — an asymmetry that leaves a successful export feeling unconfirmed, especially if the user cancels the share sheet. This adds a brief success banner ('Exported as Markdown') via the existing BannerCenter so the outcome is always visibly confirmed, matching the error path.

### Acceptance
Build the DayPage scheme (xcodebuild -scheme DayPage build). Launch on iPhone 17 simulator, add at least one memo, tap the export (square.and.arrow.up) button in the header. Verify: (1) a success banner reading 'Exported as Markdown' appears at the top and auto-dismisses, (2) the share sheet still presents, (3) the error banner still appears when export fails (e.g. simulate a write failure). No regression to the existing haptic or share-sheet behavior.