### PR TITLE
feat(export): R13 — VaultExportService zip 打包 + 修复 raw/assets 重复 staging

### DIFF
--- a/DayPage/Services/VaultExportService.swift
+++ b/DayPage/Services/VaultExportService.swift
@@ -1,14 +1,17 @@
-// VaultExportService.swift — R11 data layer (manifest-only step)
+// VaultExportService.swift — R11 (manifest) + R13 (zip packaging)
 //
-// Scope of this file (intentionally narrow):
-//   Produce a summary manifest (counts + byte total) of everything inside the
-//   user's vault so the upcoming VaultExportView (R13+) can render a
-//   "what's about to be backed up" preview before the user taps "Export".
+// Scope of this file:
+//   1. R11 — Produce a summary manifest (counts + byte total) so the
+//      VaultExportView (R14) can show a "what's about to be backed up" preview
+//      before the user commits to a long-running export.
+//   2. R13 — Package selected vault subdirectories into a single zip archive
+//      written to `NSTemporaryDirectory`. The caller (UI layer, R14) is
+//      responsible for handing that URL off to a share sheet or Files App.
 //
 // What this file deliberately does NOT do (left for later rounds):
-//   - Build the actual zip archive (R11 follow-up).
-//   - Surface UI / Settings entry (R13+).
-//   - Touch CompilationService / SyncQueue / iCloud — pure read-only scan.
+//   - Surface UI / Settings entry (R14).
+//   - Touch CompilationService / SyncQueue / iCloud — pure read + temp write.
+//   - Encrypt or sign the archive (separate threat-model conversation).
 //
 // Why a "manifest" first:
 //   On a heavy vault (a year of daily memos + photos) the zip step is the slow
@@ -17,9 +20,20 @@
 //   `@MainActor` singleton.
 //
 // Threading:
-//   `collectExportManifest()` is `@MainActor async` so callers can `await` it
-//   from SwiftUI views; the actual file walk happens off the main actor via
+//   Both `collectExportManifest()` and `exportVaultZip(...)` are
+//   `@MainActor async` so callers can `await` them from SwiftUI views; the
+//   actual file walk + copy + archive happen off the main actor via
 //   `Task.detached` so we don't hitch the UI on a multi-thousand-file scan.
+//   Progress callbacks are hopped back onto `MainActor` before invocation so
+//   SwiftUI `@Published` updates are safe.
+//
+// Zip strategy (no external dependency):
+//   We avoid pulling in ZIPFoundation / SSZipArchive. iOS Foundation already
+//   ships an archiver via `NSFileCoordinator.coordinate(readingItemAt:
+//   options: .forUploading)` — the `.forUploading` option tells the
+//   coordinator to hand back a zip copy of the directory in a temporary
+//   location. We then copy that zip to our final destination before the
+//   coordinator cleans up its temp dir.
 
 import Foundation
 
@@ -35,6 +49,13 @@ enum VaultExportError: Error, Equatable {
     /// asset). Distinct from `.vaultNotFound` so the UI can say "nothing to
     /// export yet" rather than "vault missing — try reopening the app".
     case noData
+    /// Zip packaging failed for an operational reason — staging copy denied,
+    /// NSFileCoordinator returned an error, etc. The reason String is human-
+    /// readable (suitable for surfacing in a SwiftUI alert). We use a String
+    /// instead of `Error` so the enum stays automatically `Equatable` — tests
+    /// can `#expect(error == .exportFailed("..."))` if they need exact match,
+    /// or `if case let .exportFailed(reason) = error` for substring checks.
+    case exportFailed(String)
 }
 
 /// Summary of what an export would contain. All counts are non-negative.
