### PR TITLE
Locale-aware thousands separator on the Today word-count pill

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1382,7 +1382,10 @@ struct TodayView: View {
                             timelineScrollProxy?.scrollTo("timelineTop", anchor: .top)
                         }
                     } label: {
-                        Text("\(wc)")
+                        // Locale-aware grouping (e.g. "1,234" / "1 234") so heavy
+                        // daily logs read cleanly across regions. The animation
+                        // driver below still keys off the raw Int.
+                        Text(wc.formatted(.number.grouping(.automatic)))
                             .font(DSType.mono10)
                             .tracking(1.0)
                             .monospacedDigit()


### PR DESCRIPTION
## What

The header **word-count pill** on the Today screen rendered raw integers via string interpolation (`Text("\(wc)")`), so a heavy logging day showed up as `1234` rather than `1,234`.

This formats the displayed count with a **locale-aware grouping separator** using `wc.formatted(.number.grouping(.automatic))`:
- `en_US` → `1,234`
- `fr_FR` → `1 234`
- `de_DE` → `1.234`

## Why

DayPage targets nomads / digital nomads — an inherently international audience. A raw `1234` reads worse than a grouped count and ignores regional conventions. This is a one-line, zero-risk polish that respects the user's locale.

## Scope

- 1 file changed (`DayPage/Features/Today/TodayView.swift`)
- The count-up animation driver still keys off the raw `Int` (`NumericTextContentTransition(value: Double(wc))` + `.animation(..., value: wc)`), so animation behavior is unchanged.
- `Int.formatted(_:)` is available since iOS 15; the app targets iOS 16+.

## Verification

Static verification only — this change was authored on a Linux host with no Swift toolchain, so the macOS `xcodebuild` build runs in CI. The edit is type-safe (`Int.formatted` → `String` for `Text`), needs no new imports (Foundation is transitively available via SwiftUI), and touches only the display string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)