### PR TITLE
perf(input): 消除输入框逐字卡顿，打字丝滑化

### DIFF
--- a/DayPage/DesignSystem/Motion.swift
+++ b/DayPage/DesignSystem/Motion.swift
@@ -19,6 +19,12 @@ enum Motion {
     static let slide: Animation = .timingCurve(0.2, 0.8, 0.2, 1, duration: 0.28)
     // Interactive controls with elastic settle (buttons, toggles).
     static let spring: Animation = .spring(response: 0.35, dampingFraction: 0.8)
+    // High-frequency counters (word/char count) that update on EVERY keystroke.
+    // A 0.35s spring here stacks and re-interrupts faster than the user types,
+    // starving the main thread and making typing feel "sticky". This curve is
+    // short enough that consecutive keystrokes never overlap their animations,
+    // so the count nudges quietly without ever fighting the text input.
+    static let countTick: Animation = .easeOut(duration: 0.12)
     // Sheet / card dismiss — matches system dismiss feel.
     static let dismiss: Animation = .easeOut(duration: 0.22)
     // Breathing / pulsing ambient indicator (slow in-out).

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -179,9 +179,8 @@ struct InputBarV4: View {
 
     // MARK: Derived
 
-    private var wordCount: Int {
-        TextCount.words(text)
-    }
+    /// Reads the cached count (recomputed once per text change, not per render).
+    private var wordCount: Int { cachedWordCount }
 
     private var charCount: Int { text.count }
 
@@ -686,7 +685,14 @@ struct InputBarV4: View {
                 .padding(.bottom, 14)
                 .onTapGesture { isFocused = true }
                 .accessibilityIdentifier("memo-input")
+                // Seed the cached count for any pre-filled draft (templates,
+                // restored text) so the footer is correct before the first edit.
+                .onAppear { cachedWordCount = TextCount.words(text) }
                 // US-015: clear placeholder suffix when user edits text.
+                // Single onChange owns BOTH the suffix reset and the cached word
+                // count + milestone haptic. Previously a second `onChange(of:
+                // wordCount)` forced SwiftUI to re-run the O(n) word scan every
+                // body pass just to diff its trigger value.
                 .onChange(of: text) { newValue in
                     if let tpl = activeTemplate, !templateSuffix.isEmpty {
                         if newValue != tpl.prefix {
@@ -694,9 +700,9 @@ struct InputBarV4: View {
                             activeTemplate = nil
                         }
                     }
+                    let newCount = TextCount.words(newValue)
+                    cachedWordCount = newCount
                     if newValue.isEmpty { lastMilestone = 0 }
-                }
-                .onChange(of: wordCount) { newCount in
                     let milestone = newCount / 50
                     if milestone > lastMilestone {
                         lastMilestone = milestone
@@ -878,6 +884,11 @@ struct InputBarV4: View {
 
     @State private var breathingOpacity: Double = 1.0
     @State private var lastMilestone: Int = 0
+    /// Cached word count. `wordCount` was a computed property calling the O(n)
+    /// `TextCount.words(text)`; because SwiftUI re-evaluates it on every body
+    /// pass (and to diff `onChange(of: wordCount)`), it ran the full-text scan
+    /// multiple times per keystroke. Recompute once per real text change.
+    @State private var cachedWordCount: Int = 0
 
     private var sendButton: some View {
         let affordance = sendAffordance

--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -52,6 +52,13 @@ struct WriteSheetView: View {
     @FocusState private var isFocused: Bool
     @State private var appeared: Bool = false
     @State private var lastMilestone: Int = 0
+    /// Cached counts. These were computed properties that re-ran an O(n)
+    /// full-text scan on EVERY SwiftUI body re-render — and a single keystroke
+    /// triggers several re-renders. Recomputing only inside `onChange(of: text)`
+    /// removes the per-keystroke O(n) cost that compounds into typing lag on
+    /// long drafts. All downstream readers keep using `wordCount`/`charCount`.
+    @State private var cachedWordCount: Int = 0
+    @State private var cachedCharCount: Int = 0
     @GestureState private var dragOffset: CGFloat = 0
     @State private var committedClose: Bool = false
     @State private var saveReadyPulse: Bool = false
@@ -67,8 +74,13 @@ struct WriteSheetView: View {
 
     /// CJK-aware word count: each CJK/Hiragana/Katakana ideograph = 1 word;
     /// consecutive non-CJK non-whitespace scalars = 1 Latin word per run.
-    private var wordCount: Int {
-        Self.wordCount(in: text)
+    /// Reads the cached count (recomputed once per text change, not per render).
+    private var wordCount: Int { cachedWordCount }
+
+    /// Recompute cached counts. Called once when `text` actually changes.
+    private func recomputeCounts() {
+        cachedWordCount = Self.wordCount(in: text)
+        cachedCharCount = text.count
     }
 
     static func wordCount(in text: String) -> Int {
@@ -94,7 +106,7 @@ struct WriteSheetView: View {
         return count
     }
 
-    private var charCount: Int { text.count }
+    private var charCount: Int { cachedCharCount }
 
     private var readingMinutes: Int {
         max(1, Int(ceil(Double(wordCount) / 200.0)))
@@ -181,11 +193,19 @@ struct WriteSheetView: View {
                 .gesture(swipeToDismiss)
         }
         .animation(reduceMotion ? .easeOut(duration: 0.2) : Self.sheetUp, value: appeared)
+        // Recompute the cached word/char counts ONCE per real text change,
+        // instead of on every body re-render. This is the single source of
+        // truth for both counters and keeps typing off the O(n) scan path.
+        .onChange(of: text) { _ in recomputeCounts() }
         .onAppear {
             appeared = true
             confirmingDiscard = false
-            // Let the sheet-up settle before raising the keyboard.
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+            recomputeCounts()
+            // Raise the keyboard almost immediately. The previous 0.2s delay
+            // (to "let the sheet-up settle") read as the keyboard arriving late
+            // after the tap. A 0.05s beat is enough to let the sheet-up start
+            // and avoid a layout race, while feeling effectively instant.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.05) {
                 isFocused = true
             }
         }
@@ -387,9 +407,12 @@ struct WriteSheetView: View {
             .tracking(1.0)
             .monospacedDigit()
             .foregroundColor(charCountChipColor)
-            .modifier(NumericTextContentTransition(value: Double(charCount), reduceMotion: reduceMotion))
-            .animation(reduceMotion ? nil : Motion.spring, value: charCount)
-            .animation(reduceMotion ? nil : Motion.spring, value: charCount >= Self.charThreshold)
+            // Per-keystroke spring + numericText used to re-trigger on EVERY
+            // character, stacking 0.35s animations faster than the user types.
+            // The digit now updates instantly (monospacedDigit keeps it from
+            // reflowing); only the color crossing the threshold gets a short,
+            // non-stacking tick so the "milestone" still reads as a soft cue.
+            .animation(reduceMotion ? nil : Motion.countTick, value: charCount >= Self.charThreshold)
             .frame(maxWidth: .infinity, alignment: .trailing)
             .padding(.horizontal, 22)
             .padding(.top, 8)
@@ -421,15 +444,13 @@ struct WriteSheetView: View {
                 : String(format: NSLocalizedString("writesheet.count.words.other", comment: "%d words"), wordCount)
             let readLabel = String(format: NSLocalizedString("writesheet.count.read", comment: "~%d min read"), readingMinutes)
             HStack(spacing: 0) {
+                // Counter text updates instantly per keystroke — no per-character
+                // numericText/spring (those stacked 0.35s animations under the
+                // typing cadence and starved the main thread). monospacedDigit
+                // keeps the digits from reflowing as they change.
                 Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
-                    .modifier(NumericTextContentTransition(value: Double(wordCount), reduceMotion: reduceMotion))
-                    .animation(reduceMotion ? nil : Motion.fade, value: wordCount)
-                    .animation(reduceMotion ? nil : Motion.spring, value: wordCount)
                 if showReadingTime {
                     Text(" · \(readLabel)")
-                        .modifier(NumericTextContentTransition(value: Double(readingMinutes), reduceMotion: reduceMotion))
-                        .animation(reduceMotion ? nil : Motion.fade, value: readingMinutes)
-                        .animation(reduceMotion ? nil : Motion.spring, value: readingMinutes)
                         .transition(.opacity)
                 }
             }
@@ -438,7 +459,8 @@ struct WriteSheetView: View {
             .textCase(.uppercase)
             .monospacedDigit()
             .foregroundColor(wordCountColor)
-            .animation(reduceMotion ? nil : Motion.spring, value: showReadingTime)
+            // Only the reading-time chip's appear/disappear gets a soft tick.
+            .animation(reduceMotion ? nil : Motion.countTick, value: showReadingTime)
             .padding(.trailing, 10)
             .accessibilityLabel(showReadingTime
                 ? "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars")), \(readLabel)"
@@ -641,13 +663,10 @@ struct WriteSheetView: View {
             : String(format: NSLocalizedString("writesheet.count.words.other", comment: "%d words"), wordCount)
         let readLabel = String(format: NSLocalizedString("writesheet.count.read", comment: "~%d min read"), readingMinutes)
         HStack(spacing: 0) {
+            // Instant per-keystroke update (see footer-rail counter note).
             Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
-                .modifier(NumericTextContentTransition(value: Double(wordCount), reduceMotion: reduceMotion))
-                .animation(reduceMotion ? nil : Motion.spring, value: wordCount)
             if showReadingTime {
                 Text(" · \(readLabel)")
-                    .modifier(NumericTextContentTransition(value: Double(readingMinutes), reduceMotion: reduceMotion))
-                    .animation(reduceMotion ? nil : Motion.spring, value: readingMinutes)
                     .transition(.opacity)
             }
         }
@@ -656,7 +675,7 @@ struct WriteSheetView: View {
         .textCase(.uppercase)
         .monospacedDigit()
         .foregroundColor(wordCountColor)
-        .animation(reduceMotion ? nil : Motion.spring, value: showReadingTime)
+        .animation(reduceMotion ? nil : Motion.countTick, value: showReadingTime)
         .accessibilityLabel(showReadingTime
             ? "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars")), \(readLabel)"
             : "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
@@ -705,23 +724,6 @@ struct WriteSheetView: View {
         Haptics.medium()
         isFocused = false
         onSave()
-    }
-}
-
-// MARK: - NumericTextContentTransition
-
-private struct NumericTextContentTransition: ViewModifier {
-    let value: Double
-    let reduceMotion: Bool
-
-    func body(content: Content) -> some View {
-        if #available(iOS 17.0, *) {
-            content
-                .contentTransition(reduceMotion ? .identity : .numericText(value: value))
-        } else {
-            content
-                .contentTransition(.identity)
-        }
     }
 }
 


### PR DESCRIPTION
## 问题

dock 输入框打字时"有冲突、不丝滑、不跟手"。两个输入面（内联 composer `InputBarV4` + 底部 sheet `WriteSheetView`）同源同病。

## 根因（两类确定性性能反模式）

把**每按键必变的高频值**绑在了**有时长的工作**上：

1. **逐字 O(n) 全文扫描** — `wordCount` 是 computed property 调 `TextCount.words(text)`。SwiftUI 每次 body 重算 + `onChange(of: wordCount)` diff 都会跑一遍，长文本下每按键触发数次 O(n)。
2. **逐字 spring/numericText 动画堆叠** — `.animation(Motion.spring(0.35s), value: charCount)` + `.contentTransition(.numericText)` 每字符触发。打字速度（>5 字/秒）远超 0.35s 动画时长，动画永久"被打断—重启"，主线程被动画求值占满。

核心矛盾：**按键频率 ≫ 动画时长 → 动画堆叠永不收敛 → 主线程饱和 → 打字黏**。

## 修复（把高频值从有时长动画上解绑）

- 新增 `Motion.countTick`（`easeOut 0.12s`，短到连续按键不重叠），专给计数器提示用。
- 计数缓存化：`@State cachedWordCount`，只在 `onChange(of: text)` 算一次；computed `wordCount`/`charCount` 改读缓存（下游 14+ 处引用零改动）。
- 计数器瞬时更新（`monospacedDigit` 防数字回流），移除逐字 spring + numericText，仅在跨阈值/reading-time 出现时给一次 `countTick`。
- WriteSheet 键盘聚焦延迟 `0.2s → 0.05s`（原 0.2s 读作"键盘迟到"）。
- 合并 InputBarV4 的双 `onChange`；删除 WriteSheetView 中已无引用的 `NumericTextContentTransition`。

## 验证

- ✅ `BUILD SUCCEEDED`（零 error/warning）
- ✅ **全量 95 tests, 0 failures** — `wordCount(in:)` 静态方法未动，仅改求值时机，行为零回归
- ✅ 模拟器（iPhone 17）实跑 UI 渲染正常，无布局错乱

### 说明
模拟器 GUI 文本注入不可靠（`idb ui text` 注入中文报错、英文会把 App 切后台），故未做逐字录屏对比。本修复消除的是可由代码静态分析确证的 SwiftUI 性能反模式（computed-in-onChange + per-keystroke-animation），正确性由代码审查 + 编译 + 单元测试支撑。