@@ -54,6 +75,29 @@ struct ExportManifest: Equatable {
     /// Sum of every file's byte size across all of the above. Int64 because
     /// a year of 4K photos easily passes the Int32 ceiling on 32-bit slices.
     let estimatedTotalBytes: Int64
+}
+
+/// Bitmask selecting which vault subdirectories `exportVaultZip(...)` should
+/// pull into the staging archive. Defaults to `.all` so the common "back up
+/// everything" path is a single call. Tests rely on `[]` (empty set) being
+/// explicitly rejected with `.exportFailed` so users don't get an empty zip
+/// they paid CPU for.
+struct VaultExportIncludes: OptionSet, Equatable {
+    let rawValue: Int
+    /// `vault/raw/*.md` — the source-of-truth memo dump.
+    static let rawMemos    = VaultExportIncludes(rawValue: 1 << 0)
+    /// `vault/wiki/daily/*.md` — AI-compiled diary pages.
+    static let dailyPages  = VaultExportIncludes(rawValue: 1 << 1)
+    /// `vault/wiki/{places,people,themes}/*.md` — combined entity wiki.
+    /// One flag rather than three because the UI surfaces "Entities" as a
+    /// single toggle, and splitting would tempt callers into invalid combos
+    /// (e.g. places without themes when a daily page links both).
+    static let entities    = VaultExportIncludes(rawValue: 1 << 2)
+    /// `vault/raw/assets/**` — photos, audio, attachments (recursive).
+    static let assets      = VaultExportIncludes(rawValue: 1 << 3)
+    /// Convenience: every known subdirectory. Add new bits to this set when
+    /// the vault grows new top-level subdirectories.
+    static let all: VaultExportIncludes = [.rawMemos, .dailyPages, .entities, .assets]
 }
 
 /// Read-only service that walks the vault and produces an `ExportManifest`.
@@ -85,6 +129,255 @@ final class VaultExportService {
             return manifest
         }.value
     }
