### PR TITLE
feat(compile): 去掉 3 条门槛，改为每天用户时区 0 点自动编译

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -2704,18 +2704,8 @@ struct TodayView: View {
                     }
                 }
 
-                // Museum-aesthetic inline "unlock today's page" placeholder —
-                // shown once the day has memos but hasn't been compiled and is
-                // still short of the threshold that triggers AI compilation.
-                if !viewModel.memos.isEmpty
-                    && !viewModel.isDailyPageCompiled
-                    && viewModel.memos.count < 3 {
-                    CompileUnlockCard(memoCount: viewModel.memos.count, onTap: { orbFocusToggle.toggle() })
-                        .padding(.horizontal, 20)
-                        .padding(.top, 16)
-                        .padding(.bottom, 4)
-                        .transition(.opacity)
-                }
+                // R12: "再记 N 条解锁今日成稿" 卡片已移除。编译不再有 3 条门槛——
+                // 每天 0 点自动编译前一天，手动编译按钮在 composeSection 中始终可用。
 
                 historySupplement
 
@@ -2777,55 +2767,48 @@ struct TodayView: View {
         } // end ScrollViewReader
     }
 
-    /// Compose area: compile progress dock / compile button + input bar.
+    /// Compose area: compile button + input bar.
+    ///
+    /// 编译不再有"记满 3 条才解锁"的门槛——每天用户时区 0 点会自动编译前一天
+    /// （BackgroundCompilationService），手动编译入口在此始终可用：只要当天有
+    /// memo 且尚未编译，就直接显示编译按钮，无论几条。
     @ViewBuilder
     private var composeSection: some View {
         Group {
             if !viewModel.isDailyPageCompiled && !viewModel.memos.isEmpty {
-                if viewModel.memos.count < 3 {
-                    CompileProgressDock(memoCount: viewModel.memos.count)
-                        .padding(.vertical, 6)
-                        .transition(
-                            .asymmetric(
-                                insertion: .opacity,
-                                removal: .opacity.combined(with: .scale(scale: 0.9))
-                            )
-                        )
-                } else {
-                    let aiKeyMissing = Secrets.resolvedDeepSeekApiKey.isEmpty
-                    HStack {
-                        Spacer()
-                        CompileFooterButton(
-                            memoCount: viewModel.memos.count,
-                            isCompiling: aiKeyMissing ? false : viewModel.isCompiling,
-                            isVisible: true,
-                            stage: compilationService.stage,
-                            errorMessage: aiKeyMissing ? nil : viewModel.submitError,
-                            onTap: {
-                                if aiKeyMissing {
-                                    showSettings = true
-                                } else {
-                                    viewModel.compile()
-                                }
-                            },
-                            onRetry: {
-                                if aiKeyMissing {
-                                    showSettings = true
-                                } else {
-                                    viewModel.compile()
-                                }
-                            },
-                            aiKeyMissing: aiKeyMissing
-                        )
-                        .shadow(
-                            color: DSColor.accentAmber.opacity(unlockGlow ? 0.5 : 0),
-                            radius: unlockGlow ? 18 : 0
-                        )
-                        .animation(reduceMotion ? nil : .easeOut(duration: 0.6), value: unlockGlow)
-                        Spacer()
-                    }
-                    .padding(.bottom, 4)
+                let aiKeyMissing = Secrets.resolvedDeepSeekApiKey.isEmpty
+                HStack {
+                    Spacer()
+                    CompileFooterButton(
+                        memoCount: viewModel.memos.count,
+                        isCompiling: aiKeyMissing ? false : viewModel.isCompiling,
+                        isVisible: true,
+                        stage: compilationService.stage,
+                        errorMessage: aiKeyMissing ? nil : viewModel.submitError,
+                        onTap: {
+                            if aiKeyMissing {
+                                showSettings = true
+                            } else {
+                                viewModel.compile()
+                            }
+                        },
+                        onRetry: {
+                            if aiKeyMissing {
+                                showSettings = true
+                            } else {
+                                viewModel.compile()
+                            }
+                        },
+                        aiKeyMissing: aiKeyMissing
+                    )
+                    .shadow(
+                        color: DSColor.accentAmber.opacity(unlockGlow ? 0.5 : 0),
+                        radius: unlockGlow ? 18 : 0
+                    )
+                    .animation(reduceMotion ? nil : .easeOut(duration: 0.6), value: unlockGlow)
+                    Spacer()
                 }
+                .padding(.bottom, 4)
             }
         }
         .animation(Motion.spring, value: viewModel.memos.count)

--- a/DayPage/Services/BackgroundCompilationService.swift
+++ b/DayPage/Services/BackgroundCompilationService.swift
@@ -9,12 +9,12 @@ extension Notification.Name {
     /// Posted by: BackgroundCompilationService.compileForegroundIfDue — after a
     /// successful foreground auto-retry compile.
     /// Observed by: TodayView.body (.onReceive — shows ds-style toast
-    /// "今日 Daily Page 已编译完成"). Mutex with the 2am system notification (silent in
-    /// foreground, no duplicate push).
+    /// "今日 Daily Page 已编译完成"). Mutex with the midnight (00:00) system
+    /// notification (silent in foreground, no duplicate push).
     static let compileSucceededForeground = Notification.Name("com.daypage.compileSucceededForeground")
 
     /// Posted by: BackgroundCompilationService.tryAutoCompileWeekly (R7-R8) — after
-    /// the 2am compile finishes if it's Monday AM and the prior week has >= 3 dailies.
+    /// the midnight compile finishes if it's Monday AM and the prior week has >= 3 dailies.
     /// userInfo["referenceDate"]: Date = any date inside the prior week (yesterday = Sun).
     /// Observed by: TodayView.weeklyRecapPreview (.onReceive — refreshes the top
     /// preview section).
@@ -82,12 +82,12 @@ final class BackgroundCompilationService {
 
     // MARK: - Schedule
 
-    /// 调度下一次后台应用刷新，大约在当地时间凌晨 2:00。
+    /// 调度下一次后台应用刷新，最早在用户当地时间午夜 00:00。
     /// 可重复调用；系统会忽略重复请求。
     func scheduleIfNeeded() {
         let request = BGAppRefreshTaskRequest(identifier: BackgroundCompilationService.taskIdentifier)
-        // 请求最早在今天凌晨 2:00 执行，如果已经过了，则请求明天
-        request.earliestBeginDate = nextTwoAM()
+        // 请求最早在下一个 0 点执行（iOS 只保证不早于此时刻）
+        request.earliestBeginDate = nextMidnight()
 
         do {
             try BGTaskScheduler.shared.submit(request)
@@ -153,14 +153,14 @@ final class BackgroundCompilationService {
 
     // MARK: - Foreground Retry (B3)
 
-    /// 2am 后台编译失败后，应用回到前台时自动重试今日的编译。
+    /// 0 点 后台编译失败后，应用回到前台时自动重试今日的编译。
     ///
-    /// 触发条件：今日的 raw 文件已存在但 daily page 缺失（即 2am 后台任务
+    /// 触发条件：今日的 raw 文件已存在但 daily page 缺失（即 0 点 后台任务
     /// 失败 / 被 iOS expirationHandler kill / 用户禁用了后台刷新）。
     /// 60 秒防抖避免 scenePhase 快速切换重复触发。
     ///
     /// 成功路径：发布 `compileSucceededForeground` 通知（Today 在 banner 上
-    /// 显示 ds-style toast）。**不发系统通知**，避免与 2am 的
+    /// 显示 ds-style toast）。**不发系统通知**，避免与 0 点 的
     /// `sendSuccessNotification` 重复。
     ///
     /// 失败路径：静默 + Sentry breadcrumb（用户不需要看到第二条失败通知）。
@@ -192,7 +192,7 @@ final class BackgroundCompilationService {
 
         do {
             try await CompilationService.shared.compile(for: Date(), trigger: "foreground-retry")
-            // 成功路径：广播给 Today，由 banner 体现，避免与 2am 系统通知重复。
+            // 成功路径：广播给 Today，由 banner 体现，避免与 0 点 系统通知重复。
             NotificationCenter.default.post(name: .compileSucceededForeground, object: nil)
         } catch {
             // 失败静默 — Today 已有失败 banner 链路；这里仅留 breadcrumb。
@@ -210,14 +210,14 @@ final class BackgroundCompilationService {
 
     // MARK: - Auto Weekly Recap (R8-HIGH)
 
-    /// 周一上午 2am daily 编译成功后调用：尝试编译上周的周回顾。
+    /// 周一上午 0 点 daily 编译成功后调用：尝试编译上周的周回顾。
     ///
     /// 触发条件（同时满足）：
     ///   1. 当前 weekday 是周一（Calendar weekday=2，firstWeekday=2）；
     ///   2. 上周（昨天=周日所在的 ISO 周）已编译的 daily ≥ 3 篇。
     /// 任一条件不满足 → 直接 return，无副作用。
     ///
-    /// 不抛错 — 周回顾失败不应该让 2am daily 编译路径看起来"失败"。
+    /// 不抛错 — 周回顾失败不应该让 0 点 daily 编译路径看起来"失败"。
     /// 用 Sentry breadcrumb 记录跳过/失败原因，并在成功路径发布
     /// `.weeklyRecapAvailable`，让 TodayView 的顶部 preview section 刷新。
     // internal for testability (R9-MEDIUM): WeeklyRecapAutoTriggerTests
@@ -296,7 +296,7 @@ final class BackgroundCompilationService {
                 transaction?.finish()
                 if !Secrets.sentryDSN.isEmpty { SentrySDK.flush(timeout: 5) }
                 self.sendSuccessNotification(for: yesterday)
-                // R8-HIGH: 2am compile 成功后顺手尝试编译上周回顾。
+                // R8-HIGH: 0 点 compile 成功后顺手尝试编译上周回顾。
                 // 仅周一早上触发；内部已做 ≥3 daily / referenceDate 守卫。
                 // 失败静默 — 周回顾是次要产物，不应阻塞 daily 编译完成回执。
                 await self.tryAutoCompileWeekly()
@@ -495,25 +495,29 @@ final class BackgroundCompilationService {
         return cal
     }
 
-    // MARK: - Private: Next 2:00 AM
+    // MARK: - Private: Next Midnight (00:00)
 
-    /// 计算设备当前时区中的下一个凌晨 2:00。
-    /// 如果现在还没到今天凌晨 2:00，返回今天的凌晨 2:00；否则返回明天的。
-    private func nextTwoAM() -> Date {
+    /// 计算用户当前时区中的下一个午夜 00:00。
+    /// 午夜是一天的起点，`now >= 今天 00:00` 几乎总成立，所以这里基本总是
+    /// 返回明天午夜，即"下一个 0 点"。BGTask 的 earliestBeginDate 只是
+    /// "最早可执行时间"，iOS 会在该时刻之后择机运行；真正"确保编译成功"
+    /// 靠前台 backfill / 前台重试兜底（见 backfillIfNeeded /
+    /// foregroundRetryIfNeeded）。
+    private func nextMidnight() -> Date {
         let calendar = Self.calendar
         let now = Date()
 
         var components = calendar.dateComponents([.year, .month, .day], from: now)
-        components.hour = 2
+        components.hour = 0
         components.minute = 0
         components.second = 0
 
-        guard let todayTwoAM = calendar.date(from: components) else { return now }
+        guard let todayMidnight = calendar.date(from: components) else { return now }
 
-        if todayTwoAM > now {
-            return todayTwoAM
+        if todayMidnight > now {
+            return todayMidnight
         }
 
-        return calendar.date(byAdding: .day, value: 1, to: todayTwoAM) ?? now
+        return calendar.date(byAdding: .day, value: 1, to: todayMidnight) ?? now
     }
 }


### PR DESCRIPTION
## 背景

用户反馈 Today 页那张「再记 N 条解锁今日成稿」虚线卡片（以及底部 `N / 3 MEMOS · M MORE TO UNLOCK` 进度条）是无意义的阻碍：核心价值——AI 把当天碎片连缀成日页——本就该自动发生，不该要用户手动凑满 3 条去「解锁」。

诉求：**去掉门槛 → 每天用户时区 0 点自动编译 → 每天只编译一次 → 确保编译成功。**

## 改动

### 1. 去掉 3 条编译门槛
- `TodayView.composeSection`：移除 `memos.count < 3` 分支（`CompileProgressDock` + 底部解锁进度条）。只要当天有 memo 且未编译，就直接显示 `CompileFooterButton`，**无论几条**。
- `TodayView` timeline：移除虚线卡片 `CompileUnlockCard` 的渲染。

### 2. 自动编译时间 2:00 → 0:00
- `BackgroundCompilationService`：`nextTwoAM()` → `nextMidnight()`，调度时间 `hour` 由 `2` 改为 `0`（用户当前时区午夜），同步更新注释。

### 3. 每天只编译一次 + 确保成功（无新增代码）
- **只编译一次**：沿用 `shouldCompile(for:)` 的 `vault/wiki/daily/YYYY-MM-DD.md` 存在性检查——已编译则跳过，**未改动**。
- **确保成功**：沿用既有前台兜底链路 `backfillIfNeeded()`（补编译任何缺失 daily）+ `foregroundRetryIfNeeded()`（补编译今天）。iOS 不保证 BGAppRefreshTask 精确在 0 点执行，前台兜底才是「确保成功」的真正保障。

## 测试

- ✅ `xcodebuild -scheme DayPage build`：**BUILD SUCCEEDED**（main 基线）
- ✅ `BackgroundCompilationServiceTests`：5/5 通过（`shouldCompile` 状态机未受时间改动影响）
- ✅ 模拟器（iPhone 17）视觉验证：虚线卡片与底部 `1 / 3 MEMOS · 2 MORE TO UNLOCK` 进度条已消失，直接显示编译入口

### Before（旧版，截图来自用户反馈）
- 顶部有「再记 2 条解锁今日成稿」虚线卡片
- 底部有「1 / 3 MEMOS · 2 MORE TO UNLOCK」

### After（本 PR）
- 卡片与进度条移除，直接显示「编译今日 · N 条」按钮（未配密钥时显示「Configure AI Engine」引导态）

## 备注

- `CompileUnlockCard.swift` / `CompileProgressDock` 两个组件文件**保留未删**（仅移除调用），避免牵连 i18n 字符串与潜在引用，留作后续 cleanup scope。
- 本 PR 基于 main，**不含** `feat/today-header-redesign-781`（#781 header 重设计）的改动，二者独立。