### PR TITLE
feat(settings): live appearance preview + wire up dead card-density setting

### DIFF
--- a/DayPage/Config/AppSettings.swift
+++ b/DayPage/Config/AppSettings.swift
@@ -94,6 +94,17 @@ enum CardDensity: String, CaseIterable {
         case .compact: return "紧凑"
         }
     }
+
+    /// Points to add to a body line's base `lineSpacing`. Compact tightens the
+    /// vertical rhythm of body text; comfortable keeps the design-system default.
+    /// Consumed by `BodyMDModifier` / `BodySMModifier` so the setting has a
+    /// visible effect (previously it was stored but never read anywhere).
+    var lineSpacingDelta: CGFloat {
+        switch self {
+        case .comfortable: return 0
+        case .compact: return -2
+        }
+    }
 }
 
 // MARK: - VaultLocation

--- a/DayPage/DesignSystem/Typography.swift
+++ b/DayPage/DesignSystem/Typography.swift
@@ -247,9 +247,10 @@ struct BodyMDModifier: ViewModifier {
     func body(content: Content) -> some View {
         let baseSize: CGFloat = 16
         let adjusted = baseSize + appSettings.fontSizeAdjust.delta
+        let spacing = max(0, 4 + appSettings.cardDensity.lineSpacingDelta)
         content
             .font(DSFonts.inter(size: adjusted, weight: .regular))
-            .lineSpacing(4)
+            .lineSpacing(spacing)
             .dynamicTypeSize(.xSmall ... .xxxLarge)
             .minimumScaleFactor(0.85)
     }
@@ -261,9 +262,10 @@ struct BodySMModifier: ViewModifier {
     func body(content: Content) -> some View {
         let baseSize: CGFloat = 14
         let adjusted = baseSize + appSettings.fontSizeAdjust.delta
+        let spacing = max(0, 3 + appSettings.cardDensity.lineSpacingDelta)
         content
             .font(DSFonts.inter(size: adjusted, weight: .regular))
-            .lineSpacing(3)
+            .lineSpacing(spacing)
             .dynamicTypeSize(.xSmall ... .xxxLarge)
             .minimumScaleFactor(0.85)
     }

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -395,7 +395,12 @@ struct SettingsView: View {
     // MARK: - Appearance Section
 
     private var appearanceSection: some View {
-        Section("外观") {
+        Section {
+            // Live preview — re-renders as the pickers below change so the
+            // abstract font-size / density / accent choices become tangible
+            // without leaving Settings. (#appearance-preview)
+            appearancePreviewCard
+
             // Theme (dark mode)
             Picker(selection: $appSettings.themeMode) {
                 ForEach(ThemeMode.allCases, id: \.self) { mode in
@@ -407,6 +412,7 @@ struct SettingsView: View {
             } label: {
                 Label("深色模式", systemImage: "moon.fill")
             }
+            .onChange(of: appSettings.themeMode) { _ in Haptics.soft() }
 
             // Accent color
             Picker(selection: $appSettings.accentColor) {
@@ -421,6 +427,7 @@ struct SettingsView: View {
             } label: {
                 Label("强调色", systemImage: "paintpalette")
             }
+            .onChange(of: appSettings.accentColor) { _ in Haptics.soft() }
 
             // Font size adjustment
             Picker(selection: $appSettings.fontSizeAdjust) {
@@ -430,6 +437,7 @@ struct SettingsView: View {
             } label: {
                 Label("正文字号", systemImage: "textformat.size")
             }
+            .onChange(of: appSettings.fontSizeAdjust) { _ in Haptics.soft() }
 
             // Card density
             Picker(selection: $appSettings.cardDensity) {
@@ -439,6 +447,7 @@ struct SettingsView: View {
             } label: {
                 Label("卡片密度", systemImage: "rectangle.expand.vertical")
             }
+            .onChange(of: appSettings.cardDensity) { _ in Haptics.soft() }
 
             // Press-to-talk (US-008). Invert the binding so the visible label reads
             // "Use legacy voice recording" per the PRD's legacy-fallback copy.
@@ -469,7 +478,55 @@ struct SettingsView: View {
                     OnThisDayScheduler.shared.refreshHour = val
                 }
             }
+        } header: {
+            Text("外观")
         }
+    }
+
+    // MARK: - Appearance Preview
+
+    /// A miniature memo card that mirrors the real card aesthetic (mono kicker
+    /// + serif title + body) and re-renders live as the appearance pickers
+    /// change. `bodyMDStyle()` / `bodySMStyle()` read `fontSizeAdjust` and
+    /// `cardDensity` from `AppSettings.shared`, so adjusting either control
+    /// updates this card immediately; the accent picker tints the kicker + dot.
+    private var appearancePreviewCard: some View {
+        let accent = appSettings.accentColor.color
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 6) {
+                Circle()
+                    .fill(accent)
+                    .frame(width: 6, height: 6)
+                Text("预览 · 14:30")
+                    .font(DSType.mono10)
+                    .tracking(1.0)
+                    .textCase(.uppercase)
+                    .foregroundColor(accent)
+            }
+            Text("一杯手冲，窗外是慢下来的城市。")
+                .bodyMDStyle()
+                .foregroundColor(DSColor.onBackgroundPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+            Text("调整下方字号与卡片密度，这张卡片会实时变化。")
+                .bodySMStyle()
+                .foregroundColor(DSColor.onSurfaceVariant)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(14)
+        .background(DSColor.glassLo)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                .strokeBorder(accent.opacity(0.18), lineWidth: 1)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+        .padding(.vertical, 2)
+        .animation(Motion.fade, value: appSettings.fontSizeAdjust)
+        .animation(Motion.fade, value: appSettings.cardDensity)
+        .animation(Motion.fade, value: appSettings.accentColor)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(NSLocalizedString("settings.appearance.preview.a11y", comment: "Appearance preview card accessibility label"))
     }
 
     private func themeIcon(for mode: ThemeMode) -> String {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -361,6 +361,9 @@
 "settings.clear_sample.label" = "Clear sample data";
 "settings.clear_sample.hint" = "Destructive. Permanently deletes all sample data. This cannot be undone.";
 
+/* Settings — Appearance */
+"settings.appearance.preview.a11y" = "Live preview of the body text style. Reflects the font size, card density, and accent color selected below.";
+
 /* Settings — About */
 "settings.about.version.copy_hint" = "Double tap to copy the version and build to the clipboard";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -389,6 +389,9 @@
 "settings.clear_sample.label" = "清除示例数据";
 "settings.clear_sample.hint" = "危险操作，将永久删除所有示例数据，无法撤销。";
 
+/* Settings — Appearance */
+"settings.appearance.preview.a11y" = "正文样式实时预览，会随下方的字号、卡片密度与强调色变化。";
+
 /* Settings — About */
 "settings.about.version.copy_hint" = "轻点两次复制版本号与构建号到剪贴板";
 


### PR DESCRIPTION
## Design rationale

The Settings → 外观 (Appearance) section is the app's customization hub with four pickers (theme, accent color, font size, card density), but two of them — **font size** and **card density** — have effects that are invisible while you're in Settings, so you can't tell your tap did anything. Worse, **`cardDensity` was completely dead code**: it had a picker and a persisted value but was never read by any view. And unlike the rest of this haptic-rich app, no appearance change produced any tactile confirmation.

This PR delivers one coherent improvement:

1. **Live preview card** at the top of the Appearance section — a miniature memo card (mono kicker + body text, mirroring the real card aesthetic) that re-renders in real time as you adjust font size, card density, or accent color. The abstract pickers become tangible without leaving Settings.
2. **Wires up the dead `cardDensity` setting** — it now adjusts body line spacing through the existing `BodyMD`/`BodySM` text modifiers (compact = −2pt, clamped at ≥0), so the control finally has a real, visible effect that the preview reflects.
3. **Selection haptics** on every appearance picker (`Haptics.soft()`), matching the tactile-confirmation pattern used everywhere else in the app.

## Implementation notes

- `CardDensity.lineSpacingDelta` added in `AppSettings.swift`; consumed by `BodyMDModifier` / `BodySMModifier` in `Typography.swift` (both already `@ObservedObject AppSettings.shared`, so changes propagate live).
- Preview uses semantic `DSColor` tokens (dark-mode adaptive) and `Motion.fade` (opacity-only → Reduce-Motion safe).
- Visible preview copy is hardcoded zh to match the existing convention of `SettingsView` (the whole screen is Chinese-literal); the preview's accessibility label is localized in both `en` and `zh-Hans`.
- No force-unwraps; all new code is `@MainActor`-isolated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)