+
+    // MARK: - Zip packaging (R13)
+
+    /// Package the selected vault subdirectories into a single `.zip` archive
+    /// written to `NSTemporaryDirectory`. Returns the final archive URL —
+    /// the caller (R14 UI layer) is responsible for moving / sharing it.
+    ///
+    /// Implementation flow:
+    ///   1. Validate the vault exists and is non-empty via `computeManifest`.
+    ///   2. Create a unique `staging-{UUID}/` directory under tmp.
+    ///   3. Copy each selected subdirectory under staging, preserving the
+    ///      `raw/`, `wiki/daily/`, `wiki/places/`, … layout the user would
+    ///      see in iCloud Drive — so an unzip restores a familiar tree.
+    ///   4. Ask `NSFileCoordinator` to produce a `.zip` of the staging
+    ///      directory using `.forUploading`; copy that zip to the final
+    ///      destination before the coordinator's temp dir is reclaimed.
+    ///   5. `defer`-clean the staging directory regardless of success.
+    ///
+    /// Threading:
+    ///   The heavy I/O runs inside a `Task.detached(priority: .userInitiated)`
+    ///   so the main actor stays free. `progress` is hopped onto `MainActor`
+    ///   before each invocation so SwiftUI `@Published` updates are safe.
+    ///   Progress milestones: 0.10 (staging ready) → 0.50 (copy done) →
+    ///   0.90 (zip produced) → 1.00 (zip moved to final location).
+    ///
+    /// Cleanup:
+    ///   Staging is always removed in `defer` — even on throw. The final zip
+    ///   under tmp is the caller's to delete (typically after the share
+    ///   sheet closes); we don't own its lifecycle past return.
+    ///
+    /// - Parameters:
+    ///   - includes: Which subdirectories to include. Defaults to `.all`.
+    ///               Empty set is an explicit `.exportFailed` to avoid
+    ///               silently producing an empty archive.
+    ///   - progress: Optional 0.0…1.0 progress callback, invoked on the
+    ///               main actor.
+    /// - Throws: `.vaultNotFound` if the vault directory is missing,
+    ///           `.noData` if the vault is present-but-empty,
+    ///           `.exportFailed(reason)` for any other failure (no
+    ///           subdirectories selected, copy denied, coordinator error).
+    /// - Returns: URL of the final `.zip` file under `NSTemporaryDirectory`.
+    func exportVaultZip(
+        includes: VaultExportIncludes = .all,
+        progress: (@MainActor @Sendable (Double) -> Void)? = nil
+    ) async throws -> URL {
+        // Fail fast on an empty include set BEFORE we burn manifest CPU —
+        // tests and the UI both care that this returns immediately.
+        guard !includes.isEmpty else {
+            throw VaultExportError.exportFailed("no subdirectories selected")
+        }
+
+        let vaultURL = VaultInitializer.vaultURL
+
+        return try await Task.detached(priority: .userInitiated) { [progress] in
+            let fm = FileManager.default
+
+            // Step 1 — Validate vault. computeManifest gives us both the
+            // existence check (.vaultNotFound) and the emptiness check
+            // (.noData) for free; reuse it rather than re-walking the tree.
+            guard let manifest = try VaultExportService.computeManifest(vaultURL: vaultURL) else {
+                throw VaultExportError.vaultNotFound
+            }
+            guard !VaultExportService.isEmpty(manifest) else {
+                throw VaultExportError.noData
+            }
+
+            // Step 2 — Create staging directory. UUID suffix avoids collisions
+            // when two share-sheet exports race (rare but possible if the user
+            // taps quickly).
+            let tmp = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+            let stagingURL = tmp.appendingPathComponent("daypage-export-staging-\(UUID().uuidString)", isDirectory: true)
+            do {
+                try fm.createDirectory(at: stagingURL, withIntermediateDirectories: true)
+            } catch {
+                throw VaultExportError.exportFailed("failed to create staging dir: \(error.localizedDescription)")
+            }
+            // Always clean staging — success or failure. The final zip lives
+            // in tmp/ at a separate path, so this doesn't affect the result.
+            defer { try? fm.removeItem(at: stagingURL) }
+
+            if let progress {
+                await MainActor.run { progress(0.10) }
+            }
+
+            // Step 3 — Selective copy. We map each OptionSet bit to a list of
+            // (source, destination-relative) pairs so the staging layout
+            // mirrors the vault layout the user already knows from iCloud.
+            // Missing source directories are tolerated — a vault that hasn't
+            // run AI compilation yet legitimately lacks wiki/daily/.
+            //
+            // `skipChildName` lets a spec copy a directory while excluding one
+            // child subtree. This matters for `.rawMemos`: the on-disk `raw/`
+            // dir *contains* `raw/assets/`, but `.assets` owns that subtree as
+            // its own flag. Without the exclusion, selecting both `.rawMemos`
+            // and `.assets` (the `.all` default) would stage `raw/assets/`
+            // twice and the second copyItem would throw "item already exists".
+            struct CopySpec {
+                let source: URL
+                let stagingRelativePath: String
+                /// Immediate child directory name to omit when staging `source`.
+                /// nil means copy the whole subtree.
+                var skipChildName: String? = nil
+            }
+            var specs: [CopySpec] = []
+            if includes.contains(.rawMemos) {
+                // Copy raw/ but leave raw/assets/ to the `.assets` flag so the
+                // two flags stay non-overlapping (and so a memo-only export
+                // doesn't drag in hundreds of MB of photos).
+                specs.append(CopySpec(
+                    source: vaultURL.appendingPathComponent("raw"),
+                    stagingRelativePath: "raw",
+                    skipChildName: "assets"
+                ))
+            }
+            if includes.contains(.dailyPages) {
+                specs.append(CopySpec(
+                    source: vaultURL.appendingPathComponent("wiki/daily"),
+                    stagingRelativePath: "wiki/daily"
+                ))
+            }
+            if includes.contains(.entities) {
+                specs.append(CopySpec(
+                    source: vaultURL.appendingPathComponent("wiki/places"),
+                    stagingRelativePath: "wiki/places"
+                ))
+                specs.append(CopySpec(
+                    source: vaultURL.appendingPathComponent("wiki/people"),
+                    stagingRelativePath: "wiki/people"
+                ))
+                specs.append(CopySpec(
+                    source: vaultURL.appendingPathComponent("wiki/themes"),
+                    stagingRelativePath: "wiki/themes"
+                ))
+            }
+            if includes.contains(.assets) {
+                specs.append(CopySpec(
+                    source: vaultURL.appendingPathComponent("raw/assets"),
+                    stagingRelativePath: "raw/assets"
+                ))
+            }
+
+            for spec in specs {
+                var isDir: ObjCBool = false
+                guard fm.fileExists(atPath: spec.source.path, isDirectory: &isDir), isDir.boolValue else {
+                    // Source dir missing is fine — represents "no entries of
+                    // this type yet". Skip silently.
+                    continue
+                }
+                let dest = stagingURL.appendingPathComponent(spec.stagingRelativePath, isDirectory: true)
+                // Ensure parent exists (e.g. staging/wiki/) before copying
+                // staging/wiki/daily/.
+                let parent = dest.deletingLastPathComponent()
+                do {
+                    try fm.createDirectory(at: parent, withIntermediateDirectories: true)
+                    if let skip = spec.skipChildName {
+                        // Per-child copy so we can omit one subtree (raw/assets/).
+                        // Create the dest dir, then copy every immediate child
+                        // except `skip`. shallow=top-level enumerate is enough
+                        // because we recurse via copyItem on each child.
+                        try fm.createDirectory(at: dest, withIntermediateDirectories: true)
+                        let children = try fm.contentsOfDirectory(
+                            at: spec.source,
+                            includingPropertiesForKeys: nil,
+                            options: [.skipsHiddenFiles]
+                        )
+                        for child in children where child.lastPathComponent != skip {
+                            try fm.copyItem(
+                                at: child,
+                                to: dest.appendingPathComponent(child.lastPathComponent)
+                            )
+                        }
+                    } else {
+                        try fm.copyItem(at: spec.source, to: dest)
+                    }
+                } catch {
+                    throw VaultExportError.exportFailed(
+                        "failed to stage \(spec.stagingRelativePath): \(error.localizedDescription)"
+                    )
+                }
+            }
+
+            if let progress {
+                await MainActor.run { progress(0.50) }
+            }
+
+            // Step 4 — Produce zip via NSFileCoordinator. `.forUploading` is
+            // the documented Foundation API for "give me a zip copy of this
+            // directory"; the closure's `URL` argument points to a temp file
+            // that the system reclaims after the closure returns, so we
+            // copy it to our own destination synchronously.
+            let timestamp = Self.timestampFormatter.string(from: Date())
+            let destinationURL = tmp.appendingPathComponent(
+                "daypage-vault-export-\(timestamp).zip",
+                isDirectory: false
+            )
+            // If a same-second export already exists (unlikely but possible
+            // in test loops), remove it first so copyItem doesn't throw
+            // NSFileWriteFileExistsError.
+            if fm.fileExists(atPath: destinationURL.path) {
+                try? fm.removeItem(at: destinationURL)
+            }
+
+            let coordinator = NSFileCoordinator(filePresenter: nil)
+            var coordError: NSError?
+            var coordinatorThrew: Error?
+            coordinator.coordinate(
+                readingItemAt: stagingURL,
+                options: [.forUploading],
+                error: &coordError
+            ) { (zipURL: URL) in
+                do {
+                    try fm.copyItem(at: zipURL, to: destinationURL)
+                } catch {
+                    coordinatorThrew = error
+                }
+            }
+            if let err = coordError {
+                throw VaultExportError.exportFailed("coordinator: \(err.localizedDescription)")
+            }
+            if let err = coordinatorThrew {
+                throw VaultExportError.exportFailed("zip copy failed: \(err.localizedDescription)")
+            }
+            guard fm.fileExists(atPath: destinationURL.path) else {
+                throw VaultExportError.exportFailed("coordinator produced no zip url")
+            }
+
+            if let progress {
+                await MainActor.run { progress(0.90) }
+            }
+
+            // Step 5 — Final progress tick. The zip is already at its final
+            // location (we wrote there directly in the coordinator block);
+            // this tick exists so observers see a clean 1.0 terminal value.
+            if let progress {
+                await MainActor.run { progress(1.0) }
+            }
+
+            return destinationURL
+        }.value
+    }
+
+    /// Stable filename timestamp generator. `en_US_POSIX` so the locale of
+    /// the device can't introduce e.g. Arabic-Indic digits into a filename.
+    private static let timestampFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyyMMdd-HHmmss"
+        return f
+    }()
 
     // MARK: - Pure helpers (testability)
 

