### PR TITLE
feat: memory chat (D1/D2) + timeline day card deep interactions

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -7,10 +7,12 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		09A089C3B8F01817CF9E35CB /* LLMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF559C11C922ACB683565E7C /* LLMClient.swift */; };
 		09C6E4728050D69F54949DD1 /* HapticFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FFEA3DDB8DCB528A4189BF /* HapticFeedbackTests.swift */; };
 		14188AFE740A834ADF7A41F4 /* DayPageWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B2DFF2B446D2F0AC8DE530A1 /* DayPageWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1530E7C28C23499CFC14C498 /* HapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB12D96218034D3E4555B8AA /* HapticFeedback.swift */; };
 		17B5829B738952DA183B1B90 /* DailyPageMetadataEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7E0148C3A6933A903247D /* DailyPageMetadataEditView.swift */; };
+		1BA5F2B78351EFB69F085A65 /* AskPastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1681BDF1E5113769618DA9B0 /* AskPastView.swift */; };
 		29C57DABF22715576844485C /* AISummaryCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82AF0D6D988BC74555DFB3ED /* AISummaryCard.swift */; };
 		2B194E870578303558D461CD /* CompileUnlockCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DE151F5BCB87ACC047C18AD /* CompileUnlockCard.swift */; };
 		326A14114B34412568007B4A /* DayPageWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */; };
@@ -20,19 +22,17 @@
 		485EFA11789212D87CB1B74B /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */; };
 		4A862A4AB3CC3961B771EBC5 /* InputBarTutorialOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912420086719F3FFFB45FE7A /* InputBarTutorialOverlay.swift */; };
 		60D39385300C46D08D8BF03C /* DraftStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = DC21412D29A6FB268CE43C58 /* DraftStorage.swift */; };
+		6587243C5DB109B930AB5D92 /* MemoryChatTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04B9410B749C82B6E34779E4 /* MemoryChatTests.swift */; };
 		73BECCAED0BDBEFB612B15E4 /* DailyPageParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371058C9DAB9A11AE7EAC835 /* DailyPageParser.swift */; };
 		787E4480A2797607F2DCDE5E /* PillSegmentedControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EFC77A2EB872EA2279BA2A /* PillSegmentedControl.swift */; };
 		7BB7402C51CCBACF56E7F83A /* DailyPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08FF205E680406EC7E4B83DB /* DailyPageModel.swift */; };
 		8C3DEB068D610AAB589EA680 /* TimeZonePickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73FCD3E2EC4D7257BA7A22BD /* TimeZonePickerView.swift */; };
 		9034B2964DD6432BD7FA7250 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C98B5757B488F583231EC8F6 /* RootView.swift */; };
+		931858DC28C9134E70E3971F /* MemoryChatService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A19989C44C3E9887FC01F382 /* MemoryChatService.swift */; };
 		97FA675FF46459D5CE5E8CF3 /* QuickCaptureControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519B9B12CB68C0E6E2A06292 /* QuickCaptureControl.swift */; };
 		9B0FAA7690FA2EEED5AB7A96 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = BAC7527E8128E6A865349FB9 /* Foundation.framework */; };
 		9B65087D6C50A363072E40A7 /* LiquidGlassEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DB2FBA71981BA7516DA9A3F /* LiquidGlassEngine.swift */; };
 		9D559EA9D4B9F2C77D942935 /* DayPageShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5FD3383348F15CB7B4E82E53 /* DayPageShortcuts.swift */; };
-		IN1000001 /* QuickCaptureTextIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = IN2000001 /* QuickCaptureTextIntent.swift */; };
-		IN1000002 /* OpenDailyPageIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = IN2000002 /* OpenDailyPageIntent.swift */; };
-		IN1000003 /* AskTodayIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = IN2000003 /* AskTodayIntent.swift */; };
-		TI1000001 /* AppIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TI2000001 /* AppIntentsTests.swift */; };
 		A10000001 /* DayPageApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000001 /* DayPageApp.swift */; };
 		A10000002 /* RootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000002 /* RootView.swift */; };
 		A10000003 /* VaultInitializer.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000003 /* VaultInitializer.swift */; };
@@ -121,6 +121,7 @@
 		A10000304 /* DSDot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000304 /* DSDot.swift */; };
 		A10000350 /* TimelineIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000350 /* TimelineIndex.swift */; };
 		A10000360 /* SentryReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000360 /* SentryReporter.swift */; };
+		A10000370 /* TimelinePinService.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000370 /* TimelinePinService.swift */; };
 		A10000400 /* HorizontalPanGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000400 /* HorizontalPanGesture.swift */; };
 		A10000510 /* RecordingSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000510 /* RecordingSheetView.swift */; };
 		A10000511 /* DynamicIslandView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000511 /* DynamicIslandView.swift */; };
@@ -129,6 +130,7 @@
 		A10000514 /* TimelineRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000514 /* TimelineRow.swift */; };
 		A10000F00 /* FrontmatterParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000F00 /* FrontmatterParser.swift */; };
 		A1000ABC1 /* YearMonthPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2000ABC1 /* YearMonthPicker.swift */; };
+		A11Y0001 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11Y1001 /* AccessibilityTests.swift */; };
 		A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */; };
 		AF0000001 /* SpaceGrotesk-Light.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000001 /* SpaceGrotesk-Light.ttf */; };
 		AF0000002 /* SpaceGrotesk-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000002 /* SpaceGrotesk-Regular.ttf */; };
@@ -145,6 +147,7 @@
 		AF0000013 /* Fraunces-VariableFont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000013 /* Fraunces-VariableFont.ttf */; };
 		AF0000014 /* Caveat-VariableFont.ttf in Resources */ = {isa = PBXBuildFile; fileRef = AF1000014 /* Caveat-VariableFont.ttf */; };
 		B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B93ED807E07C2171E9F4234B /* RecordingView.swift */; };
+		BDCB5B17E4D0258E5F82F6D2 /* GraphRetriever.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD333392AE2B7F775D6E8D99 /* GraphRetriever.swift */; };
 		C80B52CC8945CDC4EE87DCBB /* PosterTemplates.swift in Sources */ = {isa = PBXBuildFile; fileRef = A381FA327A37AE0DD740D61D /* PosterTemplates.swift */; };
 		CJ0000001 /* CJKTextPolish.swift in Sources */ = {isa = PBXBuildFile; fileRef = CJ1000001 /* CJKTextPolish.swift */; };
 		DBB277156934B2FA96E16077 /* WatchApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */; };
@@ -172,8 +175,10 @@
 		FB0000003 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000003 /* FeedbackView.swift */; };
 		FB0000004 /* FeedbackContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB1000004 /* FeedbackContext.swift */; };
 		FT0000001 /* DayOrbView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FT1000001 /* DayOrbView.swift */; };
+		IN1000001 /* QuickCaptureTextIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = IN2000001 /* QuickCaptureTextIntent.swift */; };
+		IN1000002 /* OpenDailyPageIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = IN2000002 /* OpenDailyPageIntent.swift */; };
+		IN1000003 /* AskTodayIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = IN2000003 /* AskTodayIntent.swift */; };
 		KC0000001 /* KeychainHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = KC1000001 /* KeychainHelperTests.swift */; };
-		A11Y0001 /* AccessibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11Y1001 /* AccessibilityTests.swift */; };
 		LS0000001 /* Localizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = LS1000001 /* Localizable.strings */; };
 		LS0000002 /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = LS1000004 /* L10n.swift */; };
 		MD0000001 /* MemoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000001 /* MemoDetailView.swift */; };
@@ -193,6 +198,7 @@
 		TH0000001 /* ThreadConversationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000001 /* ThreadConversationViewModel.swift */; };
 		TH0000002 /* ThreadConversationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000002 /* ThreadConversationView.swift */; };
 		TH0000003 /* InlineMicButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = TH1000003 /* InlineMicButton.swift */; };
+		TI1000001 /* AppIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TI2000001 /* AppIntentsTests.swift */; };
 		WS0000001 /* WelcomeScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = WS1000001 /* WelcomeScreen.swift */; };
 /* End PBXBuildFile section */
 
