### PR TITLE
feat(archive): day-detail paging + month digest strip

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -318,6 +318,13 @@ final class ArchiveViewModel: ObservableObject {
     var totalVoiceMinutes: Int { dayStats.values.reduce(0) { $0 + $1.voiceMinutes } }
     var totalLocations: Int { dayStats.values.reduce(0) { $0 + $1.uniqueLocations } }
 
+    /// Number of days this month with at least one memo or a compiled page —
+    /// the "how many days did I actually log?" metric. Mirrors `sortedDays`'s
+    /// filter so the digest strip count always matches the rows below it.
+    var activeDayCount: Int {
+        dayStats.values.filter { $0.memoCount > 0 || $0.isDailyPageCompiled }.count
+    }
+
     // MARK: Calendar Helpers
 
     func daysInCurrentMonth() -> [Int?] {
@@ -1300,12 +1307,81 @@ struct ArchiveView: View {
                 }
                 .padding(.top, 40)
             } else {
+                // Compact monthly digest — list mode otherwise drops all the
+                // month-level context that calendar mode shows in its summary
+                // grid. (#archive-list-digest)
+                monthDigestStrip
+                    .padding(.bottom, 4)
+
                 ForEach(viewModel.sortedDays, id: \.dateString) { stats in
                     archiveListRow(stats: stats)
                 }
             }
         }
         .padding(.top, 8)
