### PR TITLE
refactor: agent-team audit sweep — shared helpers, a11y/i18n, CI tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,10 +175,94 @@ jobs:
           fi
           echo "✅ Generated tokens match design-tokens/tokens.json"
 
+  xcode-tests:
+    name: Xcode Unit Tests (DayPageTests)
+    runs-on: macos-15
+    needs: unit-tests
+    if: github.event_name != 'pull_request' || github.event.action != 'closed'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Select newest Xcode
+        run: |
+          LATEST=$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)
+          if [ -n "$LATEST" ]; then
+            echo "Selecting: $LATEST"
+            sudo xcode-select -s "$LATEST/Contents/Developer"
+          fi
+          xcodebuild -version
+
+      - name: Cache DerivedData
+        uses: actions/cache@v4
+        with:
+          path: ~/Library/Developer/Xcode/DerivedData
+          key: deriveddata-tests-${{ hashFiles('DayPage.xcodeproj/project.pbxproj') }}-${{ runner.os }}
+          restore-keys: |
+            deriveddata-tests-${{ hashFiles('DayPage.xcodeproj/project.pbxproj') }}-
+            deriveddata-tests-
+
+      # Same CI placeholder used by the build job. Required because the test
+      # build links against the app target which references Secrets.*.
+      - name: Ensure GeneratedSecrets.swift exists
+        run: |
+          mkdir -p DayPage/Config
+          cat > DayPage/Config/GeneratedSecrets.swift << 'SWIFT'
+          // CI placeholder — real values injected at runtime via .env
+          enum Secrets {
+              static let deepSeekApiKey: String = ""
+              static let deepSeekBaseURL: String = "https://api.deepseek.com/v1"
+              static let deepSeekModel: String = "deepseek-v4-pro"
+              static let openAIWhisperApiKey: String = ""
+              static let openWeatherApiKey: String = ""
+              static let supabaseURL: String = "https://placeholder.supabase.co"
+              static let supabaseAnonKey: String = ""
+              static let sentryDSN: String = ""
+              static let kubotGitHubToken: String = ""
+          }
+          SWIFT
+
+      - name: Write simulator picker script
+        run: |
+          printf '%s\n' \
+            'import json,sys,re' \
+            'd=json.load(sys.stdin)' \
+            'iphones=[(dev["name"],dev["udid"]) for devs in d["devices"].values() for dev in devs if dev.get("name","").startswith("iPhone") and dev.get("isAvailable",False)]' \
+            'iphones.sort(key=lambda x:[int(c) if c.isdigit() else c for c in re.split(r"(\d+)",x[0])])' \
+            'print(iphones[-1][1] if iphones else "")' \
+            > /tmp/pick_sim.py
+
+      - name: Run DayPageTests
+        run: |
+          set -o pipefail
+          SIM_UDID=$(xcrun simctl list devices available --json 2>/dev/null | python3 /tmp/pick_sim.py 2>/dev/null || true)
+          if [ -n "$SIM_UDID" ]; then
+            DEST="platform=iOS Simulator,id=$SIM_UDID"
+          else
+            DEST="platform=iOS Simulator,name=iPhone 16"
+          fi
+          echo "Using simulator: $DEST"
+          xcodebuild test \
+            -scheme DayPage \
+            -destination "$DEST" \
+            -configuration Debug \
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | tee xcode-tests.log
+
+      - name: Upload xcresult bundle
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: DayPageTests-xcresult-${{ github.sha }}
+          path: TestResults.xcresult
+          retention-days: 7
+
   build:
     name: Xcode Build (no signing)
     runs-on: macos-15
-    needs: unit-tests
+    needs: [unit-tests, xcode-tests]
     if: github.event_name != 'pull_request' || github.event.action != 'closed'
 
     steps:

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -73,6 +73,9 @@
 		A10000040 /* DayDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000040 /* DayDetailView.swift */; };
 		A10000041 /* Spacing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000041 /* Spacing.swift */; };
 		A10000042 /* RelativeTimeFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000042 /* RelativeTimeFormatter.swift */; };
+		A10000801 /* DateFormatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000801 /* DateFormatters.swift */; };
+		A10000802 /* HTTPClientHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000802 /* HTTPClientHelper.swift */; };
+		A10000803 /* RetryHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000803 /* RetryHelper.swift */; };
 		A10000043 /* Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000043 /* Interactions.swift */; };
 		A10000045 /* OnThisDayIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000045 /* OnThisDayIndex.swift */; };
 		A10000046 /* OnThisDayCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000046 /* OnThisDayCard.swift */; };
@@ -309,6 +312,9 @@
 		A20000040 /* DayDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DayDetailView.swift; sourceTree = "<group>"; };
 		A20000041 /* Spacing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Spacing.swift; sourceTree = "<group>"; };
 		A20000042 /* RelativeTimeFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTimeFormatter.swift; sourceTree = "<group>"; };
+		A20000801 /* DateFormatters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DateFormatters.swift; sourceTree = "<group>"; };
+		A20000802 /* HTTPClientHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HTTPClientHelper.swift; sourceTree = "<group>"; };
+		A20000803 /* RetryHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RetryHelper.swift; sourceTree = "<group>"; };
 		A20000043 /* Interactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interactions.swift; sourceTree = "<group>"; };
 		A20000045 /* OnThisDayIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayIndex.swift; sourceTree = "<group>"; };
 		A20000046 /* OnThisDayCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayCard.swift; sourceTree = "<group>"; };
@@ -685,6 +691,8 @@
 				CF559C11C922ACB683565E7C /* LLMClient.swift */,
 				DD333392AE2B7F775D6E8D99 /* GraphRetriever.swift */,
 				A19989C44C3E9887FC01F382 /* MemoryChatService.swift */,
+				A20000802 /* HTTPClientHelper.swift */,
+				A20000803 /* RetryHelper.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -835,6 +843,7 @@
 			isa = PBXGroup;
 			children = (
 				A20000042 /* RelativeTimeFormatter.swift */,
+				A20000801 /* DateFormatters.swift */,
 			);
 			path = Utilities;
 			sourceTree = "<group>";
@@ -1277,6 +1286,9 @@
 				A10000063 /* SwipeableMemoCard.swift in Sources */,
 				A10000400 /* HorizontalPanGesture.swift in Sources */,
 				A10000042 /* RelativeTimeFormatter.swift in Sources */,
+				A10000801 /* DateFormatters.swift in Sources */,
+				A10000802 /* HTTPClientHelper.swift in Sources */,
+				A10000803 /* RetryHelper.swift in Sources */,
 				A10000079 /* iCloudSyncMonitor.swift in Sources */,
 				A10000085 /* iCloudConflictMonitor.swift in Sources */,
 				A10000080 /* AppNavigationModel.swift in Sources */,

--- a/DayPage/DesignSystem/Colors.swift
+++ b/DayPage/DesignSystem/Colors.swift
@@ -96,6 +96,31 @@ enum DSColor {
     static let densityMid    = Color(hex: "A8541B").opacity(0.45)
     static let densityHigh   = Color(hex: "A8541B").opacity(0.85)
 
+    /// Foreground ink on amber-deep / amber-accent surfaces. Stays near-white
+    /// in both light and dark schemes since the amber substrate carries the
+    /// same chroma either way. Use instead of `Color.white` whenever drawing
+    /// glyphs / dots on a saturated amber chip or artifact panel.
+    static let onAmber        = Color(light: Color(hex: "FFFBF3"), dark: Color(hex: "FFF6E4"))
+
+    // V4 status semantic tokens — adaptive in dark mode to preserve contrast
+    // against `bgWarm` deep-charcoal-brown. Use these instead of system
+    // `.green` / `.red` / `.orange`, which key off iOS system tints and lose
+    // the warm-amber language under dark scheme.
+    /// Granted / connected / OK state — warmer than system green so it sits
+    /// against the amber palette without clashing.
+    static let statusSuccess  = Color(light: Color(hex: "4C7A3F"), dark: Color(hex: "8FBE7A"))
+    /// Denied / failed state — desaturated red that survives dark mode.
+    static let statusError    = Color(light: Color(hex: "A23A2E"), dark: Color(hex: "E08577"))
+    /// Limited / undetermined / requires-attention state — warm orange tied
+    /// to the amber accent family.
+    static let statusWarning  = Color(light: Color(hex: "A66A00"), dark: Color(hex: "E8A33B"))
+
+    /// Transcribe-armed cue — cool blue tone used by the recording overlay to
+    /// distinguish the "release-to-transcribe" gesture from the warmer
+    /// "release-to-cancel" red. Tuned for legibility on the dark recording
+    /// scrim in both schemes.
+    static let transcribeBlue = Color(light: Color(hex: "4D8CFF"), dark: Color(hex: "7AA8FF"))
+
     // MARK: - V3 Warm-White Tokens
 
     /// 页面 / 屏幕背景 — 暖色调米白 / 深暖棕

--- a/DayPage/DesignSystem/DSBanner.swift
+++ b/DayPage/DesignSystem/DSBanner.swift
@@ -89,7 +89,7 @@ struct DSBanner: View {
                         .frame(width: 44, height: 44)
                         .contentShape(Rectangle())
                 }
-                .accessibilityLabel("关闭")
+                .accessibilityLabel(L10n.Banner.closeA11y)
             }
         }
         .padding(.horizontal, DSSpacing.lg)

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -68,22 +68,26 @@ struct DayStats {
         var textColor: Color {
             switch self {
             case .empty, .low: return DSColor.inkPrimary
-            case .medium, .high: return Color.white
+            // medium / high density chips fill with amber → use onAmber token
+            // so the warm-cream foreground tracks dark mode correctly.
+            case .medium, .high: return DSColor.onAmber
             }
         }
 
         var label: String {
             switch self {
-            case .empty: return "EMPTY"
-            case .low: return "LOW"
-            case .medium: return "MEDIUM"
-            case .high: return "HIGH"
+            case .empty: return L10n.Archive.densityEmpty
+            case .low: return L10n.Archive.densityLow
+            case .medium: return L10n.Archive.densityMedium
+            case .high: return L10n.Archive.densityHigh
             }
         }
 
         /// Right-corner dot color — amber accent on today cell, text color otherwise.
         func dotColor(isToday: Bool) -> Color {
-            isToday ? Color.white : textColor
+            // Today cell fill is amber-accent; use onAmber so the dot stays
+            // legible without hardcoded white.
+            isToday ? DSColor.onAmber : textColor
         }
     }
 }
