### PR TITLE
fix(agentry): encode dotted tool names for strict OpenAI-compatible backends

### DIFF
--- a/agentry/chat.sh
+++ b/agentry/chat.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Launch agentry's interactive TUI (chat) using the repo-root .env config.
+#
+# agentry does not read .env files itself — it only consumes process env vars —
+# so this wrapper loads the repo-root .env, maps the DeepSeek credentials onto
+# agentry's OpenAI-compatible provider, and starts `chat`. Run it from a real
+# terminal (the TUI needs a TTY):
+#
+#     ./agentry/chat.sh
+#
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+ENV_FILE="$REPO_ROOT/.env"
+BIN="$SCRIPT_DIR/bin/agentry"
+
+[ -f "$ENV_FILE" ] || { echo "error: $ENV_FILE not found" >&2; exit 1; }
+[ -x "$BIN" ] || { echo "error: $BIN missing — build with: go build -o bin/agentry ./cmd/agentry" >&2; exit 1; }
+
+# Load .env (skip comments / blank lines) into the environment.
+set -a
+# shellcheck disable=SC1090
+source <(grep -vE '^\s*#|^\s*$' "$ENV_FILE")
+set +a
+
+# Map DeepSeek (OpenAI-compatible) onto agentry's `openai` provider.
+export OPENAI_API_KEY="${DEEPSEEK_API_KEY:?DEEPSEEK_API_KEY not set in .env}"
+export OPENAI_BASE_URL="${DEEPSEEK_BASE_URL:-https://api.deepseek.com/v1}"
+MODEL="${DEEPSEEK_MODEL:-deepseek-chat}"
+
+echo "→ provider=openai  base=$OPENAI_BASE_URL  model=$MODEL"
+exec "$BIN" chat --provider openai --model "$MODEL" "$@"

