### PR TITLE
feat(voice): warn on long press-to-talk recordings

### DIFF
--- a/DayPage/Features/Today/DynamicIslandView.swift
+++ b/DayPage/Features/Today/DynamicIslandView.swift
@@ -35,6 +35,23 @@ struct DynamicIslandView: View {
     private let expandedWidth: CGFloat = 248
     private let height: CGFloat = 37
 
+    // Duration warning thresholds — kept in lockstep with RecordingSheetView so
+    // the capsule timer and the sheet timer warm together on long takes.
+    private static let amberThreshold = 300  // 5:00
+    private static let redThreshold   = 540  // 9:00
+    private static let warnAmber = Color(red: 1.0, green: 0.70, blue: 0.35)
+
+    /// Timer tint: off-white by default, amber past 5:00, red past 9:00.
+    private var timerColor: Color {
+        if elapsedSeconds >= Self.redThreshold {
+            return DSTokens.Colors.recordingRed
+        } else if elapsedSeconds >= Self.amberThreshold {
+            return Self.warnAmber
+        } else {
+            return DSTokens.Colors.accentSoft
+        }
+    }
+
     /// Fixed 18-bar mini strip, newest samples right-aligned.
     private var miniBars: [Float] {
         let count = 18
@@ -64,7 +81,8 @@ struct DynamicIslandView: View {
                         .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
                         .tracking(1.0)
                         .monospacedDigit()
-                        .foregroundColor(DSTokens.Colors.accentSoft)
+                        .foregroundColor(timerColor)
+                        .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: timerColor)
                 }
 
                 Spacer(minLength: 6)
@@ -84,7 +102,8 @@ struct DynamicIslandView: View {
                     .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
                     .tracking(1.0)
                     .monospacedDigit()
-                    .foregroundColor(DSTokens.Colors.accentSoft)
+                    .foregroundColor(timerColor)
+                    .animation(reduceMotion ? nil : .easeOut(duration: 0.18), value: timerColor)
             }
         }
         .padding(.leading, expanded ? 16 : 0)

--- a/DayPage/Features/Today/RecordingSheetView.swift
+++ b/DayPage/Features/Today/RecordingSheetView.swift
@@ -73,7 +73,31 @@ struct RecordingSheetView: View {
 
     @State private var pulse: Bool = false
     @State private var caretOn: Bool = true
+    @State private var didWarnLong: Bool = false
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    // MARK: - Duration Warning Thresholds
+    //
+    // Mirrors VoiceRecordingView (the legacy memo sheet): the timer warms to
+    // amber past 5:00 and red past 9:00 so the user knows a long take is
+    // approaching the practical transcription limit. Whole seconds.
+    private static let amberThreshold = 300  // 5:00
+    private static let redThreshold   = 540  // 9:00
+
+    /// Bright warm amber legible on the dark recording surface — between the
+    /// default off-white and `recordingRed`. Matches the orb's #FFD9A8 family.
+    private static let warnAmber = Color(red: 1.0, green: 0.70, blue: 0.35)
+
+    /// Timer tint: off-white by default, amber past 5:00, red past 9:00.
+    private var timerColor: Color {
+        if elapsedSeconds >= Self.redThreshold {
+            return DSTokens.Colors.recordingRed
+        } else if elapsedSeconds >= Self.amberThreshold {
+            return Self.warnAmber
+        } else {
+            return .white
+        }
+    }
 
     /// Fixed 64-bar strip: pad/trim the incoming history to exactly 64 samples
     /// so the trough never reflows. Newest samples sit at the right edge.
@@ -119,9 +143,22 @@ struct RecordingSheetView: View {
                     .font(DSFonts.jetBrainsMono(size: 28, weight: .medium))
                     .tracking(1.5)
                     .monospacedDigit()
-                    .foregroundColor(.white)
+                    .foregroundColor(timerColor)
+                    .animation(reduceMotion ? nil : Motion.fade, value: timerColor)
             }
             .padding(.bottom, 14)
+
+            // Soft-cap hint — surfaces once the take crosses 5:00 so the user
+            // knows a long recording approaches the transcription limit.
+            if elapsedSeconds >= Self.amberThreshold {
+                Text(NSLocalizedString("voice_recording_soft_cap_hint", comment: "建议 5 分钟内"))
+                    .font(DSFonts.jetBrainsMono(size: 11))
+                    .foregroundColor(timerColor)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.bottom, 10)
+                    .transition(.opacity)
+                    .animation(reduceMotion ? nil : Motion.fade, value: elapsedSeconds >= Self.amberThreshold)
+            }
 
             // Waveform trough — faint inset panel hosting the 64-bar strip.
             WaveformStripView(
@@ -210,6 +247,13 @@ struct RecordingSheetView: View {
         .onAppear {
             pulse = true
             startCaretBlink()
+        }
+        .onChange(of: elapsedSeconds) { seconds in
+            // Fire a single soft haptic the moment the take crosses 5:00.
+            if !didWarnLong && seconds >= Self.amberThreshold {
+                didWarnLong = true
+                Haptics.soft()
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(NSLocalizedString("recording.sheet.a11y", comment: "Recording in progress"))


### PR DESCRIPTION
## Why

The v8 press-to-talk recording surface — `RecordingSheetView` (the dark bottom sheet) plus the `DynamicIslandView` top capsule, both wired in `InputBarV4` — showed an ever-climbing **white** timer with no awareness of how long the user had been holding the mic. Meanwhile the older `VoiceRecordingView` already establishes a clear long-recording pattern (amber at 5:00, red at 9:00, a soft haptic, and a "Recommended under 5 min" hint). Since DashScope/Whisper transcription degrades and grows costlier on very long clips, a user recording for 8 minutes on the *primary* surface got zero signal they were past the comfortable limit.

This ports that established treatment to both live surfaces so the warning is consistent, honest, and reuses what already exists.

## What changed

**`RecordingSheetView.swift`**
- Timer tint now warms to **amber past 5:00** and **red past 9:00** (off-white below).
- A **soft-cap hint line** appears under the timer once past 5:00 — reuses the already-localized `voice_recording_soft_cap_hint` string (en: "Recommended under 5 min" / zh-Hans: "建议 5 分钟内").
- A **single soft haptic** (`Haptics.soft()`) fires the moment a take crosses 5:00, via `.onChange(of: elapsedSeconds)` guarded by a one-shot `didWarnLong` flag.

**`DynamicIslandView.swift`**
- The capsule timer mirrors the same amber/red thresholds so the top island and the bottom sheet warm together.

## Design notes
- Thresholds (300s / 540s) match the legacy `VoiceRecordingView` exactly.
- Warning amber `#FFB259` is bright/legible on the fixed dark `recordingBg` scrim — between the default off-white and `recordingRed`; correct in both light and dark mode (the recording surface is always dark by design).
- All three new animations are gated behind `reduceMotion`.
- `RecordingSheetView` stays **presentation-only** per its doc contract — no service dependency added. The one-time-haptic correctness relies on `elapsedSeconds` resetting to 0 on every `startRecording()` and the sheet's `@State` resetting per presentation (it only mounts while recording).

## Testing
- Build/tests handled by CI.
- Manual verification path: start a press-to-talk recording, observe the sheet + island timers turn amber at 5:00 (with a soft haptic + hint) and red at 9:00; confirm the hint/haptic appear once and that VoiceOver/reduceMotion users get a static timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)