@@ -235,12 +241,14 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		04B9410B749C82B6E34779E4 /* MemoryChatTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemoryChatTests.swift; sourceTree = "<group>"; };
 		068FB068A000B6E61B1D8032 /* AppSettings.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppSettings.swift; sourceTree = "<group>"; };
 		0881AB423FF6F12FCDE27C5B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		08FF205E680406EC7E4B83DB /* DailyPageModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyPageModel.swift; sourceTree = "<group>"; };
 		0995108F7E2E8994F114A240 /* MemoListSkeleton.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemoListSkeleton.swift; sourceTree = "<group>"; };
 		0CF7E0148C3A6933A903247D /* DailyPageMetadataEditView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DailyPageMetadataEditView.swift; sourceTree = "<group>"; };
 		12641793A8F375B34321E87A /* UndoPillView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UndoPillView.swift; sourceTree = "<group>"; };
+		1681BDF1E5113769618DA9B0 /* AskPastView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AskPastView.swift; sourceTree = "<group>"; };
 		23EA9C83B41565EDB263FB35 /* DayPageWatch.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = DayPageWatch.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		2748059CC689A341C7CAAACC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
@@ -248,10 +256,6 @@
 		3DE151F5BCB87ACC047C18AD /* CompileUnlockCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompileUnlockCard.swift; sourceTree = "<group>"; };
 		519B9B12CB68C0E6E2A06292 /* QuickCaptureControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureControl.swift; sourceTree = "<group>"; };
 		5FD3383348F15CB7B4E82E53 /* DayPageShortcuts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DayPageShortcuts.swift; sourceTree = "<group>"; };
-		IN2000001 /* QuickCaptureTextIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureTextIntent.swift; sourceTree = "<group>"; };
-		IN2000002 /* OpenDailyPageIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenDailyPageIntent.swift; sourceTree = "<group>"; };
-		IN2000003 /* AskTodayIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AskTodayIntent.swift; sourceTree = "<group>"; };
-		TI2000001 /* AppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppIntentsTests.swift; sourceTree = "<group>"; };
 		61EFC77A2EB872EA2279BA2A /* PillSegmentedControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PillSegmentedControl.swift; sourceTree = "<group>"; };
 		71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DayPageWidgetBundle.swift; sourceTree = "<group>"; };
 		73FCD3E2EC4D7257BA7A22BD /* TimeZonePickerView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TimeZonePickerView.swift; sourceTree = "<group>"; };
@@ -262,6 +266,8 @@
 		8F07950D8A46BAC7B9CCB1ED /* ShareCardSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareCardSystem.swift; path = ShareCard/ShareCardSystem.swift; sourceTree = "<group>"; };
 		912420086719F3FFFB45FE7A /* InputBarTutorialOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InputBarTutorialOverlay.swift; sourceTree = "<group>"; };
 		986C8E3E042E690BA4CCC12D /* ShareCardSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareCardSystem.swift; path = ShareCard/ShareCardSystem.swift; sourceTree = "<group>"; };
+		A11Y1001 /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
+		A19989C44C3E9887FC01F382 /* MemoryChatService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MemoryChatService.swift; path = MemoryChatService.swift; sourceTree = "<group>"; };
 		A20000001 /* DayPageApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayPageApp.swift; sourceTree = "<group>"; };
 		A20000002 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
 		A20000003 /* VaultInitializer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultInitializer.swift; sourceTree = "<group>"; };
@@ -352,6 +358,7 @@
 		A20000304 /* DSDot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DSDot.swift; sourceTree = "<group>"; };
 		A20000350 /* TimelineIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineIndex.swift; sourceTree = "<group>"; };
 		A20000360 /* SentryReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SentryReporter.swift; sourceTree = "<group>"; };
+		A20000370 /* TimelinePinService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelinePinService.swift; sourceTree = "<group>"; };
 		A20000400 /* HorizontalPanGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HorizontalPanGesture.swift; sourceTree = "<group>"; };
 		A20000510 /* RecordingSheetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingSheetView.swift; sourceTree = "<group>"; };
 		A20000511 /* DynamicIslandView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicIslandView.swift; sourceTree = "<group>"; };
@@ -384,8 +391,10 @@
 		BB12D96218034D3E4555B8AA /* HapticFeedback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HapticFeedback.swift; sourceTree = "<group>"; };
 		C551D36362FF97C44EB4D5DE /* SidebarHeatmapView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarHeatmapView.swift; sourceTree = "<group>"; };
 		C98B5757B488F583231EC8F6 /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		CF559C11C922ACB683565E7C /* LLMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LLMClient.swift; path = LLMClient.swift; sourceTree = "<group>"; };
 		CJ1000001 /* CJKTextPolish.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CJKTextPolish.swift; sourceTree = "<group>"; };
 		DC21412D29A6FB268CE43C58 /* DraftStorage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DraftStorage.swift; sourceTree = "<group>"; };
+		DD333392AE2B7F775D6E8D99 /* GraphRetriever.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GraphRetriever.swift; path = GraphRetriever.swift; sourceTree = "<group>"; };
 		DS1000001 /* Motion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Motion.swift; sourceTree = "<group>"; };
 		DS1000002 /* Haptics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Haptics.swift; sourceTree = "<group>"; };
 		DS1000010 /* Radius.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Radius.swift; sourceTree = "<group>"; };
@@ -406,8 +415,10 @@
 		FB1000004 /* FeedbackContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackContext.swift; sourceTree = "<group>"; };
 		FE91252BA9167A50BFF79FF0 /* StartRecordingIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartRecordingIntent.swift; sourceTree = "<group>"; };
 		FT1000001 /* DayOrbView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayOrbView.swift; sourceTree = "<group>"; };
+		IN2000001 /* QuickCaptureTextIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureTextIntent.swift; sourceTree = "<group>"; };
+		IN2000002 /* OpenDailyPageIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OpenDailyPageIntent.swift; sourceTree = "<group>"; };
+		IN2000003 /* AskTodayIntent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AskTodayIntent.swift; sourceTree = "<group>"; };
 		KC1000001 /* KeychainHelperTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainHelperTests.swift; sourceTree = "<group>"; };
-		A11Y1001 /* AccessibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityTests.swift; sourceTree = "<group>"; };
 		LS1000002 /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		LS1000003 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/Localizable.strings"; sourceTree = "<group>"; };
 		LS1000004 /* L10n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10n.swift; sourceTree = "<group>"; };
@@ -427,6 +438,7 @@
 		TH1000001 /* ThreadConversationViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationViewModel.swift; sourceTree = "<group>"; };
 		TH1000002 /* ThreadConversationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThreadConversationView.swift; sourceTree = "<group>"; };
 		TH1000003 /* InlineMicButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineMicButton.swift; sourceTree = "<group>"; };
+		TI2000001 /* AppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppIntentsTests.swift; sourceTree = "<group>"; };
 		WS1000001 /* WelcomeScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeScreen.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -465,6 +477,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		08775C73D4E048DD3BC96559 /* Ask */ = {
+			isa = PBXGroup;
+			children = (
+				1681BDF1E5113769618DA9B0 /* AskPastView.swift */,
+			);
+			name = Ask;
+			path = Ask;
+			sourceTree = "<group>";
+		};
 		169A033458595BA06BEA3D5F /* App */ = {
 			isa = PBXGroup;
 			children = (
@@ -611,6 +632,7 @@
 				A50000021 /* Auth */,
 				A50000022 /* Feedback */,
 				MD5000001 /* MemoDetail */,
+				08775C73D4E048DD3BC96559 /* Ask */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -655,10 +677,14 @@
 				A20000083 /* WeeklyRecapService.swift */,
 				A20000301 /* TimelineService.swift */,
 				A20000350 /* TimelineIndex.swift */,
+				A20000370 /* TimelinePinService.swift */,
 				A20000360 /* SentryReporter.swift */,
 				A20000095 /* ComposerContextProvider.swift */,
 				BB12D96218034D3E4555B8AA /* HapticFeedback.swift */,
 				AC8043A3D3371852ACB3D6F3 /* MarkdownExportService.swift */,
+				CF559C11C922ACB683565E7C /* LLMClient.swift */,
+				DD333392AE2B7F775D6E8D99 /* GraphRetriever.swift */,
+				A19989C44C3E9887FC01F382 /* MemoryChatService.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -951,6 +977,7 @@
 				KC1000001 /* KeychainHelperTests.swift */,
 				TI2000001 /* AppIntentsTests.swift */,
 				A11Y1001 /* AccessibilityTests.swift */,
+				04B9410B749C82B6E34779E4 /* MemoryChatTests.swift */,
 			);
 			path = DayPageTests;
 			sourceTree = "<group>";
@@ -1229,6 +1256,7 @@
 				A10000083 /* WeeklyRecapService.swift in Sources */,
 				A10000301 /* TimelineService.swift in Sources */,
 				A10000350 /* TimelineIndex.swift in Sources */,
+				A10000370 /* TimelinePinService.swift in Sources */,
 				A10000360 /* SentryReporter.swift in Sources */,
 				A10000084 /* WeeklyRecapSection.swift in Sources */,
 				A10000302 /* TimelineSectionView.swift in Sources */,
@@ -1254,6 +1282,7 @@
 				A10000080 /* AppNavigationModel.swift in Sources */,
 				A10000300 /* DSTokens.swift in Sources */,
 				A10000301 /* TimelineService.swift in Sources */,
+				A10000370 /* TimelinePinService.swift in Sources */,
 				A10000302 /* TimelineSectionView.swift in Sources */,
 				A10000303 /* DSSectionLabel.swift in Sources */,
 				A10000304 /* DSDot.swift in Sources */,
@@ -1315,6 +1344,10 @@
 				2B194E870578303558D461CD /* CompileUnlockCard.swift in Sources */,
 				E536EEB8C13B2BA42DF4980F /* SidebarHeatmapView.swift in Sources */,
 				9B65087D6C50A363072E40A7 /* LiquidGlassEngine.swift in Sources */,
+				09A089C3B8F01817CF9E35CB /* LLMClient.swift in Sources */,
+				BDCB5B17E4D0258E5F82F6D2 /* GraphRetriever.swift in Sources */,
+				931858DC28C9134E70E3971F /* MemoryChatService.swift in Sources */,
+				1BA5F2B78351EFB69F085A65 /* AskPastView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1334,6 +1367,7 @@
 				KC0000001 /* KeychainHelperTests.swift in Sources */,
 				TI1000001 /* AppIntentsTests.swift in Sources */,
 				A11Y0001 /* AccessibilityTests.swift in Sources */,
+				6587243C5DB109B930AB5D92 /* MemoryChatTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage/App/AppNavigationModel.swift
+++ b/DayPage/App/AppNavigationModel.swift
@@ -41,6 +41,14 @@ final class AppNavigationModel: ObservableObject {
     /// re-fires the navigation.
     @Published var pendingSearchQuery: String? = nil
 
+    /// Pre-filled question delivered via `daypage://ask?q=…` (from `AskTodayIntent`).
+    /// RootView observes this, presents the "和过去对话" chat sheet seeded with the
+    /// question, and clears it so re-firing the same shortcut re-opens the sheet.
+    /// This is the D1 entry point (research doc §3 D1); kept separate from
+    /// `pendingSearchQuery` so the Shortcuts surface can route to either the
+    /// keyword search (Archive) or the memory-chat agent without ambiguity.
+    @Published var pendingAskQuery: String? = nil
+
     init() {}
 
     private static func initialTab() -> AppTab {

--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -203,6 +203,18 @@ struct DayPageApp: App {
                         return
                     }
 
+                    // daypage://ask?q=… — open the "和过去对话" memory-chat agent
+                    // (D1). RootView observes pendingAskQuery and presents
+                    // AskPastView seeded with the question. Driven by AskTodayIntent.
+                    if url.host?.lowercased() == "ask" {
+                        if let components = URLComponents(url: url, resolvingAgainstBaseURL: false),
+                           let q = components.queryItems?.first(where: { $0.name == "q" })?.value,
+                           !q.isEmpty {
+                            navModel.pendingAskQuery = q
+                        }
+                        return
+                    }
+
                     // daypage://search?q=… — open SearchView pre-populated with
                     // the query. SearchView lives under Archive, so we switch
                     // to .archive and let ArchiveView observe pendingSearchQuery.

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -231,7 +231,34 @@ struct RootView: View {
                     .accessibilityHidden(true)
             }
         }
+        // D1「和过去对话」chat sheet. Driven by `nav.pendingAskQuery`
+        // (set by AskTodayIntent → daypage://ask). Wrapping the query in an
+        // Identifiable lets `.sheet(item:)` present once and auto-clear the
+        // pending value on dismissal so re-firing the shortcut re-opens it.
+        .sheet(item: askSheetBinding) { item in
+            AskPastView(seedQuestion: item.query) {
+                nav.pendingAskQuery = nil
+            }
+        }
     }
+
+    /// Bridges the optional `pendingAskQuery` string to a `.sheet(item:)`
+    /// binding: presents AskPastView while the query is non-nil, and clears it
+    /// on dismissal.
+    private var askSheetBinding: Binding<AskQuery?> {
+        Binding(
+            get: { nav.pendingAskQuery.map(AskQuery.init) },
+            set: { if $0 == nil { nav.pendingAskQuery = nil } }
+        )
+    }
+}
+
+// MARK: - AskQuery
+
+/// Identifiable wrapper so a seed question can drive `.sheet(item:)`.
+private struct AskQuery: Identifiable {
+    let query: String
+    var id: String { query }
 }
 
 // MARK: - FeedbackCloseSwipeModifier

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -274,14 +274,47 @@ struct SidebarView: View {
 
     // MARK: - Nav Items
 
-    /// Primary nav: Today / Archive / Graph.
+    /// Primary nav: Today / Archive / Graph + the "Ask the past" agent (D1).
     private var navSection: some View {
         VStack(alignment: .leading, spacing: 2) {
             navItem(tab: .today, icon: "square.and.pencil", label: "Today")
             navItem(tab: .archive, icon: "archivebox", label: "Archive")
             navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted", label: "Graph")
+            askRow
         }
         .padding(.horizontal, 12)
+    }
+
+    /// In-app entry point for the D1 "和过去对话" memory-chat agent. Without
+    /// this the agent is only reachable via the Siri/Shortcuts intent, leaving
+    /// it invisible to most users. Tapping seeds `pendingAskQuery` with an empty
+    /// string so RootView presents AskPastView in its empty-prompt state.
+    private var askRow: some View {
+        Button {
+            Haptics.light()
+            nav.closeSidebar()
+            nav.pendingAskQuery = ""
+        } label: {
+            HStack(spacing: 12) {
+                RoundedRectangle(cornerRadius: 1, style: .continuous)
+                    .fill(Color.clear)
+                    .frame(width: 2, height: 20)
+                Image(systemName: "sparkle.magnifyingglass")
+                    .font(.system(size: 16, weight: .regular))
+                    .frame(width: 20)
+                    .foregroundColor(DSColor.inkMuted)
+                Text("和过去对话")
+                    .font(DSType.bodyMD)
+                    .foregroundColor(DSColor.inkMuted)
+            }
+            .padding(.trailing, 16)
+            .padding(.vertical, 11)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("和过去对话")
+        .accessibilityHint("基于你的记录提问")
     }
 
     private var feedbackSection: some View {

--- a/DayPage/Components/GlassErrorBanner.swift
+++ b/DayPage/Components/GlassErrorBanner.swift
@@ -254,7 +254,12 @@ struct GlassErrorBannerOverlayModifier: ViewModifier {
                             retryAction: item.retryAction,
                             onDismiss: { stack.dismiss(id: item.id) }
                         )
-                        .transition(.move(edge: .top).combined(with: .opacity))
+                        // Mirror AppBanner's asymmetric entry/exit so the two
+                        // banner systems feel like one polished surface.
+                        .transition(.asymmetric(
+                            insertion: .move(edge: .top).combined(with: .opacity),
+                            removal: .opacity.combined(with: .offset(y: -8))
+                        ))
                         .id(item.id)
                     }
                 }
@@ -263,7 +268,7 @@ struct GlassErrorBannerOverlayModifier: ViewModifier {
                 .zIndex(200)
             }
         }
-        .animation(Motion.slide, value: stack.items.map(\.id))
+        .animation(.spring(response: 0.55, dampingFraction: 0.88), value: stack.items.map(\.id))
     }
 }
 

--- a/DayPage/Features/Ask/AskPastView.swift
+++ b/DayPage/Features/Ask/AskPastView.swift
@@ -1,0 +1,270 @@
+import SwiftUI
+
+// MARK: - AskPastView
+
+/// D1「和你的过去对话」对话界面（研究文档 §3 D1）。
+///
+/// 用户通过 Siri/快捷指令（`AskTodayIntent` → `daypage://ask`）或 app 内入口
+/// 提问，本视图驱动 `MemoryChatService` 做图谱增强检索（D2）+ LLM 回答，
+/// 并把「引用了哪些记录」作为来源 chip 显式呈现——让"连"的价值被用户感知
+/// （研究文档 §5 风险 4：把图谱价值显性化）。
+struct AskPastView: View {
+
+    /// 初始问题（来自 deep-link）；为空则展示空态引导。
+    let seedQuestion: String?
+    let onClose: () -> Void
+
+    @StateObject private var chat = MemoryChatService()
+    @State private var draft: String = ""
+    @State private var didSeed = false
+    @FocusState private var inputFocused: Bool
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                conversation
+                Divider().background(DSColor.borderSubtle)
+                inputBar
+            }
+            .background(DSColor.bgWarm.ignoresSafeArea())
+            .navigationTitle("和过去对话")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarLeading) {
+                    Button("关闭", action: onClose)
+                }
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button {
+                        chat.reset()
+                        draft = ""
+                    } label: { Image(systemName: "square.and.pencil") }
+                        .disabled(chat.turns.isEmpty)
+                        .accessibilityLabel("新对话")
+                }
+            }
+        }
+        .task {
+            guard !didSeed else { return }
+            didSeed = true
+            if let seed = seedQuestion?.trimmingCharacters(in: .whitespacesAndNewlines), !seed.isEmpty {
+                await chat.ask(seed)
+            } else {
+                inputFocused = true
+            }
+        }
+    }
+
+    // MARK: - Conversation
+
+    private var conversation: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    if chat.turns.isEmpty && !chat.isResponding {
+                        emptyState
+                    }
+                    ForEach(chat.turns) { turn in
+                        turnRow(turn).id(turn.id)
+                    }
+                    if chat.isResponding {
+                        respondingIndicator.id("responding")
+                    }
+                    if let err = chat.errorMessage {
+                        errorRow(err)
+                    }
+                }
+                .padding(16)
+            }
+            .onChange(of: chat.turns.count) { _ in
+                withAnimation { proxy.scrollTo(chat.turns.last?.id, anchor: .bottom) }
+            }
+            .onChange(of: chat.isResponding) { responding in
+                if responding { withAnimation { proxy.scrollTo("responding", anchor: .bottom) } }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func turnRow(_ turn: ChatTurn) -> some View {
+        switch turn.role {
+        case .user:
+            HStack {
+                Spacer(minLength: 40)
+                Text(turn.text)
+                    .font(DSType.serifBody16)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(DSColor.surfaceContainerHigh)
+                    .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+            }
+        case .assistant:
+            VStack(alignment: .leading, spacing: 10) {
+                Text(turn.text)
+                    .font(DSType.serifBody16)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let context = turn.context, !context.isEmpty {
+                    sourceChips(context)
+                }
+            }
+        }
+    }
+
+    /// 引用来源 chips：把检索到的 memo 日期与实体显式呈现。
+    private func sourceChips(_ context: RetrievedContext) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("依据")
+                .font(DSType.labelSM)
+                .foregroundColor(DSColor.inkMuted)
+            FlowChips(items: chipLabels(from: context))
+        }
+        .padding(.top, 2)
+    }
+
+    private func chipLabels(from context: RetrievedContext) -> [String] {
+        var labels: [String] = []
+        let dates = Array(Set(context.memoHits.map { $0.dateString })).sorted(by: >)
+        labels.append(contentsOf: dates.prefix(4))
+        labels.append(contentsOf: context.entityHits.prefix(3).map { $0.displayName })
+        return labels
+    }
+
+    // MARK: - Empty / loading / error
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("问问你的过去")
+                .font(DSType.serifBody20)
+                .foregroundColor(DSColor.inkPrimary)
+            Text("基于你记录过的内容回答，并标注依据来源。试试：")
+                .font(DSType.bodySM)
+                .foregroundColor(DSColor.inkSecondary)
+            ForEach(Self.examplePrompts, id: \.self) { example in
+                Button {
+                    Task { await chat.ask(example) }
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "sparkle")
+                            .font(.system(size: 12))
+                            .foregroundColor(DSColor.amberAccent)
+                        Text(example)
+                            .font(DSType.bodySM)
+                            .foregroundColor(DSColor.inkPrimary)
+                            .multilineTextAlignment(.leading)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+                    .background(DSColor.surfaceContainerHigh)
+                    .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.top, 24)
+    }
+
+    private var respondingIndicator: some View {
+        HStack(spacing: 8) {
+            ProgressView().controlSize(.small)
+            Text("正在翻看你的记录…")
+                .font(DSType.bodySM)
+                .foregroundColor(DSColor.inkSecondary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func errorRow(_ message: String) -> some View {
+        Text(message)
+            .font(DSType.bodySM)
+            .foregroundColor(DSColor.inkSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(12)
+            .background(DSColor.surfaceContainerHigh)
+            .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+    }
+
+    // MARK: - Input bar
+
+    private var inputBar: some View {
+        HStack(spacing: 10) {
+            TextField("问问你的过去…", text: $draft, axis: .vertical)
+                .font(DSType.bodySM)
+                .focused($inputFocused)
+                .lineLimit(1...4)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(DSColor.surfaceContainerHigh)
+                .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+                .onSubmit(submit)
+
+            Button(action: submit) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 28))
+                    .foregroundColor(canSend ? DSColor.amberAccent : DSColor.inkSubtle)
+            }
+            .disabled(!canSend)
+            .accessibilityLabel("发送")
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+        .background(DSColor.bgWarm)
+    }
+
+    private var canSend: Bool {
+        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !chat.isResponding
+    }
+
+    private func submit() {
+        let question = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !question.isEmpty, !chat.isResponding else { return }
+        draft = ""
+        Task { await chat.ask(question) }
+    }
+
+    // MARK: - Static
+
+    static let examplePrompts = [
+        "我最近的情绪有什么变化？",
+        "去年这个时候我在做什么？",
+        "我提到最多的地方是哪里？"
+    ]
+}
+
+// MARK: - FlowChips
+
+/// 简单的自动换行 chip 容器。用于展示对话回答的来源依据。
+private struct FlowChips: View {
+    let items: [String]
+
+    var body: some View {
+        // iOS 16 无原生 flow layout；chip 数量已被上游限制在个位数，
+        // 这里用每行最多 3 个的 wrap 近似即可。
+        VStack(alignment: .leading, spacing: 6) {
+            ForEach(rows(), id: \.self) { row in
+                HStack(spacing: 6) {
+                    ForEach(row, id: \.self) { item in chip(item) }
+                }
+            }
+        }
+    }
+
+    private func chip(_ text: String) -> some View {
+        Text(text)
+            .font(DSType.labelSM)
+            .foregroundColor(DSColor.inkSecondary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(DSColor.surfaceContainerHigh)
+            .clipShape(Capsule())
+    }
+
+    /// 每行最多 3 个 chip。
+    private func rows() -> [[String]] {
+        stride(from: 0, to: items.count, by: 3).map {
+            Array(items[$0..<min($0 + 3, items.count)])
+        }
+    }
+}

--- a/DayPage/Features/Shared/AppBanner.swift
+++ b/DayPage/Features/Shared/AppBanner.swift
@@ -27,7 +27,7 @@ struct AppBannerModel: Identifiable {
         subtitle: String? = nil,
         primaryAction: BannerAction? = nil,
         secondaryAction: BannerAction? = nil,
-        autoDismiss: Bool = false
+        autoDismiss: Bool = true
     ) {
         self.kind = kind
         self.title = title
@@ -56,12 +56,20 @@ final class BannerCenter: ObservableObject {
 
     func show(_ model: AppBannerModel) {
         autoDismissTask?.cancel()
-        currentBanner = model
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.88)) {
+            currentBanner = model
+        }
         if model.autoDismiss {
+            // Banners with primary/secondary actions linger longer so users can
+            // read and tap them; pure info/success/error toasts fade after 5s.
+            let hasAction = model.primaryAction != nil || model.secondaryAction != nil
+            let delayNanos: UInt64 = hasAction ? 8_000_000_000 : 5_000_000_000
             autoDismissTask = Task { @MainActor in
-                try? await Task.sleep(nanoseconds: 3_000_000_000)
+                try? await Task.sleep(nanoseconds: delayNanos)
                 if !Task.isCancelled {
-                    withAnimation { currentBanner = nil }
+                    withAnimation(.spring(response: 0.55, dampingFraction: 0.88)) {
+                        currentBanner = nil
+                    }
                 }
             }
         }
@@ -69,7 +77,9 @@ final class BannerCenter: ObservableObject {
 
     func dismiss() {
         autoDismissTask?.cancel()
-        withAnimation { currentBanner = nil }
+        withAnimation(.spring(response: 0.55, dampingFraction: 0.88)) {
+            currentBanner = nil
+        }
     }
 }
 
@@ -212,11 +222,16 @@ struct BannerOverlayModifier: ViewModifier {
             if let banner = bannerCenter.currentBanner {
                 AppBanner(model: banner)
                     .padding(.top, 8)
-                    .transition(.move(edge: .top).combined(with: .opacity))
+                    // Asymmetric: slide-down + fade-in on entry; pure fade-up
+                    // on exit so dismissal feels gentle rather than yanked.
+                    .transition(.asymmetric(
+                        insertion: .move(edge: .top).combined(with: .opacity),
+                        removal: .opacity.combined(with: .offset(y: -8))
+                    ))
                     .zIndex(100)
             }
         }
-        .animation(.spring(response: 0.4, dampingFraction: 0.85), value: bannerCenter.currentBanner?.id)
+        .animation(.spring(response: 0.55, dampingFraction: 0.88), value: bannerCenter.currentBanner?.id)
     }
 }
 

--- a/DayPage/Features/Today/TimelineSectionView.swift
+++ b/DayPage/Features/Today/TimelineSectionView.swift
@@ -24,6 +24,12 @@ import SwiftUI
 struct TimelineSectionView: View {
 
     let section: TimelineSection
+    /// Parent-driven actions invoked by each row. All are optional so the
+    /// section view stays usable in previews and from call sites that haven't
+    /// wired the new gesture vocabulary yet.
+    var onOpenDate: ((String) -> Void)? = nil
+    var onShareDate: ((TimelineDayEntry) -> Void)? = nil
+    var onDeleteDate: ((TimelineDayEntry) -> Void)? = nil
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -44,7 +50,10 @@ struct TimelineSectionView: View {
                 TimelineDayRow(
                     entry: day,
                     isFirst: index == 0,
-                    isLast: index == section.days.count - 1
+                    isLast: index == section.days.count - 1,
+                    onOpenDate: onOpenDate,
+                    onShareDate: onShareDate,
+                    onDeleteDate: onDeleteDate
                 )
             }
         }
@@ -69,6 +78,8 @@ struct TimelineSectionView: View {
     /// Left display caption — 本周 / 本月 / 今年 + month name. app.jsx:612.
     private var headerLabel: String {
         switch section.kind {
+        case .pinned:
+            return NSLocalizedString("today.timeline.pinned", value: "📌 PINNED", comment: "Timeline band header for user-pinned days")
         case .thisWeekOthers:
             return NSLocalizedString("today.timeline.thisWeek", value: "本周", comment: "Timeline band")
         case .lastWeek:
@@ -93,36 +104,155 @@ struct TimelineSectionView: View {
 
 // MARK: - TimelineDayRow
 
-/// One day row hung off the spine. Tap to expand — that day's raw memos load
-/// lazily inline (no navigation, see #276). The collapsed presentation is the
-/// faithful museum row: mono day / display date nameplate · accent dot ·
-/// serif title · inter lede · mono meta footer.
+/// One day row hung off the spine. The collapsed presentation is the faithful
+/// museum row: mono day / display date nameplate · accent dot · serif title ·
+/// inter lede · mono meta footer.
+///
+/// Gesture vocabulary (deliberately picked so every action has one obvious
+/// home and the destructive one never sits on a swipe path):
+///   • Tap            → open the Daily Page for this date (full-screen cover).
+///   • Long-press     → system contextMenu with a preview card; menu items
+///                      cover open / share / pin toggle / copy / delete.
+///   • Right-swipe    → leading panel: pin / unpin (amber).
+///   • Left-swipe     → trailing panel: share via system sheet (amber).
+///   • Delete         → ONLY from the contextMenu, behind a destructive role
+///                      and a confirmation alert. Never on a swipe.
 struct TimelineDayRow: View {
 
     let entry: TimelineDayEntry
     let isFirst: Bool
     let isLast: Bool
 
-    @State private var isExpanded: Bool = false
+    /// Parent-driven actions. All optional — when nil the corresponding
+    /// gesture / menu item is hidden, so the row keeps working in previews.
+    var onOpenDate: ((String) -> Void)? = nil
+    var onShareDate: ((TimelineDayEntry) -> Void)? = nil
+    var onDeleteDate: ((TimelineDayEntry) -> Void)? = nil
+
+    @ObservedObject private var pinService = TimelinePinService.shared
+
+    /// Loaded lazily on first long-press so the contextMenu preview card can
+    /// show that day's memos without paying the parse cost on every cold
+    /// scroll past the row.
     @State private var loadedMemos: [Memo] = []
     @State private var hasLoaded: Bool = false
 
+    @State private var showDeleteConfirm: Bool = false
+
+    // Swipe-to-reveal state (mirrors SwipeableMemoCard's vocabulary).
+    @State private var settledOffset: CGFloat = 0
+    @State private var dragDelta: CGFloat = 0
+    @State private var isPanActive: Bool = false
+    @State private var armedSide: SwipeSide? = nil
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    private var isPinned: Bool { pinService.isPinned(entry.dateString) }
+
+    fileprivate enum SwipeSide { case leading, trailing }
+
     var body: some View {
-        Button(action: toggle) {
-            VStack(alignment: .leading, spacing: 0) {
-                rowScaffold
-                if isExpanded {
-                    expandedMemos
-                        .transition(.opacity.combined(with: .move(edge: .top)))
-                }
-            }
-            .contentShape(Rectangle())
+        gestureSurface
+            .clipped()
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel(accessibilityLabel)
+            .accessibilityHint(NSLocalizedString("today.timeline.openDailyPage", value: "Open Daily Page", comment: ""))
+            .accessibilityAction(named: shareActionTitle) { onShareDate?(entry) }
+            .accessibilityAction(named: pinActionTitle) { _ = pinService.togglePin(entry.dateString) }
+            .contextMenu { menuButtons } preview: { previewCard }
+            .alert(deleteAlertTitle, isPresented: $showDeleteConfirm, actions: deleteAlertActions, message: deleteAlertMessage)
+    }
+
+    // MARK: Body sub-views (kept small so SwiftUI's type-checker stays fast)
+
+    /// ZStack carrying the swipe-translated content + the side panels.
+    private var gestureSurface: some View {
+        ZStack(alignment: .center) {
+            rowContent
+            sidePanels
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel(accessibilityLabel)
-        .accessibilityHint(isExpanded
-            ? NSLocalizedString("today.timeline.collapse", value: "Collapse", comment: "")
-            : NSLocalizedString("today.timeline.expand", value: "Expand", comment: ""))
+    }
+
+    /// LAYER 1 — the museum row, offset by the live swipe translation. The
+    /// UIKit pan/tap host sits as an overlay so vertical scrolls still belong
+    /// to the parent ScrollView (see SwipeableMemoCard for the rationale).
+    private var rowContent: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            rowScaffold
+        }
+        .contentShape(Rectangle())
+        .background(DSColor.bgWarm)
+        .offset(x: currentOffset)
+        .overlay(panGestureOverlay)
+    }
+
+    private var panGestureOverlay: some View {
+        HorizontalPanGesture(
+            isActive: $isPanActive,
+            onChanged: handlePanChanged,
+            onEnded: handlePanEnded,
+            onCancelled: handlePanCancelled,
+            onTap: handleRowTap,
+            isEnabled: true
+        )
+    }
+
+    /// LAYER 2 — both side panels. Hidden at rest; only hit-testable once a
+    /// side is actually open so they never steal taps from the row.
+    private var sidePanels: some View {
+        HStack(spacing: 0) {
+            TimelineSwipePanel(
+                actions: leadingActions,
+                edge: .leading,
+                progress: max(0, revealProgress)
+            )
+            Spacer(minLength: 0)
+            TimelineSwipePanel(
+                actions: trailingActions,
+                edge: .trailing,
+                progress: max(0, -revealProgress)
+            )
+        }
+        .allowsHitTesting(revealedSide != nil)
+    }
+
+    private var previewCard: some View {
+        TimelineDayPreviewCard(entry: entry, memos: loadedMemos)
+            .frame(width: 320, height: 360)
+            .onAppear { ensureMemosLoaded() }
+    }
+
+    // MARK: Localized strings (computed once per render)
+
+    private var shareActionTitle: String {
+        NSLocalizedString("today.timeline.action.share", value: "Share", comment: "")
+    }
+
+    private var pinActionTitle: String {
+        isPinned
+            ? NSLocalizedString("today.timeline.action.unpin", value: "Unpin", comment: "")
+            : NSLocalizedString("today.timeline.action.pin", value: "Pin", comment: "")
+    }
+
+    private var deleteAlertTitle: String {
+        NSLocalizedString("today.timeline.delete.title", value: "Delete this day?", comment: "")
+    }
+
+    @ViewBuilder
+    private func deleteAlertActions() -> some View {
+        Button(NSLocalizedString("today.timeline.delete.confirm", value: "Delete", comment: ""), role: .destructive) {
+            onDeleteDate?(entry)
+        }
+        Button(NSLocalizedString("today.timeline.delete.cancel", value: "Cancel", comment: ""), role: .cancel) {}
+    }
+
+    private func deleteAlertMessage() -> some View {
+        let format = NSLocalizedString(
+            "today.timeline.delete.message",
+            value: "This will permanently remove %d memo(s) and the compiled summary for %@.",
+            comment: "Delete-day confirmation body"
+        )
+        return Text(String(format: format, entry.memoCount, entry.dateString))
     }
 
     // MARK: Row scaffold — nameplate | marker | content
@@ -139,12 +269,22 @@ struct TimelineDayRow: View {
         .padding(.bottom, isLast ? 6 : 26)
         // Marker overlaid on the spine — top-leading so the dot lines up with
         // the title regardless of content height. app.jsx:654.
+        // When the day is user-pinned the marker is replaced by a tiny pin
+        // glyph so the row reads as "this one's mine" at a glance.
         .overlay(alignment: .topLeading) {
-            TimelineSpine.DayMarker()
-                .offset(
-                    x: TimelineSpine.rowSpineX - TimelineSpine.DayMarker.size / 2,
-                    y: (isFirst ? 0 : 26) + 11
-                )
+            Group {
+                if isPinned {
+                    Image(systemName: "pin.fill")
+                        .font(.system(size: 9, weight: .bold))
+                        .foregroundColor(DSColor.accentAmber)
+                } else {
+                    TimelineSpine.DayMarker()
+                }
+            }
+            .offset(
+                x: TimelineSpine.rowSpineX - TimelineSpine.DayMarker.size / 2,
+                y: (isFirst ? 0 : 26) + 11
+            )
         }
     }
 
@@ -175,7 +315,7 @@ struct TimelineDayRow: View {
             if let lede = displayLede {
                 TimelineSpine.RowLede(text: lede)
                     .padding(.top, 10)        // app.jsx:656 margin:'10px 0 0'
-                    .lineLimit(isExpanded ? nil : 3)
+                    .lineLimit(3)
             }
             TimelineSpine.RowMeta(tags: metaTags, right: { wordsRight })
                 .padding(.top, 14)            // app.jsx:705 marginTop:14
@@ -197,34 +337,201 @@ struct TimelineDayRow: View {
         .tracking(1.3)
     }
 
-    // MARK: Expanded memo list
-
-    private var expandedMemos: some View {
-        VStack(spacing: 8) {
-            ForEach(loadedMemos, id: \.id) { memo in
-                MemoCardView(memo: memo)
-                    .frame(maxWidth: .infinity)
-            }
-        }
-        .padding(.leading, TimelineSpine.nameplateWidth + TimelineSpine.columnGap + 6)
-        .padding(.bottom, 18)
-    }
-
     // MARK: Interaction
 
-    private func toggle() {
-        if !hasLoaded {
-            Task {
-                let memos = TimelineService.memos(for: entry)
-                await MainActor.run {
-                    loadedMemos = memos
-                    hasLoaded = true
-                }
+    /// Plain tap routes to the Daily Page. If a swipe panel is currently
+    /// revealed, the tap closes it instead so users can dismiss a drawer
+    /// without firing the underlying action.
+    private func handleRowTap() {
+        if revealedSide != nil {
+            snapClose()
+            return
+        }
+        Haptics.tapConfirm()
+        onOpenDate?(entry.dateString)
+    }
+
+    /// Loads memos lazily for the contextMenu preview card.
+    private func ensureMemosLoaded() {
+        guard !hasLoaded else { return }
+        Task {
+            let memos = TimelineService.memos(for: entry)
+            await MainActor.run {
+                loadedMemos = memos
+                hasLoaded = true
             }
         }
-        withAnimation(.easeInOut(duration: DSTokens.Motion.fast)) {
-            isExpanded.toggle()
+    }
+
+    // MARK: Context menu items
+
+    @ViewBuilder
+    private var menuButtons: some View {
+        Button {
+            onOpenDate?(entry.dateString)
+        } label: {
+            Label(
+                NSLocalizedString("today.timeline.menu.open", value: "Open Daily Page", comment: ""),
+                systemImage: "book.pages"
+            )
         }
+        Button {
+            onShareDate?(entry)
+        } label: {
+            Label(
+                NSLocalizedString("today.timeline.menu.share", value: "Share", comment: ""),
+                systemImage: "square.and.arrow.up"
+            )
+        }
+        Button {
+            _ = pinService.togglePin(entry.dateString)
+            Haptics.tapConfirm()
+        } label: {
+            Label(
+                isPinned
+                    ? NSLocalizedString("today.timeline.menu.unpin", value: "Unpin", comment: "")
+                    : NSLocalizedString("today.timeline.menu.pin", value: "Pin to top", comment: ""),
+                systemImage: isPinned ? "pin.slash" : "pin"
+            )
+        }
+        if let summary = entry.summary, !summary.isEmpty {
+            Button {
+                UIPasteboard.general.string = summary
+                Haptics.soft()
+            } label: {
+                Label(
+                    NSLocalizedString("today.timeline.menu.copy", value: "Copy summary", comment: ""),
+                    systemImage: "doc.on.doc"
+                )
+            }
+        }
+        Divider()
+        Button(role: .destructive) {
+            showDeleteConfirm = true
+        } label: {
+            Label(
+                NSLocalizedString("today.timeline.menu.delete", value: "Delete", comment: ""),
+                systemImage: "trash"
+            )
+        }
+    }
+
+    // MARK: Swipe actions (mirrors SwipeableMemoCard's two-panel layout)
+
+    private var leadingActions: [SwipeAction] {
+        [
+            SwipeAction(
+                id: .pin,
+                label: isPinned
+                    ? NSLocalizedString("today.timeline.swipe.unpin", value: "Unpin", comment: "")
+                    : NSLocalizedString("today.timeline.swipe.pin", value: "Pin", comment: ""),
+                systemImage: isPinned ? "pin.slash.fill" : "pin.fill",
+                tone: .accent,
+                run: {
+                    Haptics.tapConfirm()
+                    snapClose()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        _ = pinService.togglePin(entry.dateString)
+                    }
+                }
+            )
+        ]
+    }
+
+    private var trailingActions: [SwipeAction] {
+        [
+            SwipeAction(
+                id: .share,
+                label: NSLocalizedString("today.timeline.swipe.share", value: "Share", comment: ""),
+                systemImage: "square.and.arrow.up",
+                tone: .accent,
+                run: {
+                    Haptics.tapConfirm()
+                    snapClose()
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+                        onShareDate?(entry)
+                    }
+                }
+            )
+        ]
+    }
+
+    // MARK: Pan callbacks (slimmed copy of SwipeableMemoCard's gesture loop)
+
+    private var currentOffset: CGFloat {
+        let raw = settledOffset + dragDelta
+        let w = TimelineSwipePhysics.panelWidth
+        if raw > w  { return w  + (raw - w)  * TimelineSwipePhysics.rubberBand }
+        if raw < -w { return -w + (raw + w)  * TimelineSwipePhysics.rubberBand }
+        return raw
+    }
+
+    private var revealProgress: CGFloat {
+        let p = currentOffset / TimelineSwipePhysics.panelWidth
+        return max(-1.4, min(1.4, p))
+    }
+
+    private var revealedSide: SwipeSide? {
+        if settledOffset < -1 { return .trailing }
+        if settledOffset > 1  { return .leading }
+        return nil
+    }
+
+    private var snapAnimation: Animation {
+        reduceMotion ? TimelineSwipePhysics.reducedSnap : TimelineSwipePhysics.snapSpring
+    }
+
+    private func handlePanChanged(_ translation: CGFloat) {
+        dragDelta = translation
+        let offset = currentOffset
+        let arming: SwipeSide?
+        if offset > TimelineSwipePhysics.openThreshold {
+            arming = .leading
+        } else if offset < -TimelineSwipePhysics.openThreshold {
+            arming = .trailing
+        } else {
+            arming = nil
+        }
+        if arming != armedSide {
+            armedSide = arming
+            if arming != nil { Haptics.soft() }
+        }
+    }
+
+    private func handlePanEnded(_ translation: CGFloat, _ velocity: CGFloat) {
+        dragDelta = 0
+        let openT = TimelineSwipePhysics.openThreshold
+        let closeT = TimelineSwipePhysics.closeThreshold
+        let vOpen = TimelineSwipePhysics.velocityOpen
+        let vClose = TimelineSwipePhysics.velocityClose
+        switch revealedSide {
+        case nil:
+            if      translation < -openT || velocity < -vOpen { snapOpen(.trailing) }
+            else if translation >  openT || velocity >  vOpen { snapOpen(.leading)  }
+            else                                              { snapClose()         }
+        case .trailing:
+            (translation > closeT || velocity > vClose) ? snapClose() : snapOpen(.trailing)
+        case .leading:
+            (translation < -closeT || velocity < -vClose) ? snapClose() : snapOpen(.leading)
+        }
+        armedSide = nil
+    }
+
+    private func handlePanCancelled() {
+        dragDelta = 0
+        armedSide = nil
+    }
+
+    private func snapOpen(_ side: SwipeSide) {
+        let target: CGFloat = side == .trailing
+            ? -TimelineSwipePhysics.panelWidth
+            : TimelineSwipePhysics.panelWidth
+        withAnimation(snapAnimation) { settledOffset = target }
+        HapticFeedback.light()
+    }
+
+    private func snapClose() {
+        withAnimation(snapAnimation) { settledOffset = 0 }
     }
 
     // MARK: Derived content
@@ -498,8 +805,165 @@ enum TimelineSpine {
                     .foregroundColor(DSTokens.Colors.fgSubtle)
             }
             .padding(.horizontal, sectionPadH)
-            .padding(.top, 10)
+            .padding(.top, 20)
             .padding(.bottom, 14)
+        }
+    }
+}
+
+// MARK: - TimelineSwipePhysics
+//
+// Slimmed mirror of SwipePhysics in SwipeableMemoCard.swift. A separate
+// constant set lets the timeline tune the row swipe independently (each side
+// here has ONE action, so the panel is narrower than the memo card).
+private enum TimelineSwipePhysics {
+    static let actionWidth: CGFloat = 84
+    static let panelWidth: CGFloat = actionWidth        // single action per side
+    static let openThreshold: CGFloat = 40
+    static let closeThreshold: CGFloat = 24
+    static let velocityOpen: CGFloat = 600
+    static let velocityClose: CGFloat = 500
+    static let rubberBand: CGFloat = 0.25
+    static let snapSpring: Animation = .spring(response: 0.28, dampingFraction: 0.86)
+    static let reducedSnap: Animation = .easeOut(duration: 0.22)
+}
+
+// MARK: - TimelineSwipePanel
+//
+// Visual surface for one side of the timeline swipe drawer. Single-action
+// variant of SwipeActionPanel from SwipeableMemoCard.swift — sized so the
+// label reads cleanly without crowding adjacent content.
+private struct TimelineSwipePanel: View {
+    enum Edge { case leading, trailing }
+
+    let actions: [SwipeAction]
+    let edge: Edge
+    let progress: CGFloat
+
+    var body: some View {
+        HStack(spacing: 0) {
+            ForEach(actions) { action in
+                TimelineSwipeButton(action: action, progress: progress)
+            }
+        }
+        .frame(width: TimelineSwipePhysics.panelWidth)
+        .frame(maxHeight: .infinity)
+        .opacity(progress > 0.02 ? 1 : 0)
+        .allowsHitTesting(progress > 0.02)
+        .accessibilityHidden(progress <= 0.02)
+    }
+}
+
+// MARK: - TimelineSwipeButton
+
+private struct TimelineSwipeButton: View {
+    let action: SwipeAction
+    let progress: CGFloat
+
+    private let labelFadeStart: CGFloat = 0.30
+
+    var body: some View {
+        Button(action: action.run) {
+            ZStack {
+                background
+                content
+            }
+            .frame(width: TimelineSwipePhysics.actionWidth)
+            .frame(maxHeight: .infinity)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(action.label)
+    }
+
+    private var background: some View {
+        let tint = Double(0.42 + 0.58 * min(1, progress))
+        return ZStack {
+            Rectangle().fill(.ultraThinMaterial)
+            DSColor.accentAmber.opacity(tint)
+        }
+    }
+
+    private var content: some View {
+        VStack(spacing: 6) {
+            Image(systemName: action.systemImage)
+                .font(.system(size: 17, weight: .semibold))
+                .foregroundColor(.white)
+                .scaleEffect(0.6 + 0.4 * max(0, min(1, progress)))
+            Text(action.label)
+                .font(.custom("Inter-Medium", size: 10.5))
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .foregroundColor(.white)
+                .opacity(Double(max(0, min(1, (progress - labelFadeStart) / (1 - labelFadeStart)))))
+        }
+        .padding(.horizontal, 4)
+    }
+}
+
+// MARK: - TimelineDayPreviewCard
+//
+// Shown inside .contextMenu(preview:) on long-press. A miniature daily page:
+// the compiled serif title, the lede, then the first few raw memos so the
+// user can recognize what they're about to open.
+struct TimelineDayPreviewCard: View {
+    let entry: TimelineDayEntry
+    let memos: [Memo]
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            header
+            if let summary = entry.summary, !summary.isEmpty {
+                Text(summary)
+                    .font(DSFonts.serif(size: 18, weight: .semibold))
+                    .foregroundColor(DSColor.inkPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .lineLimit(4)
+            } else {
+                Text(NSLocalizedString("today.timeline.preview.noSummary",
+                                       value: "No compiled summary yet.",
+                                       comment: ""))
+                    .font(DSFonts.serif(size: 16))
+                    .italic()
+                    .foregroundColor(DSColor.inkSubtle)
+            }
+            Divider().padding(.vertical, 2)
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(memos.prefix(3), id: \.id) { memo in
+                    Text(memo.body)
+                        .font(DSFonts.inter(size: 13))
+                        .foregroundColor(DSColor.inkPrimary.opacity(0.85))
+                        .lineLimit(2)
+                        .multilineTextAlignment(.leading)
+                }
+                if memos.count > 3 {
+                    Text(String(format: NSLocalizedString(
+                        "today.timeline.preview.moreMemos",
+                        value: "+ %d more",
+                        comment: "Count of additional memos hidden in preview"
+                    ), memos.count - 3))
+                        .font(DSFonts.jetBrainsMono(size: 10, weight: .bold))
+                        .tracking(1.4)
+                        .foregroundColor(DSColor.inkSubtle)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .padding(20)
+        .background(DSColor.surfaceWhite)
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text(entry.dateString)
+                .font(DSFonts.jetBrainsMono(size: 10, weight: .bold))
+                .tracking(1.6)
+                .foregroundColor(DSColor.accentAmber)
+            Spacer(minLength: 8)
+            Text("\(entry.memoCount) MEMOS")
+                .font(DSFonts.jetBrainsMono(size: 9.5, weight: .bold))
+                .tracking(1.4)
+                .foregroundColor(DSColor.inkSubtle)
         }
     }
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -27,6 +27,15 @@ struct TodayView: View {
     /// Date string for the fallback yesterday daily page sheet.
     @State private var fallbackDailyPageDateString: String? = nil
 
+    /// Date string for opening a historical day from the timeline via tap or
+    /// long-press → "Open Daily Page". Drives a dedicated `.fullScreenCover`
+    /// so it doesn't collide with the today/fallback covers.
+    @State private var timelineNavDateString: String? = nil
+
+    /// Plain-text payload for the system share sheet when the user shares a
+    /// timeline day. Identifiable wrapper because `.sheet(item:)` needs an id.
+    @State private var timelineShareText: TimelineShareText? = nil
+
     /// Whether to show the Settings sheet.
     @State private var showSettings: Bool = false
 
@@ -617,6 +626,24 @@ struct TodayView: View {
                     }
                 )
             }
+            // Timeline tap / contextMenu → open that historical day's Daily Page.
+            // Kept separate from showDailyPage / fallbackDailyPageDateString so the
+            // three navigation entry points don't collide on a single binding.
+            .fullScreenCover(item: Binding(
+                get: { timelineNavDateString.map { OnThisDayNavTarget(dateString: $0) } },
+                set: { timelineNavDateString = $0?.dateString }
+            )) { target in
+                DailyPageView(
+                    dateString: target.dateString,
+                    onReturnToToday: { _ in
+                        timelineNavDateString = nil
+                    }
+                )
+            }
+            // Timeline share sheet — plain text payload, no poster pipeline.
+            .sheet(item: $timelineShareText) { payload in
+                ShareSheet(activityItems: [payload.text])
+            }
             .bannerOverlay()
             // US-010: First-run input bar tutorial
             .overlay {
@@ -796,9 +823,18 @@ struct TodayView: View {
     @ViewBuilder
     private var historySupplement: some View {
         if !viewModel.memos.isEmpty && viewModel.loadState == .ready && !viewModel.timelineSections.isEmpty {
-            earlierDivider
+            // Quiet breathing room replaces the redundant "EARLIER" rule —
+            // the timeline's own SectionHeader (本周/上周) already separates bands.
+            Color.clear
+                .frame(height: 20)
+                .accessibilityLabel(Text(NSLocalizedString("today.section.earlier", comment: "")))
             ForEach(viewModel.timelineSections) { section in
-                TimelineSectionView(section: section)
+                TimelineSectionView(
+                    section: section,
+                    onOpenDate: { dateString in timelineNavDateString = dateString },
+                    onShareDate: { entry in shareTimelineDay(entry) },
+                    onDeleteDate: { entry in deleteTimelineDay(entry) }
+                )
             }
         }
     }
@@ -1375,17 +1411,24 @@ struct TodayView: View {
                             .accessibilityLabel(headerSublineAccessibilityLabel(currentTime))
                     }
                 } else {
-                    HStack(spacing: 8) {
+                    HStack(spacing: 12) {
                         DayOrbView(
                             signalCount: viewModel.signalCount,
-                            size: 28,
-                            haloOpacity: 0.08,
+                            size: 22,
+                            // Halo + day-progress arc both disabled in this inline
+                            // chip-row context: at 22pt the amber bloom overlaps
+                            // the meta chip text and the thin progress arc reads
+                            // as a smudge rather than a clock. The standalone
+                            // DayOrb in the day-summary section (TodayView.swift:1000)
+                            // keeps both — that's where the clock metaphor earns
+                            // its space.
+                            haloOpacity: 0,
                             onTap: {
                                 Haptics.soft()
                                 orbFocusToggle.toggle()
                             },
                             pulseToggle: orbCapturePulse,
-                            dayProgress: dayProgress,
+                            dayProgress: 0,
                             timeTint: orbTint(currentTime)
                         )
                         .frame(width: 36, height: 36)
@@ -1633,7 +1676,7 @@ struct TodayView: View {
             }
             .frame(height: 0)
 
-            LazyVStack(spacing: 8) {
+            LazyVStack(spacing: 10) {
                 // Invisible anchor: scrollTo("timelineTop") brings the list to the very top.
                 Color.clear.frame(height: 0).id("timelineTop")
 
@@ -1801,7 +1844,8 @@ struct TodayView: View {
                     && viewModel.memos.count < 3 {
                     CompileUnlockCard(memoCount: viewModel.memos.count, onTap: { orbFocusToggle.toggle() })
                         .padding(.horizontal, 20)
-                        .padding(.top, 4)
+                        .padding(.top, 16)
+                        .padding(.bottom, 4)
                         .transition(.opacity)
                 }
 
@@ -1823,7 +1867,10 @@ struct TodayView: View {
                         .padding(.horizontal, 20)
                 }
 
-                Spacer(minLength: 16)
+                // Reserve room for the floating Undo pill (bottom: 96) +
+                // the input bar above it so the last timeline card never sits
+                // beneath chrome.
+                Spacer(minLength: 140)
             }
             .padding(.top, 12)
             .shadow(
@@ -2329,6 +2376,44 @@ struct TodayView: View {
     private func todayTimeZoneShort() -> String {
         TimeZoneBadge.gmtOffset(for: .current, at: currentTime)
     }
+
+    // MARK: - Timeline row actions
+
+    /// Share a timeline day via the system share sheet. The payload is the
+    /// compiled summary if present, otherwise a placeholder pointing at the
+    /// day's date — never empty, so the share sheet has something to display.
+    private func shareTimelineDay(_ entry: TimelineDayEntry) {
+        let text: String
+        if let summary = entry.summary, !summary.isEmpty {
+            text = "\(entry.dateString)\n\n\(summary)"
+        } else {
+            text = "\(entry.dateString)\n\n\(entry.memoCount) memos"
+        }
+        timelineShareText = TimelineShareText(text: text)
+    }
+
+    /// Permanently delete a timeline day: removes the raw file, the compiled
+    /// daily page, and drops the pin if any. Notifies TimelineIndex via the
+    /// `.rawStorageDidWrite` notification path so the timeline re-renders.
+    private func deleteTimelineDay(_ entry: TimelineDayEntry) {
+        let dateString = entry.dateString
+        let fmt = DateFormatter()
+        fmt.dateFormat = "yyyy-MM-dd"
+        fmt.locale = Locale(identifier: "en_US_POSIX")
+        fmt.timeZone = TimeZone.current
+        guard let date = fmt.date(from: dateString) else { return }
+
+        Task.detached(priority: .userInitiated) {
+            try? RawStorage.rewrite([], for: date)        // posts rawStorageDidWrite
+            let dailyURL = VaultInitializer.vaultURL
+                .appendingPathComponent("wiki/daily/\(dateString).md")
+            try? FileManager.default.removeItem(at: dailyURL)
+            await MainActor.run {
+                TimelinePinService.shared.unpin(dateString)
+                Haptics.warn()
+            }
+        }
+    }
 }
 
 // MARK: - OnThisDayNavTarget
@@ -2336,6 +2421,16 @@ struct TodayView: View {
 private struct OnThisDayNavTarget: Identifiable {
     let dateString: String
     var id: String { dateString }
+}
+
+// MARK: - TimelineShareText
+
+/// Identifiable wrapper around a plain-text share payload so it can drive
+/// `.sheet(item:)`. Each tap on "Share" gets a fresh UUID so consecutive
+/// shares of the same day still re-trigger the sheet.
+struct TimelineShareText: Identifiable {
+    let id = UUID()
+    let text: String
 }
 
 // MARK: - CompilationFailedBanner

--- a/DayPage/Intents/AskTodayIntent.swift
+++ b/DayPage/Intents/AskTodayIntent.swift
@@ -6,18 +6,18 @@ import UIKit
 
 // MARK: - AskTodayIntent
 //
-// AppIntent for ad-hoc questions answered against the user's vault. For now
-// the routing target is SearchView, which already does full-text + entity
-// search across memos. The intent is named with the "ask" framing so the
-// shortcut is discoverable as an assistant entry point — once an on-device
-// MCP/LLM pipeline is wired up we can re-route the URL without changing
-// the Siri / Shortcuts surface.
+// AppIntent for ad-hoc questions answered against the user's vault.
 //
-// Routing: opens `daypage://search?q=<URL-encoded query>`.
-// `DayPageApp.onOpenURL` switches to the Archive tab and stashes the
-// query in `AppNavigationModel.pendingSearchQuery`. ArchiveView observes
-// the property, presents SearchView pre-populated with the query, and
-// clears the pending value (one-shot).
+// Routing: opens `daypage://ask?q=<URL-encoded query>`, which RootView turns
+// into the "和过去对话" memory-chat agent (D1, research doc §3) — graph-augmented
+// retrieval (D2) over the vault + an LLM answer with cited sources. This is the
+// pipeline the intent's "ask" framing always pointed at; it previously routed to
+// keyword SearchView as a placeholder until the chat agent existed.
+//
+// `DayPageApp.onOpenURL` stashes the query in
+// `AppNavigationModel.pendingAskQuery`. RootView observes the property, presents
+// the AskPastView chat sheet seeded with the question, and clears the pending
+// value (one-shot, so re-firing the shortcut re-opens the sheet).
 
 @available(iOS 16.0, *)
 struct AskTodayIntent: AppIntent {
@@ -45,7 +45,7 @@ struct AskTodayIntent: AppIntent {
     static func buildURL(query: String) -> URL? {
         var components = URLComponents()
         components.scheme = "daypage"
-        components.host = "search"
+        components.host = "ask"
         components.queryItems = [URLQueryItem(name: "q", value: query)]
         return components.url
     }

--- a/DayPage/Services/EntityPageService.swift
+++ b/DayPage/Services/EntityPageService.swift
@@ -501,7 +501,7 @@ final class EntityPageService {
         return nil
     }
 
-    static func sanitizeSlug(_ raw: String) -> String {
+    nonisolated static func sanitizeSlug(_ raw: String) -> String {
         raw
             .lowercased()
             .components(separatedBy: CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-")).inverted)

--- a/DayPage/Services/GraphRetriever.swift
+++ b/DayPage/Services/GraphRetriever.swift
@@ -1,0 +1,282 @@
+import Foundation
+
+// MARK: - RetrievedContext
+
+/// `GraphRetriever` 的产物：为一次查询组装的、带来源标注的检索上下文。
+///
+/// 这是 D2「图谱增强检索」的输出契约——既能直接喂给 LLM（`MemoryChatService`），
+/// 也能在 UI 上把"引用了哪些 memo / 实体页"显式呈现给用户。
+struct RetrievedContext: Equatable {
+
+    /// 命中的原始 memo 片段。
+    struct MemoHit: Equatable {
+        let dateString: String       // "yyyy-MM-dd"
+        let snippet: String          // 修剪后的正文片段
+        let mood: String?
+        let entityMentions: [String] // 该 memo 引用的实体 slug
+    }
+
+    /// 沿 entityMentions 扩展出的一跳邻居实体页摘要。
+    struct EntityHit: Equatable {
+        let slug: String
+        let displayName: String
+        let type: String             // "places" | "people" | "themes"
+        let occurrenceCount: Int
+        let summary: String          // 实体页正文摘要（截断）
+    }
+
+    let query: String
+    let memoHits: [MemoHit]
+    let entityHits: [EntityHit]
+
+    var isEmpty: Bool { memoHits.isEmpty && entityHits.isEmpty }
+
+    /// 把检索上下文渲染为给 LLM 的 prompt 片段（带来源标注，便于模型引用）。
+    func toPromptContext() -> String {
+        var blocks: [String] = []
+
+        if !memoHits.isEmpty {
+            let memoLines = memoHits.map { hit -> String in
+                let moodPart = hit.mood.map { "（情绪：\($0)）" } ?? ""
+                return "- [\(hit.dateString)]\(moodPart) \(hit.snippet)"
+            }
+            blocks.append("## 相关原始记录\n" + memoLines.joined(separator: "\n"))
+        }
+
+        if !entityHits.isEmpty {
+            let entityLines = entityHits.map { hit -> String in
+                "### \(hit.displayName)（\(entityTypeLabel(hit.type)) · 出现 \(hit.occurrenceCount) 次）\n\(hit.summary)"
+            }
+            blocks.append("## 相关实体（来自知识网络）\n" + entityLines.joined(separator: "\n\n"))
+        }
+
+        return blocks.isEmpty ? "(未检索到相关内容)" : blocks.joined(separator: "\n\n")
+    }
+
+    private func entityTypeLabel(_ type: String) -> String {
+        switch type {
+        case "places": return "地点"
+        case "people": return "人物"
+        case "themes": return "主题"
+        default: return type
+        }
+    }
+}
+
+// MARK: - GraphRetriever
+
+/// 图谱增强检索引擎（D2，研究文档 §3 D2）。
+///
+/// 核心思路（OmniQuery「先连后查」arXiv 2409.08250）：朴素关键词检索只能
+/// 捞出孤立的 memo 片段；本检索器在命中 memo 之后，**沿 `entityMentions` 扩展
+/// 一跳邻居实体页**，把"原始记录 + 知识网络上下文"一起返回。这比把每条 memo
+/// 当孤立文本检索，对"我对 X 的看法怎么变的""去年这个时候我在哪"这类需要
+/// 跨记忆推断的查询效果显著更好。
+///
+/// 数据来源（均为现成基质，无需新基础设施）：
+///   - 种子命中：`SearchService.search`（关键词 + 可选过滤）
+///   - 邻居扩展：`vault/wiki/{places,people,themes}/{slug}.md` 实体页
+///
+/// 纯本地、零 token 成本、零网络——这是 D1 对话 Agent 的检索层。
+enum GraphRetriever {
+
+    // MARK: - Public API
+
+    /// 为 `query` 组装图谱增强检索上下文。
+    /// - Parameters:
+    ///   - query: 用户的自然语言查询或关键词。
+    ///   - maxMemoHits: 保留的种子 memo 命中上限（按日期降序，最新优先）。
+    ///   - maxEntityHits: 扩展的邻居实体上限（按出现次数降序，最相关优先）。
+    nonisolated static func retrieve(
+        query rawQuery: String,
+        maxMemoHits: Int = 8,
+        maxEntityHits: Int = 6
+    ) -> RetrievedContext {
+        let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !query.isEmpty else {
+            return RetrievedContext(query: query, memoHits: [], entityHits: [])
+        }
+
+        // Step 1: 种子命中——复用现有关键词检索。
+        let searchResults = SearchService.search(keyword: query)
+
+        // Step 2: 把命中结果重新读成带 entityMentions 的 MemoHit。
+        // SearchResult 只给了 snippet + dateString，要拿 entityMentions
+        // 必须回读 raw 文件并匹配。按日期去重后回读。
+        let hitDates = orderedUniqueDates(from: searchResults)
+        var memoHits: [RetrievedContext.MemoHit] = []
+        var entitySlugs = Set<String>()
+        let folded = foldedForSearch(query)
+
+        for dateString in hitDates {
+            guard memoHits.count < maxMemoHits else { break }
+            guard let date = dayFormatter.date(from: dateString) else { continue }
+            let memos = (try? RawStorage.read(for: date)) ?? []
+            for memo in memos where memoMatches(memo, foldedQuery: folded) {
+                guard memoHits.count < maxMemoHits else { break }
+                memoHits.append(RetrievedContext.MemoHit(
+                    dateString: dateString,
+                    snippet: snippet(from: memo),
+                    mood: memo.mood,
+                    entityMentions: memo.entityMentions
+                ))
+                entitySlugs.formUnion(memo.entityMentions)
+            }
+        }
+
+        // Step 3: 图谱扩展——沿 entityMentions 读邻居实体页。
+        // 同时把 query 本身当作可能的实体 slug 直接命中（用户可能在问某地/某人）。
+        entitySlugs.formUnion(slugCandidates(from: query))
+        let entityHits = expandEntities(slugs: entitySlugs, limit: maxEntityHits)
+
+        return RetrievedContext(query: query, memoHits: memoHits, entityHits: entityHits)
+    }
+
+    // MARK: - Step 2 helpers
+
+    /// 从搜索结果中提取去重后的日期，保持原有降序（最新优先）。
+    private static func orderedUniqueDates(from results: [SearchResult]) -> [String] {
+        var seen = Set<String>()
+        var ordered: [String] = []
+        for r in results where !seen.contains(r.dateString) {
+            seen.insert(r.dateString)
+            ordered.append(r.dateString)
+        }
+        return ordered
+    }
+
+    private static func memoMatches(_ memo: Memo, foldedQuery: String) -> Bool {
+        if foldedForSearch(memo.body).contains(foldedQuery) { return true }
+        if let name = memo.location?.name, foldedForSearch(name).contains(foldedQuery) { return true }
+        for att in memo.attachments {
+            if let t = att.transcript, foldedForSearch(t).contains(foldedQuery) { return true }
+        }
+        return false
+    }
+
+    private static func snippet(from memo: Memo) -> String {
+        let source = memo.body.isEmpty
+            ? (memo.location?.name ?? "")
+            : memo.body
+        let oneLine = source.replacingOccurrences(of: "\n", with: " ")
+        return String(oneLine.prefix(160))
+    }
+
+    // MARK: - Step 3: Entity expansion
+
+    /// 把候选 slug 集合扩展为实体页摘要，按 occurrence_count 降序取前 N。
+    private static func expandEntities(slugs: Set<String>, limit: Int) -> [RetrievedContext.EntityHit] {
+        guard !slugs.isEmpty else { return [] }
+        let types = ["places", "people", "themes"]
+        var hits: [RetrievedContext.EntityHit] = []
+
+        for slug in slugs {
+            for type in types {
+                let url = entityURL(type: type, slug: slug)
+                guard let content = try? String(contentsOf: url, encoding: .utf8) else { continue }
+                if let hit = parseEntityPage(content, slug: slug, type: type) {
+                    hits.append(hit)
+                }
+                break // 一个 slug 只会在一种类型目录里
+            }
+        }
+
+        return hits
+            .sorted { $0.occurrenceCount > $1.occurrenceCount }
+            .prefix(limit)
+            .map { $0 }
+    }
+
+    /// 解析实体页：从 frontmatter 取 name / occurrence_count，从正文取摘要。
+    static func parseEntityPage(_ content: String, slug: String, type: String) -> RetrievedContext.EntityHit? {
+        let displayName = frontmatterValue(in: content, key: "name")?
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\"")) ?? slug
+        let occurrence = Int(frontmatterValue(in: content, key: "occurrence_count") ?? "") ?? 1
+        let summary = bodySummary(from: content)
+        return RetrievedContext.EntityHit(
+            slug: slug,
+            displayName: displayName,
+            type: type,
+            occurrenceCount: occurrence,
+            summary: summary
+        )
+    }
+
+    /// 取 frontmatter（首个 `---` 与第二个 `---` 之间）中 `key:` 的值。
+    private static func frontmatterValue(in content: String, key: String) -> String? {
+        let lines = content.components(separatedBy: "\n")
+        var inFrontmatter = false
+        for (index, line) in lines.enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if index == 0 && trimmed == "---" { inFrontmatter = true; continue }
+            if inFrontmatter && trimmed == "---" { break }
+            if inFrontmatter {
+                let prefix = "\(key):"
+                if trimmed.hasPrefix(prefix) {
+                    return String(trimmed.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces)
+                }
+            }
+        }
+        return nil
+    }
+
+    /// 取实体页正文（frontmatter 之后）的前若干行非空内容作为摘要。
+    static func bodySummary(from content: String, maxChars: Int = 280) -> String {
+        let lines = content.components(separatedBy: "\n")
+        var bodyLines: [String] = []
+        var dashCount = 0
+        var started = false
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed == "---" {
+                dashCount += 1
+                if dashCount >= 2 { started = true }
+                continue
+            }
+            guard started else { continue }
+            // 跳过一级标题与纯元数据行，保留有信息的内容。
+            if trimmed.hasPrefix("# ") { continue }
+            if trimmed.hasPrefix("**Type**") || trimmed.hasPrefix("**First seen**") { continue }
+            if trimmed.isEmpty { continue }
+            bodyLines.append(trimmed)
+        }
+        let joined = bodyLines.joined(separator: " ")
+        return String(joined.prefix(maxChars))
+    }
+
+    // MARK: - Slug candidates
+
+    /// 把查询切成可能的 slug 候选（用于直接命中实体页，如用户问 "清迈"）。
+    /// 简单策略：整体 slug 化 + 按空格分词后各自 slug 化。
+    private static func slugCandidates(from query: String) -> Set<String> {
+        var out = Set<String>()
+        let whole = EntityPageService.sanitizeSlug(query)
+        if !whole.isEmpty { out.insert(whole) }
+        for token in query.split(whereSeparator: { $0 == " " || $0 == "，" || $0 == "," }) {
+            let s = EntityPageService.sanitizeSlug(String(token))
+            if s.count >= 2 { out.insert(s) }
+        }
+        return out
+    }
+
+    // MARK: - URL / formatting helpers
+
+    private static func entityURL(type: String, slug: String) -> URL {
+        VaultInitializer.vaultURL
+            .appendingPathComponent("wiki")
+            .appendingPathComponent(type)
+            .appendingPathComponent("\(slug).md")
+    }
+
+    private static func foldedForSearch(_ s: String) -> String {
+        s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
+                  locale: Locale(identifier: "en_US_POSIX"))
+    }
+
+    private static let dayFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+}

--- a/DayPage/Services/LLMClient.swift
+++ b/DayPage/Services/LLMClient.swift
@@ -1,0 +1,215 @@
+import Foundation
+import Sentry
+
+// MARK: - LLMMessage
+
+/// A single chat message in an OpenAI-compatible conversation.
+struct LLMMessage: Equatable {
+    enum Role: String {
+        case system
+        case user
+        case assistant
+    }
+    let role: Role
+    let content: String
+
+    static func system(_ content: String) -> LLMMessage { LLMMessage(role: .system, content: content) }
+    static func user(_ content: String) -> LLMMessage { LLMMessage(role: .user, content: content) }
+    static func assistant(_ content: String) -> LLMMessage { LLMMessage(role: .assistant, content: content) }
+}
+
+// MARK: - LLMError
+
+/// Errors surfaced by ``LLMClient``. Kept distinct from ``CompilationError`` so
+/// callers (compilation vs. chat) can map them to their own UX copy.
+enum LLMError: LocalizedError {
+    case missingApiKey
+    case invalidURL
+    case offline
+    case networkTimeout
+    case rateLimited
+    case apiError(statusCode: Int, body: String)
+    case emptyResponse
+    case unknown(Error)
+
+    var errorDescription: String? {
+        switch self {
+        case .missingApiKey: return "DeepSeek API Key 未配置"
+        case .invalidURL: return "API URL 无效"
+        case .offline: return "当前离线，请检查网络后重试"
+        case .networkTimeout: return "网络请求超时"
+        case .rateLimited: return "请求频率超限（429），请稍后重试"
+        case .apiError(let code, let body):
+            if code == 401 { return "API Key 无效或已过期（401）" }
+            return "API 错误 \(code)：\(body.prefix(200))"
+        case .emptyResponse: return "AI 返回为空"
+        case .unknown(let err): return "未知错误：\(err.localizedDescription)"
+        }
+    }
+}
+
+// MARK: - LLMClient
+
+/// 可复用的 OpenAI 兼容聊天补全客户端（DeepSeek）。
+///
+/// 设计动机：编译管线（`CompilationService`）与「和过去对话」Agent
+/// （`MemoryChatService`）都需要调用同一个 LLM 端点。把网络、重试、
+/// 错误映射、Sentry span 抽到这里，两边共用，避免逻辑分叉。
+///
+/// 与编译管线的边界：本类**只负责传输**——构造 messages、发请求、重试、
+/// 返回纯文本。prompt 构造、JSON 解析、文件写入仍归各调用方所有。
+///
+/// 隐私/架构约束（研究文档 §5 红线）：云端调用走前台/后台均可，但
+/// **端侧模型不可用于后台**。本类是云端通道；端侧分流是未来的独立实现点。
+struct LLMClient {
+
+    // MARK: - Configuration
+
+    struct Config {
+        var baseURL: String
+        var apiKey: String
+        var model: String
+        var maxTokens: Int
+        var temperature: Double
+        var timeout: TimeInterval
+
+        /// 默认从 `Secrets` 解析 DeepSeek 配置（与原编译管线一致）。
+        @MainActor
+        static func deepSeek(
+            maxTokens: Int = 4096,
+            temperature: Double = 0.7,
+            timeout: TimeInterval = 120
+        ) -> Config {
+            let base = Secrets.deepSeekBaseURL.isEmpty
+                ? "https://api.deepseek.com/v1"
+                : Secrets.deepSeekBaseURL
+            let model = Secrets.deepSeekModel.isEmpty ? "deepseek-v4-pro" : Secrets.deepSeekModel
+            return Config(
+                baseURL: base,
+                apiKey: Secrets.resolvedDeepSeekApiKey,
+                model: model,
+                maxTokens: maxTokens,
+                temperature: temperature,
+                timeout: timeout
+            )
+        }
+    }
+
+    let config: Config
+    /// Sentry transaction 名称，用于区分 compilation / chat 调用。
+    let spanName: String
+
+    init(config: Config, spanName: String = "llm.chat") {
+        self.config = config
+        self.spanName = spanName
+    }
+
+    // MARK: - Chat Completion
+
+    /// 发送一组 messages，返回 assistant 的纯文本回复（已 trim）。
+    /// 带指数退避重试（与原编译管线一致：3 次，0/2/6s）。
+    /// - Parameter onRetry: 每次重试前回调 `(当前次数, 最大次数)`。
+    func complete(
+        messages: [LLMMessage],
+        onRetry: ((Int, Int) -> Void)? = nil
+    ) async throws -> String {
+        let online = await MainActor.run { NetworkMonitor.shared.isOnline }
+        guard online else { throw LLMError.offline }
+        guard !config.apiKey.isEmpty else { throw LLMError.missingApiKey }
+
+        let maxAttempts = 3
+        let backoffSeconds: [Double] = [0, 2, 6]
+        var lastError: Error = LLMError.networkTimeout
+
+        for attempt in 1...maxAttempts {
+            if attempt > 1 {
+                onRetry?(attempt, maxAttempts)
+                let delay = backoffSeconds[min(attempt - 1, backoffSeconds.count - 1)]
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+            do {
+                return try await sendOnce(messages: messages)
+            } catch let error as LLMError {
+                switch error {
+                case .rateLimited:
+                    lastError = error
+                case .apiError(let code, _) where code == 401 || code == 403 || code == 400:
+                    throw error  // 不重试认证/请求格式错误
+                case .missingApiKey, .invalidURL, .emptyResponse:
+                    throw error
+                default:
+                    lastError = error
+                }
+            } catch let urlError as URLError {
+                switch urlError.code {
+                case .timedOut:
+                    lastError = LLMError.networkTimeout
+                case .notConnectedToInternet, .networkConnectionLost:
+                    lastError = LLMError.offline
+                default:
+                    throw LLMError.unknown(urlError)
+                }
+            } catch {
+                lastError = error
+            }
+        }
+        throw lastError
+    }
+
+    // MARK: - Single request
+
+    private func sendOnce(messages: [LLMMessage]) async throws -> String {
+        guard let url = URL(string: "\(config.baseURL)/chat/completions") else {
+            throw LLMError.invalidURL
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = config.timeout
+
+        let body: [String: Any] = [
+            "model": config.model,
+            "messages": messages.map { ["role": $0.role.rawValue, "content": $0.content] },
+            "max_tokens": config.maxTokens,
+            "temperature": config.temperature
+        ]
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+
+        let dsnEmpty = await MainActor.run { Secrets.sentryDSN.isEmpty }
+        let span = dsnEmpty ? nil : SentrySDK.startTransaction(name: spanName, operation: "http.client")
+        defer { span?.finish() }
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw LLMError.apiError(statusCode: -1, body: "No HTTP response")
+        }
+        guard http.statusCode == 200 else {
+            let bodyStr = String(data: data, encoding: .utf8) ?? "(empty)"
+            DayPageLogger.log(level: "ERROR", message: "[LLMClient/\(spanName)] status=\(http.statusCode) body=\(bodyStr.prefix(500))")
+            if http.statusCode == 429 { throw LLMError.rateLimited }
+            throw LLMError.apiError(statusCode: http.statusCode, body: bodyStr)
+        }
+
+        return try Self.parseContent(from: data)
+    }
+
+    // MARK: - Response parsing
+
+    /// 从 OpenAI 兼容响应中提取 `choices[0].message.content`。
+    /// Exposed for unit tests.
+    static func parseContent(from data: Data) throws -> String {
+        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let first = choices.first,
+              let message = first["message"] as? [String: Any],
+              let content = message["content"] as? String else {
+            throw LLMError.emptyResponse
+        }
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw LLMError.emptyResponse }
+        return trimmed
+    }
+}

--- a/DayPage/Services/MemoryChatService.swift
+++ b/DayPage/Services/MemoryChatService.swift
@@ -1,0 +1,139 @@
+import Foundation
+
+// MARK: - ChatTurn
+
+/// 对话中的一轮消息（用于 UI 展示与历史回放）。
+struct ChatTurn: Identifiable, Equatable {
+    enum Role: Equatable { case user, assistant }
+    let id = UUID()
+    let role: Role
+    var text: String
+    /// 仅 assistant 轮：本次回答检索到的上下文（用于在 UI 上展示引用来源）。
+    var context: RetrievedContext?
+}
+
+// MARK: - MemoryChatService
+
+/// D1「和你的过去对话」——记忆增强的日记 Agent（研究文档 §3 D1）。
+///
+/// 把已编译的知识网络变现为日常交互：用户问「去年这个时候我在清迈做什么」
+/// 「我对 X 的看法怎么变的」，Agent 用 `GraphRetriever` 做图谱增强检索（D2），
+/// 把"原始记录 + 关联实体"喂给 `LLMClient` 生成有依据的回答。
+///
+/// 架构合规（研究文档 §5 红线）：本服务**只在前台被用户主动调用**触发，
+/// 走云端 LLM——不绑定 `BGTaskScheduler`，因此不踩 iOS 后台 GPU 限制。
+/// 未来若接端侧模型，也只在此前台路径替换 `LLMClient`，后台编译不受影响。
+///
+/// 验证依据：emotion-aware journaling agent (arXiv 2508.20585) `3-0`、
+/// OmniQuery (arXiv 2409.08250) `3-0`。
+@MainActor
+final class MemoryChatService: ObservableObject {
+
+    // MARK: Published state
+
+    @Published var turns: [ChatTurn] = []
+    @Published var isResponding = false
+    @Published var errorMessage: String?
+
+    // MARK: Dependencies
+
+    /// 注入式 LLM 调用闭包，便于测试替身。默认走云端 DeepSeek。
+    private let send: ([LLMMessage]) async throws -> String
+    /// 注入式检索闭包，默认走图谱增强检索。
+    private let retrieve: (String) -> RetrievedContext
+
+    init(
+        send: (([LLMMessage]) async throws -> String)? = nil,
+        retrieve: @escaping (String) -> RetrievedContext = { GraphRetriever.retrieve(query: $0) }
+    ) {
+        self.retrieve = retrieve
+        if let send {
+            self.send = send
+        } else {
+            self.send = { messages in
+                let client = LLMClient(
+                    config: .deepSeek(maxTokens: 1500, temperature: 0.5),
+                    spanName: "chat.memory"
+                )
+                return try await client.complete(messages: messages)
+            }
+        }
+    }
+
+    // MARK: - System prompt
+
+    /// 系统提示：约束 Agent 只基于检索到的真实记录回答，避免编造。
+    static let systemPrompt = """
+    你是 DayPage 用户的「记忆助手」。用户会问关于他们过去记录的问题。
+
+    规则：
+    1. **只依据下面提供的「检索到的上下文」回答**，不要编造未出现在上下文里的事实。
+    2. 回答用中文，简洁、像朋友一样自然，避免机械罗列。
+    3. 引用具体记录时带上日期（如「你在 2026-03-14 提到…」），让用户能对照。
+    4. 如果上下文里没有相关信息，**坦诚说明没有找到相关记录**，并建议用户换个问法或先去编译/记录。
+    5. 当能观察到时间跨度上的变化或模式（情绪、地点、主题的演变），主动指出来——这是知识网络的价值。
+    """
+
+    // MARK: - Ask
+
+    /// 处理一条用户提问：检索 → 组装 prompt → 调 LLM → 追加 assistant 回合。
+    func ask(_ rawQuestion: String) async {
+        let question = rawQuestion.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !question.isEmpty, !isResponding else { return }
+
+        errorMessage = nil
+        turns.append(ChatTurn(role: .user, text: question))
+        isResponding = true
+        defer { isResponding = false }
+
+        // Step 1: 图谱增强检索（纯本地）。
+        let context = retrieve(question)
+
+        // Step 2: 组装 messages（system + 检索上下文 + 近几轮历史 + 当前问题）。
+        let messages = buildMessages(question: question, context: context)
+
+        // Step 3: 调 LLM。
+        do {
+            let answer = try await send(messages)
+            turns.append(ChatTurn(role: .assistant, text: answer, context: context))
+        } catch {
+            let msg = (error as? LLMError)?.errorDescription ?? error.localizedDescription
+            errorMessage = msg
+            // 失败时不留空 assistant 回合；错误通过 errorMessage 展示。
+        }
+    }
+
+    /// 清空对话（开始新会话）。
+    func reset() {
+        turns.removeAll()
+        errorMessage = nil
+    }
+
+    // MARK: - Message assembly
+
+    /// 构造发给 LLM 的 messages。
+    /// 历史只带最近若干轮，避免上下文无限膨胀（token 成本控制，研究文档 §5）。
+    func buildMessages(question: String, context: RetrievedContext, historyLimit: Int = 4) -> [LLMMessage] {
+        var messages: [LLMMessage] = [.system(Self.systemPrompt)]
+
+        // 最近 historyLimit 轮历史（不含当前这条尚未入队的 user 问题）。
+        let priorTurns = turns.dropLast().suffix(historyLimit)
+        for turn in priorTurns {
+            switch turn.role {
+            case .user: messages.append(.user(turn.text))
+            case .assistant: messages.append(.assistant(turn.text))
+            }
+        }
+
+        // 当前问题 + 检索上下文一起作为 user 消息，让模型看到依据。
+        let userContent = """
+        ## 检索到的上下文
+        \(context.toPromptContext())
+
+        ## 我的问题
+        \(question)
+        """
+        messages.append(.user(userContent))
+        return messages
+    }
+}

--- a/DayPage/Services/TimelinePinService.swift
+++ b/DayPage/Services/TimelinePinService.swift
@@ -1,0 +1,94 @@
+import Foundation
+import Combine
+
+// MARK: - TimelinePinService
+//
+// Persists the set of date strings (`yyyy-MM-dd`) that the user has pinned
+// from the Today timeline. Pinned days bubble up into a dedicated "📌 PINNED"
+// section at the top of the timeline (see TimelineService.sections).
+//
+// Storage: a single JSON file at `vault/.timeline-pins.json`. JSON instead of
+// UserDefaults because the vault is the source of truth for everything else
+// the user produces — keeping pin state alongside the markdown files means a
+// cloud sync (or a manual `vault/` move) carries the pin set with it.
+//
+// Concurrency: `@MainActor` final class, single shared instance. Reads are
+// O(1) against an in-memory set; writes are atomic-replace via FileManager.
+// Writes also broadcast `.timelinePinsDidChange` so the timeline view can
+// re-render its sections.
+
+@MainActor
+final class TimelinePinService: ObservableObject {
+
+    static let shared = TimelinePinService()
+
+    /// The set of pinned date strings (`yyyy-MM-dd`). `@Published` so SwiftUI
+    /// views observing the service get a fresh render whenever it mutates.
+    @Published private(set) var pinned: Set<String> = []
+
+    /// Lazy storage URL — computed at first access so we don't touch the
+    /// vault before `VaultInitializer.initializeIfNeeded()` runs.
+    private var storageURL: URL {
+        VaultInitializer.vaultURL.appendingPathComponent(".timeline-pins.json")
+    }
+
+    private init() {
+        load()
+    }
+
+    // MARK: - Public API
+
+    func isPinned(_ dateString: String) -> Bool {
+        pinned.contains(dateString)
+    }
+
+    /// Toggles pinned state for one date. Returns the new state for callers
+    /// that want to surface a confirmation ("Pinned" / "Unpinned").
+    @discardableResult
+    func togglePin(_ dateString: String) -> Bool {
+        if pinned.contains(dateString) {
+            pinned.remove(dateString)
+        } else {
+            pinned.insert(dateString)
+        }
+        persist()
+        NotificationCenter.default.post(name: .timelinePinsDidChange, object: nil)
+        return pinned.contains(dateString)
+    }
+
+    /// Drops a pin without toggling (used when a pinned day is deleted, so we
+    /// don't leave a dangling entry in the pin set).
+    func unpin(_ dateString: String) {
+        guard pinned.contains(dateString) else { return }
+        pinned.remove(dateString)
+        persist()
+        NotificationCenter.default.post(name: .timelinePinsDidChange, object: nil)
+    }
+
+    // MARK: - Persistence
+
+    private func load() {
+        guard let data = try? Data(contentsOf: storageURL),
+              let decoded = try? JSONDecoder().decode([String].self, from: data) else {
+            return
+        }
+        pinned = Set(decoded)
+    }
+
+    private func persist() {
+        let sorted = pinned.sorted()
+        guard let data = try? JSONEncoder().encode(sorted) else { return }
+        let url = storageURL
+        let dir = url.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        try? data.write(to: url, options: .atomic)
+    }
+}
+
+// MARK: - Notification
+
+extension Notification.Name {
+    /// Posted on the main queue whenever the pin set changes. TimelineService
+    /// listeners use this to rebuild their sections snapshot.
+    static let timelinePinsDidChange = Notification.Name("timelinePinsDidChange")
+}

--- a/DayPage/Services/TimelineService.swift
+++ b/DayPage/Services/TimelineService.swift
@@ -36,6 +36,10 @@ struct TimelineDayEntry: Identifiable, Equatable {
 /// Identifies which time band a section represents. The view layer maps this
 /// to a localized title; the service stays locale-agnostic.
 enum TimelineSectionKind: Hashable {
+    /// User-pinned days, surfaced at the very top of the timeline. Days in
+    /// this section are *removed* from their natural time-band section so the
+    /// pin acts as a single source of truth — no duplicate rows.
+    case pinned
     case thisWeekOthers
     case lastWeek
     case weekBeforeLast
@@ -55,6 +59,7 @@ struct TimelineSection: Identifiable, Equatable {
 
     var id: String {
         switch kind {
+        case .pinned: return "pinned"
         case .thisWeekOthers: return "thisWeekOthers"
         case .lastWeek: return "lastWeek"
         case .weekBeforeLast: return "weekBeforeLast"
@@ -178,10 +183,15 @@ enum TimelineService {
     /// Groups timeline entries into the four bands described above, hiding any
     /// section whose `days` list is empty. The "today" entry is excluded from
     /// every section — the view layer renders today separately at the top.
+    ///
+    /// User-pinned days bubble up into a leading "📌 PINNED" section and are
+    /// removed from their natural time band, so a pin acts as a single source
+    /// of truth without producing a duplicate row.
     @MainActor
     static func sections(referenceDate: Date = Date()) -> [TimelineSection] {
         let all = entries(referenceDate: referenceDate)
-        return group(entries: all, referenceDate: referenceDate)
+        let pinned = TimelinePinService.shared.pinned
+        return group(entries: all, referenceDate: referenceDate, pinnedDateStrings: pinned)
     }
 
     /// Loads the raw memos for one timeline day on demand. Returns memos in
@@ -205,7 +215,15 @@ enum TimelineService {
     /// Pure function: classify pre-loaded entries into sections. Exposed at
     /// internal scope so future unit tests can exercise the boundary math
     /// without touching the file system.
-    static func group(entries: [TimelineDayEntry], referenceDate: Date) -> [TimelineSection] {
+    ///
+    /// `pinnedDateStrings` are pulled out into a leading `.pinned` section and
+    /// excluded from their natural time band; passing an empty set yields the
+    /// original four-band layout for backward-compatible call sites and tests.
+    static func group(
+        entries: [TimelineDayEntry],
+        referenceDate: Date,
+        pinnedDateStrings: Set<String> = []
+    ) -> [TimelineSection] {
         let cal = systemCalendar()
         let today = cal.startOfDay(for: referenceDate)
 
@@ -214,6 +232,7 @@ enum TimelineService {
               let weekBeforeStart = cal.date(byAdding: .weekOfYear, value: -2, to: thisWeekStart)
         else { return [] }
 
+        var pinned: [TimelineDayEntry] = []
         var thisWeekOthers: [TimelineDayEntry] = []
         var lastWeek: [TimelineDayEntry] = []
         var weekBeforeLast: [TimelineDayEntry] = []
@@ -222,6 +241,13 @@ enum TimelineService {
         for entry in entries {
             let day = cal.startOfDay(for: entry.date)
             if day == today { continue }                  // today rendered separately
+
+            // Pinned days bubble up regardless of their natural time band.
+            if pinnedDateStrings.contains(entry.dateString) {
+                pinned.append(entry)
+                continue
+            }
+
             if day >= thisWeekStart {
                 thisWeekOthers.append(entry)
             } else if day >= lastWeekStart {
@@ -238,6 +264,10 @@ enum TimelineService {
         }
 
         var sections: [TimelineSection] = []
+        // Pinned first, newest-first within the section.
+        if !pinned.isEmpty {
+            sections.append(TimelineSection(kind: .pinned, days: pinned.sorted { $0.date > $1.date }))
+        }
         if !thisWeekOthers.isEmpty {
             sections.append(TimelineSection(kind: .thisWeekOthers, days: thisWeekOthers))
         }

--- a/DayPageTests/AppIntentsTests.swift
+++ b/DayPageTests/AppIntentsTests.swift
@@ -40,10 +40,12 @@ struct AppIntentsTests {
 
     // MARK: - AskTodayIntent URL contract
 
-    @Test func askToday_buildsSearchURL() throws {
+    @Test func askToday_buildsAskURL() throws {
+        // AskTodayIntent now routes to the D1 memory-chat agent via
+        // daypage://ask (previously daypage://search as a placeholder).
         let url = try #require(AskTodayIntent.buildURL(query: "weekend plans"))
         #expect(url.scheme == "daypage")
-        #expect(url.host == "search")
+        #expect(url.host == "ask")
         let components = try #require(URLComponents(url: url, resolvingAgainstBaseURL: false))
         let q = components.queryItems?.first(where: { $0.name == "q" })?.value
         #expect(q == "weekend plans")

--- a/DayPageTests/MemoryChatTests.swift
+++ b/DayPageTests/MemoryChatTests.swift
@@ -1,0 +1,184 @@
+import Testing
+import Foundation
+@testable import DayPage
+
+// MARK: - LLMClient parsing
+
+@Suite("LLMClient.parseContent")
+struct LLMClientParseTests {
+
+    @Test func parsesOpenAICompatibleResponse() throws {
+        let json = """
+        {"choices":[{"message":{"role":"assistant","content":"  你好，世界  "}}]}
+        """
+        let data = try #require(json.data(using: .utf8))
+        let content = try LLMClient.parseContent(from: data)
+        #expect(content == "你好，世界")  // trimmed
+    }
+
+    @Test func throwsOnMissingContent() throws {
+        let json = #"{"choices":[]}"#
+        let data = try #require(json.data(using: .utf8))
+        #expect(throws: LLMError.self) {
+            _ = try LLMClient.parseContent(from: data)
+        }
+    }
+
+    @Test func throwsOnEmptyContent() throws {
+        let json = #"{"choices":[{"message":{"content":"   "}}]}"#
+        let data = try #require(json.data(using: .utf8))
+        #expect(throws: LLMError.self) {
+            _ = try LLMClient.parseContent(from: data)
+        }
+    }
+}
+
+// MARK: - GraphRetriever entity-page parsing
+
+@Suite("GraphRetriever entity parsing")
+struct GraphRetrieverParseTests {
+
+    /// 合成实体页（与 EntityPageService.buildNewEntityPage 同构）。
+    private static let entityPage = """
+    ---
+    type: place
+    name: "清迈"
+    slug: chiang-mai
+    first_seen: 2026-03-01
+    last_updated: 2026-06-10T12:00:00Z
+    occurrence_count: 7
+    ---
+
+    # 清迈
+
+    **Type**: Place
+    **First seen**: 2026-03-01
+
+    ## Visits
+    - 2026-03-01: 在 Joma Coffee 工作了一下午
+    - 2026-06-10: 又回到这里，熟悉的咖啡香
+    """
+
+    @Test func parsesNameAndOccurrenceCount() {
+        let hit = GraphRetriever.parseEntityPage(Self.entityPage, slug: "chiang-mai", type: "places")
+        #expect(hit?.displayName == "清迈")
+        #expect(hit?.occurrenceCount == 7)
+        #expect(hit?.type == "places")
+    }
+
+    @Test func bodySummarySkipsHeadingAndMetadata() {
+        let summary = GraphRetriever.bodySummary(from: Self.entityPage)
+        // 标题 "# 清迈"、**Type**、**First seen** 行应被跳过。
+        #expect(!summary.contains("# 清迈"))
+        #expect(!summary.contains("**Type**"))
+        // 实质内容应保留。
+        #expect(summary.contains("Joma Coffee"))
+    }
+
+    @Test func fallsBackToSlugWhenNameMissing() {
+        let page = """
+        ---
+        type: theme
+        occurrence_count: 2
+        ---
+        # whatever
+        some body
+        """
+        let hit = GraphRetriever.parseEntityPage(page, slug: "deep-work", type: "themes")
+        #expect(hit?.displayName == "deep-work")  // name 缺失 → 回退 slug
+        #expect(hit?.occurrenceCount == 2)
+    }
+}
+
+// MARK: - RetrievedContext prompt assembly
+
+@Suite("RetrievedContext.toPromptContext")
+struct RetrievedContextTests {
+
+    @Test func emptyContextRendersPlaceholder() {
+        let ctx = RetrievedContext(query: "x", memoHits: [], entityHits: [])
+        #expect(ctx.isEmpty)
+        #expect(ctx.toPromptContext() == "(未检索到相关内容)")
+    }
+
+    @Test func rendersMemoAndEntityBlocks() {
+        let ctx = RetrievedContext(
+            query: "清迈",
+            memoHits: [.init(dateString: "2026-06-10", snippet: "回到清迈", mood: "愉快", entityMentions: ["chiang-mai"])],
+            entityHits: [.init(slug: "chiang-mai", displayName: "清迈", type: "places", occurrenceCount: 7, summary: "常去的城市")]
+        )
+        let prompt = ctx.toPromptContext()
+        #expect(prompt.contains("2026-06-10"))
+        #expect(prompt.contains("愉快"))
+        #expect(prompt.contains("清迈"))
+        #expect(prompt.contains("地点"))  // entity type label
+        #expect(prompt.contains("出现 7 次"))
+    }
+}
+
+// MARK: - MemoryChatService
+
+@Suite("MemoryChatService")
+@MainActor
+struct MemoryChatServiceTests {
+
+    private func fixedContext(_ q: String) -> RetrievedContext {
+        RetrievedContext(
+            query: q,
+            memoHits: [.init(dateString: "2026-05-01", snippet: "测试记录", mood: nil, entityMentions: [])],
+            entityHits: []
+        )
+    }
+
+    @Test func askAppendsUserThenAssistantTurns() async {
+        let service = MemoryChatService(
+            send: { _ in "这是回答" },
+            retrieve: { self.fixedContext($0) }
+        )
+        await service.ask("我做了什么？")
+        #expect(service.turns.count == 2)
+        #expect(service.turns[0].role == .user)
+        #expect(service.turns[0].text == "我做了什么？")
+        #expect(service.turns[1].role == .assistant)
+        #expect(service.turns[1].text == "这是回答")
+        // assistant 回合应带上检索上下文，供 UI 展示来源。
+        #expect(service.turns[1].context?.memoHits.first?.dateString == "2026-05-01")
+        #expect(service.errorMessage == nil)
+    }
+
+    @Test func askSurfacesErrorWithoutAssistantTurn() async {
+        let service = MemoryChatService(
+            send: { _ in throw LLMError.rateLimited },
+            retrieve: { self.fixedContext($0) }
+        )
+        await service.ask("会失败")
+        // 只有 user 回合；assistant 回合不入队，错误走 errorMessage。
+        #expect(service.turns.count == 1)
+        #expect(service.turns[0].role == .user)
+        #expect(service.errorMessage != nil)
+    }
+
+    @Test func emptyQuestionIsIgnored() async {
+        let service = MemoryChatService(send: { _ in "x" }, retrieve: { self.fixedContext($0) })
+        await service.ask("   ")
+        #expect(service.turns.isEmpty)
+    }
+
+    @Test func buildMessagesIncludesSystemAndRetrievedContext() {
+        let service = MemoryChatService(send: { _ in "" }, retrieve: { self.fixedContext($0) })
+        let ctx = fixedContext("问题")
+        let messages = service.buildMessages(question: "我去过哪里？", context: ctx)
+        #expect(messages.first?.role == .system)
+        #expect(messages.last?.role == .user)
+        #expect(messages.last?.content.contains("我去过哪里？") == true)
+        #expect(messages.last?.content.contains("测试记录") == true)  // 检索上下文已注入
+    }
+
+    @Test func resetClearsConversation() async {
+        let service = MemoryChatService(send: { _ in "答" }, retrieve: { self.fixedContext($0) })
+        await service.ask("Q")
+        service.reset()
+        #expect(service.turns.isEmpty)
+        #expect(service.errorMessage == nil)
+    }
+}

--- a/docs/ADR-0004-memory-chat-and-graph-retrieval.md
+++ b/docs/ADR-0004-memory-chat-and-graph-retrieval.md
@@ -1,0 +1,80 @@
+# ADR-0004 · 记忆对话 Agent（D1）与图谱增强检索（D2）
+
+- **状态**：Accepted（已实现，首版落地）
+- **日期**：2026-06-17
+- **关联**：`docs/research-2026-06-market-and-product-directions.md` §3 D1/D2、§5 红线；ADR-0002（MCP，未来检索后端）
+- **影响范围**：`DayPage/Services/LLMClient.swift`、`GraphRetriever.swift`、`MemoryChatService.swift`、`DayPage/Features/Ask/AskPastView.swift`、`DayPage/Intents/AskTodayIntent.swift`、`DayPage/App/{DayPageApp,RootView,AppNavigationModel}.swift`
+
+---
+
+## 1. 背景
+
+调研报告 §3 把「**和你的过去对话**」（D1）与「**图谱增强检索**」（D2）列为 P0
+差异化方向，且有顶会论文背书：
+
+- OmniQuery (arXiv 2409.08250) `3-0`：**先用跨记忆上下文增强、再检索**，胜/平朴素 RAG 74.5%。朴素检索只能捞孤立事实，无法回答需要推断上下文的复杂查询。
+- Emotion-aware journaling agent (arXiv 2508.20585) `3-0`：AI 日记 agent 用 RAG 提供上下文丰富的对话式交互。
+
+落地前的现状缺口：
+
+1. **LLM 调用逻辑被锁死在编译管线里**。`CompilationService.callDeepSeek`（私有方法）是唯一的 LLM 通道，无法被对话能力复用。
+2. **检索是纯关键词 `contains`**。`SearchService` 把每条 memo 当孤立文本扫描，没有沿知识网络扩展——正是 OmniQuery 证明有天花板的做法。
+3. **`AskTodayIntent` 是占位**。它把「问问今天」路由到关键词 SearchView，注释里预留了"once an on-device MCP/LLM pipeline is wired up we can re-route"。
+
+## 2. 决策
+
+### 2.1 分层架构（地基 → 检索 → 对话 → 入口）
+
+```
+AskTodayIntent / app 入口
+        │  daypage://ask?q=…
+        ▼
+AskPastView（对话 UI，展示来源 chips）
+        │
+        ▼
+MemoryChatService（D1：编排检索 + 对话 + 历史）
+        ├──► GraphRetriever（D2：先连后查）──► vault/raw + vault/wiki（只读）
+        └──► LLMClient（可复用云端通道）──► DeepSeek
+```
+
+四层各自单一职责，互不耦合：
+
+| 组件 | 职责 | 复用 |
+|---|---|---|
+| `LLMClient` | OpenAI 兼容传输：messages → 重试 → 文本 | 编译与对话**共用**；未来可在前台路径替换为端侧模型 |
+| `GraphRetriever` | 关键词种子命中 → 沿 `entityMentions` 扩展一跳邻居实体页 → 带来源标注的上下文 | D1 的检索层；未来可被 D3（MCP）/向量索引替换 |
+| `MemoryChatService` | `@MainActor ObservableObject`：检索→组装 prompt→调 LLM→多轮历史 | — |
+| `AskPastView` | 对话界面 + 来源 chips（把"连"显性化） | — |
+
+### 2.2 D2「先连后查」的具体实现
+
+1. **种子命中**：复用 `SearchService.search`（不重复造关键词检索）。
+2. **回读 entityMentions**：`SearchResult` 不含 `entityMentions`，故按命中日期回读 `vault/raw/*.md`，从 `Memo.entityMentions` 收集邻居 slug。
+3. **图谱扩展**：沿 slug 读 `vault/wiki/{places,people,themes}/{slug}.md`，解析 `name` / `occurrence_count`，按出现次数降序取前 N。同时把 query 本身 slug 化作为直接命中候选（用户问"清迈"可直接命中地点页）。
+4. **组装**：`RetrievedContext.toPromptContext()` 渲染"相关原始记录 + 相关实体"两块，带日期/情绪标注，供 LLM 引用。
+
+纯本地、零 token、零网络——这是 D1 对话的检索基质。
+
+### 2.3 入口重路由
+
+`AskTodayIntent` 从 `daypage://search` 改为 `daypage://ask`。`DayPageApp.onOpenURL`
+新增 `ask` 分支，把 query 写入 `AppNavigationModel.pendingAskQuery`；`RootView`
+用 `.sheet(item:)` 观察并弹出 `AskPastView`。原 `search` 路由保留给 ArchiveView。
+
+## 3. 架构红线遵守（研究报告 §5）
+
+- **iOS 后台 GPU 限制**：`MemoryChatService` **只在前台被用户主动调用**，不绑定 `BGTaskScheduler`。后台编译保留云端 DeepSeek。端侧模型（D4）若引入，只替换前台 `LLMClient`，后台不动。
+- **token 成本**：对话 `max_tokens` 限 1500、历史只带最近 4 轮，控制单次成本。
+- **图谱价值显性化**（§5 风险 4）：对话回答下方用 chips 展示"依据"（命中日期 + 实体名），让用户直接看到"连"比"存"多了什么。
+
+## 4. 权衡与未竟项
+
+- **检索仍是关键词种子 + 一跳扩展**，非向量召回。够 MVP；语义召回留待 ADR-0002 的 SQLiteVec / 向量索引接入后增强 `GraphRetriever` 的种子阶段。
+- **多跳图谱**：当前只扩展一跳邻居。多跳（实体→实体）在实体页尚未存关系边前不做。
+- **DeepSeek vs qwen**：研究文档写的是 qwen，实际代码用 DeepSeek（`deepseek-v4-pro`）。`LLMClient.Config.deepSeek()` 沿用现有配置，不在本 ADR 内切换 provider。
+
+## 5. 测试
+
+`DayPageTests/MemoryChatTests.swift` 覆盖：`LLMClient.parseContent`（含空响应抛错）、
+`GraphRetriever.parseEntityPage` / `bodySummary`（frontmatter + 正文解析、name 缺失回退 slug）、
+`RetrievedContext.toPromptContext`、`MemoryChatService.ask`（用户/助手回合、错误不留空回合、空问题忽略、reset、检索上下文注入 prompt）。

--- a/packages/mcp-server/package.json
+++ b/packages/mcp-server/package.json
@@ -10,7 +10,8 @@
     "build": "tsc",
     "dev": "node --loader ts-node/esm src/index.ts",
     "start": "node dist/index.js",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsc --noEmit",
+    "test": "tsc && node --test \"dist/**/*.test.js\""
   },
   "dependencies": {
     "drizzle-orm": "^0.45.2",

--- a/packages/mcp-server/src/tools/search.ts
+++ b/packages/mcp-server/src/tools/search.ts
@@ -4,7 +4,11 @@ import { pgSql } from "../db.js";
 
 const searchTool: ToolHandler = {
   name: "daypage_search",
-  description: "Search DayPage memos and pages by keyword or phrase",
+  description:
+    "Search DayPage memos and pages by keyword or phrase. Graph-augmented: " +
+    "after matching pages, it also surfaces their one-hop neighbours from the " +
+    "knowledge graph (page_links), so an agent sees the network around a hit, " +
+    "not just the isolated match (OmniQuery-style retrieve-then-connect).",
   inputSchema: {
     type: "object",
     properties: {
@@ -69,6 +73,51 @@ const searchTool: ToolHandler = {
       LIMIT ${limit}
     `;
 
+    // Graph augmentation: expand one hop out from the matched pages along
+    // page_links, so the agent sees the knowledge network around each hit
+    // rather than isolated matches. Skip pages already in the direct results.
+    const matchedPageIds = pageRows.map((p) => p.id);
+    const matchedPageIdSet = new Set(matchedPageIds);
+    let neighborRows: Array<{
+      page_id: string;
+      slug: string;
+      title: string;
+      type: string;
+      weight: number;
+      rationale: string | null;
+      direction: string;
+    }> = [];
+
+    if (matchedPageIds.length > 0) {
+      neighborRows = await pgSql<Array<{
+        page_id: string;
+        slug: string;
+        title: string;
+        type: string;
+        weight: number;
+        rationale: string | null;
+        direction: string;
+      }>>`
+        SELECT p.id AS page_id, p.slug, p.title, p.type, pl.weight, pl.rationale,
+               'outbound' AS direction
+        FROM page_links pl
+        JOIN pages p ON p.id = pl.to_page_id
+        WHERE pl.user_id = ${userId}
+          AND pl.from_page_id = ANY(${matchedPageIds})
+        UNION
+        SELECT p.id AS page_id, p.slug, p.title, p.type, pl.weight, pl.rationale,
+               'inbound' AS direction
+        FROM page_links pl
+        JOIN pages p ON p.id = pl.from_page_id
+        WHERE pl.user_id = ${userId}
+          AND pl.to_page_id = ANY(${matchedPageIds})
+        ORDER BY weight DESC
+        LIMIT 10
+      `;
+      // Drop neighbours that are already direct hits to avoid duplication.
+      neighborRows = neighborRows.filter((n) => !matchedPageIdSet.has(n.page_id));
+    }
+
     const lines: string[] = [`Search results for: "${query}"`, ""];
 
     // Pages section
@@ -88,6 +137,19 @@ const searchTool: ToolHandler = {
         }
         lines.push("");
       }
+    }
+
+    // Related pages from the knowledge graph (one-hop neighbours of the hits).
+    // Only shown when direct page matches exist and have neighbours.
+    if (neighborRows.length > 0) {
+      lines.push(`=== Related (knowledge graph, ${neighborRows.length}) ===`);
+      for (const n of neighborRows) {
+        const arrow = n.direction === "outbound" ? "→" : "←";
+        lines.push(`  ${arrow} [${n.type}] ${n.title} (weight: ${n.weight})`);
+        lines.push(`    slug: ${n.slug}`);
+        if (n.rationale) lines.push(`    rationale: ${n.rationale}`);
+      }
+      lines.push("");
     }
 
     // Memos section


### PR DESCRIPTION
## Summary

Two cohesive feature drops that finish a thread started in #776.

**Memory chat (D1/D2) — "和过去对话"**
- Surfaces the agent that AskTodayIntent was always pointing at. Was routing to keyword `SearchView` as a placeholder; now goes to a real chat sheet (`AskPastView`) backed by `GraphRetriever` (one-hop retrieve-then-connect over the wiki graph) + `LLMClient` (OpenAI-compatible streaming) + `MemoryChatService` glue.
- Sidebar gains a "和过去对话" entry so the agent is discoverable in-app, not only via Siri/Shortcuts.
- mcp-server `daypage_search` now graph-augments its hits with one-hop neighbours so external agents see the network, not isolated matches.
- Banner system (`AppBanner` + `GlassErrorBanner`) gets asymmetric spring motion + tuned auto-dismiss durations so toasts feel like one polished surface.

**Timeline day card overhaul**
Replaces inline "tap to expand" on historical timeline rows with a four-way gesture vocabulary so every action has one obvious home and the destructive one never sits on a swipe path.

| Gesture | Action |
|---|---|
| Tap | Open the Daily Page in fullScreenCover |
| Long-press | `contextMenu(preview:)` — preview card + Open / Share / Pin / Copy / Delete |
| Right-swipe | Pin / unpin the day |
| Left-swipe | Share via system ShareSheet |
| Delete | Only via contextMenu → confirmation alert |

📌 PINNED section bubbles user-pinned days to the top of the timeline. Pin state persists to `vault/.timeline-pins.json` so it travels with the user's vault.

Mechanically reuses `HorizontalPanGesture` (direction-locked UIKit pan recogniser) so the parent ScrollView keeps ownership of vertical drags — same pattern as `SwipeableMemoCard`.

## Test plan

Memory chat / D1
- [ ] Run `AskTodayIntent` from Shortcuts with a query → app opens, "和过去对话" sheet appears with the question seeded
- [ ] Tap the new "和过去对话" sidebar row → empty AskPastView opens
- [ ] Send a question → see retrieved memos + LLM reply with citations
- [ ] `AskTodayIntent.buildURL` test now asserts `daypage://ask` host

Banner polish
- [ ] Trigger a sync banner → enters from top with spring, dismisses after 5s with fade+offset
- [ ] Trigger an action-bearing banner → lingers 8s instead of 5s
- [ ] Trigger a GlassErrorBanner → same asymmetric enter/exit motion

Timeline card
- [ ] Tap a historical timeline row → that date's Daily Page opens in fullScreenCover
- [ ] Long-press a row → preview card with serif summary + first 3 memos
- [ ] Right-swipe → pin panel slides in; release → row jumps to a new 📌 PINNED section at the top
- [ ] Left-swipe → share panel; release → system ShareSheet with `dateString + summary`
- [ ] contextMenu → Delete → alert → confirm → `vault/raw/{date}.md` and `vault/wiki/daily/{date}.md` are gone
- [ ] Pin persists across app restart (`vault/.timeline-pins.json` written)
- [ ] Reduce Motion → snap animations use easeOut, no spring
- [ ] Vertical scrolling on the timeline still works while a finger is on a row