### PR TITLE
fix: resolve ambiguous operator '-' in DayOrbView rotation

### DIFF
--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -174,7 +174,7 @@ struct DayOrbView: View {
                     .frame(width: 5, height: 5)
                     .shadow(color: timeTint.opacity(0.8), radius: 3, x: 0, y: 0)
                     .offset(y: -(size + 6) / 2)
-                    .rotationEffect(.degrees(360 * dayProgress - 90))
+                    .rotationEffect(.degrees(360 * Double(dayProgress) - 90))
                     .animation(reduceMotion ? nil : .linear(duration: 1), value: dayProgress)
                     .allowsHitTesting(false)
             }


### PR DESCRIPTION
## 背景

PR #748 合并后,CI run [27186026177](https://github.com/getyak/daypage/actions/runs/27186026177) 仍编译失败。

## 根因

\`DayPage/Features/Today/DayOrbView.swift:177\` 表达式 \`360 * dayProgress - 90\`(\`dayProgress\` 为 \`CGFloat\`)。因 \`.degrees()\` 期望 \`Double\` 参数,表达式混入 \`CGFloat\` 字面量后,编译器无法确定 \`-\` 用 \`CoreFoundation.CGFloat.-\` 还是 \`Swift.Double.-\`,触发 **ambiguous use of operator '-'**。这是该 run 里唯一的 \`error:\`(其余为 Swift 6 并发 warning,不阻断 Build)。

## 修复

显式 \`Double(dayProgress)\`,让整个表达式确定为 \`Double\`:

\`\`\`swift
.rotationEffect(.degrees(360 * Double(dayProgress) - 90))
\`\`\`

## 验证

- 本地 \`xcodebuild -scheme DayPage -destination 'iPhone 17' build\` → \`** BUILD SUCCEEDED **\`