### PR TITLE
Spin the settings gear on tap

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -99,6 +99,10 @@ struct TodayView: View {
     @State private var orbBreathing: Bool = false
     @State private var orbTapBounce: Bool = false
 
+    /// Accumulated rotation for the settings gear — a gear should turn when
+    /// tapped. Bumped by a quarter turn on each tap so the spin feels mechanical.
+    @State private var settingsGearRotation: Double = 0
+
     /// Hint offset for the one-time swipe-left nudge on the Daily Page card.
     @State private var dailyPageHintOffset: CGFloat = 0
     @State private var memoCardHintOffset: CGFloat = 0
@@ -1475,6 +1479,10 @@ struct TodayView: View {
 
             Button {
                 Haptics.soft()
+                // A gear should turn when tapped — give it a quarter spin.
+                if !reduceMotion {
+                    withAnimation(Motion.spring) { settingsGearRotation += 90 }
+                }
                 showSettings = true
             } label: {
                 Image(systemName: "gearshape")
@@ -1483,6 +1491,7 @@ struct TodayView: View {
                     .frame(width: 28, height: 28)
                     .glassSurface(in: Circle())
                     .clipShape(Circle())
+                    .rotationEffect(.degrees(settingsGearRotation))
             }
             .accessibilityLabel("Settings")
             .accessibilityHint("Opens app settings")


### PR DESCRIPTION
=== IDEA: Spin the settings gear on tap ===
=== DESC: The settings gear in the Today header now does a quarter-turn spring spin each time it's tapped — gears should turn. ===

## What

The settings gear button in the Today header (`TodayView.swift`) was the plainest interactive element in the row: it fired only a soft haptic with no visual feedback, while every sibling button (export, word-count pill, scroll-to-top) has a tactile micro-interaction.

This adds a delightful, intuitive micro-interaction: the gear icon does a **quarter-turn spring spin** on each tap. Gears should turn — so it reads as obvious and earned, not decorative.

## Implementation

- New `@State private var settingsGearRotation` accumulator.
- On tap, bump rotation by 90° inside `withAnimation(Motion.spring)`.
- `.rotationEffect(.degrees(settingsGearRotation))` on the gear icon.
- Guarded by `reduceMotion` — no spin when Reduce Motion is enabled.

## Scope

1 file, +9 lines. Uses only APIs already used throughout `TodayView.swift`. No behavior change to navigation — it still opens Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)