### PR TITLE
feat(archive): tap month title to open a year/month jump picker

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		A10000009 /* RawStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000009 /* RawStorage.swift */; };
 		A10000010 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010 /* TodayView.swift */; };
 		A10000011 /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000011 /* ArchiveView.swift */; };
+		A1000ABC1 /* YearMonthPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000ABC1 /* YearMonthPicker.swift */; };
 		A10000012 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000012 /* GraphView.swift */; };
 		A10000013 /* TodayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000013 /* TodayViewModel.swift */; };
 		A10000014 /* MemoCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000014 /* MemoCardView.swift */; };
@@ -261,6 +262,7 @@
 		A20000009 /* RawStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorage.swift; sourceTree = "<group>"; };
 		A20000010 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		A20000011 /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
+		A2000ABC1 /* YearMonthPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YearMonthPicker.swift; sourceTree = "<group>"; };
 		A20000012 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
 		A20000013 /* TodayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewModel.swift; sourceTree = "<group>"; };
 		A20000014 /* MemoCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoCardView.swift; sourceTree = "<group>"; };
@@ -737,6 +739,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000011 /* ArchiveView.swift */,
+				A2000ABC1 /* YearMonthPicker.swift */,
 				A20000028 /* SearchView.swift */,
 				A20000031 /* RawMemoView.swift */,
 				A20000040 /* DayDetailView.swift */,
@@ -1168,6 +1171,7 @@
 				TD0000001 /* DayProgress.swift in Sources */,
 				TD0000002 /* TimeOfDay.swift in Sources */,
 				A10000011 /* ArchiveView.swift in Sources */,
+				A1000ABC1 /* YearMonthPicker.swift in Sources */,
 				A10000012 /* GraphView.swift in Sources */,
 				A10000035 /* GraphViewModel.swift in Sources */,
 				A10000013 /* TodayViewModel.swift in Sources */,

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -350,6 +350,16 @@ final class ArchiveViewModel: ObservableObject {
         loadMonth()
     }
 
+    /// Jump directly to an arbitrary year/month (driven by the YearMonthPicker).
+    /// No-ops when the target equals the current month so the picker doesn't
+    /// trigger a redundant reload + transition.
+    func goToMonth(year: Int, month: Int) {
+        guard year != currentYear || month != currentMonth else { return }
+        currentYear = year
+        currentMonth = month
+        loadMonth()
+    }
+
     var today: Int {
         Calendar.current.component(.day, from: Date())
     }
@@ -463,6 +473,21 @@ struct ArchiveView: View {
     // 二者皆无 → 50% 半透明灰色（仍可点击）。
     @State private var rawDates: Set<String> = []
     @State private var dailyDates: Set<String> = []
+
+    /// Controls the year/month jump picker overlay (opened by tapping the
+    /// Archive header's month title).
+    @State private var showMonthPicker: Bool = false
+
+    /// "yyyy-MM" set of months that hold at least one entry, derived from the
+    /// pre-scanned raw/daily date sets. Drives the activity dots in the picker
+    /// at zero extra disk cost.
+    private var monthsWithEntries: Set<String> {
+        var months = Set<String>()
+        for dateStr in rawDates.union(dailyDates) where dateStr.count == 10 {
+            months.insert(String(dateStr.prefix(7)))  // "yyyy-MM-dd" → "yyyy-MM"
+        }
+        return months
+    }
 
     var body: some View {
         NavigationStack {
@@ -620,6 +645,31 @@ struct ArchiveView: View {
                     }
                 }
             }
+            // Year/month jump picker — custom overlay (scrim + card) so it
+            // floats lightly over the calendar with the app's Motion curves.
+            .overlay {
+                if showMonthPicker {
+                    YearMonthPicker(
+                        selectedYear: viewModel.currentYear,
+                        selectedMonth: viewModel.currentMonth,
+                        monthsWithEntries: monthsWithEntries,
+                        onSelect: { year, month in
+                            let isBackward = (year, month) < (viewModel.currentYear, viewModel.currentMonth)
+                            monthNavDirection = isBackward ? .leading : .trailing
+                            withAnimation(reduceMotion ? nil : Motion.spring) {
+                                viewModel.goToMonth(year: year, month: month)
+                            }
+                            withAnimation(reduceMotion ? nil : Motion.fade) { showMonthPicker = false }
+                            UIAccessibility.post(notification: .announcement, argument: viewModel.currentMonthTitle)
+                        },
+                        onClose: {
+                            withAnimation(reduceMotion ? nil : Motion.fade) { showMonthPicker = false }
+                        }
+                    )
+                    .transition(.opacity)
+                    .zIndex(60)
+                }
+            }
         }
     }
 
