### PR TITLE
fix(search): localize starter search suggestions

### DIFF
--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -1210,7 +1210,16 @@ struct SearchView: View {
 
     // MARK: - Starter suggestions (shown only when no history and no indexed entities)
 
-    private static let starterSuggestions: [String] = ["今天", "本周", "本月", "位置", "照片", "语音"]
+    /// Localized starter chips, parsed from a comma-separated string so each locale supplies
+    /// terms users in that language would actually type. Falls back to the English defaults.
+    private static let starterSuggestions: [String] = {
+        let raw = NSLocalizedString("search.starterSuggestions", comment: "Comma-separated starter search suggestions")
+        let parsed = raw
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+        return parsed.isEmpty ? ["Today", "This Week", "This Month", "Place", "Photo", "Voice"] : parsed
+    }()
 
     // MARK: - Formatting helpers
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -419,6 +419,8 @@
 "search.section.quickSearch"      = "Quick Search";
 "search.section.recentSearches"   = "Recent Searches";
 "search.section.topEntities"      = "Frequent Entities";
+/* Comma-separated starter search suggestions, shown as tappable chips when there is no search history. Translate each term so it matches what users in this locale would actually type. */
+"search.starterSuggestions"       = "Today,This Week,This Month,Place,Photo,Voice";
 
 /* Search — recent searches */
 "search.recent.clear"             = "Clear";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -447,6 +447,8 @@
 "search.section.quickSearch"      = "快捷检索";
 "search.section.recentSearches"   = "最近搜索";
 "search.section.topEntities"      = "高频实体";
+/* Comma-separated starter search suggestions, shown as tappable chips when there is no search history. */
+"search.starterSuggestions"       = "今天,本周,本月,位置,照片,语音";
 
 /* Search — recent searches */
 "search.recent.clear"             = "清除";


### PR DESCRIPTION
## Problem

The starter chips shown in Search's empty state (under **Quick Search** and the **Try searching** prompt) were hardcoded to Chinese strings:

```swift
private static let starterSuggestions: [String] = ["今天", "本周", "本月", "位置", "照片", "语音"]
```

For users running the app in English, these chips rendered as literal Chinese text, and tapping one ran a search for an untranslated keyword — a broken first-run experience for the search feature.

## Fix

Move the suggestions into `Localizable.strings` as a single comma-separated `search.starterSuggestions` key, parsed at load (trimmed, empties dropped) with an English hardcoded fallback if the key is ever missing.

- **en**: `Today,This Week,This Month,Place,Photo,Voice`
- **zh-Hans**: `今天,本周,本月,位置,照片,语音` (unchanged behavior for Chinese users)

## Scope

- `DayPage/Features/Archive/SearchView.swift` — read localized key instead of hardcoded array
- `DayPage/Resources/en.lproj/Localizable.strings` — new key
- `DayPage/Resources/zh-Hans.lproj/Localizable.strings` — new key

No behavior change for zh-Hans; English-locale users now see English starter chips. No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)