--- a/agentry/internal/core/provider/openaicompat/openaicompat.go
+++ b/agentry/internal/core/provider/openaicompat/openaicompat.go
@@ -254,8 +254,10 @@ func toWireMessage(m provider.Message) wireMessage {
 	switch m.Role {
 	case provider.RoleTool:
 		// A tool result: role:tool with the originating call id and content.
+		// The name must match the (encoded) function name the model emitted, so
+		// the backend can correlate the result with its tool call.
 		wm.ToolCallID = m.ToolCallID
-		wm.Name = m.Name
+		wm.Name = encodeToolName(m.Name)
 		c := m.Text
 		wm.Content = &c
 	case provider.RoleAssistant:
@@ -270,7 +272,7 @@ func toWireMessage(m provider.Message) wireMessage {
 					ID:   tc.ID,
 					Type: "function",
 					Function: wireFunctionCall{
-						Name:      tc.Name,
+						Name:      encodeToolName(tc.Name),
 						Arguments: argsToString(tc.Args),
 					},
 				})
@@ -284,12 +286,41 @@ func toWireMessage(m provider.Message) wireMessage {
 	return wm
 }
 
+// Agentry tool names use a "<namespace>.<verb>" convention (e.g. "fs.read",
+// "web.fetch", "agent.<name>"), but some OpenAI-compatible backends — notably
+// DeepSeek — reject function names that don't match ^[a-zA-Z0-9_-]+$, so the dot
+// triggers an HTTP 400 before any tool can run. encodeToolName/decodeToolName
+// are a transport-only escaping that keeps the wire name within that charset
+// while preserving the real registry key on the way back.
+//
+// Only the dot is rewritten ("." <-> "__"); names already within the charset —
+// including ones that legitimately contain underscores like "get_weather" — are
+// passed through untouched, so this is invisible to backends that never had a
+// problem. The namespaced convention never places an underscore directly against
+// the dot, so "__" is an unambiguous stand-in for the separator.
+func encodeToolName(name string) string {
+	if !strings.Contains(name, ".") {
+		return name // already wire-safe (covers plain and underscore-only names)
+	}
+	return strings.ReplaceAll(name, ".", "__")
+}
+
+// decodeToolName reverses encodeToolName, mapping the "__" separator back to a
+// dot. Names without "__" (the common case, and any plain underscore name)
+// round-trip unchanged.
+func decodeToolName(name string) string {
+	if !strings.Contains(name, "__") {
+		return name
+	}
+	return strings.ReplaceAll(name, "__", ".")
+}
+
 // toWireTool maps a ToolSpec to the OpenAI function-tool shape.
 func toWireTool(t provider.ToolSpec) wireTool {
 	return wireTool{
 		Type: "function",
 		Function: wireFunctionSpec{
-			Name:        t.Name,
+			Name:        encodeToolName(t.Name),
 			Description: t.Description,
 			Parameters:  t.Schema,
 		},
@@ -483,8 +514,10 @@ func flushToolCalls(send func(provider.Event) bool, calls map[int]*toolCallAccum
 			args = "{}"
 		}
 		tc := &provider.ToolCall{
-			ID:   acc.id,
-			Name: acc.name,
+			ID: acc.id,
+			// Decode the wire name back to the real registry key (e.g.
+			// "fs__read" -> "fs.read") so the engine can resolve the tool.
+			Name: decodeToolName(acc.name),
 			Args: json.RawMessage(args),
 		}
 		if !send(provider.Event{Kind: provider.EventToolCall, ToolCall: tc}) {

--- a/agentry/internal/core/provider/openaicompat/openaicompat_test.go
+++ b/agentry/internal/core/provider/openaicompat/openaicompat_test.go
@@ -442,3 +442,51 @@ func TestStreamFatal4xxNoRetry(t *testing.T) {
 		t.Errorf("server calls = %d, want 1 (401 not retried)", n)
 	}
 }
+
+// isWireSafe reports whether s matches the strict ^[A-Za-z0-9_-]+$ charset that
+// backends like DeepSeek enforce on function names.
+func isWireSafe(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9', r == '_', r == '-':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+func TestToolNameEncodeRoundTrip(t *testing.T) {
+	cases := []string{
+		"fs.read", "fs.write", "fs.list", "shell.exec",
+		"web.fetch", "web.extract", "web.search",
+		"browser.navigate", "browser.screenshot",
+		"agent.researcher", "agent.code_reviewer", // profile name with underscore
+		"plain", "echo", "with-dash", "get_weather", // already wire-safe
+		"a.b.c", // multiple dots
+	}
+	for _, original := range cases {
+		enc := encodeToolName(original)
+		if !isWireSafe(enc) {
+			t.Errorf("encodeToolName(%q) = %q is not wire-safe", original, enc)
+		}
+		if got := decodeToolName(enc); got != original {
+			t.Errorf("round-trip failed: %q -> %q -> %q", original, enc, got)
+		}
+	}
+}
+
+func TestToolNameEncodeFastPath(t *testing.T) {
+	// Names already within the charset must pass through untouched (no alloc/escaping).
+	for _, s := range []string{"plain", "echo", "with-dash", "abc123"} {
+		if got := encodeToolName(s); got != s {
+			t.Errorf("encodeToolName(%q) = %q, want unchanged", s, got)
+		}
+		if got := decodeToolName(s); got != s {
+			t.Errorf("decodeToolName(%q) = %q, want unchanged", s, got)
+		}
+	}
+}


### PR DESCRIPTION
## Why

`agentry` 的内置工具采用 `<namespace>.<verb>` 命名（`fs.read`、`web.fetch`、`browser.navigate`、`agent.<name>`）。部分 OpenAI-compatible 后端 —— 尤其是 **DeepSeek** —— 对 function name 按 `^[a-zA-Z0-9_-]+$` 严格校验，名字里的点会在任何工具运行前直接触发 **HTTP 400**。DashScope/qwen 和 OpenAI 本身接受点，所以此前 adapter 一直没暴露这个问题。

复现（用根目录 `.env` 的 DeepSeek 凭据映射到 openai provider）：
```
http 400: Invalid 'tools[0].function.name': string does not match pattern.
Expected a string that matches the pattern '^[a-zA-Z0-9_-]+$'.
```

## What

在 `openaicompat` provider 加一层**仅作用于传输层、可逆**的工具名转义：
- 出站：`.` → `__`（`fs.read` → `fs__read`）
- 入站：`__` → `.`（解码回真实注册名，引擎才能按真名找到工具）
- 已在字符集内的名字（含合法下划线名如 `get_weather`）**原样透传**，对本就正常的后端零影响
- namespaced 命名约定不会让下划线紧贴点，故 `__` 是无歧义的分隔符替身

接入全部 5 个注入点：出站 tool spec、出站 assistant `tool_calls`、`role:tool` 结果名、入站流式 `tool_call` 名。**Session 日志仍存真实工具名**，编码只活在 HTTP 边界。

新增 `agentry/chat.sh`：加载根目录 `.env` 并把 DeepSeek 凭据映射到 openai provider，一条命令启动交互式 TUI。

## Test

- 新增 `TestToolNameEncodeRoundTrip` / `TestToolNameEncodeFastPath`（round-trip + wire-safe 字符集 + 透传）
- 既有 `TestRequestShape`（`get_weather` 透传契约）保持通过
- `go test ./...` 全包通过、`go vet ./...` 干净
- 真实验证：DeepSeek 纯文本对话调通；工具名 400 已消失

## Known follow-up (out of scope)

带工具调用的回合仍会撞 DeepSeek 的**另一个**严格校验：`role:tool` 消息前必须紧跟带 `tool_calls` 的 assistant 消息。这属于 agent 引擎消息重建的独立 bug，**单独跟踪**，不在本 PR 范围。纯对话已完全可用。