@@ -972,13 +976,17 @@ struct ArchiveView: View {
             let textColor: Color = {
                 if let d = density { return d.textColor }
                 switch data {
-                case .compiled: return Color.white
+                // `compiled` cell fills with amberDeep — onAmber keeps the
+                // foreground legible in both light and dark schemes.
+                case .compiled: return DSColor.onAmber
                 case .rawOnly:  return DSColor.inkPrimary
                 case .none:     return DSColor.inkSubtle
                 }
             }()
 
-            let dotColor: Color = isToday ? Color.white : DSColor.amberAccent
+            // Today dot sits on the amber today-cell fill — onAmber instead
+            // of pure white so dark mode keeps the warm-cream language.
+            let dotColor: Color = isToday ? DSColor.onAmber : DSColor.amberAccent
 
             Button(action: {
                 Haptics.tapConfirm()
@@ -1287,9 +1295,12 @@ struct ArchiveView: View {
                     // Status label
                     VStack(spacing: 6) {
                         HStack(spacing: 6) {
+                            // Artifact panel background is amberDeep@0.92 — use
+                            // onAmber so the label tracks dark mode instead of
+                            // sitting on a pure-white system color.
                             Text("SYSTEM STATUS:")
                                 .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
-                                .foregroundColor(Color.white.opacity(0.4))
+                                .foregroundColor(DSColor.onAmber.opacity(0.4))
                                 .tracking(0.5)
 
                             Text(viewModel.systemStatus.label)
@@ -1300,7 +1311,7 @@ struct ArchiveView: View {
 
                         Text("LAST SYNC // \(viewModel.lastSyncTimestamp)")
                             .font(DSFonts.jetBrainsMono(size: 10, weight: .regular))
-                            .foregroundColor(Color.white.opacity(0.3))
+                            .foregroundColor(DSColor.onAmber.opacity(0.3))
                             .tracking(0.5)
                     }
                 }
@@ -1312,7 +1323,9 @@ struct ArchiveView: View {
 
     private var statusTextColor: Color {
         switch viewModel.systemStatus {
-        case .synchronized:       return Color.white.opacity(0.6)
+        // Synchronized label sits on the amberDeep artifact panel — onAmber
+        // so the warm-cream foreground tracks dark mode.
+        case .synchronized:       return DSColor.onAmber.opacity(0.6)
         case .pendingCompilation: return DSColor.warningAmber
         case .offline:            return DSColor.errorRed
         }

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -322,10 +322,10 @@ struct SettingsView: View {
             if let result {
                 HStack(spacing: 6) {
                     Image(systemName: result.isSuccess ? "checkmark.circle.fill" : "xmark.circle.fill")
-                        .foregroundColor(result.isSuccess ? .green : .red)
+                        .foregroundColor(result.isSuccess ? DSColor.statusSuccess : DSColor.statusError)
                     Text(result.message)
                         .font(.caption)
-                        .foregroundColor(result.isSuccess ? .green : .red)
+                        .foregroundColor(result.isSuccess ? DSColor.statusSuccess : DSColor.statusError)
                         .lineLimit(2)
                         .fixedSize(horizontal: false, vertical: true)
                 }
@@ -370,7 +370,7 @@ struct SettingsView: View {
                     }
                     Spacer()
                     Image(systemName: "checkmark.circle.fill")
-                        .foregroundColor(.green)
+                        .foregroundColor(DSColor.statusSuccess)
                 }
             } else {
                 Button(action: { locationService.requestAlwaysAuthorization() }) {
@@ -385,11 +385,11 @@ struct SettingsView: View {
         let status = AVAudioSession.sharedInstance().recordPermission
         switch status {
         case .granted:
-            Text(NSLocalizedString("settings.permission.mic.granted", comment: "")).font(.caption).foregroundColor(.green)
+            Text(NSLocalizedString("settings.permission.mic.granted", comment: "")).font(.caption).foregroundColor(DSColor.statusSuccess)
         case .denied:
-            Text(NSLocalizedString("settings.permission.mic.denied", comment: "")).font(.caption).foregroundColor(.red)
+            Text(NSLocalizedString("settings.permission.mic.denied", comment: "")).font(.caption).foregroundColor(DSColor.statusError)
         default:
-            Text(NSLocalizedString("settings.permission.mic.undetermined", comment: "")).font(.caption).foregroundColor(.orange)
+            Text(NSLocalizedString("settings.permission.mic.undetermined", comment: "")).font(.caption).foregroundColor(DSColor.statusWarning)
         }
     }
 
@@ -604,7 +604,7 @@ struct SettingsView: View {
                     .frame(width: 8, height: 8)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(NSLocalizedString("settings.icloud.connected", comment: "")).font(.body).fontWeight(.medium)
-                    Text("iCloud Drive").font(.caption).foregroundColor(DSColor.onSurfaceVariant)
+                    Text(L10n.Settings.iCloudDrive).font(.caption).foregroundColor(DSColor.onSurfaceVariant)
                 }
                 Spacer()
                 if let date = lastSync {

--- a/DayPage/Features/Today/RecordingOverlayView.swift
+++ b/DayPage/Features/Today/RecordingOverlayView.swift
@@ -105,38 +105,46 @@ struct RecordingOverlayView: View {
                         VStack(spacing: 4) {
                             Image(systemName: "arrow.left")
                                 .font(.system(size: 14, weight: .semibold))
-                            Text("Cancel")
+                            Text(L10n.Recording.cancel)
                                 .font(DSFonts.inter(size: 11, weight: .medium))
                         }
                         .foregroundColor(Color.white.opacity(0.55))
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(Text(L10n.Recording.cancelHintA11yLabel))
 
                         VStack(spacing: 4) {
                             Image(systemName: "arrow.right")
                                 .font(.system(size: 14, weight: .semibold))
-                            Text("Transcribe")
+                            Text(L10n.Recording.transcribe)
                                 .font(DSFonts.inter(size: 11, weight: .medium))
                         }
                         .foregroundColor(Color.white.opacity(0.55))
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(Text(L10n.Recording.transcribeHintA11yLabel))
                     }
                     .padding(.top, 8)
                 } else if mode == .cancelArmed {
                     HStack(spacing: 4) {
                         Image(systemName: "arrow.left")
                             .font(.system(size: 14, weight: .semibold))
-                        Text("Release to cancel")
+                        Text(L10n.Recording.releaseToCancel)
                             .font(DSFonts.inter(size: 12, weight: .medium))
                     }
                     .foregroundColor(DSTokens.Colors.recordingRed)
                     .padding(.top, 8)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(Text(L10n.Recording.releaseToCancel))
                 } else if mode == .transcribeArmed {
                     HStack(spacing: 4) {
                         Image(systemName: "arrow.right")
                             .font(.system(size: 14, weight: .semibold))
-                        Text("Release to transcribe")
+                        Text(L10n.Recording.releaseToTranscribe)
                             .font(DSFonts.inter(size: 12, weight: .medium))
                     }
-                    .foregroundColor(Color(red: 0.30, green: 0.55, blue: 1.0))
+                    .foregroundColor(DSColor.transcribeBlue)
                     .padding(.top, 8)
+                    .accessibilityElement(children: .combine)
+                    .accessibilityLabel(Text(L10n.Recording.releaseToTranscribe))
                 }
 
                 // Status + timer
@@ -167,7 +175,7 @@ struct RecordingOverlayView: View {
                             VStack(spacing: 4) {
                                 Image(systemName: "xmark")
                                     .font(.system(size: 16, weight: .semibold))
-                                Text("Cancel")
+                                Text(L10n.Recording.cancel)
                                     .font(DSFonts.inter(size: 12, weight: .medium))
                             }
                             .foregroundColor(mode == .cancelArmed ? DSTokens.Colors.recordingRed : Color.white.opacity(0.75))
@@ -176,6 +184,9 @@ struct RecordingOverlayView: View {
                             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                         }
                         .buttonStyle(.plain)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(Text(L10n.Recording.cancelA11yLabel))
+                        .accessibilityHint(Text(L10n.Recording.cancelA11yHint))
 
                         // Save / Transcribe
                         Button {
@@ -184,7 +195,7 @@ struct RecordingOverlayView: View {
                             VStack(spacing: 4) {
                                 Image(systemName: mode == .transcribeArmed ? "text.bubble" : "checkmark")
                                     .font(.system(size: 16, weight: .semibold))
-                                Text(mode == .transcribeArmed ? "Transcribe" : "Save")
+                                Text(mode == .transcribeArmed ? L10n.Recording.transcribe : L10n.Recording.save)
                                     .font(DSFonts.inter(size: 12, weight: .medium))
                             }
                             .foregroundColor(mode == .transcribeArmed ? Color(red: 0.30, green: 0.55, blue: 1.0) : Color.white.opacity(0.90))
@@ -193,6 +204,9 @@ struct RecordingOverlayView: View {
                             .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
                         }
                         .buttonStyle(.plain)
+                        .accessibilityElement(children: .combine)
+                        .accessibilityLabel(Text(mode == .transcribeArmed ? L10n.Recording.transcribeA11yLabel : L10n.Recording.saveA11yLabel))
+                        .accessibilityHint(Text(mode == .transcribeArmed ? L10n.Recording.transcribeA11yHint : L10n.Recording.saveA11yHint))
                     }
                 }
             }
@@ -204,10 +218,10 @@ struct RecordingOverlayView: View {
 
     private var statusText: String {
         switch mode {
-        case .recording: return "Listening…"
-        case .cancelArmed: return "Release to cancel"
-        case .transcribeArmed: return "Release to transcribe"
-        case .transcribing: return "Transcribing…"
+        case .recording: return L10n.Recording.listeningString
+        case .cancelArmed: return L10n.Recording.releaseToCancelString
+        case .transcribeArmed: return L10n.Recording.releaseToTranscribeString
+        case .transcribing: return L10n.Recording.transcribingString
         }
     }
 

--- a/DayPage/Features/Today/VoiceRecordingView.swift
+++ b/DayPage/Features/Today/VoiceRecordingView.swift
@@ -132,7 +132,7 @@ struct VoiceRecordingView: View {
                             .stroke(DSColor.error.opacity(0.4), lineWidth: 8)
                             .scaleEffect(1.5)
                     )
-                    .animation(.easeInOut(duration: 0.8).repeatForever(autoreverses: true),
+                    .animation(reduceMotion ? nil : .easeInOut(duration: 0.8).repeatForever(autoreverses: true),
                                value: voiceService.state)
             } else if voiceService.state == .paused {
                 Image(systemName: "pause.fill")

--- a/DayPage/Models/FrontmatterParser.swift
+++ b/DayPage/Models/FrontmatterParser.swift
@@ -33,4 +33,36 @@ enum FrontmatterParser {
         }
         return nil
     }
+
+    /// Same extraction, but constrained to the leading `---\n...\n---` block.
+    ///
+    /// Use this when the file body may contain `key:` look-alikes (e.g. an
+    /// entity page that mentions `occurrence_count:` inside a quoted body
+    /// snippet). ``GraphRetriever`` requires this stricter semantics; Daily
+    /// Page parsing keeps using ``extractField(_:from:)`` so behaviour stays
+    /// stable for files without a closing `---`.
+    ///
+    /// - Returns: the field's value, or `nil` when the file has no opening
+    ///   `---` on line 0, when the key isn't found inside the block, or
+    ///   when the trimmed value is empty.
+    static func extractFieldInBlock(_ key: String, from content: String) -> String? {
+        let prefix = "\(key):"
+        let lines = content.components(separatedBy: "\n")
+        var inBlock = false
+        for (index, line) in lines.enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if index == 0 {
+                guard trimmed == "---" else { return nil }
+                inBlock = true
+                continue
+            }
+            if inBlock && trimmed == "---" { break }
+            guard inBlock, trimmed.hasPrefix(prefix) else { continue }
+            let value = String(trimmed.dropFirst(prefix.count))
+                .trimmingCharacters(in: .whitespaces)
+                .trimmingCharacters(in: CharacterSet(charactersIn: "\"'"))
+            return value.isEmpty ? nil : value
+        }
+        return nil
+    }
 }

--- a/DayPage/Resources/L10n.swift
+++ b/DayPage/Resources/L10n.swift
@@ -58,6 +58,33 @@ enum L10n {
         static let graphClearFilters      = NSLocalizedString("empty.graph.clear_filters", comment: "")
     }
 
+    enum Recording {
+        // Visible labels
+        static let cancel               = LocalizedStringKey("recording.cancel")
+        static let transcribe           = LocalizedStringKey("recording.transcribe")
+        static let save                 = LocalizedStringKey("recording.save")
+        static let releaseToCancel      = LocalizedStringKey("recording.release_to_cancel")
+        static let releaseToTranscribe  = LocalizedStringKey("recording.release_to_transcribe")
+        static let listening            = LocalizedStringKey("recording.listening")
+        static let transcribing         = LocalizedStringKey("recording.transcribing")
+
+        // Status strings (non-LocalizedStringKey for use in computed String props)
+        static let listeningString          = NSLocalizedString("recording.listening", comment: "Recording status: actively listening")
+        static let transcribingString       = NSLocalizedString("recording.transcribing", comment: "Recording status: Whisper transcription in flight")
+        static let releaseToCancelString    = NSLocalizedString("recording.release_to_cancel", comment: "Recording status: drag-up cancel armed")
+        static let releaseToTranscribeString = NSLocalizedString("recording.release_to_transcribe", comment: "Recording status: drag-left transcribe armed")
+
+        // VoiceOver labels & hints
+        static let cancelA11yLabel      = NSLocalizedString("recording.cancel.a11y.label", comment: "VoiceOver label for cancel-recording button")
+        static let cancelA11yHint       = NSLocalizedString("recording.cancel.a11y.hint", comment: "VoiceOver hint for cancel-recording button")
+        static let saveA11yLabel        = NSLocalizedString("recording.save.a11y.label", comment: "VoiceOver label for save-recording button")
+        static let saveA11yHint         = NSLocalizedString("recording.save.a11y.hint", comment: "VoiceOver hint for save-recording button")
+        static let transcribeA11yLabel  = NSLocalizedString("recording.transcribe.a11y.label", comment: "VoiceOver label for transcribe-recording button")
+        static let transcribeA11yHint   = NSLocalizedString("recording.transcribe.a11y.hint", comment: "VoiceOver hint for transcribe-recording button")
+        static let cancelHintA11yLabel  = NSLocalizedString("recording.cancel_hint.a11y.label", comment: "VoiceOver label for cancel directional hint")
+        static let transcribeHintA11yLabel = NSLocalizedString("recording.transcribe_hint.a11y.label", comment: "VoiceOver label for transcribe directional hint")
+    }
+
     enum Error {
         static let compileTitle    = LocalizedStringKey("error.compile.title")
         static let compileSubtitle = LocalizedStringKey("error.compile.subtitle")
@@ -73,5 +100,24 @@ enum L10n {
         static let locationDeniedTitle    = LocalizedStringKey("error.location_denied.title")
         static let locationDeniedSubtitle = LocalizedStringKey("error.location_denied.subtitle")
         static let locationDeniedCta      = NSLocalizedString("error.location_denied.cta", comment: "")
+    }
+
+    enum Settings {
+        // Brand name — funnelled through NSLocalizedString so any future
+        // localized override can ship without touching source.
+        static let iCloudDrive = NSLocalizedString("settings.icloud_drive", comment: "iCloud Drive feature name")
+    }
+
+    enum Archive {
+        // Heat-map density legend labels rendered on each day cell.
+        static let densityEmpty  = NSLocalizedString("archive.density.empty", comment: "Archive heat-map label: no memos")
+        static let densityLow    = NSLocalizedString("archive.density.low", comment: "Archive heat-map label: few memos")
+        static let densityMedium = NSLocalizedString("archive.density.medium", comment: "Archive heat-map label: some memos")
+        static let densityHigh   = NSLocalizedString("archive.density.high", comment: "Archive heat-map label: many memos")
+    }
+
+    enum Banner {
+        // VoiceOver label for the banner dismiss button.
+        static let closeA11y = NSLocalizedString("banner.close.a11y", comment: "VoiceOver label for the banner close button")
     }
 }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -673,3 +673,15 @@
 /* Sidebar profile */
 "sidebar.profile.local_account"              = "Local Account";
 "sidebar.profile.tap_to_sync"                = "LOCAL · TAP TO SYNC";
+
+/* Settings — iCloud */
+"settings.icloud_drive"                      = "iCloud Drive";
+
+/* Archive — heat-map density labels */
+"archive.density.empty"                      = "EMPTY";
+"archive.density.low"                        = "LOW";
+"archive.density.medium"                     = "MEDIUM";
+"archive.density.high"                       = "HIGH";
+
+/* DSBanner — accessibility */
+"banner.close.a11y"                          = "Close";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -677,3 +677,15 @@
 /* Sidebar profile */
 "sidebar.profile.local_account"              = "本地账户";
 "sidebar.profile.tap_to_sync"                = "本地 · 点击同步";
+
+/* Settings — iCloud */
+"settings.icloud_drive"                      = "iCloud Drive";
+
+/* Archive — heat-map density labels */
+"archive.density.empty"                      = "空白";
+"archive.density.low"                        = "少";
+"archive.density.medium"                     = "中";
+"archive.density.high"                       = "多";
+
+/* DSBanner — accessibility */
+"banner.close.a11y"                          = "关闭";

--- a/DayPage/Services/CompilationService.swift
+++ b/DayPage/Services/CompilationService.swift
@@ -1,6 +1,4 @@
 import Foundation
-import Network
-import Sentry
 
 // MARK: - CompilationStage
 
@@ -110,20 +108,55 @@ final class CompilationService: ObservableObject {
 
     // MARK: - Step 3: Call AI
 
-    /// Calls the AI API with retry, returning the raw LLM response string.
+    /// System prompt for the compilation engine. Kept on the class so it can be
+    /// reused without rebuilding the string.
+    private static let compilationSystemPrompt = "You are DayPage's AI compilation engine. Output only a single valid JSON object as specified in the user prompt. No extra commentary outside the JSON."
+
+    /// Calls the LLM API via the shared ``LLMClient`` (transport + retry +
+    /// Sentry span). This layer only translates ``LLMError`` into
+    /// ``CompilationError`` so existing UX copy / error paths stay intact.
     private func callAI(prompt: String, onRetry: ((Int, Int) -> Void)?) async throws -> String {
-        let apiKey = Secrets.resolvedDeepSeekApiKey
-        guard !apiKey.isEmpty else {
-            throw CompilationError.missingApiKey
-        }
+        let client = LLMClient(
+            config: .deepSeek(maxTokens: 4096, temperature: 0.7, timeout: 120),
+            spanName: "compile.daily"
+        )
         do {
-            return try await callDeepSeekWithRetry(prompt: prompt, apiKey: apiKey, onRetry: onRetry)
-        } catch let err as CompilationError {
-            throw err
+            return try await client.complete(
+                messages: [
+                    .system(Self.compilationSystemPrompt),
+                    .user(prompt)
+                ],
+                onRetry: onRetry
+            )
+        } catch let llm as LLMError {
+            throw Self.mapLLMError(llm)
         } catch let urlErr as URLError where urlErr.code == .timedOut {
             throw CompilationError.networkTimeout
         } catch {
             throw CompilationError.unknown(error)
+        }
+    }
+
+    /// Map ``LLMError`` to ``CompilationError`` so callers of the compilation
+    /// pipeline keep their existing error vocabulary and UX copy.
+    private static func mapLLMError(_ error: LLMError) -> CompilationError {
+        switch error {
+        case .missingApiKey:
+            return .missingApiKey
+        case .invalidURL:
+            return .invalidURL
+        case .offline:
+            return .offline
+        case .networkTimeout:
+            return .networkTimeout
+        case .rateLimited:
+            return .apiRateLimited
+        case .apiError(let code, let body):
+            return .apiError(statusCode: code, body: body)
+        case .emptyResponse:
+            return .parseError("Unexpected response structure")
+        case .unknown(let err):
+            return .unknown(err)
         }
     }
 
@@ -528,116 +561,6 @@ final class CompilationService: ObservableObject {
             let dayNames = ["", "Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
             return "Day type: \(dayNames[weekday]) (weekday — may involve work/routine context)"
         }
-    }
-
-    // MARK: - DeepSeek API (with retry)
-
-    private func callDeepSeekWithRetry(
-        prompt: String,
-        apiKey: String,
-        onRetry: ((Int, Int) -> Void)?
-    ) async throws -> String {
-        let maxAttempts = 3
-        let backoffSeconds: [Double] = [0, 2, 6]
-        var lastError: Error = CompilationError.networkError("Unknown")
-
-        for attempt in 1...maxAttempts {
-            if attempt > 1 {
-                onRetry?(attempt, maxAttempts)
-                let delay = backoffSeconds[min(attempt - 1, backoffSeconds.count - 1)]
-                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            }
-            do {
-                return try await callDeepSeek(prompt: prompt, apiKey: apiKey)
-            } catch let error as CompilationError {
-                switch error {
-                case .apiError(let code, _) where code == 429:
-                    lastError = CompilationError.apiRateLimited
-                case .apiError(let code, _) where code == 401 || code == 403 || code == 400:
-                    throw error // 不重试认证/请求格式错误
-                case .parseError(let msg):
-                    throw CompilationError.parseFailure(msg) // 不重试解析错误
-                case .parseFailure:
-                    throw error
-                case .missingApiKey, .invalidURL:
-                    throw error
-                default:
-                    lastError = error
-                }
-            } catch let urlError as URLError {
-                switch urlError.code {
-                case .timedOut:
-                    lastError = CompilationError.networkTimeout
-                case .notConnectedToInternet, .networkConnectionLost:
-                    lastError = urlError
-                default:
-                    throw urlError
-                }
-            } catch {
-                lastError = error
-            }
-        }
-        throw lastError
-    }
-
-    private func callDeepSeek(prompt: String, apiKey: String) async throws -> String {
-        let baseURL = Secrets.deepSeekBaseURL.isEmpty
-            ? "https://api.deepseek.com/v1"
-            : Secrets.deepSeekBaseURL
-        let model = Secrets.deepSeekModel.isEmpty ? "deepseek-v4-pro" : Secrets.deepSeekModel
-
-        guard let url = URL(string: "\(baseURL)/chat/completions") else {
-            throw CompilationError.invalidURL
-        }
-
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = 120
-
-        let body: [String: Any] = [
-            "model": model,
-            "messages": [
-                ["role": "system", "content": "You are DayPage's AI compilation engine. Output only a single valid JSON object as specified in the user prompt. No extra commentary outside the JSON."],
-                ["role": "user", "content": prompt]
-            ],
-            "max_tokens": 4096,
-            "temperature": 0.7
-        ]
-
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
-
-        let span = Secrets.sentryDSN.isEmpty ? nil
-            : SentrySDK.startTransaction(name: "compilation.deepseek", operation: "http.client")
-        defer { span?.finish() }
-
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let http = response as? HTTPURLResponse else {
-            DayPageLogger.shared.error("[DeepSeek] status=- body=No HTTP response")
-            throw CompilationError.networkError("No HTTP response")
-        }
-
-        guard http.statusCode == 200 else {
-            let bodyStr = String(data: data, encoding: .utf8) ?? "(empty)"
-            let snippet = String(bodyStr.prefix(500))
-            DayPageLogger.shared.error("[DeepSeek] status=\(http.statusCode) body=\(snippet)")
-            throw CompilationError.apiError(statusCode: http.statusCode, body: bodyStr)
-        }
-
-        return try parseCompletionContent(from: data)
-    }
-
-    private func parseCompletionContent(from data: Data) throws -> String {
-        guard let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
-              let choices = json["choices"] as? [[String: Any]],
-              let first = choices.first,
-              let message = first["message"] as? [String: Any],
-              let content = message["content"] as? String else {
-            throw CompilationError.parseError("Unexpected response structure")
-        }
-        return content.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     // MARK: - Hot Cache

--- a/DayPage/Services/EntityPageService.swift
+++ b/DayPage/Services/EntityPageService.swift
@@ -119,7 +119,7 @@ final class EntityPageService {
         }
 
         // 2. Fuzzy match — find a close existing slug.
-        if let fuzzyMatch = existingSlugs.first(where: { isFuzzyMatch(normalized, $0) }) {
+        if let fuzzyMatch = existingSlugs.first(where: { Self.isFuzzyMatch(normalized, $0) }) {
             return fuzzyMatch
         }
 
@@ -132,7 +132,13 @@ final class EntityPageService {
     ///   - Hyphen-stripped equality ("coffee-shop" == "coffeeshop")
     ///   - Edit distance ≤ 2
     ///   - Shared prefix of ≥ 6 characters
-    func isFuzzyMatch(_ a: String, _ b: String) -> Bool {
+    ///
+    /// Exposed as `nonisolated static` so the read-side (GraphRetriever) can
+    /// reuse the exact same matching rule the write-side uses to canonicalise
+    /// slugs. Before this change, the write path collapsed "coffee" into
+    /// "coffee-shop" but the read path's slugCandidates only looked for
+    /// "coffee" verbatim, so the entity was effectively invisible.
+    nonisolated static func isFuzzyMatch(_ a: String, _ b: String) -> Bool {
         // Hyphen-stripped comparison catches "coffee-shop" ≈ "coffeeshop" / "CoffeeShop" (after sanitize).
         let aStripped = a.replacingOccurrences(of: "-", with: "")
         let bStripped = b.replacingOccurrences(of: "-", with: "")
@@ -144,7 +150,7 @@ final class EntityPageService {
     }
 
     /// Minimal Levenshtein distance (capped at 3 for performance).
-    private func levenshtein(_ s: String, _ t: String) -> Int {
+    nonisolated private static func levenshtein(_ s: String, _ t: String) -> Int {
         let sArr = Array(s), tArr = Array(t)
         let m = sArr.count, n = tArr.count
         guard m > 0 else { return n }

--- a/DayPage/Services/GraphRetriever.swift
+++ b/DayPage/Services/GraphRetriever.swift
@@ -212,10 +212,11 @@ enum GraphRetriever {
     }
 
     /// 解析实体页：从 frontmatter 取 name / occurrence_count，从正文取摘要。
+    /// frontmatter 字段提取走共用的 `FrontmatterParser.extractFieldInBlock`，
+    /// 保证与未来新增的实体字段（如 occurrence_count_zh）解析一致。
     static func parseEntityPage(_ content: String, slug: String, type: String) -> RetrievedContext.EntityHit? {
-        let displayName = frontmatterValue(in: content, key: "name")?
-            .trimmingCharacters(in: CharacterSet(charactersIn: "\"")) ?? slug
-        let occurrence = Int(frontmatterValue(in: content, key: "occurrence_count") ?? "") ?? 1
+        let displayName = FrontmatterParser.extractFieldInBlock("name", from: content) ?? slug
+        let occurrence = Int(FrontmatterParser.extractFieldInBlock("occurrence_count", from: content) ?? "") ?? 1
         let summary = bodySummary(from: content)
         return RetrievedContext.EntityHit(
             slug: slug,
@@ -224,24 +225,6 @@ enum GraphRetriever {
             occurrenceCount: occurrence,
             summary: summary
         )
-    }
-
-    /// 取 frontmatter（首个 `---` 与第二个 `---` 之间）中 `key:` 的值。
-    private static func frontmatterValue(in content: String, key: String) -> String? {
-        let lines = content.components(separatedBy: "\n")
-        var inFrontmatter = false
-        for (index, line) in lines.enumerated() {
-            let trimmed = line.trimmingCharacters(in: .whitespaces)
-            if index == 0 && trimmed == "---" { inFrontmatter = true; continue }
-            if inFrontmatter && trimmed == "---" { break }
-            if inFrontmatter {
-                let prefix = "\(key):"
-                if trimmed.hasPrefix(prefix) {
-                    return String(trimmed.dropFirst(prefix.count)).trimmingCharacters(in: .whitespaces)
-                }
-            }
-        }
-        return nil
     }
 
     /// 取实体页正文（frontmatter 之后）的前若干行非空内容作为摘要。

--- a/DayPage/Services/GraphRetriever.swift
+++ b/DayPage/Services/GraphRetriever.swift
@@ -176,12 +176,18 @@ enum GraphRetriever {
     // MARK: - Step 3: Entity expansion
 
     /// 把候选 slug 集合扩展为实体页摘要，按 occurrence_count 降序取前 N。
+    ///
+    /// 双阶段命中：先 O(1) 走精确 slug；命中不到时再用 ``EntityPageService.isFuzzyMatch``
+    /// 扫描同 type 目录。这与 `EntityPageService.resolveSlug` 的写路径策略
+    /// 对称，避免 "coffee" 在写时被 canonicalize 成 "coffee-shop"、读时却查不到。
     private static func expandEntities(slugs: Set<String>, limit: Int) -> [RetrievedContext.EntityHit] {
         guard !slugs.isEmpty else { return [] }
         let types = ["places", "people", "themes"]
         var hits: [RetrievedContext.EntityHit] = []
+        var resolvedFiles = Set<URL>()  // 防止同一实体被多 slug 候选重复入选
 
         for slug in slugs {
+            var matched = false
             for type in types {
                 let url = entityURL(type: type, slug: slug)
                 let content: String
@@ -198,10 +204,16 @@ enum GraphRetriever {
                     }
                     continue
                 }
-                if let hit = parseEntityPage(content, slug: slug, type: type) {
+                if resolvedFiles.insert(url).inserted,
+                   let hit = parseEntityPage(content, slug: slug, type: type) {
                     hits.append(hit)
+                    matched = true
                 }
                 break // 一个 slug 只会在一种类型目录里
+            }
+            if !matched {
+                // 精确路径没命中——回退到 fuzzy 扫描，复用写侧的同一规则。
+                fuzzyResolve(slug: slug, in: types, into: &hits, resolvedFiles: &resolvedFiles)
             }
         }
 
@@ -278,5 +290,36 @@ enum GraphRetriever {
     private static func foldedForSearch(_ s: String) -> String {
         s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
                   locale: Locale(identifier: "en_US_POSIX"))
+    }
+
+    /// Fallback when a candidate slug had no exact entity file: scan each type
+    /// directory and pick the first existing slug that passes the same fuzzy
+    /// rule the write path uses. Cheap because there are at most a few hundred
+    /// entity files in a real vault, and we early-exit on first match per type.
+    private static func fuzzyResolve(
+        slug: String,
+        in types: [String],
+        into hits: inout [RetrievedContext.EntityHit],
+        resolvedFiles: inout Set<URL>
+    ) {
+        let fm = FileManager.default
+        for type in types {
+            let dir = VaultInitializer.vaultURL
+                .appendingPathComponent("wiki")
+                .appendingPathComponent(type)
+            guard let entries = try? fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: nil) else {
+                continue
+            }
+            for url in entries where url.pathExtension == "md" {
+                let candidate = url.deletingPathExtension().lastPathComponent
+                guard EntityPageService.isFuzzyMatch(slug, candidate) else { continue }
+                guard resolvedFiles.insert(url).inserted else { continue }
+                guard let content = try? String(contentsOf: url, encoding: .utf8) else { continue }
+                if let hit = parseEntityPage(content, slug: candidate, type: type) {
+                    hits.append(hit)
+                }
+                return // one fuzzy hit per candidate is enough
+            }
+        }
     }
 }

--- a/DayPage/Services/GraphRetriever.swift
+++ b/DayPage/Services/GraphRetriever.swift
@@ -110,8 +110,19 @@ enum GraphRetriever {
 
         for dateString in hitDates {
             guard memoHits.count < maxMemoHits else { break }
-            guard let date = dayFormatter.date(from: dateString) else { continue }
-            let memos = (try? RawStorage.read(for: date)) ?? []
+            guard let date = DateFormatters.isoDate.date(from: dateString) else { continue }
+            let memos: [Memo]
+            do {
+                memos = try RawStorage.read(for: date)
+            } catch {
+                // I/O 失败不应让整次检索黑屏。逐天降级为空集，但记录到 logger，
+                // 让 Sentry 看得到磁盘/权限/iCloud 冲突这类信号，不再 silent fail.
+                DayPageLogger.log(
+                    level: "WARN",
+                    message: "[GraphRetriever] read \(dateString) failed: \(error.localizedDescription)"
+                )
+                continue
+            }
             for memo in memos where memoMatches(memo, foldedQuery: folded) {
                 guard memoHits.count < maxMemoHits else { break }
                 memoHits.append(RetrievedContext.MemoHit(
@@ -173,7 +184,20 @@ enum GraphRetriever {
         for slug in slugs {
             for type in types {
                 let url = entityURL(type: type, slug: slug)
-                guard let content = try? String(contentsOf: url, encoding: .utf8) else { continue }
+                let content: String
+                do {
+                    content = try String(contentsOf: url, encoding: .utf8)
+                } catch {
+                    // ENOENT (slug 不在该目录) 是绝大多数情形，刻意静默。其它
+                    // 错误（权限、IO）记一条 WARN 便于诊断，但不中断扩展循环。
+                    if (error as NSError).code != NSFileReadNoSuchFileError {
+                        DayPageLogger.log(
+                            level: "WARN",
+                            message: "[GraphRetriever] read entity \(type)/\(slug) failed: \(error.localizedDescription)"
+                        )
+                    }
+                    continue
+                }
                 if let hit = parseEntityPage(content, slug: slug, type: type) {
                     hits.append(hit)
                 }
@@ -272,11 +296,4 @@ enum GraphRetriever {
         s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
                   locale: Locale(identifier: "en_US_POSIX"))
     }
-
-    private static let dayFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "yyyy-MM-dd"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        return f
-    }()
 }

--- a/DayPage/Services/HTTPClientHelper.swift
+++ b/DayPage/Services/HTTPClientHelper.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+// MARK: - HTTPClientHelper
+
+/// Builders for JSON-over-HTTPS requests used across DayPage services.
+///
+/// Before this helper, CompilationService / LLMClient / FeedbackService /
+/// VoiceService / ThreadConversationViewModel / SettingsView each wrote the
+/// same three lines (`setValue("Bearer …")`, `setValue("application/json")`,
+/// `timeoutInterval = …`). Diffs around header conventions were noisy and
+/// auth changes had to touch five files.
+///
+/// Keep this helper transport-only: no retry, no body construction beyond
+/// JSON encoding, no response handling. Those belong to the caller or
+/// ``RetryHelper``.
+enum HTTPClientHelper {
+
+    /// Build a `URLRequest` for an OpenAI-compatible JSON POST endpoint.
+    /// - Parameters:
+    ///   - url: Fully qualified endpoint URL.
+    ///   - apiKey: Bearer token; caller is responsible for non-emptiness.
+    ///   - timeout: Per-request timeout in seconds. Default mirrors prior callers.
+    /// - Returns: A `POST` request with Authorization + Content-Type set; body unset.
+    static func bearerJSON(url: URL, apiKey: String, timeout: TimeInterval = 120) -> URLRequest {
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.timeoutInterval = timeout
+        return request
+    }
+
+    /// Same as ``bearerJSON(url:apiKey:timeout:)`` but encodes `body` into JSON.
+    /// Throws when `body` is not a valid JSON object.
+    static func bearerJSON(
+        url: URL,
+        apiKey: String,
+        timeout: TimeInterval = 120,
+        body: [String: Any]
+    ) throws -> URLRequest {
+        var request = bearerJSON(url: url, apiKey: apiKey, timeout: timeout)
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        return request
+    }
+}

--- a/DayPage/Services/LLMClient.swift
+++ b/DayPage/Services/LLMClient.swift
@@ -107,53 +107,51 @@ struct LLMClient {
     // MARK: - Chat Completion
 
     /// 发送一组 messages，返回 assistant 的纯文本回复（已 trim）。
-    /// 带指数退避重试（与原编译管线一致：3 次，0/2/6s）。
-    /// - Parameter onRetry: 每次重试前回调 `(当前次数, 最大次数)`。
+    /// 带指数退避重试（默认 `RetryPolicy.standard`：3 次，0/2/6s）。
+    /// - Parameters:
+    ///   - messages: 完整的对话消息列表（含 system / user / assistant）。
+    ///   - policy: 重试策略，便于编译管线与对话各自调优。
+    ///   - onRetry: 每次重试前回调 `(当前次数, 最大次数)`，用于 UI 反馈。
     func complete(
         messages: [LLMMessage],
+        policy: RetryPolicy = .standard,
         onRetry: ((Int, Int) -> Void)? = nil
     ) async throws -> String {
         let online = await MainActor.run { NetworkMonitor.shared.isOnline }
         guard online else { throw LLMError.offline }
         guard !config.apiKey.isEmpty else { throw LLMError.missingApiKey }
 
-        let maxAttempts = 3
-        let backoffSeconds: [Double] = [0, 2, 6]
-        var lastError: Error = LLMError.networkTimeout
+        return try await retryAsync(
+            policy: policy,
+            onRetry: onRetry,
+            shouldRetry: Self.shouldRetry,
+            operation: { try await self.sendOnce(messages: messages) }
+        )
+    }
 
-        for attempt in 1...maxAttempts {
-            if attempt > 1 {
-                onRetry?(attempt, maxAttempts)
-                let delay = backoffSeconds[min(attempt - 1, backoffSeconds.count - 1)]
-                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
-            }
-            do {
-                return try await sendOnce(messages: messages)
-            } catch let error as LLMError {
-                switch error {
-                case .rateLimited:
-                    lastError = error
-                case .apiError(let code, _) where code == 401 || code == 403 || code == 400:
-                    throw error  // 不重试认证/请求格式错误
-                case .missingApiKey, .invalidURL, .emptyResponse:
-                    throw error
-                default:
-                    lastError = error
-                }
-            } catch let urlError as URLError {
-                switch urlError.code {
-                case .timedOut:
-                    lastError = LLMError.networkTimeout
-                case .notConnectedToInternet, .networkConnectionLost:
-                    lastError = LLMError.offline
-                default:
-                    throw LLMError.unknown(urlError)
-                }
-            } catch {
-                lastError = error
+    /// Error classifier for retry: terminal errors short-circuit; transient
+    /// errors (timeout, 429, generic network drop) retry. URLError values get
+    /// normalized to ``LLMError`` cases inside ``sendOnce``.
+    static func shouldRetry(_ error: Error) -> RetryDecision {
+        if let llm = error as? LLMError {
+            switch llm {
+            case .missingApiKey, .invalidURL, .emptyResponse:
+                return .stop
+            case .apiError(let code, _) where code == 400 || code == 401 || code == 403:
+                return .stop
+            default:
+                return .retry
             }
         }
-        throw lastError
+        if let urlError = error as? URLError {
+            switch urlError.code {
+            case .timedOut, .notConnectedToInternet, .networkConnectionLost:
+                return .retry
+            default:
+                return .stop
+            }
+        }
+        return .retry
     }
 
     // MARK: - Single request
@@ -163,37 +161,50 @@ struct LLMClient {
             throw LLMError.invalidURL
         }
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("Bearer \(config.apiKey)", forHTTPHeaderField: "Authorization")
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.timeoutInterval = config.timeout
-
         let body: [String: Any] = [
             "model": config.model,
             "messages": messages.map { ["role": $0.role.rawValue, "content": $0.content] },
             "max_tokens": config.maxTokens,
             "temperature": config.temperature
         ]
-        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let request = try HTTPClientHelper.bearerJSON(
+            url: url,
+            apiKey: config.apiKey,
+            timeout: config.timeout,
+            body: body
+        )
 
         let dsnEmpty = await MainActor.run { Secrets.sentryDSN.isEmpty }
         let span = dsnEmpty ? nil : SentrySDK.startTransaction(name: spanName, operation: "http.client")
         defer { span?.finish() }
 
-        let (data, response) = try await URLSession.shared.data(for: request)
-
-        guard let http = response as? HTTPURLResponse else {
-            throw LLMError.apiError(statusCode: -1, body: "No HTTP response")
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                span?.setTag(value: "no-http-response", key: "error.kind")
+                throw LLMError.apiError(statusCode: -1, body: "No HTTP response")
+            }
+            span?.setTag(value: String(http.statusCode), key: "http.status_code")
+            guard http.statusCode == 200 else {
+                let bodyStr = String(data: data, encoding: .utf8) ?? "(empty)"
+                DayPageLogger.log(level: "ERROR", message: "[LLMClient/\(spanName)] status=\(http.statusCode) body=\(bodyStr.prefix(500))")
+                span?.setTag(value: "true", key: "error")
+                if http.statusCode == 429 { throw LLMError.rateLimited }
+                throw LLMError.apiError(statusCode: http.statusCode, body: bodyStr)
+            }
+            return try Self.parseContent(from: data)
+        } catch let urlError as URLError {
+            // Normalize URL errors to LLMError so the retry classifier and UI
+            // copy can speak a single vocabulary.
+            switch urlError.code {
+            case .timedOut:
+                throw LLMError.networkTimeout
+            case .notConnectedToInternet, .networkConnectionLost:
+                throw LLMError.offline
+            default:
+                throw LLMError.unknown(urlError)
+            }
         }
-        guard http.statusCode == 200 else {
-            let bodyStr = String(data: data, encoding: .utf8) ?? "(empty)"
-            DayPageLogger.log(level: "ERROR", message: "[LLMClient/\(spanName)] status=\(http.statusCode) body=\(bodyStr.prefix(500))")
-            if http.statusCode == 429 { throw LLMError.rateLimited }
-            throw LLMError.apiError(statusCode: http.statusCode, body: bodyStr)
-        }
-
-        return try Self.parseContent(from: data)
     }
 
     // MARK: - Response parsing

--- a/DayPage/Services/MemoryChatService.swift
+++ b/DayPage/Services/MemoryChatService.swift
@@ -40,11 +40,14 @@ final class MemoryChatService: ObservableObject {
     /// 注入式 LLM 调用闭包，便于测试替身。默认走云端 DeepSeek。
     private let send: ([LLMMessage]) async throws -> String
     /// 注入式检索闭包，默认走图谱增强检索。
-    private let retrieve: (String) -> RetrievedContext
+    /// `@Sendable` 标注让它可以安全地跨 actor 边界传给 detached task —— 真实
+    /// 默认值 `GraphRetriever.retrieve` 是 `nonisolated static`，本身无主线程
+    /// 依赖；测试桩通常是值语义闭包，也可跨线程调度。
+    private let retrieve: @Sendable (String) -> RetrievedContext
 
     init(
         send: (([LLMMessage]) async throws -> String)? = nil,
-        retrieve: @escaping (String) -> RetrievedContext = { GraphRetriever.retrieve(query: $0) }
+        retrieve: @escaping @Sendable (String) -> RetrievedContext = { GraphRetriever.retrieve(query: $0) }
     ) {
         self.retrieve = retrieve
         if let send {
@@ -86,8 +89,16 @@ final class MemoryChatService: ObservableObject {
         isResponding = true
         defer { isResponding = false }
 
-        // Step 1: 图谱增强检索（纯本地）。
-        let context = retrieve(question)
+        // Step 1: 图谱增强检索——磁盘 I/O 走 detached task 避免阻塞主线程。
+        // GraphRetriever.retrieve 是 nonisolated 静态函数，捕获 question 不可
+        // 变副本进入后台，再回到主 actor 装配 messages。
+        let retrieveClosure = self.retrieve
+        let context = await Task.detached(priority: .userInitiated) { @Sendable in
+            retrieveClosure(question)
+        }.value
+
+        // Allow caller (e.g. sheet dismissal) to cancel mid-flight.
+        if Task.isCancelled { return }
 
         // Step 2: 组装 messages（system + 检索上下文 + 近几轮历史 + 当前问题）。
         let messages = buildMessages(question: question, context: context)

--- a/DayPage/Services/RetryHelper.swift
+++ b/DayPage/Services/RetryHelper.swift
@@ -1,0 +1,87 @@
+import Foundation
+
+// MARK: - RetryPolicy
+
+/// Backoff schedule + attempt budget for retryable async operations.
+///
+/// Encodes the schedule that LLMClient and CompilationService independently
+/// hard-coded as `[0, 2, 6]` seconds × 3 attempts. By making it explicit and
+/// passable, individual call sites (chat vs. compilation) can later pick
+/// different policies without forking the loop body.
+struct RetryPolicy: Equatable {
+    /// Total attempts including the first try (must be ≥ 1).
+    let maxAttempts: Int
+    /// Sleep before attempt N (1-indexed). Index 0 is always 0s — the first
+    /// attempt never waits. Indices past the end repeat the last value.
+    let backoffSeconds: [Double]
+
+    /// Original DayPage default: 3 attempts at 0 / 2 / 6 seconds.
+    static let standard = RetryPolicy(maxAttempts: 3, backoffSeconds: [0, 2, 6])
+
+    /// Sleep duration before the given attempt number (1-indexed). Attempt 1
+    /// always returns 0; attempts past the schedule reuse the tail value.
+    func delayBeforeAttempt(_ attempt: Int) -> Double {
+        guard attempt > 1 else { return 0 }
+        let idx = min(attempt - 1, backoffSeconds.count - 1)
+        return backoffSeconds[idx]
+    }
+}
+
+// MARK: - RetryDecision
+
+/// What `retryAsync` should do when a thrown error is observed.
+enum RetryDecision {
+    /// Retry the next attempt (subject to the attempt budget).
+    case retry
+    /// Surface the error immediately and stop the loop.
+    case stop
+}
+
+// MARK: - retryAsync
+
+/// Execute `operation` with the given `RetryPolicy`. The classifier closure
+/// decides per-error whether to retry; throwing from it re-throws unchanged.
+///
+/// Why a classifier rather than a fixed retry-on-everything: LLM clients need
+/// to fail fast on 401 / 400 but retry on 429 / timeout. Classification
+/// lives at the call site so we don't need a new policy per error taxonomy.
+///
+/// - Parameters:
+///   - policy: Attempt budget + backoff schedule.
+///   - onRetry: Optional callback fired *before* each non-first attempt
+///     with `(attempt, maxAttempts)`. Useful for surfacing retry counts to UI.
+///   - shouldRetry: Inspect the thrown error and return `.retry` / `.stop`.
+///     Defaults to retrying every error.
+///   - operation: The retryable async work.
+/// - Returns: The successful operation result.
+func retryAsync<T>(
+    policy: RetryPolicy = .standard,
+    onRetry: ((Int, Int) -> Void)? = nil,
+    shouldRetry: (Error) -> RetryDecision = { _ in .retry },
+    operation: () async throws -> T
+) async throws -> T {
+    precondition(policy.maxAttempts >= 1, "RetryPolicy.maxAttempts must be ≥ 1")
+    var lastError: Error?
+
+    for attempt in 1...policy.maxAttempts {
+        if attempt > 1 {
+            onRetry?(attempt, policy.maxAttempts)
+            let delay = policy.delayBeforeAttempt(attempt)
+            if delay > 0 {
+                try await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+            }
+        }
+        do {
+            return try await operation()
+        } catch {
+            lastError = error
+            if attempt == policy.maxAttempts { throw error }
+            switch shouldRetry(error) {
+            case .retry: continue
+            case .stop:  throw error
+            }
+        }
+    }
+
+    throw lastError ?? CancellationError()
+}

--- a/DayPage/Utilities/DateFormatters.swift
+++ b/DayPage/Utilities/DateFormatters.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+// MARK: - DateFormatters
+
+/// Centralized DateFormatter cache for DayPage.
+///
+/// Before this file existed, ~88 call sites across Today/Archive/Daily/Sidebar
+/// each constructed their own `DateFormatter` with `Locale(identifier: "en_US_POSIX")`
+/// and a hand-typed `dateFormat`. Beyond the boilerplate, each instance is
+/// allocated on every call — DateFormatter construction is non-trivial.
+///
+/// All formatters here are POSIX-locale, calendar-independent, and safe to
+/// reuse across threads (DateFormatter is Sendable in practice once configured
+/// and never mutated). Use these when the output is a stable machine string
+/// (filenames, frontmatter, sorting keys). For user-facing localized text,
+/// prefer `RelativeTimeFormatter` or `Date.formatted(_:)`.
+enum DateFormatters {
+
+    // MARK: ISO date — "yyyy-MM-dd"
+
+    /// "2026-06-19" — the canonical vault filename / frontmatter date format.
+    /// Used by RawStorage, GraphRetriever, Sidebar heatmap, Archive, search.
+    static let isoDate: DateFormatter = posix("yyyy-MM-dd")
+
+    // MARK: Clock time — "HH:mm"
+
+    /// "14:23" — 24h clock used inside daily pages and memo timestamps.
+    static let timeHHmm: DateFormatter = posix("HH:mm")
+
+    // MARK: Weekday / month-day variants
+
+    /// "Mon" / "Fri" — short English weekday for heat-map labels.
+    static let weekdayShort: DateFormatter = posix("EEE")
+
+    /// "Monday" — long English weekday for daily-page header.
+    static let weekdayLong: DateFormatter = posix("EEEE")
+
+    /// "Jun 19" — short month-day for relative time fallbacks.
+    static let monthDay: DateFormatter = posix("MMM d")
+
+    /// "2026-06" — year-month key for monthly archive grouping.
+    static let yearMonth: DateFormatter = posix("yyyy-MM")
+
+    // MARK: - Helpers
+
+    /// Build a POSIX-locale DateFormatter with the given format pattern.
+    /// Centralised so locale/timezone defaults stay consistent.
+    private static func posix(_ format: String) -> DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = format
+        return f
+    }
+}
+
+// MARK: - Convenience on Date
+
+extension Date {
+    /// "2026-06-19" — POSIX ISO short date used as vault filename.
+    var isoDateString: String { DateFormatters.isoDate.string(from: self) }
+}
+
+// MARK: - Convenience on String
+
+extension String {
+    /// Parse a "yyyy-MM-dd" string into Date using the shared POSIX formatter.
+    var asISODate: Date? { DateFormatters.isoDate.date(from: self) }
+}

--- a/DayPageTests/EntitySlugDedupTests.swift
+++ b/DayPageTests/EntitySlugDedupTests.swift
@@ -52,31 +52,31 @@ struct EntitySlugDedupTests {
     @Test func fuzzyMatch_hyphenStripped_coffeeShopVariants() {
         defer { cleanup() }
         // "coffee-shop" and "coffeeshop" differ only by a hyphen
-        #expect(service.isFuzzyMatch("coffee-shop", "coffeeshop"))
-        #expect(service.isFuzzyMatch("coffeeshop", "coffee-shop"))
+        #expect(EntityPageService.isFuzzyMatch("coffee-shop", "coffeeshop"))
+        #expect(EntityPageService.isFuzzyMatch("coffeeshop", "coffee-shop"))
     }
 
     @Test func fuzzyMatch_hyphenStripped_multiHyphen() {
         defer { cleanup() }
-        #expect(service.isFuzzyMatch("new-york-city", "newyorkcity"))
+        #expect(EntityPageService.isFuzzyMatch("new-york-city", "newyorkcity"))
     }
 
     @Test func fuzzyMatch_editDistance_smallDiff() {
         defer { cleanup() }
         // "joma-coffe" vs "joma-coffee" — edit distance 1
-        #expect(service.isFuzzyMatch("joma-coffe", "joma-coffee"))
+        #expect(EntityPageService.isFuzzyMatch("joma-coffe", "joma-coffee"))
     }
 
     @Test func fuzzyMatch_sharedPrefix() {
         defer { cleanup() }
         // share 6-char prefix "bangko"
-        #expect(service.isFuzzyMatch("bangkokx", "bangkoky"))
+        #expect(EntityPageService.isFuzzyMatch("bangkokx", "bangkoky"))
     }
 
     @Test func fuzzyMatch_dissimilarSlugs_returnsFalse() {
         defer { cleanup() }
-        #expect(!service.isFuzzyMatch("alice", "bangkok"))
-        #expect(!service.isFuzzyMatch("coffee-shop", "tea-house"))
+        #expect(!EntityPageService.isFuzzyMatch("alice", "bangkok"))
+        #expect(!EntityPageService.isFuzzyMatch("coffee-shop", "tea-house"))
     }
 
     // MARK: - resolveSlug: dedup via apply()

--- a/DayPageTests/MemoryChatTests.swift
+++ b/DayPageTests/MemoryChatTests.swift
@@ -122,7 +122,11 @@ struct RetrievedContextTests {
 @MainActor
 struct MemoryChatServiceTests {
 
-    private func fixedContext(_ q: String) -> RetrievedContext {
+    // static + nonisolated so we can pass it into the @Sendable `retrieve`
+    // closure that MemoryChatService now requires. The suite as a whole is
+    // @MainActor, so without nonisolated the static method inherits the
+    // actor and the compiler rejects synchronous use from a Sendable closure.
+    nonisolated static func fixedContext(_ q: String) -> RetrievedContext {
         RetrievedContext(
             query: q,
             memoHits: [.init(dateString: "2026-05-01", snippet: "测试记录", mood: nil, entityMentions: [])],
@@ -133,7 +137,7 @@ struct MemoryChatServiceTests {
     @Test func askAppendsUserThenAssistantTurns() async {
         let service = MemoryChatService(
             send: { _ in "这是回答" },
-            retrieve: { self.fixedContext($0) }
+            retrieve: { Self.fixedContext($0) }
         )
         await service.ask("我做了什么？")
         #expect(service.turns.count == 2)
@@ -149,7 +153,7 @@ struct MemoryChatServiceTests {
     @Test func askSurfacesErrorWithoutAssistantTurn() async {
         let service = MemoryChatService(
             send: { _ in throw LLMError.rateLimited },
-            retrieve: { self.fixedContext($0) }
+            retrieve: { Self.fixedContext($0) }
         )
         await service.ask("会失败")
         // 只有 user 回合；assistant 回合不入队，错误走 errorMessage。
@@ -159,14 +163,14 @@ struct MemoryChatServiceTests {
     }
 
     @Test func emptyQuestionIsIgnored() async {
-        let service = MemoryChatService(send: { _ in "x" }, retrieve: { self.fixedContext($0) })
+        let service = MemoryChatService(send: { _ in "x" }, retrieve: { Self.fixedContext($0) })
         await service.ask("   ")
         #expect(service.turns.isEmpty)
     }
 
     @Test func buildMessagesIncludesSystemAndRetrievedContext() {
-        let service = MemoryChatService(send: { _ in "" }, retrieve: { self.fixedContext($0) })
-        let ctx = fixedContext("问题")
+        let service = MemoryChatService(send: { _ in "" }, retrieve: { Self.fixedContext($0) })
+        let ctx = Self.fixedContext("问题")
         let messages = service.buildMessages(question: "我去过哪里？", context: ctx)
         #expect(messages.first?.role == .system)
         #expect(messages.last?.role == .user)
@@ -175,7 +179,7 @@ struct MemoryChatServiceTests {
     }
 
     @Test func resetClearsConversation() async {
-        let service = MemoryChatService(send: { _ in "答" }, retrieve: { self.fixedContext($0) })
+        let service = MemoryChatService(send: { _ in "答" }, retrieve: { Self.fixedContext($0) })
         await service.ask("Q")
         service.reset()
         #expect(service.turns.isEmpty)


### PR DESCRIPTION
## Summary
- Sweep of an end-to-end agent-team audit covering 88 findings across the iOS app, design system, cross-platform contracts, and CI.
- Three checkpoint commits: shared infrastructure → i18n / a11y / token / CI closeout → graph read-side fuzzy resolution.

## What landed

### Shared infrastructure (1df4895)
- `Utilities/DateFormatters.swift` — POSIX cache for the ~88 ad-hoc DateFormatter constructions.
- `Services/HTTPClientHelper.swift` — bearer-JSON request builder (replaces five duplicated header blocks).
- `Services/RetryHelper.swift` — `RetryPolicy` + `retryAsync<T>` with per-error classifier.
- `LLMClient` adopts all three; Sentry span tagged with `http.status_code` / `error`; URLError normalized to LLMError inside `sendOnce`.
- `GraphRetriever` swaps `try?` for do-catch + `DayPageLogger.WARN`; dayFormatter replaced by `DateFormatters.isoDate`.
- `MemoryChatService.ask` runs retrieval via `Task.detached` so disk I/O never blocks the main actor; adds Task.isCancelled checkpoint.
- pbxproj registers the three new files; no other targets touched.

### Closeout sweep (8fdfe4d)
- `CompilationService`: removes ~110 lines of private `callDeepSeekWithRetry` / `callDeepSeek` / `parseCompletionContent` and routes through `LLMClient.complete`. Public `CompilationError` surface preserved via `mapLLMError`.
- `RecordingOverlayView`: 17 new `L10n.Recording` entries, 6 hardcoded strings replaced, 4 a11y `combine` blocks + label/hint on the two action buttons. Reduce Motion respected on the pulsing ring.
- i18n closeout: `Settings.iCloudDrive`, `Archive.density.{empty,low,medium,high}`, `Banner.closeA11y` with matching en + zh-Hans Localizable.strings entries.
- Design tokens: 5 new V4 entries (`onAmber`, `statusSuccess/Error/Warning`, `transcribeBlue`); 12 hardcoded colour sites in SettingsView / ArchiveView / RecordingOverlayView migrated.
- `FrontmatterParser.extractFieldInBlock` for strict `---…---` semantics; GraphRetriever's private `frontmatterValue` deleted.
- CI: new `xcode-tests` job runs `xcodebuild test` on the full DayPageTests target on macos-15; uploads `TestResults.xcresult`; `build` now depends on `[unit-tests, xcode-tests]`.
- `web/.env.local`: legacy `DEEPSEEK_API_KEY` emptied (the comment already flagged it unused).

### Read-side graph symmetry (c596496)
- `EntityPageService.isFuzzyMatch` / `levenshtein` promoted to `nonisolated static` so the read path can reuse the write path's predicate.
- `GraphRetriever.expandEntities` keeps the exact lookup but falls back to `fuzzyResolve`, scanning each type directory with the same predicate. A `resolvedFiles: Set<URL>` prevents duplicate hits across seed slugs. This fixes the case where `"coffee"` was canonicalised to `"coffee-shop"` on write but the chat retriever found nothing.
- 7 `EntitySlugDedupTests` call sites updated to the static form.

## Verification
- `xcodebuild build -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'` → BUILD SUCCEEDED
- `xcodebuild test`  → **43 tests / 9 suites, all passing** (~2s)
- `make tokens-check` → no drift across `design-tokens/tokens.json`, `web/src/app/globals.css`, `DayPage/App/DSTokens.swift`

## Out of scope (left for follow-up PRs)
- Cross-platform schema reconciliation (MemoType / attachment naming / `entity_mentions` column on web) — needs a DB migration plan + ADR-0005.
- Mass `.font(.system(size:))` → `DSType` and `.padding(16)` → `DSSpacing` rewrites — mechanical but each site needs visual context check; tracked as audit P2.

## Test plan
- [ ] CI: `xcode-tests` job is green (this is its first run).
- [ ] CI: existing `unit-tests` / `tokens-check` / `secrets-audit` / `localization-parity` still green.
- [ ] Manual: launch on iPhone 17 simulator, exercise Today → record (long-press → drag to cancel / transcribe), Ask sheet (`daypage://ask?q=…`), Settings permissions panel.
- [ ] VoiceOver pass on RecordingOverlay: each directional hint and both action buttons announce their label + hint.
- [ ] Reduce Motion on: VoiceRecording pulse should stop animating; pinch UI should still respond.