### PR TITLE
feat(cards): show mic glyph in memo meta row for voice memos

### DIFF
--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -289,15 +289,21 @@ struct MemoCardView: View {
             // overrides remain in the long-press contextMenu below.
             HStack(spacing: 8) {
                 // Single line of metadata: precise 24h time as "15·23".
-                let photoFlag = memo.type == .mixed && memo.attachments.contains { $0.kind == "photo" }
+                let photoFlag = memo.attachments.contains { $0.kind == "photo" }
+                let voiceFlag = memo.attachments.contains { $0.kind == "audio" }
                 Text(Self.cardTimeFmt.string(from: memo.created).replacingOccurrences(of: ":", with: "·"))
                     .font(DSFonts.jetBrainsMono(size: 10))
                     .tracking(1.6)
                     .foregroundColor(DSColor.inkSubtle)
 
-                // Tiny photo glyph hints a mixed entry without a loud chip.
+                // Tiny attachment glyphs hint content type without a loud chip.
                 if photoFlag {
                     Image(systemName: "photo")
+                        .font(.system(size: 8, weight: .medium))
+                        .foregroundColor(DSColor.inkSubtle)
+                }
+                if voiceFlag {
+                    Image(systemName: "mic")
                         .font(.system(size: 8, weight: .medium))
                         .foregroundColor(DSColor.inkSubtle)
                 }


### PR DESCRIPTION
## Summary

- Adds a tiny `mic` SF Symbol to the memo card meta row when a voice/audio attachment is present
- Mirrors the existing `photo` glyph treatment — same 8pt weight, same `inkSubtle` color
- Also widens the `photoFlag` check from `memo.type == .mixed &&` to just `memo.attachments.contains` so mixed-type memos always show both glyphs consistently

## Test plan

- [ ] Record a voice memo → card meta row shows `mic` glyph next to the timestamp
- [ ] Add a photo → `photo` glyph appears; voice memo shows both glyphs
- [ ] Text-only memo → no extra glyphs (timestamp only)
- [ ] Museum aesthetic unchanged — glyphs are tiny (8pt), muted, non-intrusive

🤖 Generated with [Claude Code](https://claude.com/claude-code)