### PR TITLE
feat(settings): tap version row to copy version + build

### DIFF
--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -61,6 +61,11 @@ struct SettingsView: View {
     @State private var showCleanupConfirm = false
     @State private var showClearSampleConfirm = false
 
+    // Tap-to-copy confirmation for the About → version row.
+    // Briefly true after the user taps the version row to copy it to the
+    // clipboard, swapping the value for a "已复制" checkmark for ~1.5s.
+    @State private var didCopyVersion = false
+
     var body: some View {
         NavigationStack {
             List {
@@ -766,13 +771,29 @@ struct SettingsView: View {
 
     private var aboutSection: some View {
         Section("关于") {
-            HStack {
-                Text("版本")
-                Spacer()
-                Text(appVersion)
-                    .foregroundColor(DSColor.onSurfaceVariant)
-                    .font(.caption)
+            // Tap to copy "DayPage <version> (<build>)" to the clipboard, so the
+            // exact version can be pasted into a support request or bug report.
+            Button(action: copyVersionInfo) {
+                HStack {
+                    Text("版本")
+                        .foregroundColor(DSColor.onSurface)
+                    Spacer()
+                    if didCopyVersion {
+                        Label("已复制", systemImage: "checkmark")
+                            .labelStyle(.titleAndIcon)
+                            .foregroundColor(DSColor.accentAmber)
+                            .font(.caption)
+                            .transition(.opacity)
+                    } else {
+                        Text(appVersion)
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .font(.caption)
+                            .transition(.opacity)
+                    }
+                }
             }
+            .buttonStyle(.plain)
+            .accessibilityHint(NSLocalizedString("settings.about.version.copy_hint", comment: "Tap to copy version hint"))
             HStack {
                 Text("Build")
                 Spacer()
@@ -780,6 +801,18 @@ struct SettingsView: View {
                     .foregroundColor(DSColor.onSurfaceVariant)
                     .font(.caption)
             }
+        }
+    }
+
+    /// Copies "DayPage <version> (<build>)" to the clipboard and shows a brief
+    /// "已复制" confirmation on the version row.
+    private func copyVersionInfo() {
+        UIPasteboard.general.string = "DayPage \(appVersion) (\(buildNumber))"
+        Haptics.success()
+        withAnimation(Motion.fade) { didCopyVersion = true }
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(1.5))
+            withAnimation(Motion.fade) { didCopyVersion = false }
         }
     }
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -361,6 +361,9 @@
 "settings.clear_sample.label" = "Clear sample data";
 "settings.clear_sample.hint" = "Destructive. Permanently deletes all sample data. This cannot be undone.";
 
+/* Settings — About */
+"settings.about.version.copy_hint" = "Double tap to copy the version and build to the clipboard";
+
 /* Settings — AI Engine (US-014) */
 "settings.ai.section_title" = "AI Engine";
 "settings.ai.model" = "Model";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -389,6 +389,9 @@
 "settings.clear_sample.label" = "清除示例数据";
 "settings.clear_sample.hint" = "危险操作，将永久删除所有示例数据，无法撤销。";
 
+/* Settings — About */
+"settings.about.version.copy_hint" = "轻点两次复制版本号与构建号到剪贴板";
+
 /* Settings — AI Engine (US-014) */
 "settings.ai.section_title" = "AI 引擎";
 "settings.ai.model" = "模型";


### PR DESCRIPTION
## What

Make the **Settings → 关于 (About)** version row tap-to-copy.

Previously the version and build numbers were static, read-only rows. Tapping the **版本 (Version)** row now:

- Copies `DayPage <version> (<build>)` to the clipboard
- Fires a success haptic
- Briefly swaps the value for a **已复制 (Copied)** checkmark (~1.5s)

## Why

A small, frequently-loved touch: when a user hits a problem and wants to file a bug or contact support, they can grab the exact version+build in one tap instead of squinting and retyping it. Especially handy for nomads on the move.

## Implementation notes

- Self-contained; only touches `aboutSection` in `SettingsView.swift` plus one localized accessibility-hint string.
- Reuses existing patterns already in the codebase: `UIPasteboard.general`, `Haptics.success()`, `Motion.fade`, and `DSColor` tokens.
- Added `settings.about.version.copy_hint` to both `en` and `zh-Hans` strings for the VoiceOver hint.
- iOS 16+ safe (`Task.sleep(for:)`, `Label`, `.labelStyle(.titleAndIcon)`).

## Testing

- Built locally is not possible on this Linux host (no `xcodebuild`); relying on CI (macOS runner) for the `DayPage` scheme build.
- Manual review: change is UI-only on an existing settings screen, no storage/AI-pipeline impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)