### PR TITLE
fix(today): 修复真机 arm64e Release 启动栈溢出闪退

### DIFF
--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1,6 +1,21 @@
 import SwiftUI
 import CoreLocation
 
+// MARK: - View.modify helper (crash-fix utility)
+//
+// Applies a transform that returns `some View`, inserting a type-erasure-free
+// boundary between modifier groups. Used by TodayView.body to split a giant
+// modifier chain into several shallower generic types — see the crash-fix
+// comment in TodayView.body. The transform itself decides the concrete type,
+// so each `.modify { ... }` call caps the nesting depth the Swift runtime must
+// resolve at launch on arm64e Release builds.
+extension View {
+    @ViewBuilder
+    func modify<Transformed: View>(_ transform: (Self) -> Transformed) -> Transformed {
+        transform(self)
+    }
+}
+
 struct TodayView: View {
 
     @EnvironmentObject private var authService: AuthService
@@ -652,6 +667,27 @@ struct TodayView: View {
                     .animation(Motion.rise, value: viewModel.submitError)
                 }
             }
+            // CRASH-FIX (真机 arm64e Release 启动栈溢出): TodayView.body 原本在
+            // 单一 NavigationStack/ZStack 上链式挂了 ~37 个顶层 modifier
+            // (.onChange/.onReceive/.sheet/.fullScreenCover/.overlay)，编译成一个
+            // 极深的嵌套泛型类型。真机 Release 下 Swift runtime 用
+            // swift_getTypeByMangledName 解析该类型时递归深度超限 → SIGSEGV
+            // (KERN_PROTECTION_FAILURE at Stack Guard)。模拟器/Debug 栈布局不同
+            // 故不复现。把 modifier 链拆成 3 个 @ViewBuilder 修饰函数，每个返回
+            // 独立 `some View` 类型，在中间插入类型边界，打断运行时递归深度。
+            .modify { applyNavigationAndOverlays($0) }
+            .modify { applyLifecycleHooks($0) }
+            .modify { applySheetsAndCovers($0) }
+            .modify { applyAuxiliarySheets($0) }
+        }
+    }
+
+    // MARK: - Body modifier groups (crash-fix: break giant generic type)
+
+    /// navigationBar 隐藏 + 侧栏边缘手势 + memo 详情 navigationDestination。
+    @ViewBuilder
+    private func applyNavigationAndOverlays(_ content: some View) -> some View {
+        content
             .navigationBarHidden(true)
             // US-030: left-edge swipe (within first 20pt) opens sidebar
             .gesture(
@@ -683,6 +719,12 @@ struct TodayView: View {
                     MemoDetailView(memo: memo, vm: viewModel)
                 }
             }
+    }
+
+    /// 所有生命周期/状态监听 hook（onAppear / onChange / onReceive）。
+    @ViewBuilder
+    private func applyLifecycleHooks(_ content: some View) -> some View {
+        content
             .onAppear {
                 clearDraftIfExpired()
                 // R4-B2: SceneStorage may come back empty after a process kill
@@ -851,6 +893,12 @@ struct TodayView: View {
                     withAnimation { iCloudConflictBannerVisible = false }
                 }
             }
+    }
+
+    /// 所有 sheet / fullScreenCover / banner / writeSheet overlay 与 quick-capture hook。
+    @ViewBuilder
+    private func applySheetsAndCovers(_ content: some View) -> some View {
+        content
             // Daily Page full-screen sheet
             .fullScreenCover(isPresented: $showDailyPage) {
                 let dateStr: String = {
@@ -955,6 +1003,14 @@ struct TodayView: View {
             .sheet(item: $timelineShareText) { payload in
                 ShareSheet(activityItems: [payload.text])
             }
+    }
+
+    /// banner overlay + tutorial + auth/weekly/migration/share-card sheets +
+    /// writeSheet overlay + quick-capture hooks。`applySheetsAndCovers` 的后半，
+    /// 进一步拆分以把单段嵌套泛型深度压到栈安全范围内（crash-fix 第二刀）。
+    @ViewBuilder
+    private func applyAuxiliarySheets(_ content: some View) -> some View {
+        content
             .bannerOverlay()
             // US-010: First-run input bar tutorial
             .overlay {
@@ -1009,7 +1065,6 @@ struct TodayView: View {
                 viewModel.isShowingVoiceRecorder = true
                 nav.pendingRecordingTrigger = nil
             }
-        }
     }
 
     // MARK: - Sync Banner Logic


### PR DESCRIPTION
## 现象

TestFlight 真机启动**即闪退**，模拟器一切正常。最近两个版本回归（之前能进）。

## 根因（崩溃日志确诊）

崩溃日志 `DayPage-2026-06-22-171703.ips`：

- **异常**：`EXC_BAD_ACCESS / SIGSEGV`，地址落在 **Stack Guard 区**（`16fc1c000-16fc20000`）→ **栈溢出**的教科书签名。
- **栈帧**：Swift runtime 的 `decodeMangledType ⇄ decodeGenericArgs ⇄ swift_getTypeByMangledName` **无限自递归**（`recursionInfoArray.triggered=true`）。
- **触发链**：`App.main → NavigationStack.init → ZStack.init → ViewBodyAccessor.updateBody`，崩在 **TodayView.body 首次求值**。

**根因**：`TodayView.body` 在单一 `NavigationStack { ZStack {...} }` 上链式挂了 **~37 个顶层 modifier**（15 个 `.onChange`/`.onReceive` + 13 个 `.sheet`/`.fullScreenCover` + 多个 `.overlay`），编译成一个**极深的嵌套泛型类型**。真机 **arm64e + Release** 下，Swift runtime 按需解析该类型的 mangled name 时**递归深度超过栈容量 → SIGSEGV**。

**为什么模拟器正常**：模拟器是 x86_64/Debug，栈布局与类型解析路径不同，不触发。这也解释了为什么 Sentry 没抓到（崩溃发生在 `SentrySDK.start` 之前的首帧渲染），以及"代码区间无 diff 回归"——不是某行新代码，而是 body 复杂度长期累积越过了栈深度阈值。

## 修复

把 `TodayView.body` 的 modifier 链拆成 **4 个 `@ViewBuilder` 修饰函数**，经一个通用 `View.modify` 扩展串联。每个函数返回独立 `some View` 类型，在中间插入类型边界，把单个巨型嵌套泛型类型拆成 4 个浅得多的类型（modifier 数 **4 / 12 / 13 / 8**），让运行时解析深度回到栈安全范围。

- `applyNavigationAndOverlays` — navBar / 边缘手势 / navigationDestination
- `applyLifecycleHooks` — 所有 onAppear / onChange / onReceive
- `applySheetsAndCovers` — 前半 sheet / cover
- `applyAuxiliarySheets` — 后半 banner / tutorial / migration / writeSheet + hook

**所有逻辑逐字保留，零行为变更**，仅重组结构。

## 测试

- ✅ Debug 配置 BUILD SUCCEEDED
- ✅ **Release 配置 BUILD SUCCEEDED**（崩溃发生的配置）

> 注：这是确定性的栈深度修复，需发新版在真机确认不再闪退。