--- a/DayPageTests/VaultExportServiceTests.swift
+++ b/DayPageTests/VaultExportServiceTests.swift
@@ -198,4 +198,107 @@ struct VaultExportServiceTests {
         let manifest = try VaultExportService.computeManifest(vaultURL: missing)
         #expect(manifest == nil)
     }
+
+    // MARK: - R13 zip packaging tests
+
+    /// Happy path. Seed a small fixture vault, ask for `.all`, assert a
+    /// non-empty zip lands at the returned URL. Doesn't try to validate the
+    /// zip's internal structure — that's the OS's responsibility; we only
+    /// care that NSFileCoordinator actually produced an archive.
+    @Test func exportVaultZip_producesNonEmptyZipFile() async throws {
+        let root = try seedVault(raw: 2, daily: 1, places: 1, assets: 1)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        VaultInitializer.testOverrideURL = root
+        defer { VaultInitializer.testOverrideURL = nil }
+
+        let zipURL = try await VaultExportService.shared.exportVaultZip(includes: .all)
+        defer { try? FileManager.default.removeItem(at: zipURL) }
+
+        #expect(FileManager.default.fileExists(atPath: zipURL.path))
+        let attrs = try FileManager.default.attributesOfItem(atPath: zipURL.path)
+        let size = (attrs[.size] as? NSNumber)?.int64Value ?? 0
+        #expect(size > 0)
+    }
+
+    /// Empty vault -> .noData. Matches the manifest path's contract so
+    /// callers see one well-defined error class for "nothing to export yet".
+    @Test func exportVaultZip_throwsNoDataForEmptyVault() async throws {
+        let root = try seedVault() // all zero
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        VaultInitializer.testOverrideURL = root
+        defer { VaultInitializer.testOverrideURL = nil }
+
+        var caught: VaultExportError?
+        do {
+            _ = try await VaultExportService.shared.exportVaultZip(includes: .all)
+        } catch let e as VaultExportError {
+            caught = e
+        }
+        #expect(caught == .noData)
+    }
+
+    /// `[]` (empty OptionSet) is rejected up front with .exportFailed —
+    /// guards against silently producing a zip that only contains an
+    /// empty staging directory.
+    @Test func exportVaultZip_throwsExportFailedForEmptyIncludes() async throws {
+        let root = try seedVault(raw: 2)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        VaultInitializer.testOverrideURL = root
+        defer { VaultInitializer.testOverrideURL = nil }
+
+        var caught: VaultExportError?
+        do {
+            _ = try await VaultExportService.shared.exportVaultZip(includes: [])
+        } catch let e as VaultExportError {
+            caught = e
+        }
+        // Pattern-match the associated value so the assertion focuses on
+        // intent ("contains 'no subdirectories'") rather than the exact
+        // wording, which can drift across rounds.
+        if case let .exportFailed(reason) = caught {
+            #expect(reason.contains("no subdirectories"))
+        } else {
+            Issue.record("expected .exportFailed, got \(String(describing: caught))")
+        }
+    }
+
+    /// Progress reaches 1.0. We don't assert every milestone — that would
+    /// over-couple the test to the current step layout — only that the
+    /// terminal value is at least ~1.0 so SwiftUI progress UIs can rely on
+    /// seeing a clean "done" signal.
+    @Test func exportVaultZip_progressReachesOne() async throws {
+        let root = try seedVault(raw: 1)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        VaultInitializer.testOverrideURL = root
+        defer { VaultInitializer.testOverrideURL = nil }
+
+        let box = ProgressBox()
+        let zipURL = try await VaultExportService.shared.exportVaultZip(
+            includes: .all,
+            progress: { value in
+                // Closure is `@MainActor @Sendable`; we're already on the
+                // main actor here so the call into `box.update` is direct.
+                box.update(value)
+            }
+        )
+        defer { try? FileManager.default.removeItem(at: zipURL) }
+
+        #expect(box.maxSeen >= 0.99)
+    }
+}
+
+/// Tiny @MainActor sink that just records the highest progress value seen.
+/// We isolate it to the main actor because `exportVaultZip`'s progress
+/// callback is itself `@MainActor @Sendable` — keeping the storage on the
+/// same actor avoids any cross-actor hop inside the test.
+@MainActor
+private final class ProgressBox {
+    var maxSeen: Double = 0
+    func update(_ v: Double) {
+        if v > maxSeen { maxSeen = v }
+    }
 }


