### PR TITLE
fix(export): CJK-aware word count in Markdown export

### DIFF
--- a/DayPage/Services/MarkdownExportService.swift
+++ b/DayPage/Services/MarkdownExportService.swift
@@ -219,8 +219,35 @@ enum MarkdownExportService {
 
     // MARK: - Private Helpers
 
+    /// CJK-aware word counter — mirrors `TodayViewModel.wordCount` so the
+    /// exported `export_word_count` and Summary footer match the in-app readout.
+    /// Each CJK ideograph counts as one word; runs of non-CJK non-whitespace
+    /// characters count as one word each. A naive whitespace split would count
+    /// an entire spaceless Chinese/Japanese sentence as a single word, badly
+    /// undercounting for users who journal in those scripts.
     private static func wordCount(_ text: String) -> Int {
-        text.split(whereSeparator: \.isWhitespace).filter { !$0.isEmpty }.count
+        var count = 0
+        var inLatinRun = false
+        for scalar in text.unicodeScalars {
+            let v = scalar.value
+            let isCJK = (v >= 0x4E00 && v <= 0x9FFF)
+                     || (v >= 0x3400 && v <= 0x4DBF)
+                     || (v >= 0x20000 && v <= 0x2A6DF)
+                     || (v >= 0xF900 && v <= 0xFAFF)
+                     || (v >= 0x2E80 && v <= 0x2EFF)
+                     || (v >= 0x3000 && v <= 0x303F)
+            let isWhitespace = CharacterSet.whitespacesAndNewlines.contains(scalar)
+            if isCJK {
+                inLatinRun = false
+                count += 1
+            } else if isWhitespace {
+                inLatinRun = false
+            } else if !inLatinRun {
+                inLatinRun = true
+                count += 1
+            }
+        }
+        return count
     }
 
     private static func slug(_ entity: String) -> String {

--- a/DayPageTests/MarkdownExportServiceTests.swift
+++ b/DayPageTests/MarkdownExportServiceTests.swift
@@ -413,6 +413,27 @@ struct MarkdownExportServiceTests {
         #expect(!content.contains("## Summary"))
     }
 
+    // CJK text has no spaces, so a naive whitespace split would count an entire
+    // sentence as one word. Each ideograph must count as a word, matching the
+    // in-app readout. "今天天气很好" = 6 ideographs.
+    @Test func wordCount_countsCJKIdeographsIndividually() {
+        let memo = makeMemo(body: "今天天气很好", secondsOffset: 0)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate()
+        )
+        #expect(content.contains("export_word_count: 6"))
+        #expect(content.contains("> 6 words"))
+    }
+
+    // Mixed CJK + Latin: "今天 coffee shop" = 2 ideographs + 2 latin runs = 4.
+    @Test func wordCount_handlesMixedCJKAndLatin() {
+        let memo = makeMemo(body: "今天 coffee shop", secondsOffset: 0)
+        let content = MarkdownExportService.buildExportContent(
+            memos: [memo], date: makeDate()
+        )
+        #expect(content.contains("export_word_count: 4"))
+    }
+
     // MARK: - Long date title and time_range frontmatter
 
     @Test func titleLine_containsWeekdayName() {


### PR DESCRIPTION
## Problem

The Markdown export's word counter (`MarkdownExportService.wordCount`) used a naive whitespace split. CJK scripts (Chinese, Japanese) don't separate words with spaces, so a sentence like `今天天气很好` (6 ideographs) was counted as **1 word**.

This wrong total leaked into two user-facing places in every exported `.md` file:
- the `export_word_count:` YAML frontmatter key
- the `## Summary` footer's `> N words` line

…and it disagreed with the in-app word-count pill on the Today screen, which is already CJK-aware. For DayPage's target users (nomads / digital nomads who frequently journal in mixed CJK + Latin), this made the export stats meaningless.

## Fix

Mirror the existing CJK-aware algorithm from `TodayViewModel.wordCount`:
- each CJK ideograph counts as one word
- runs of non-CJK non-whitespace characters count as one word each

Pure-Latin / whitespace-delimited counts are **unchanged** — all existing export tests still hold (`"hello world" + "foo bar baz"` → 5). The export's word total now matches what users see in-app.

## Tests

Added two tests:
- `wordCount_countsCJKIdeographsIndividually` — `今天天气很好` → 6
- `wordCount_handlesMixedCJKAndLatin` — `今天 coffee shop` → 4

Build/test verification deferred to CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)