@@ -671,22 +721,42 @@ struct ArchiveView: View {
 
     private var archiveHeader: some View {
         HStack(alignment: .firstTextBaseline, spacing: 0) {
-            Button {
-                nav.openSidebar()
-            } label: {
-                VStack(alignment: .leading, spacing: 2) {
+            VStack(alignment: .leading, spacing: 2) {
+                // "Archive" title — opens the sidebar (tap), keeping the
+                // primary navigation affordance the rest of the app uses.
+                Button {
+                    nav.openSidebar()
+                } label: {
                     Text("Archive")
                         .font(DSType.serifDisplay28)
                         .foregroundColor(DSColor.inkPrimary)
-                    Text(viewModel.currentMonthTitle.uppercased())
-                        .font(DSType.mono10)
-                        .foregroundColor(DSColor.inkSubtle)
-                        .tracking(1.0)
                 }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Open navigation")
+                .accessibilityIdentifier("sidebar-menu-button")
+
+                // Month subtitle — now a jump-to-month affordance. A chevron
+                // signals it's interactive; tapping opens the YearMonthPicker.
+                Button {
+                    Haptics.soft()
+                    withAnimation(reduceMotion ? nil : Motion.fade) { showMonthPicker = true }
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(viewModel.currentMonthTitle.uppercased())
+                            .font(DSType.mono10)
+                            .foregroundColor(DSColor.inkSubtle)
+                            .tracking(1.0)
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundColor(DSColor.inkSubtle)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(String(format: NSLocalizedString("archive.picker.open", comment: "Jump to month, current %@"), viewModel.currentMonthTitle))
+                .accessibilityHint(NSLocalizedString("archive.picker.open.hint", comment: "Opens the month picker"))
+                .accessibilityIdentifier("archive-month-picker-button")
             }
-            .buttonStyle(.plain)
-            .accessibilityLabel("Open navigation")
-            .accessibilityIdentifier("sidebar-menu-button")
 
             Spacer()
 

--- a/DayPage/Features/Archive/YearMonthPicker.swift
+++ b/DayPage/Features/Archive/YearMonthPicker.swift
@@ -1,0 +1,243 @@
+import SwiftUI
+
+// MARK: - YearMonthPicker
+//
+// Fast jump-to-month overlay for the Archive. Replaces the "tap chevron 20
+// times" friction for nomad users with months/years of history: a year stepper
+// plus a 3×4 grid of the 12 months. Months that already hold entries carry an
+// amber dot (sourced from the Archive's pre-scanned raw/daily date sets — no
+// extra disk I/O), so the sheet doubles as a year-at-a-glance activity map.
+//
+// Presented as a custom overlay (scrim + card) rather than a system `.sheet`
+// so it can sit lightly over the calendar and animate with the app's own
+// Motion curves. Selecting a month calls `onSelect(year, month)` and dismisses.
+
+struct YearMonthPicker: View {
+
+    /// The year currently being browsed in the picker (independent of the
+    /// year that is committed — the user can scrub years before picking).
+    @State private var browseYear: Int
+
+    /// The month/year that is currently shown in the Archive (highlighted).
+    let selectedYear: Int
+    let selectedMonth: Int
+
+    /// Set of "yyyy-MM" strings that contain at least one entry. Used to mark
+    /// months with an activity dot. Derived once by the caller from the
+    /// already-pre-scanned vault date sets.
+    let monthsWithEntries: Set<String>
+
+    /// Called with the chosen (year, month) when the user taps a month.
+    let onSelect: (Int, Int) -> Void
+    /// Called to dismiss without selecting (scrim tap / close button).
+    let onClose: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// The real current year/month — used to ring "today's" month and to gate
+    /// future months (journaling is retrospective; you can't browse ahead).
+    private let realYear: Int
+    private let realMonth: Int
+
+    /// Earliest year the stepper can reach: the earliest year that holds an
+    /// entry, but never later than the currently-selected year (so the picker
+    /// can always represent where the user already is). Prevents the user from
+    /// scrubbing endlessly into empty past years.
+    private var minYear: Int {
+        let entryYears = monthsWithEntries.compactMap { Int($0.prefix(4)) }
+        let earliestEntry = entryYears.min() ?? selectedYear
+        return min(earliestEntry, selectedYear)
+    }
+
+    init(
+        selectedYear: Int,
+        selectedMonth: Int,
+        monthsWithEntries: Set<String>,
+        onSelect: @escaping (Int, Int) -> Void,
+        onClose: @escaping () -> Void
+    ) {
+        self.selectedYear = selectedYear
+        self.selectedMonth = selectedMonth
+        self.monthsWithEntries = monthsWithEntries
+        self.onSelect = onSelect
+        self.onClose = onClose
+        _browseYear = State(initialValue: selectedYear)
+        let now = Calendar.current.dateComponents([.year, .month], from: Date())
+        self.realYear = now.year ?? selectedYear
+        self.realMonth = now.month ?? selectedMonth
+    }
+
+    var body: some View {
+        ZStack {
+            // Dim scrim — tap to dismiss.
+            Color.black.opacity(0.32)
+                .ignoresSafeArea()
+                .contentShape(Rectangle())
+                .onTapGesture { onClose() }
+                .accessibilityLabel(NSLocalizedString("archive.picker.dismiss", comment: "Dismiss month picker"))
+                .accessibilityAddTraits(.isButton)
+
+            card
+                .padding(.horizontal, 32)
+        }
+    }
+
+    // MARK: - Card
+
+    private var card: some View {
+        VStack(spacing: 20) {
+            yearStepper
+            monthGrid
+        }
+        .padding(20)
+        .background(DSColor.glassLo)
+        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 20, style: .continuous)
+                .strokeBorder(DSColor.glassRim, lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: 20, style: .continuous))
+        .shadow(color: Color.black.opacity(0.18), radius: 24, y: 10)
+        // Stop scrim taps from falling through the card.
+        .contentShape(Rectangle())
+        .onTapGesture { }
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: - Year Stepper
+
+    private var yearStepper: some View {
+        HStack(spacing: 0) {
+            stepperButton(systemName: "chevron.left", forward: false)
+                .accessibilityLabel(NSLocalizedString("archive.picker.prev_year", comment: "Previous year"))
+                .opacity(browseYear <= minYear ? 0.3 : 1.0)
+                .disabled(browseYear <= minYear)
+
+            Spacer()
+
+            Text(verbatim: String(browseYear))
+                .font(DSType.serifDisplay28)
+                .foregroundColor(DSColor.inkPrimary)
+                .monospacedDigit()
+                .animation(reduceMotion ? nil : Motion.fade, value: browseYear)
+                .accessibilityLabel(String(format: NSLocalizedString("archive.picker.year_label", comment: "Year %d"), browseYear))
+
+            Spacer()
+
+            stepperButton(systemName: "chevron.right", forward: true)
+                .accessibilityLabel(NSLocalizedString("archive.picker.next_year", comment: "Next year"))
+                // Never browse a year wholly in the future.
+                .opacity(browseYear >= realYear ? 0.3 : 1.0)
+                .disabled(browseYear >= realYear)
+        }
+    }
+
+    private func stepperButton(systemName: String, forward: Bool) -> some View {
+        Button {
+            Haptics.soft()
+            withAnimation(reduceMotion ? nil : Motion.spring) {
+                browseYear += forward ? 1 : -1
+            }
+        } label: {
+            Image(systemName: systemName)
+                .font(DSType.bodyMD)
+                .foregroundColor(DSColor.inkMuted)
+                .frame(width: 44, height: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Month Grid
+
+    private let columns = Array(repeating: GridItem(.flexible(), spacing: 8), count: 3)
+
+    private var monthGrid: some View {
+        LazyVGrid(columns: columns, spacing: 8) {
+            ForEach(1...12, id: \.self) { month in
+                monthCell(month)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func monthCell(_ month: Int) -> some View {
+        let isSelected = (browseYear == selectedYear && month == selectedMonth)
+        let isRealMonth = (browseYear == realYear && month == realMonth)
+        let isFuture = browseYear > realYear || (browseYear == realYear && month > realMonth)
+        let hasEntries = monthsWithEntries.contains(String(format: "%04d-%02d", browseYear, month))
+
+        Button {
+            guard !isFuture else { return }
+            Haptics.tapConfirm()
+            onSelect(browseYear, month)
+        } label: {
+            VStack(spacing: 5) {
+                Text(Self.monthShortSymbol(month))
+                    .monoLabelStyle(size: 11)
+                    .foregroundColor(monthTextColor(isSelected: isSelected, isFuture: isFuture))
+
+                // Activity dot — present only when the month holds entries.
+                Circle()
+                    .fill(isSelected ? Color.white : DSColor.amberAccent)
+                    .frame(width: 4, height: 4)
+                    .opacity(hasEntries ? 1 : 0)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 52)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(isSelected ? DSColor.amberDeep : DSColor.glassLo)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .strokeBorder(
+                        isRealMonth ? DSColor.amberAccent : DSColor.glassRim,
+                        lineWidth: isRealMonth ? 1.5 : 0.5
+                    )
+            )
+            .opacity(isFuture ? 0.3 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .disabled(isFuture)
+        .accessibilityLabel(Self.monthFullSymbol(month))
+        .accessibilityValue(monthAccessibilityValue(hasEntries: hasEntries, isFuture: isFuture))
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private func monthTextColor(isSelected: Bool, isFuture: Bool) -> Color {
+        if isSelected { return .white }
+        if isFuture { return DSColor.inkSubtle }
+        return DSColor.inkPrimary
+    }
+
+    private func monthAccessibilityValue(hasEntries: Bool, isFuture: Bool) -> String {
+        if isFuture { return NSLocalizedString("archive.picker.future_unavailable", comment: "Future month, unavailable") }
+        return hasEntries
+            ? NSLocalizedString("archive.picker.has_entries", comment: "Has entries")
+            : NSLocalizedString("archive.picker.no_entries", comment: "No entries")
+    }
+
+    // MARK: - Month Symbols
+
+    /// Localized short month symbol (e.g. "JAN" / "1月"), uppercased for the
+    /// app's mono label aesthetic. Uses standalone symbols so they read
+    /// correctly out of a date context.
+    private static func monthShortSymbol(_ month: Int) -> String {
+        let symbols = shortFormatter.standaloneShortMonthSymbols ?? shortFormatter.shortMonthSymbols
+        guard let symbols, month >= 1, month <= symbols.count else { return String(month) }
+        return symbols[month - 1].uppercased()
+    }
+
+    private static func monthFullSymbol(_ month: Int) -> String {
+        let symbols = shortFormatter.standaloneMonthSymbols ?? shortFormatter.monthSymbols
+        guard let symbols, month >= 1, month <= symbols.count else { return String(month) }
+        return symbols[month - 1]
+    }
+
+    private static let shortFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale.current
+        return f
+    }()
+}

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -348,6 +348,17 @@
 /* Archive — async month loading (US-015) */
 "archive.loading_month" = "Loading…";
 
+/* Archive — year/month jump picker */
+"archive.picker.open" = "Jump to month, currently %@";
+"archive.picker.open.hint" = "Opens a picker to jump to any month";
+"archive.picker.dismiss" = "Dismiss month picker";
+"archive.picker.prev_year" = "Previous year";
+"archive.picker.next_year" = "Next year";
+"archive.picker.year_label" = "Year %d";
+"archive.picker.has_entries" = "Has entries";
+"archive.picker.no_entries" = "No entries";
+"archive.picker.future_unavailable" = "Future month, unavailable";
+
 /* Settings — Accessibility labels/hints */
 "settings.close.label" = "Close Settings";
 "settings.apikey.paste.label" = "Paste API key from clipboard";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -376,6 +376,17 @@
 /* Archive — async month loading (US-015) */
 "archive.loading_month" = "加载中…";
 
+/* Archive — year/month jump picker */
+"archive.picker.open" = "跳转月份，当前 %@";
+"archive.picker.open.hint" = "打开选择器以跳转到任意月份";
+"archive.picker.dismiss" = "关闭月份选择器";
+"archive.picker.prev_year" = "上一年";
+"archive.picker.next_year" = "下一年";
+"archive.picker.year_label" = "%d 年";
+"archive.picker.has_entries" = "有记录";
+"archive.picker.no_entries" = "无记录";
+"archive.picker.future_unavailable" = "未来月份，不可用";
+
 /* Settings — Accessibility labels/hints */
 "settings.close.label" = "关闭设置";
 "settings.apikey.paste.label" = "从剪贴板粘贴 API Key";


### PR DESCRIPTION
## Problem

DayPage's Archive only let you move through time **one month at a time** — two chevrons (`monthNavigationRow`) and a horizontal swipe on the calendar, both stepping ±1 month. The "TODAY" button only jumps *forward* to the current month.

For the app's target user — a digital nomad who accumulates **months to years** of daily entries — revisiting "that week in Lisbon last October" from June 2026 meant tapping the back-chevron **~20 times**, waiting for a grid transition each time. There was no year navigation, no jump-to-date, no scrubbing.

Worse, the Archive header already rendered the month title, but tapping it **opened the sidebar** — a wasted, misleading affordance. Users instinctively tap a date label expecting a date picker (iOS Calendar convention).

## Solution

Make the header's month subtitle a **jump-to-month** control. Tapping it opens a new `YearMonthPicker` overlay:

- **Year stepper** (‹ 2026 ›) — one tap = ±12 months
- **3×4 grid of the 12 months** — current selection filled amber, today's real month ringed
- **Activity dots** on months that hold entries, sourced from the Archive's already-pre-scanned `rawDates`/`dailyDates` sets — **zero extra disk I/O**, so the picker doubles as a year-at-a-glance "where did I journal" map
- Tap a month → jump + dismiss. **20 taps collapse to 2.**

## Details

- New `ArchiveViewModel.goToMonth(year:month:)` for direct jumps (no-ops on same month)
- Derived `monthsWithEntries` (`"yyyy-MM"` set) from the existing pre-scan — no new load path
- **Future months gated** (journaling is retrospective — can't browse ahead); **past-year scrubbing bounded** by the earliest entry year so you can't scroll endlessly into empty centuries
- Pure SwiftUI, reuses existing `DSColor` / `DSType` / `Motion` / `Haptics` tokens — looks like it was always there
- **Dark mode**: all adaptive `Color(light:dark:)` tokens
- **i18n**: 9 new keys in both `en.lproj` and `zh-Hans.lproj`; month names via locale-aware `standaloneMonthSymbols`
- **VoiceOver**: every month cell labeled with name + has-entries/future state + selected trait; year steppers labeled
- **Reduce-motion**: all animations gated
- The Archive title still opens the sidebar — that affordance is preserved, just split from the month label

## Testing

- `xcodebuild` build runs in CI.
- No force-unwraps; value-type View, `DateFormatter` read on main only, `@MainActor` ViewModel call — no thread-safety concerns.
- `project.pbxproj` updated with the 4 standard entries for the new file (BuildFile / FileReference / group / Sources phase); brace/paren balance verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)