### PR TITLE
auto: Animated word-count milestone toast on the Today timeline

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -106,8 +106,10 @@ struct TodayView: View {
     @State private var lastWordMilestone: Int = 0
 
     /// When non-nil, a glass milestone toast is shown at the top of the timeline.
-    /// Cleared automatically after 2.5 s by the scheduled Task in the word-count onChange.
+    /// Cleared automatically after 2.5 s by milestoneToastTask.
     @State private var wordMilestoneToast: Int? = nil
+    /// Tracks the active dismiss Task so a new milestone cancels the prior timer before starting its own.
+    @State private var milestoneToastTask: Task<Void, Never>? = nil
 
     /// Session-only: true once the 3-memo unlock celebration has fired this session.
     /// Resets to false when memo count drops back below 3 so delete+readd re-fires it.
@@ -1813,7 +1815,8 @@ struct TodayView: View {
             withAnimation(reduceMotion ? nil : Motion.rise) {
                 wordMilestoneToast = crossed
             }
-            Task { @MainActor in
+            milestoneToastTask?.cancel()
+            milestoneToastTask = Task { @MainActor in
                 try? await Task.sleep(for: .seconds(2.5))
                 withAnimation(reduceMotion ? nil : Motion.rise) {
                     wordMilestoneToast = nil

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -105,6 +105,10 @@ struct TodayView: View {
     /// Reset to 0 when all memos are deleted so milestones re-arm on a fresh day.
     @State private var lastWordMilestone: Int = 0
 
+    /// When non-nil, a glass milestone toast is shown at the top of the timeline.
+    /// Cleared automatically after 2.5 s by the scheduled Task in the word-count onChange.
+    @State private var wordMilestoneToast: Int? = nil
+
     /// Session-only: true once the 3-memo unlock celebration has fired this session.
     /// Resets to false when memo count drops back below 3 so delete+readd re-fires it.
     @State private var didCelebrateUnlock: Bool = false
@@ -356,6 +360,23 @@ struct TodayView: View {
                         lastScrollMilestone = 0
                     }
                 }
+                // Word-count milestone glass toast — slides in from the top for 2.5 s.
+                .overlay(alignment: .top) {
+                    if let milestone = wordMilestoneToast {
+                        Text(String(format: NSLocalizedString("today.milestone.words", comment: ""), milestone))
+                            .font(DSType.mono10)
+                            .tracking(1.0)
+                            .textCase(.uppercase)
+                            .foregroundColor(DSColor.amberAccent)
+                            .padding(.horizontal, 16)
+                            .padding(.vertical, 9)
+                            .glassSurface(in: Capsule())
+                            .padding(.top, 8)
+                            .transition(.move(edge: .top).combined(with: .opacity))
+                            .allowsHitTesting(false)
+                    }
+                }
+                .animation(reduceMotion ? nil : Motion.rise, value: wordMilestoneToast != nil)
                 // Submit error toast — scoped animation lives on the overlay
                 // container so only the toast itself animates, not the whole
                 // ZStack tree. (#217)
@@ -1786,11 +1807,18 @@ struct TodayView: View {
             let crossed = milestones.filter { count >= $0 }.max() ?? 0
             guard crossed > lastWordMilestone else { return }
             lastWordMilestone = crossed
-            Haptics.success()
-            let message = String(format: NSLocalizedString("today.wordcount.milestone", comment: ""), crossed)
-            UIAccessibility.post(notification: .announcement, argument: message)
-            let bannerTitle = String(format: NSLocalizedString("today.wordcount.milestone.banner", comment: ""), crossed)
-            bannerCenter.show(AppBannerModel(kind: .success, title: bannerTitle, autoDismiss: true))
+            Haptics.tapConfirm()
+            let announcement = String(format: NSLocalizedString("today.milestone.words", comment: ""), crossed)
+            UIAccessibility.post(notification: .announcement, argument: announcement)
+            withAnimation(reduceMotion ? nil : Motion.rise) {
+                wordMilestoneToast = crossed
+            }
+            Task { @MainActor in
+                try? await Task.sleep(for: .seconds(2.5))
+                withAnimation(reduceMotion ? nil : Motion.rise) {
+                    wordMilestoneToast = nil
+                }
+            }
         }
         .onChange(of: viewModel.memos.isEmpty) { isEmpty in
             if isEmpty { lastWordMilestone = 0 }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -164,6 +164,7 @@
 "today.wordcount.milestone" = "You've written %d words today";
 "today.wordcount.milestone.banner" = "Nice — %d words today ✍️";
 "today.wordcount.pill.hint" = "Scroll to the latest entry";
+"today.milestone.words" = "%d words today ✍️";
 
 /* Archive Day Empty */
 "empty.archive_day.title" = "No page for this day.";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -164,6 +164,7 @@
 "today.wordcount.milestone" = "你今天已经写了 %d 个词";
 "today.wordcount.milestone.banner" = "不错 — 今天已写 %d 个词 ✍️";
 "today.wordcount.pill.hint" = "滚动到最新一条";
+"today.milestone.words" = "今天已写 %d 个词 ✍️";
 
 /* Archive Day Empty */
 "empty.archive_day.title" = "这一天还没有日记页。";


### PR DESCRIPTION
## Animated word-count milestone toast on the Today timeline

When today's total word count crosses a milestone (100 / 250 / 500 words), surface a brief, celebratory glass toast ("100 words today ✍️") with a soft haptic — reusing the existing `lastWordMilestone` state already tracked in TodayView but currently only used for haptics. This rewards sustained capture, the app's core loop, with a visible moment instead of a silent buzz.

### Acceptance
Adding memos that push today's word count past 100 (then 250, 500) shows a glass toast at the top of the Today screen for ~2.5s with a confirm haptic, fires exactly once per threshold per session, never re-fires on the same threshold, re-arms after all memos are deleted, respects Reduce Motion (no slide animation but still announces via VoiceOver), and the DayPage scheme builds cleanly on the iPhone 17 simulator.

Closes #746