### PR TITLE
auto: Add VoiceOver announcements & haptic feedback to the global AppBanner system

### DIFF
--- a/DayPage/Features/Shared/AppBanner.swift
+++ b/DayPage/Features/Shared/AppBanner.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // MARK: - Banner Kind
 
@@ -107,6 +108,9 @@ struct AppBanner: View {
                     .padding(.top, 2)
                 }
             }
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityAddTraits(.isStaticText)
             Spacer()
             Button {
                 bannerCenter.dismiss()
@@ -116,6 +120,8 @@ struct AppBanner: View {
                     .foregroundColor(foregroundColor.opacity(0.6))
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+            .accessibilityIdentifier("banner-dismiss-button")
         }
         .padding(DSSpacing.cardGap)
         .background(backgroundColor)
@@ -125,6 +131,15 @@ struct AppBanner: View {
         )
         .cornerRadius(DSSpacing.radiusCard)
         .padding(.horizontal, DSSpacing.cardGap)
+        .onAppear {
+            switch model.kind {
+            case .error:            Haptics.warn()
+            case .success:          Haptics.success()
+            case .info, .progress:  Haptics.soft()
+            }
+            let announcement = [model.title, model.subtitle].compactMap { $0 }.joined(separator: ". ")
+            UIAccessibility.post(notification: .announcement, argument: announcement)
+        }
     }
 
     @ViewBuilder
@@ -147,6 +162,10 @@ struct AppBanner: View {
                 .font(.system(size: 20))
                 .foregroundColor(accentColor)
         }
+    }
+
+    private var accessibilityLabel: String {
+        [model.title, model.subtitle].compactMap { $0 }.joined(separator: ". ")
     }
 
     private var backgroundColor: Color {


### PR DESCRIPTION
## Add VoiceOver announcements & haptic feedback to the global AppBanner system

The app-wide toast/banner system (AppBanner) fires silently — no haptic feedback and no VoiceOver announcement when a banner appears, despite every other notification surface in the app (e.g. TodayView's submit-error toast) firing Haptics.warn() and posting UIAccessibility announcements. This makes errors/successes invisible to VoiceOver users and inconsistent with the codebase's established haptic ladder. Add kind-appropriate haptics (warn on error, success on success) and a UIAccessibility announcement plus a labeled accessibility container on banner appearance.

### Acceptance
Build the DayPage scheme cleanly (xcodebuild -scheme DayPage build, iPhone 17 sim). With VoiceOver on, triggering an error banner (e.g. force an export failure) speaks the banner title+subtitle and fires a warning haptic; a success banner fires the success haptic. The dismiss 'X' is reachable by VoiceOver and reads 'Dismiss'. No visual/layout regression to the banner. Change is confined to AppBanner.swift and under ~40 lines.