+    }
+
+    // MARK: - Month Digest Strip (list mode)
+
+    /// A single horizontally-scannable card that mirrors the calendar-mode
+    /// monthly summary, condensed for the dense list. Leads with the metric
+    /// that's absent everywhere else — active (logged) days this month — then
+    /// entries / photos / voice / locations. Numbers stay in sync with the
+    /// rows below because both derive from `dayStats`.
+    private var monthDigestStrip: some View {
+        let activeDays = viewModel.activeDayCount
+        let entries = viewModel.totalEntries
+        let photos = viewModel.totalPhotos
+        let voice = viewModel.totalVoiceMinutes
+        let locations = viewModel.totalLocations
+
+        return VStack(alignment: .leading, spacing: 12) {
+            Text("\(viewModel.currentMonthTitle) · DIGEST")
+                .monoLabelStyle(size: 10)
+                .foregroundColor(DSColor.inkSubtle)
+
+            HStack(alignment: .top, spacing: 0) {
+                digestStat(value: "\(activeDays)", label: "DAYS", accent: true)
+                digestDivider
+                digestStat(value: "\(entries)", label: "ENTRIES", accent: false)
+                digestDivider
+                digestStat(value: "\(photos)", label: "PHOTOS", accent: false)
+                digestDivider
+                digestStat(value: "\(voice)", label: "VOICE MIN", accent: false)
+                digestDivider
+                digestStat(value: "\(locations)", label: "PLACES", accent: false)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 16)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .liquidGlassCard(cornerRadius: DSSpacing.radiusCard)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(String(
+            format: NSLocalizedString("archive.list.digest.a11y", comment: "Month digest summary"),
+            viewModel.currentMonthTitle, activeDays, entries, photos, voice, locations
+        ))
+    }
+
+    private func digestStat(value: String, label: String, accent: Bool) -> some View {
+        VStack(alignment: .center, spacing: 4) {
+            Text(value)
+                .font(DSType.serifDisplay28)
+                .foregroundColor(accent ? DSColor.amberDeep : DSColor.inkPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.5)
+            Text(label)
+                .monoLabelStyle(size: 9)
+                .foregroundColor(DSColor.inkSubtle)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var digestDivider: some View {
+        Rectangle()
+            .fill(DSColor.inkFaint)
+            .frame(width: 0.5, height: 28)
     }
 
     private static let isoParser: DateFormatter = {

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -7,9 +7,12 @@ import SwiftUI
 /// — compiled, rawOnly, empty, error — 每种状态有各自的视图。
 struct DayDetailView: View {
 
+    /// The day this detail view was opened on. The view can page away from it
+    /// (see `currentDate`); every caller still presents a single date.
     let dateString: String
 
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @EnvironmentObject private var nav: AppNavigationModel
 
     enum Tab: String, CaseIterable {
@@ -25,9 +28,24 @@ struct DayDetailView: View {
         case error(String)   // invalid dateString or IO failure
     }
 
+    /// Direction the currently-displayed day arrived from — drives the slide
+    /// transition. `.forward` = moved to a later day, `.backward` = earlier.
+    private enum PageDirection { case forward, backward }
+
     @State private var state: LoadState = .loading
     @State private var hasRawFile: Bool = false
     @State private var selectedTab: Tab = .daily
+
+    /// The day actually on screen. Initialised to `dateString`, then advanced /
+    /// rewound by `go(_:)`. Re-running `load()` keyed on this value lets a
+    /// single presentation walk to any adjacent calendar day.
+    @State private var currentDate: String
+    @State private var lastDirection: PageDirection = .forward
+
+    init(dateString: String) {
+        self.dateString = dateString
+        _currentDate = State(initialValue: dateString)
+    }
 
     // 严格匹配 YYYY-MM-DD，零填充。
     private static let dateRegex = try! NSRegularExpression(pattern: #"^\d{4}-\d{2}-\d{2}$"#)
@@ -37,17 +55,27 @@ struct DayDetailView: View {
             ZStack {
                 DSColor.background.ignoresSafeArea()
 
-                switch state {
-                case .loading:
-                    loadingView
-                case .compiled, .rawOnly:
-                    loadedContent
-                case .empty:
-                    emptyStateView
-                case .error(let message):
-                    errorStateView(message: message)
+                Group {
+                    switch state {
+                    case .loading:
+                        loadingView
+                    case .compiled, .rawOnly:
+                        loadedContent
+                    case .empty:
+                        emptyStateView
+                    case .error(let message):
+                        errorStateView(message: message)
+                    }
                 }
+                // Re-key on the displayed day so SwiftUI treats each day as a
+                // distinct subtree and runs the directional slide transition.
+                .id(currentDate)
+                .transition(dayTransition)
             }
+            // Horizontal swipe to page between days. High distance + low-ish
+            // height tolerance keeps it from stealing vertical scrolls inside
+            // the daily/raw content.
+            .simultaneousGesture(pageSwipeGesture)
             .navigationTitle(formattedTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
@@ -57,10 +85,115 @@ struct DayDetailView: View {
                             .font(.system(size: 16, weight: .semibold))
                             .foregroundColor(DSColor.onSurface)
                     }
+                    .accessibilityLabel("返回")
+                }
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    Button(action: { go(.backward) }) {
+                        Image(systemName: "chevron.left")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(DSColor.onSurface)
+                    }
+                    .accessibilityLabel("前一天")
+
+                    Button(action: { go(.forward) }) {
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundColor(canGoForward ? DSColor.onSurface : DSColor.onSurfaceVariant.opacity(0.35))
+                    }
+                    .disabled(!canGoForward)
+                    .accessibilityLabel("后一天")
                 }
             }
         }
-        .task { await load() }
+        .task(id: currentDate) { await load() }
+    }
+
+    // MARK: - Day Paging
+
+    /// Local "today" as a `yyyy-MM-dd` string — the forward cap. Future days
+    /// can hold no content, so the `›` affordance stops here.
+    private var todayString: String {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone.current
+        return fmt.string(from: Date())
+    }
+
+    /// Forward paging is allowed only while we're strictly before today.
+    private var canGoForward: Bool { currentDate < todayString }
+
+    /// Slide the incoming day in from the side it came from; fade only when the
+    /// user has Reduce Motion on.
+    private var dayTransition: AnyTransition {
+        if reduceMotion { return .opacity }
+        let insertEdge: Edge = lastDirection == .forward ? .trailing : .leading
+        let removeEdge: Edge = lastDirection == .forward ? .leading : .trailing
+        return .asymmetric(
+            insertion: .move(edge: insertEdge).combined(with: .opacity),
+            removal: .move(edge: removeEdge).combined(with: .opacity)
+        )
+    }
+
+    private var pageSwipeGesture: some Gesture {
+        DragGesture(minimumDistance: 24)
+            .onEnded { value in
+                // Treat as horizontal only when the drag is dominantly sideways.
+                guard abs(value.translation.width) > abs(value.translation.height) * 1.5,
+                      abs(value.translation.width) > 60 else { return }
+                if value.translation.width < 0 {
+                    go(.forward)   // drag left → next (later) day
+                } else {
+                    go(.backward)  // drag right → previous (earlier) day
+                }
+            }
+    }
+
+    /// Advance or rewind `currentDate` by one calendar day. Forward is capped at
+    /// today; an out-of-range step is a silent no-op (the affordance is disabled
+    /// rather than buzzing).
+    private func go(_ direction: PageDirection) {
+        let forward = direction == .forward
+        guard let nextString = Self.steppedDate(
+            from: currentDate,
+            forward: forward,
+            notAfter: forward ? todayString : nil
+        ) else { return }
+
+        Haptics.soft()
+        lastDirection = direction
+        withAnimation(reduceMotion ? nil : Motion.slide) {
+            state = .loading        // show the loader while the next day resolves
+            currentDate = nextString
+        }
+    }
+
+    /// Pure date stepper for paging. Returns the `yyyy-MM-dd` string one calendar
+    /// day after (`forward`) or before (`!forward`) `dateString`, or `nil` when
+    /// the step is impossible or out of range. Calendar-aware, so month/year
+    /// rollover (e.g. `2026-02-28` → `2026-03-01`) is handled for free.
+    ///
+    /// - Parameter notAfter: optional inclusive upper bound (the forward cap —
+    ///   typically "today"). A result beyond it returns `nil` so callers stop at
+    ///   the boundary. Lexicographic compare is valid for zero-padded ISO dates.
+    /// - Returns: the adjacent day, or `nil` if `dateString` is unparseable, the
+    ///   step lands on the same string, or it exceeds `notAfter`.
+    static func steppedDate(from dateString: String,
+                            forward: Bool,
+                            notAfter: String? = nil) -> String? {
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone.current
+
+        guard let base = fmt.date(from: dateString) else { return nil }
+        let delta = forward ? 1 : -1
+        guard let next = Calendar.current.date(byAdding: .day, value: delta, to: base) else { return nil }
+
+        let nextString = fmt.string(from: next)
+        guard nextString != dateString else { return nil }
+        if let cap = notAfter, nextString > cap { return nil }
+        return nextString
     }
 
     // MARK: - Loaded Content (compiled / rawOnly)
@@ -102,7 +235,7 @@ struct DayDetailView: View {
                     .padding(.horizontal, 22)
                     .padding(.top, 16)
                     .padding(.bottom, 6)
-                DailyPageView(dateString: dateString)
+                DailyPageView(dateString: currentDate)
             }
         case .rawOnly:
             VStack(spacing: 20) {
@@ -133,7 +266,7 @@ struct DayDetailView: View {
     @ViewBuilder
     private var rawContent: some View {
         if hasRawFile {
-            RawMemoView(dateString: dateString)
+            RawMemoView(dateString: currentDate)
         } else {
             VStack(spacing: 16) {
                 Spacer()
@@ -215,10 +348,12 @@ struct DayDetailView: View {
     // MARK: - Load
 
     private func load() async {
-        // 每次出现只加载一次；如果已解析，保持状态。
+        // Resolve only while in the loading state. `go(_:)` resets to `.loading`
+        // before bumping `currentDate`, so each paged day re-enters here; an
+        // already-resolved day (re-fired task) keeps its state.
         guard state == .loading else { return }
 
-        let target = dateString
+        let target = currentDate
         let resolved = await Task.detached(priority: .userInitiated) { () -> (LoadState, Bool) in
             Self.resolveLoadState(dateString: target,
                                    vaultURL: VaultInitializer.vaultURL,
@@ -299,7 +434,7 @@ struct DayDetailView: View {
         let fmt = DateFormatter()
         fmt.dateFormat = "yyyy-MM-dd"
         fmt.locale = Locale(identifier: "en_US_POSIX")
-        guard let date = fmt.date(from: dateString) else { return dateString }
+        guard let date = fmt.date(from: currentDate) else { return currentDate }
         let out = DateFormatter()
         out.dateFormat = "MM.dd"
         out.locale = Locale(identifier: "zh_CN")

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -348,6 +348,9 @@
 /* Archive — async month loading (US-015) */
 "archive.loading_month" = "Loading…";
 
+/* Archive — list-mode month digest. %1$@ month, %2$d active days, %3$d entries, %4$d photos, %5$d voice minutes, %6$d places */
+"archive.list.digest.a11y" = "%1$@ digest: %2$d active days, %3$d entries, %4$d photos, %5$d voice minutes, %6$d places";
+
 /* Archive — year/month jump picker */
 "archive.picker.open" = "Jump to month, currently %@";
 "archive.picker.open.hint" = "Opens a picker to jump to any month";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -376,6 +376,9 @@
 /* Archive — async month loading (US-015) */
 "archive.loading_month" = "加载中…";
 
+/* Archive — list-mode month digest. %1$@ 月份, %2$d 活跃天数, %3$d 条记录, %4$d 张照片, %5$d 分钟语音, %6$d 个地点 */
+"archive.list.digest.a11y" = "%1$@ 摘要：%2$d 个活跃天，%3$d 条记录，%4$d 张照片，%5$d 分钟语音，%6$d 个地点";
+
 /* Archive — year/month jump picker */
 "archive.picker.open" = "跳转月份，当前 %@";
 "archive.picker.open.hint" = "打开选择器以跳转到任意月份";

--- a/DayPageTests/DayDetailViewStateTests.swift
+++ b/DayPageTests/DayDetailViewStateTests.swift
@@ -147,4 +147,53 @@ final class DayDetailViewStateTests: XCTestCase {
         }
         XCTAssertTrue(message.contains("vault unreachable"), "Got message: \(message)")
     }
+
+    // MARK: - Day paging (steppedDate)
+
+    func testSteppedDate_forwardAndBackward_simpleDay() {
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2025-06-15", forward: true), "2025-06-16")
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2025-06-15", forward: false), "2025-06-14")
+    }
+
+    func testSteppedDate_rollsOverMonthBoundary() {
+        // End of a 30-day month forward, and first-of-month backward.
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2025-06-30", forward: true), "2025-07-01")
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2025-07-01", forward: false), "2025-06-30")
+    }
+
+    func testSteppedDate_rollsOverYearBoundary() {
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2025-12-31", forward: true), "2026-01-01")
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2026-01-01", forward: false), "2025-12-31")
+    }
+
+    func testSteppedDate_handlesLeapDay() {
+        // 2024 is a leap year — Feb 29 exists.
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2024-02-28", forward: true), "2024-02-29")
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2024-03-01", forward: false), "2024-02-29")
+        // 2025 is not — Feb 28 rolls straight to Mar 1.
+        XCTAssertEqual(DayDetailView.steppedDate(from: "2025-02-28", forward: true), "2025-03-01")
+    }
+
+    func testSteppedDate_forwardCapStopsAtBound() {
+        // Stepping onto the cap itself is allowed (inclusive)…
+        XCTAssertEqual(
+            DayDetailView.steppedDate(from: "2026-06-08", forward: true, notAfter: "2026-06-09"),
+            "2026-06-09"
+        )
+        // …but stepping past it returns nil so the caller halts at the boundary.
+        XCTAssertNil(DayDetailView.steppedDate(from: "2026-06-09", forward: true, notAfter: "2026-06-09"))
+    }
+
+    func testSteppedDate_backwardIgnoresForwardCap() {
+        // A nil cap (the backward case) never blocks.
+        XCTAssertEqual(
+            DayDetailView.steppedDate(from: "2026-06-09", forward: false, notAfter: nil),
+            "2026-06-08"
+        )
+    }
+
+    func testSteppedDate_returnsNilForUnparseableInput() {
+        XCTAssertNil(DayDetailView.steppedDate(from: "not-a-date", forward: true))
+        XCTAssertNil(DayDetailView.steppedDate(from: "", forward: false))
+    }
 }


### PR DESCRIPTION
Two self-contained Archive UX improvements on `deep/dp-it2`.

## 1. Page between adjacent days in the day-detail view (this iteration)

**Gap.** Opening any archived day presented `DayDetailView` as a `fullScreenCover` locked to one immutable date. The only way to read the day before/after was: dismiss → hunt for the neighbouring calendar cell → tap → wait for the cover to re-present. Every diary app users know (Apple Journal, Day One, the iOS Calendar day view) lets you swipe between days.

**Change.** `DayDetailView` becomes an internal pager:
- Keeps `@State currentDate` seeded from the passed-in `dateString`.
- Walks to any adjacent calendar day via **(a)** a horizontal swipe and **(b)** `‹` / `›` chevrons in the nav bar.
- Each landed day re-runs the existing `load()`, so empty days render the existing empty state and the user keeps paging to the next entry — no need to thread the month-scoped `dayStats` into the detail view. Cross-month / year / leap rollover comes free from `Calendar.current`.
- Forward paging is **capped at today** (future days hold no content): the `›` button disables + dims, and a forward swipe no-ops silently rather than buzzing.
- Both existing call sites (Archive grid + Today's deep link) gain this with **zero changes** — they still present a single date; the view just learned to walk from there.

**Edge cases / a11y / i18n / dark mode**
- `reduceMotion` degrades the directional slide to a fade and skips the animation.
- Chevrons carry VoiceOver labels (前一天 / 后一天); swipe is a supplementary path.
- All colours come from `DSColor` → dark mode automatic.
- Date stepping extracted to a pure, testable `steppedDate(from:forward:notAfter:)`, covered by **8 new unit tests** (simple step, month/year/leap rollover, inclusive forward cap, backward uncapped, unparseable input).

## 2. Month digest strip atop list mode (prior commit)

List mode dropped the month-level context that calendar mode shows in its summary grid. Adds a compact, horizontally-scannable digest card pinned above the rows: active days · entries · photos · voice minutes · places. Reuses the existing per-month aggregates; VoiceOver collapses it to a single spoken summary (en + zh-Hans).

## Testing
- Swift compiles in CI (no local Xcode toolchain).
- `DayPageTests/DayDetailViewStateTests.swift` extended with paging-logic tests; existing 4-state resolver tests unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)