### PR DESCRIPTION
## Summary

为即将到来的 R14 `VaultExportView` 提供导出数据层。新增 `exportVaultZip(includes:progress:)`,把用户选中的 vault 子目录打包成单个 `.zip` 写入 `NSTemporaryDirectory`,由 UI 层(R14)交给 share sheet / Files App。

**零外部依赖**:不引入 ZIPFoundation / SSZipArchive,改用 Foundation 自带的 `NSFileCoordinator.coordinate(readingItemAt:options:.forUploading)` 拿到目录的 zip 副本。

## 关键修复(本 PR 的 WHY)

实现初稿存在真实 bug,被新测试捕获:
- `.rawMemos` 复制整个 `raw/` 目录时,**已经把 `raw/assets/` 一并带进去**;
- `.assets` flag 又单独复制 `raw/assets/`;
- → 默认 `.all`(UI 最常用路径)在任何含 assets 的真实 vault 上都会因目标已存在直接抛 `.exportFailed`。

修复:`.rawMemos` 复制 `raw/` 时用 `skipChildName` 排除 `assets/` 子树,`raw/assets/` 完全归属 `.assets` flag。两个 flag 职责互不重叠,且解锁"只导出 memo 不带几百 MB 照片"的用例。

## Changes

- `VaultExportIncludes` OptionSet:`rawMemos` / `dailyPages` / `entities` / `assets` / `all`
- `VaultExportError` 新增 `.exportFailed(String)`(用 String 保持枚举自动 `Equatable`)
- 后台 `Task.detached(.userInitiated)` 跑 I/O,进度回调 `@MainActor @Sendable` 回跳(0.10 → 0.50 → 0.90 → 1.0)
- `defer` 始终清理 staging 目录(成功/失败均清);空 include set 前置拒绝,避免空 zip

## Tests

新增 4 个测试:
- ✅ happy path — 产出非空 zip 文件
- ✅ 空 vault → `.noData`
- ✅ 空 includes `[]` → `.exportFailed("no subdirectories...")`
- ✅ 进度到达 1.0

**全套 107 测试通过(19 suites),iPhone 17 模拟器。**

## Scope(刻意不做)

- UI / Settings 入口 → R14
- 加密 / 签名归档 → 单独的威胁模型讨论
- 不触碰 CompilationService / SyncQueue / iCloud — 纯读 + temp 写