### PR TITLE
polish(today): 安静化输入栏氛围动效 + 照片查看器双击缩放

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -4,22 +4,28 @@ import Photos
 import PhotosUI
 import UIKit
 
-// MARK: - BlinkingModifier (composer.jsx caret animation)
-private struct BlinkingModifier: ViewModifier {
+// MARK: - BreathingCaretModifier (composer.jsx caret animation)
+//
+// The idle dock caret used to hard-blink (opacity 1 → 0 every 0.6s), which on a
+// deliberately quiet, museum-still home surface reads as visual noise that keeps
+// tugging the eye. We replace the blink with a slow, low-contrast "breath"
+// (opacity 1 → 0.3 over 1.1s) so the caret signals "writable here" without ever
+// fully disappearing or demanding attention.
+private struct BreathingCaretModifier: ViewModifier {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
-    @State private var visible = true
+    @State private var dimmed = false
     func body(content: Content) -> some View {
         content
-            .opacity(visible ? 1 : 0)
+            .opacity(dimmed ? 0.3 : 1)
             .onAppear {
-                // Vestibular-sensitive: skip the repeating blink entirely when
+                // Vestibular-sensitive: skip the repeating motion entirely when
                 // Reduce Motion is on; leave the caret in its solid state.
                 guard !reduceMotion else {
-                    visible = true
+                    dimmed = false
                     return
                 }
-                withAnimation(.easeInOut(duration: 0.6).repeatForever()) {
-                    visible = false
+                withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                    dimmed = true
                 }
             }
     }
@@ -437,9 +443,9 @@ struct InputBarV4: View {
                         .foregroundStyle(DSColor.inkSubtle)
                         .lineLimit(1)
                     Rectangle()
-                        .fill(DSColor.amberDeep.opacity(0.5))
+                        .fill(DSColor.amberDeep.opacity(0.35))
                         .frame(width: 2, height: 14)
-                        .modifier(BlinkingModifier())
+                        .modifier(BreathingCaretModifier())
                 }
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .padding(.leading, 4)
@@ -923,11 +929,28 @@ struct InputBarV4: View {
         .disabled(isDisabled)
         .accessibilityLabel(affordance.accessibilityLabel)
         .accessibilityIdentifier("memo-send")
-        .onAppear { startBreathing() }
-        .onChange(of: affordance) { _ in startBreathing() }
+        .onAppear { startBreathing(for: affordance) }
+        .onChange(of: affordance) { startBreathing(for: $0) }
     }
 
-    private func startBreathing() {
+    /// The ambient "breathing" pulse is only ever visible for the `.empty`
+    /// (translucent mic ring) and `.multimodal` (white ring) affordances —
+    /// every other state paints a solid amber fill that masks `breathingOpacity`
+    /// entirely. Previously a `repeatForever` animation was (re)started for ALL
+    /// states, so while the user was simply typing (`.textOnly`) an invisible,
+    /// perpetual animation kept driving state changes and the compositor for no
+    /// visual payoff. Gate it to the states that use it, reset the rest to solid,
+    /// and honor Reduce Motion (a frozen mid-pulse value would otherwise stick).
+    private func startBreathing(for affordance: SendAffordance) {
+        let usesBreathing: Bool
+        switch affordance {
+        case .empty, .multimodal: usesBreathing = true
+        case .textOnly, .textAndPhoto, .locationOnly: usesBreathing = false
+        }
+        guard usesBreathing, !reduceMotion else {
+            withAnimation(Motion.fade) { breathingOpacity = 1.0 }
+            return
+        }
         withAnimation(Motion.breathing) {
             breathingOpacity = 0.45
         }

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -1200,7 +1200,10 @@ private struct SendAffordanceIcon: View {
                 }
             }
         }
-        .animation(Motion.spring, value: affordance)
+        // Affordance transitions are already animated by the parent button's
+        // `.animation(Motion.spring, value: affordance)` (which wraps this icon),
+        // so an inner copy only made SwiftUI interpolate the same change twice.
+        // Removed for a single, crisp morph. (P2 #7)
     }
 }
 

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -495,6 +495,25 @@ struct PhotoFullScreenViewer: View {
                                 }
                         )
                     )
+                    // Double-tap to zoom: matches the iOS muscle memory for
+                    // full-screen photos (pinch + swipe-to-dismiss were already
+                    // here, but a quick double-tap was the missing reflex).
+                    // Centered toggle between fit (1x) and 2x; reuses the existing
+                    // snap spring and honors Reduce Motion. A two-finger pinch and
+                    // a one-finger double-tap can't collide, so this composes
+                    // cleanly with the SimultaneousGesture above.
+                    .onTapGesture(count: 2) {
+                        withAnimation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.75)) {
+                            if scale > 1.0 {
+                                scale = minScale
+                                offset = .zero
+                            } else {
+                                scale = 2.0
+                            }
+                        }
+                        lastScale = scale
+                        lastOffset = offset
+                    }
             }
 
             // Close button

--- a/docs/ux-audits/2026-06-23-experience-polish-audit.md
+++ b/docs/ux-audits/2026-06-23-experience-polish-audit.md
@@ -1,0 +1,130 @@
+# DayPage 体验深度优化审计 — 2026-06-23
+
+> 自动化「daily-ui」任务产物。目标：以极简为原则，优化 **输入体验 / 显示体验 / 操作体验**，打磨动效、细节、观感与美观。
+>
+> 本文档为**讨论与 Issue 草案**，不直接改码。按 `CLAUDE.md` 约定，设计改动须先讨论 → 开 Issue → 分支实现 → 测试 → PR。每条均给出文件位置、现状、具体优化（含数值）、影响与工作量。
+>
+> 审计范围：`DayPage/Features/Today/*`、`DayPage/DesignSystem/*`、`DayPage/Features/Archive/*`、`DayPage/App/*`。
+
+---
+
+## 一、本轮最高优先级（建议优先开 Issue）
+
+这五项要么是无障碍合规、要么是「低成本高观感」收益，且与本次「极简 + 输入体验」主题最契合。
+
+### P0-1 · 集中化弹簧/时长 token，消除全局动效不一致 〔影响 高 / 工作量 低〕
+现状：全代码库散落 **15 种 spring `response`（0.18–0.55）**、**12 种 `dampingFraction`（0.5–0.9）**，以及多个 ad-hoc `.easeOut(0.25/0.5)`。同一类交互（如按钮按压）在不同文件取不同值；`DSPicker` 的展开 `0.35/0.85` 与收起 `0.3/0.9` 甚至不对称。
+
+优化：在 `DesignSystem/Motion.swift` 增设语义化 token 并全量替换调用点：
+- `Motion.buttonPress = .spring(response: 0.25, dampingFraction: 0.82)`（统一 0.8/0.85 两派）
+- `Motion.panelToggle = .spring(response: 0.32, dampingFraction: 0.85)`（picker/面板开合同一曲线）
+- `Motion.pulseCapture = .spring(response: 0.20, dampingFraction: 0.60)`（计数/pop 等高频反馈）
+- `Motion.swipeSnap = .spring(response: 0.28, dampingFraction: 0.86)`（导出 `SwipePhysics` 现值）
+- 合并 `fade(0.18)` 与 `dismiss(0.22)` → 统一 `dismiss = 0.20`；为 `CompileUnlockCard` 的 pop 增设 `Motion.popConfirm = .spring(response: 0.18, dampingFraction: 0.60)`。
+
+收益：观感统一、未来调参一处改全局。约 20 行新增 + 30 处替换。
+
+### P0-2 · 补齐 Reduce Motion 无障碍覆盖 〔影响 高 / 工作量 中〕
+现状（合规缺口）：
+- `Interactions.swift` `PressableCardModifier`：`scaleEffect(0.98)` **始终应用**，关掉动效仍有跳变。
+- `RecordingOverlayView.swift`：双环 `.easeInOut(1.6).repeatForever()` **未判断** `reduceMotion`，前庭敏感用户会持续看到运动——属违规。
+- `DayOrbView.swift`：`capturePulse` 的 `scaleEffect(1.10)` 无 guard。
+
+优化：
+- `PressableCardModifier`：`if !reduceMotion { scaleEffect(0.98) }`，关掉时整体跳过而非瞬时缩放。
+- `RecordingOverlayView`：`onAppear` 脉冲前加 `guard !reduceMotion else { return }`。
+- `DayOrbView`：缩放包进 `if !reduceMotion`。
+- 在 `Motion.swift` 提供 `animatedScale(_:to:when:)` 复用 helper。
+建议在开启 Reduce Motion 的真机上验收。
+
+### P0-3 · 写入页键盘聚焦的两段式延迟 〔影响 高 / 工作量 中〕
+现状：`WriteSheetView.swift` L209–215 在 `onAppear` 后 `Task.sleep(80ms)` 再 set focus。Sheet 已升起但光标晚 ~100ms 出现，产生「升起→再聚焦」的两段感，直接拖慢「快速记一笔」。
+
+优化：降到 50ms 并改用 `@FocusState` + `.focused($isFocused)`，在同步 `onAppear` 内 `isFocused = true`，让聚焦在首帧布局前入队；保留 sleep 仅作兜底。这是输入体验的核心路径。
+
+### P0-4 · 录音脉冲过慢、双环冗余 〔影响 中 / 工作量 低〕
+现状：`RecordingOverlayView.swift` L33–56 双环 `.easeInOut(1.6).repeatForever()`，相位差 0.3s。1.6s 在录音场景里读起来像「卡住/思考」，而非「正在录」（系统级录音指示通常 0.8–1.0s）。双环还增加认知负担。
+
+优化：脉冲降到 **1.0s**；**删除内环**只留单外环（更干净）。若设计坚持双环：外 1.0s / 内 1.2s，相位差降到 0.15s。（与 P0-2 的 reduceMotion guard 一并做。）
+
+### P0-5 · 长按说话：0–250ms「死区」无视觉反馈 〔影响 中 / 工作量 中〕
+现状：`PressToTalkButton.swift` L106–155。触摸后需按住 0.25s 才出现环动画（且环 0.8s 时长 > 0.25s 阈值，几乎只闪一下，见 I 区）。这违反「视觉先于触觉」原则——用户不确定按压是否被识别。
+
+优化：触摸即给即时视觉确认——`primaryContainer` 背景轻移 或 `scale(1.08)`，在 haptic 触发前可见；并把 `preRecording` 环动画从 0.8s 降到 0.45s（或直接去掉，因 0.25s 即转录音态）。
+
+---
+
+## 二、输入体验（Input）
+
+| # | 文件 · 位置 | 现状 | 优化（含数值） | 影响 / 工作量 |
+|---|---|---|---|---|
+| I-1 | `WriteSheetView.swift` 升起动画 L~99 | `timingCurve(0.2,0.8,0.2,1, 0.32)`，控制点造成轻微 overshoot，320ms 略钝 | 收紧为 280ms + `cubic-bezier(0.25,0.46,0.45,0.94)`；可试 240ms | 中 / 低 |
+| I-2 | `WriteSheetView.swift` 计数 L372–385 | 字数瞬时更新、阅读时长 chip 却带 `Motion.countTick` 过渡——半动画，观感犹豫 | 二选一统一：要么计数也加 0.15s scale+opacity tick，要么阅读时长也改瞬时（**推荐瞬时，更极简**） | 中 / 低 |
+| I-3 | `WriteSheetView.swift` SavePillPressStyle L38–44 | 按压 `scale 0.96` + `easeInOut 0.12s`，0.12s 偏慢 | 降到 0.08s（贴近系统按压手感），缩放保持 0.96 | 低 / 低 |
+| I-4 | `AttachmentMenuPopover.swift` L48–61 | 四宫格 `HStack(spacing: 0)`，图标 22pt，略挤 | 改 `spacing: 4`，图标 22→20pt，给「克制留白」 | 低 / 低 |
+| I-5 | `InputBarV4.swift` BreathingCaret L6–23 | 呼吸光标 `easeInOut(1.1).repeatForever`，周期 2.2s（非整数） | 取整 1.0s（周期 2.0s，对齐 60fps 帧倍数） | 低 / 低 |
+| I-6 | `InputBarV4.swift` dock 阴影 L654–655 | 主阴影 r10/0.45 + 次阴影 r1/0.18（次阴影几乎不可见，徒增渲染） | 删次阴影；主阴影 opacity 0.45→0.35、r10→8 | 低 / 低 |
+| I-7 | `InputBarV4.swift` `composingCardMorph` L398+ | 旧「composing card」死代码留存，增加阅读负担 | 单独 PR 清理（非 UX，属维护） | 低 / 低 |
+| I-8 | `InputBarV4.swift` 缺附件/位置 haptic | 加附件、设/清位置、清草稿均无触觉确认 | 照片/位置写入 → `Haptics.commit()`；清位置 → `Haptics.light()` | 中 / 中 |
+
+---
+
+## 三、动效与设计系统（Motion / Design System）
+
+| # | 文件 · 位置 | 现状 | 优化（含数值） | 影响 / 工作量 |
+|---|---|---|---|---|
+| M-1 | `DSButton.swift` / `Interactions.swift` 按压缩放 | 缩放值不一：按钮 0.97、卡片 0.98、归档 0.93、对话框 0.96 | 主点击面统一 **0.96**；0.93 仅留给破坏性操作（删除）；写进注释 | 中 / 低 |
+| M-2 | `Elevation.swift` / `Surfaces.swift` / `LiquidGlassEngine.swift` | 玻璃阴影配方 5 套各异；`LiquidGlassCard` 内联硬编码阴影未走 `DSElevation` 枚举 | `LiquidGlassCard` 改用 `.elevation(.glass)`；新增 `DSElevation.subtle`（0.03/0.06）给 `GlassDisc`；统一近/远 radius·offset 对 | 高 / 中 |
+| M-3 | `Surfaces.swift` / `Colors.swift` glassEdge | 顶部「湿边」高光只在 `LiquidGlassCard` 用，`GlassDisc`/`Pill`/`Chip` 漏掉，且 `TodayView` 内重复手写 | 抽 `glassHighlight(_ shape:)` helper，默认应用所有玻璃面；少数冲突处用参数关掉 | 中 / 低 |
+| M-4 | `Haptics.swift` 等 | 触觉只在「提交」时触发，不引导手势；滑动越阈、删除/撤销缺触觉 | `SwipeableMemoCard` 越阈 → `Haptics.rigid(0.3)`；`DayOrbView` 计数减少 → `Haptics.light()`；在 `Haptics.swift` 注明「越阈=rigid0.3 / 提交=medium / 移除=light」 | 中 / 中 |
+| M-5 | `LiquidGlassEngine.swift` 全文 | 为 iOS 26 原生玻璃做双轨桥接（~80 行），native/legacy 两路 reduce-transparency 兜底几乎重复，tint 三岔逻辑费解 | 若原生玻璃仍属推测：删 engine 仅留 legacy 暖玻璃并直接命名 `dpGlass`；若已确认：用 `#if ENABLE_NATIVE_GLASS` 编译开关 + `tint ?? amberSoft` 统一 | 低（对 UX）/ 中 |
+
+---
+
+## 四、显示体验（Display）
+
+| # | 文件 · 位置 | 现状 | 优化（含数值） | 影响 / 工作量 |
+|---|---|---|---|---|
+| D-1 | `TodayView.swift` 横幅区 L320–414 | AI key / 同步队列 / iCloud 冲突 / 位置草稿 四条横幅 0 间距堆叠；小屏（SE / 12 mini）150–180pt 把输入框挤出屏外 | 每条 `.padding(.bottom, 4)`；`bannerCount ≥ 3` 时隐藏最低优先级（位置草稿）保住输入框 | 高（小屏）/ 低 |
+| D-2 | `MemoCardView.swift` 附件 L158–226 | 语音/照片/文件线性 VStack 堆叠，无分组，混合附件卡可达 +60–100pt | 收进可折叠「附件托盘」，横向 badge 计数 + 「+2 more」 | 高 / 中 |
+| D-3 | `AISummaryCard.swift` 打字机 L42–52 | 0.38s 前导 + 36–66ms/字，150 字需 5–10s；点按跳过但不易发现 | 前导降 180ms、速度 24–36ms/字（典型 3–4s）；或整段 200ms 淡入 + 设置里随 Reduce Motion 关闭 | 中 / 低 |
+| D-4 | `TimelineRow.swift` L312–321 | 标题→lede 10pt、lede→meta 14pt，密集日节奏杂乱 | 统一 8pt 区间 token；标题→lede 收到 6pt | 中 / 低 |
+| D-5 | `ArchiveView.swift` 月度卡 L1304–1330 | 四项统计同字号同权重，主指标「总条数」不突出；四块玻璃面成噪声 | 「总条数」serif 38pt + `amberDeep`，其余 28pt + `inkPrimary`；去玻璃背景改纯白面 + 0.5pt 边 | 中 / 中 |
+
+---
+
+## 五、操作体验（Operation）
+
+| # | 文件 · 位置 | 现状 | 优化（含数值） | 影响 / 工作量 |
+|---|---|---|---|---|
+| O-1 | `SwipeableMemoCard.swift` L86–470 | 左右双向共 6 个滑动动作（pin/more + share/delete），两套手势路径达同类操作，过度设计 | 收敛为**单向左滑**主操作（分享/删除）；pin/more 移入长按菜单（对齐 Apple Notes/Reminders） | 高 / 中 |
+| O-2 | `TimelineRow.swift` 菜单 L369–417 | 长按菜单与滑动动作完全重复，菜单冗长且不教用户滑动 | 菜单精简为「打开当日页 + 删除」，分享/pin 交给滑动，菜单作无障碍兜底 | 中 / 低 |
+| O-3 | `DayDetailView.swift` 翻页手势 L138–149 | 横向翻页阈值 24pt + 1.5:1，小屏自然滑动易判定模糊需重滑 | `minimumDistance` 20pt、比例 2.0:1；或仅在滚动到顶部（offset≈0）时启用翻页 | 中 / 低 |
+| O-4 | `AISummaryCard.swift` 点按 L68–79 | 同一 tap：动画中=加速、动画完=跳转，切换无提示，易误跳 | 完成后才显「→」chevron 暗示；或完成后改双击跳转、单击仅加速 | 中 / 低–中 |
+| O-5 | `ArchiveView.swift` 日历空格 L1013–1093 | 空日 50% 透明仍可点进详情，"看着空却像按钮" | 空格去透明保持实底 + 0.5pt borderSubtle 描边表「可点但空」；有内容格用实底无描边 | 中 / 低 |
+| O-6 | `UndoPillView.swift` L42–54 / L155 | 倒计时环 `easeInOut(0.4)` 与底层线性 5s 倒计时不同步、视觉跳；VoiceOver 仅在剩 3s 播报（反应时间偏短） | 环改 `.linear` 或去掉单独 easing；播报移到剩 4s 并含「Undo available for 4 more seconds」 | 中 / 低 |
+
+---
+
+## 六、极简与美观（Aesthetics）
+
+| # | 文件 · 位置 | 现状 | 优化 | 影响 / 工作量 |
+|---|---|---|---|---|
+| A-1 | `AISummaryCard.swift` 头部 L91–112 | sparkle + 「AI·今日一句」+ 「TODAY」+ chevron 四元素拥挤，窄屏换行 | 删冗余「TODAY」（卡片永在 Today 页），仅留 sparkle+标签（左）/ chevron（右） | 低 / 低 |
+| A-2 | `MemoCardView.swift` meta 行 L290–315 | 无附件时 meta 行读作空 padding，glyph 8pt 低对比 | 无附件时整行隐藏并把底 padding 14→8pt；有则 glyph 提到 12pt | 低–中 / 低 |
+| A-3 | `TimelineRow.swift` 标记 L666–727 | 日/周/月/年标记均实心 accent，暗背景下定义感弱 | 周/月/年改 1.2pt 描边无填充，日保持实心点，增强层级与暗色对比 | 低–中 / 中 |
+| A-4 | `TodayView.swift` 多选工具条 L457–463 | padding 上 8 下 4 不对称、无分隔，浮空感 | 上下统一 12pt + 底部 0.5pt borderSubtle 分隔线落地 | 低 / 低 |
+
+---
+
+## 七、建议落地顺序
+
+1. **P0-2 Reduce Motion 合规** + **P0-4 录音脉冲**（同一文件，合并一个无障碍 PR）。
+2. **P0-1 Motion token 集中化**（低成本、全局观感提升的基础设施，先做能让后续调参收敛）。
+3. **P0-3 键盘聚焦** + **P0-5 长按反馈**（输入主路径手感）。
+4. **D-1 横幅密度**（小屏关键回归）。
+5. **M-2 Elevation 统一** + **M-3 玻璃高光**（视觉语言基础）。
+6. **O-1 滑动收敛**（需设计评审，操作模型变更，单独 Issue 深入讨论）。
+7. 其余细节项可打包成「polish sweep」批量 PR。
+
+> 注：O-1 / D-2 / M-5 涉及交互或架构取舍，建议先各开一个设计 Issue 讨论，不要直接进 polish sweep。

--- a/docs/ux-optimization-audit-2026-06-23.md
+++ b/docs/ux-optimization-audit-2026-06-23.md
@@ -1,0 +1,108 @@
+# DayPage 体验深度优化审计 — 2026-06-23
+
+> 自动化定时任务产出（`daily-ui`）。目标：以极简为核心，优化 **输入体验 / 显示体验 / 操作体验 / 动效 / 细节 / 观感**。
+>
+> 本文是**设计讨论稿**，不是已合入的改动。按 `CLAUDE.md` 约定，设计类改动需先讨论 → 开 issue → 分支实现 → PR。本稿即为「先深度设计并讨论」的输入材料，附带可直接落地的优先级与 token 方案，便于后续逐条转为 issue。
+>
+> 审计基于当前源码（非设计稿），覆盖 `DesignSystem/*`、`Features/Today/*` 及 Archive / Graph / Daily / Entity / Root / Sidebar。所有条目均带具体文件与符号定位。
+
+---
+
+## 一、核心结论
+
+设计系统已相当成熟：Motion / Haptics / Colors / Radius / Spacing 等 token 齐备，且 ~80% 的界面正确使用。**体验上的「不够极简、不够顺滑」并非缺少基础设施，而是三类系统性裂缝：**
+
+1. **Token 渗漏（最高频问题）** — 圆角（硬编码 `0 / 6 / 8 / 12 / 14`）、阴影/蒙层不透明度、字号字距在各文件零散硬编码，绕过了已有 token。这是「观感不统一」的根因。
+2. **动效与触感不对称** — 进入/退出曲线不一致；同类交互有的给 haptic、有的不给；个别 transition 退化为默认 `linear`。这是「不够顺滑、缺少高级感」的根因。
+3. **缺少几个语义 token** — 不透明度（placeholder / scrim / shadow 分级）、几个专用动画（caretBlink / ringStroke），导致开发者「只能硬编码」。补齐后能从源头堵住裂缝。
+
+**建议路线：先做一次「token 收口 + 动效统一」的低风险打磨（P0/P1），再做少量「质感升级」的有设计含量的改动（P2）。** P0/P1 几乎纯属一致性重构，风险低、收益直接体现在「极简、统一、顺滑」。
+
+---
+
+## 二、按主题的优化清单
+
+### A. 极简与观感（视觉收口）
+
+最影响「干不干净、统不统一」的一组。核心是**消灭硬编码圆角，统一到 `DSRadius`**：
+
+- 锐角矩形（`cornerRadius(0)`）出现在 `EntityPageView` 类型徽章（L239-240）、metaChip（L274-277）、relatedMemo 背景（L359）与 `DailyPageView` 分段控件（L305）。在 v4 Liquid Glass 语言下，连续小圆角比锐角更高级；建议至少 `DSRadius.xs`。
+- 散落圆角：`ArchiveView` 日历格 `6`（L1051）、`GraphView` 匹配导航按钮 `8`（L218）与 zeroMatch toast `14`（L1062）、`MemoCardView` 照片缩略图/位置卡 `12`（多处）、`DailyPageView` sourceSignals `18`（L376）。统一映射到 `DSRadius.xs/sm/md/lg`，并为照片缩略图新增 `DSRadius.photoThumbnail = 12`。
+- 装饰渐变硬编码 hex：`SidebarView` 头像渐变 `#C9A677 → #5D3000`（L157）。抽成语义色 `DSColor.avatarGradient`。
+- 蒙层不透明度不一致：`RootView` 侧栏 scrim `0.28`（L151）vs 反馈面板 scrim `0.42`（L175）。统一为 `DSColor.scrimOpacity`（建议单一值，或 `scrim.light/heavy` 两档）。
+- 字距/字号硬编码：`EntityPageView` section `.kerning(3)`（L291）与 `ArchiveView` 的 `.tracking()` 不统一；`TimelineSectionView` nameplate 字号 `9.5/13`（L294-304）、`DailyPageView` source label `.tracking(1.6)`（L363）。统一走 `DSType` 语义样式（如 `DSType.sectionLabel` / 新增 `timelineWeekday`）。
+
+### B. 输入体验
+
+- **聚焦时序**：`InputBarV4` 在 `requestFocusToggle` 同一 tick 内触发 morph + focus（L354-356），键盘上升与 spring 易叠帧产生 jank。复用 `WriteSheetView` 已验证的「延迟 ~80ms 聚焦」模式（WriteSheetView L245-248），并把该模式注释化为团队约定。
+- **行数限制硬编码**：`InputBarV4` `.lineLimit(1...8)`（L682）、`WriteSheetView` `.lineLimit(3...10)`（L451）。提为 `InputLimits` token，便于统一调参。
+- **占位符可读性**：`InputBarV4` 斜体 serif 占位符在同字号下偏难读（L441）；占位符不透明度多处硬编码（WriteSheet L438-440 `0.6`）。新增 `DSOpacity.placeholder` 并统一。
+- **极简取舍**：`InputBarV4` dock 垂直 padding 上 10 下 14（L256-261）不对称且意图不明，建议对称化或注明意图。
+
+### C. 显示体验
+
+- **数字滚动**：`UndoPillView` 倒计时环平滑滑动但秒数整跳（L111-134），节奏割裂。改用 `.contentTransition(.numericText())`（iOS 16+）让数字平滑过渡。
+- **Orb 收起锚点**：`TodayView` orb 退出用 `.scale` 但锚点 `.top`（L449），小屏会「向上捏」而非均匀缩小；改 `.center`。
+- **打字机节奏**：`AISummaryCard` TypewriterText 抖动速率硬编码（L238-240），且需确认 reduce-motion 下确实被 `animated:` 关闭（L42-48）。caret 闪烁动画硬编码 `easeInOut 0.5`（L213-215）→ 提为 `Motion.caretBlink`。
+- **深度层级**：`MemoCardView` 顶部语音/照片行与底部 meta 行阴影不一致（L286），需统一 elevation 语义。
+
+### D. 操作体验（反馈与触感）
+
+- **缺触感的同类操作**：`TimelineSectionView` 「复制摘要」静默无反馈（L397）→ 补 `Haptics.soft()` + 1.5s「已复制」toast；`MemoCardView` 语音播放按钮在播放真正开始前无 haptic（L743 vs L909）；`CompileFooterButton` 按压 scale 0.96 但无 haptic（L129）。
+- **缺按压态**：`TimelineSectionView` 行点击（L346-352）、`InputBarV4` 加号按钮（L420-426）按下时无 scale/opacity 反馈。统一走 `PressableCardModifier` / `scaleEffect(isPressed)`。
+- **可发现性**：`SwipeableMemoCard` 滑动与长按 contextMenu 并存但长按难被发现（L268）；首次可给一次性轻提示。armed 与 fully-revealed 两态目前无视觉区分（L416 vs L433）。
+
+### E. 动效统一（曲线一致性）
+
+- **进/出不对称**：`TodayView` scroll-to-top 出现/消失同曲线、退出无滑出（L553）→ 退出改 `.move(edge: .bottom)` 非对称 transition；`SwipeableMemoCard` spring `0.28` vs reduced `0.22` 等多处「进 spring / 出 easeOut」时长不一，需统一或明确注明。
+- **弹簧曲线不统一**：`GraphView` ClearFiltersPressStyle `response 0.3/damp 0.7`（L1243）vs 通用按钮 `0.25/0.85`；`InputBarV4` 录制面 `0.32/0.85`（L396）vs dock morph `0.3`。收敛到 `Motion.spring` 或少数命名曲线。
+- **退化为 linear**：`UndoPillView` 环 stroke 动画未指定曲线（L47），环颜色 amber↔error 瞬切无过渡（L148-151）；`InputBarV4` too-short toast 用泛型 `easeInOut 0.2`（L311）→ 改 `Motion.fade`。
+- **reduce-motion 覆盖不全**：`GraphView` zoomIndicator 用非标准 `.default.speed(0)` 兜底（L829）；`ArchiveView` filter chip 用 `Motion.spring` 而按压态走 `respectReduceMotion`（L1268）。统一经 `Motion.respectReduceMotion(_:)` / `dsAnimation`。
+- **离场未取消**：`ArchiveView` `todayPulse` 呼吸动画切 tab 不停止（L699），应在 `onDisappear` 取消。
+
+### F. 细节 / 杂项
+
+- 多处硬编码字体 `.custom("Inter-Medium", size: …)`（UndoPill L50、SwipeAction L599、CompileFooter L64 等）→ 走 `DSType`。
+- 硬编码中文串未本地化：`CompileFooterButton` 「编译今日 · N 条」（L108）。
+- 魔法数命名化：swipe 阈值 `28`（UndoPill L82）、可见阈值 `0.02`（SwipeableMemoCard L521）、时段边界 `5..12/12..18`（CompileFooter L173）、spine 像素对齐 `-0.25`（TimelineSection L69）。
+
+---
+
+## 三、建议新增的设计 token（堵源头）
+
+```
+DSRadius.photoThumbnail = 12          // 照片/缩略图统一圆角
+DSOpacity.placeholder                 // 占位符文本
+DSOpacity.scrim (light / heavy)       // 模态/侧栏蒙层
+DSOpacity.shadow (subtle / glow)      // 阴影分级，替代散落的 0.04 / 0.6
+DSColor.scrimOpacity                  // 收口 RootView 两处 scrim
+DSColor.avatarGradient                // 替代 Sidebar 内联 hex
+Motion.caretBlink                     // AISummaryCard 光标
+Motion.ringStroke                     // UndoPill 进度环 stroke/颜色
+DSType.timelineWeekday / timelineMonthDay / swipeActionLabel
+InputLimits.composerMaxLines / writeSheetMin/Max
+```
+
+补齐后，第二节大量「硬编码」条目可被机械替换，且新代码无处可硬编码。
+
+---
+
+## 四、优先级与落地建议
+
+**P0 — 视觉收口（低风险、收益最直接，建议先做）**
+统一所有硬编码圆角到 `DSRadius`；新增并替换圆角/不透明度 token；收口两处 scrim；头像渐变改语义色。纯一致性重构，无行为变更，最能体现「极简、统一」。
+
+**P1 — 动效与触感统一（中低风险）**
+统一弹簧曲线到 `Motion.spring`；补齐缺失 haptic 与按压态；修复退化为 linear 的 transition；reduce-motion 全覆盖；scroll-to-top / orb 等进出场打磨。直接体现「顺滑」。
+
+**P2 — 质感升级（需设计含量，单独 issue 讨论）**
+倒计时数字 `numericText` 平滑、打字机节奏、swipe armed/revealed 双态视觉、深度层级统一。每项单独开 issue 配视觉对比。
+
+**建议拆分为 3 个 issue（P0 / P1 / P2）**，P0 与 P1 可各自一个 PR 批量推进；P2 逐项小 PR。每个 PR 按 `CLAUDE.md`：iPhone 17 模拟器构建 + 跑测 + 截图核验，并 link 对应 issue。
+
+---
+
+### 自动化运行说明
+- 本次为无人值守定时任务，未对源码做任何写入；仅产出本审计稿（符合「设计改动需先讨论/开 issue」约定与 write-action 限制）。
+- 所有定位行号基于本次读取的当前源码，后续若有改动需复核。
+- 未自动创建 GitHub issue（属 write 操作且需你确认拆分粒度）；如需，我可据第四节直接生成 3 个 issue 草稿。

--- a/docs/ux-polish-audit-2026-06-23.md
+++ b/docs/ux-polish-audit-2026-06-23.md
@@ -1,0 +1,227 @@
+# DayPage 体验精修审计 — 2026-06-23
+
+> 自动化「daily-ui」运行产物。目标：以**极简**为方向，优化输入体验、显示体验、操作体验、动效与细节观感。
+>
+> **重要说明**：本次运行在 Linux 沙箱中，无法执行 `xcodebuild` / 模拟器验证，因此**未直接改动源码**。按项目规范（设计改动需先讨论 → 开 issue → 分支实现 → 测试验证 → PR），这里输出的是一份**已基于真实源码逐行核对**的、可直接拆成 issue 的精修清单。每条都标注了文件与行号、风险等级、以及具体改法。
+
+当前代码库已经非常成熟：`Motion` 动效令牌、5 级 `Haptics` 触觉阶梯、`reduceMotion` 全面降级、波形/缩略图的滚动性能优化都已到位。下面的建议都是**在这个高完成度基线上的“最后 5%”打磨**，而不是补基础。
+
+---
+
+## P0 — 高性价比、低风险（建议优先做）
+
+### 1. 静止 dock 的光标常驻闪烁是视觉噪声
+`InputBarV4.swift:439-443` + `BlinkingModifier`（8-26 行）
+
+首页输入坞中央的「记下此刻」后面跟着一个**永远在闪**的琥珀竖条（`.repeatForever()`）。在一个主打「极简、留白、博物馆式安静」的首页上，一个停不下来的闪烁点会持续把视线拽过去，和整体气质相悖。
+
+**改法（任选其一，由轻到重）：**
+- 最小改动：把闪烁频率放慢并降低对比 —— `easeInOut(duration: 0.6)` → `1.1s`，竖条不透明度从 `0.5` 降到 `0.35`，让它像「呼吸」而非「闪烁」。
+- 更彻底：静止态不画光标，仅在用户开始聚焦/展开 composer 时才出现光标。静止坞用一个**不动**的细竖条作为「可写入」的隐喻即可。
+
+风险：极低（纯视觉）。收益：直接提升首页「静」的观感。
+
+### 2. 发送按钮的「呼吸」动画在不需要它的状态也一直跑
+`InputBarV4.swift:889-934`
+
+`startBreathing()` 启动一个 `Motion.breathing`（`repeatForever`）动画，并在 `onAppear` + 每次 `affordance` 变化时重启。但 `breathingOpacity` 只有 `.empty` 和 `.multimodal` 两个形态在视觉上用到（`.textOnly/.textAndPhoto/.locationOnly` 用的是实心白/实心琥珀，看不到呼吸）。也就是说，用户在打字时（`.textOnly`）后台仍有一个无意义的 `repeatForever` 动画在驱动状态变化，徒增合成与潜在耗电。
+
+**改法：** 仅在 `affordance == .empty || affordance is .multimodal` 时调用 `startBreathing()`；其它形态显式把 `breathingOpacity` 复位为 `1.0` 并停止呼吸。
+
+风险：低。收益：省一个常驻动画 + 语义更干净。
+
+### 3. 删除已确认的死代码，减少认知负担
+`InputBarV4.swift`
+
+经 grep 全仓确认以下成员**仅在本文件内被引用/注释**，无任何外部调用：
+- `composingCardMorph`（617-753 行）及其专属子视图链
+- `dockSideButton`（481-499 行）
+- `dockTextButton`（503-520 行）
+
+文件头注释（238-248 行）已写明 `composingCardMorph` 是「故意保留的死代码，下一轮清除」。本轮可以执行这次清除：InputBarV4 会从 ~1200 行瘦到约 850 行，富文本编辑唯一入口是 `WriteSheetView`，删除后行为不变。
+
+风险：低（删除未引用代码；删前用 `grep` 复核一次即可）。收益：可维护性、二进制体积、阅读成本。
+
+---
+
+## P1 — 操作体验缺口（用户会期待但目前没有）
+
+### 4. 全屏看图缺少「双击放大/还原」
+`MemoCardView.swift:418-547`（`PhotoFullScreenViewer`）
+
+现在支持捏合缩放 + 下滑关闭，但**没有双击缩放**——这是 iOS 用户对全屏图片的肌肉记忆。Graph/TodayView 里都已用到 `TapGesture(count: 2)`，这里却独缺。
+
+**改法：** 加一个 `onTapGesture(count: 2)`：当前 `scale<=1` 时双击放大到 `2.0` 并以点击点为锚点；否则回到 `1.0` 复位 `offset`，全部走已有的 `spring(response:0.3, dampingFraction:0.75)` 并尊重 `reduceMotion`。
+
+风险：低（与现有手势 `SimultaneousGesture` 共存，注意手势优先级）。收益：明显补齐预期交互。
+
+### 5. 竖图被强制 4:5 裁切，宽图会丢内容
+`MemoCardView.swift:1236-1241`（`PhotoThumbnailView`）
+
+时间线为了统一节奏，把所有缩略图 `aspectRatio(contentMode: .fill)` 进 4:5 竖框再 `.clipped()`。对竖构图照片很好，但**横构图/全景照片会被裁掉两侧主体**，用户在卡片上看不到自己拍的东西。
+
+**改法：** 按原图宽高比分流——竖图维持 4:5 fill 裁切；横图改用 `contentMode: .fit` 配一个最大高度（如 220pt）做信箱式留边，既保住节奏上限又不切主体。可读 EXIF/像素尺寸或 `UIImage.size` 判断方向。
+
+风险：中（要测各种比例 + iCloud 占位态）。收益：内容完整性，避免「拍了但看不到」。
+
+### 6. 附件菜单 → 相册选择器之间有硬编码 0.35s 延迟
+`InputBarV4.swift:318-322`
+
+为了让 popover 关闭动画跑完再弹系统相册，用了 `asyncAfter(deadline: .now()+0.35)`。功能没问题，但 0.35s 的「点了没反应」在快速操作时会被感知为卡顿。
+
+**改法：** 改用 `sheet` 的 `onDismiss` 回调来串联（popover 真正 dismiss 后再翻 `showPhotosPicker`），用事件代替定时器，既消除魔法数字也让转场更跟手。
+
+风险：低。收益：操作跟手度。
+
+---
+
+## P2 — 细节与一致性（锦上添花）
+
+### 7. 发送按钮的同一动画被声明了两次
+`InputBarV4.swift:920`（外层 ZStack）与 `1180`（`SendAffordanceIcon` 内部）都对 `value: affordance` 加了 `.animation(Motion.spring, …)`。嵌套的相同隐式动画会让 SwiftUI 对同一变化跑两层插值。建议只在外层保留一处，内层移除，形态切换更利落。风险：低。
+
+### 8. 触觉阶梯里 `rigid(intensity:)` 似乎未被调用
+`Haptics.swift:25-27` 暴露了带强度的 `rigid`，注释举例「caret 首次出现用 0.3」。值得 grep 一遍调用点（本轮未逐一核）——若确实没接线，要么补上「光标首次出现的 0.3 轻触」这一处设计意图，要么从公共 API 收掉，避免「定义了但没用」的语义债。风险：低。
+
+### 9. 两个 toast 用手写 `Task.sleep` 计时器
+`InputBarV4.swift:1013-1039`（`flashTooShortToast` / `flashMicHintToast`）逻辑正确且互斥处理得当，但两段几乎重复。可抽一个 `flashToast(_ kind:duration:)` 收敛重复，降低后续改文案/时长时漏改一处的风险。风险：极低（纯重构）。
+
+### 10. 卡片底部时间戳的「·」分隔是好细节，但可统一
+`MemoCardView.swift:294` 用 `15·23` 替换 `:`，很有「博物馆标签」味道。location 卡（129 行）和 voice 卡用的是相对时间。建议确认整条时间线**同一屏内时间表达一致**（要么都精确点分、要么都相对），避免一屏内两种时间语言并存。风险：低（纯设计决策，建议先和你确认）。
+
+---
+
+## 建议的落地顺序
+
+1. **先开一个 issue：「输入坞静止态观感精修」**，覆盖 #1（光标闪烁）+ #2（呼吸动画）+ #3（死代码清理）——同属 InputBarV4，一个分支一次 PR 最经济。
+2. **再开一个 issue：「全屏看图与缩略图交互补齐」**，覆盖 #4（双击放大）+ #5（横图裁切）。
+3. P2 项可作为「体验细节收口」攒到一个 chore PR。
+
+每个 PR 按 `CLAUDE.md` 流程：`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'` 构建 + 跑测试 + iPhone 17 模拟器肉眼验证后再合。
+
+---
+
+*本审计基于以下文件的逐行阅读：`DesignSystem/Motion.swift`、`DesignSystem/Interactions.swift`、`DesignSystem/Haptics.swift`、`Features/Today/InputBarV4.swift`、`Features/Today/MemoCardView.swift`，并用全仓 grep 核实了死代码与缺失交互。所有行号对应 2026-06-23 main 分支（HEAD 7d14e79）。*
+
+---
+
+## 进度更新 — Day 2（同日第二轮 daily-ui 运行）
+
+### 已落地
+- **P0 #1 + #2 已提交**：分支 `polish/calm-input-bar-ambient-motion`，commit `df9d695`
+  —— 静止光标由「硬闪」改为「慢呼吸」（1→0.3 / 1.1s，竖条 0.5→0.35）；发送按钮的 `repeatForever` 呼吸动画收敛到唯一会渲染它的两个形态（`.empty` / `.multimodal`），其它形态复位为实心并尊重 Reduce Motion。
+- **P1 #4 已应用（待编译验证）**：`MemoCardView.swift` 的 `PhotoFullScreenViewer` 新增 `.onTapGesture(count: 2)` —— 双击在 1x↔2x 间切换，复用既有 `spring(response:0.3, dampingFraction:0.75)` 并尊重 Reduce Motion。采用**居中缩放**而非「锚定点击点」，以避免引入 `GeometryReader` 坐标换算，换取在无编译器环境下的稳妥落地（锚点版可作为后续增强）。已对该 struct 做括号/花括号配平校验（31/31、57/57）。
+
+### 本轮环境限制（重要）
+本轮运行在 Linux 沙箱：**无 `xcodebuild` / 模拟器**，且仓库 `.git/index.lock` 被宿主进程占用、沙箱内无权删除 —— 因此**无法 commit、无法构建、无法跑测试**。已应用的 #4 改动以**工作区未提交修改**形式留在 `MemoCardView.swift`，待具备构建能力的环境接手。
+
+> 收尾动作（请在宿主端 / 可构建环境执行）：
+> 1. `InputBarV4.swift` 的暂存区处于「staged 还原 + unstaged 重应用」的纠缠态，净结果等于 HEAD。锁释放后执行 `git restore --staged DayPage/Features/Today/InputBarV4.swift` 即可清理为干净工作区（文件内容不变，仍是已抛光版本）。
+> 2. 构建 + 测试 + iPhone 17 模拟器肉眼验证 #4 后再提交：`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'`。
+
+### 下一批：可直接套用的补丁（turnkey）
+
+**#7 — 删除重复的隐式动画（最低风险，一行删除）**
+`InputBarV4.swift:926`（外层 ZStack）与 `:1203`（`SendAffordanceIcon` 内部）对同一 `value: affordance` 各声明了一次 `.animation(Motion.spring, …)`，导致同一变化跑两层插值。**保留 926 外层，删除 1203 内层**即可让形态切换更利落。
+> 本轮未改动 `InputBarV4.swift`，因其暂存区处于纠缠态且 git 被锁；待锁释放、按上面步骤 1 清理后再删 1203 行，避免在混乱索引上叠加 diff。
+
+**#5 — 横构图缩略图按比例分流（中风险，需编译验证）**
+`MemoCardView.swift` 的 `PhotoThumbnailView`（约 1236–1241）当前对所有缩略图强制 4:5 fill 裁切，横图会被切掉两侧主体。建议按 `UIImage.size` 方向分流：竖图维持 4:5 fill；横图改 `.fit` + 最大高度（如 220pt）信箱式留边。因为两分支返回的视图类型不同，需用 `@ViewBuilder` 或显式包裹，且涉及 iCloud 占位态，**必须在模拟器编译验证**，故本轮仅出规格、不盲改。建议草案：
+> 给 `thumbnail: UIImage?` 增加方向判断（`thumb.size.width > thumb.size.height * 1.1` 视为横图）；横图分支用 `.aspectRatio(contentMode: .fit).frame(maxHeight: 220).frame(maxWidth: .infinity)`，竖图分支保持现状；两分支置于 `@ViewBuilder` 计算属性内。占位 `Rectangle` 维持 4:5 以稳住加载期布局节奏。
+
+**#3 — 死代码清理（低风险但量大，需编译器兜底）**
+`composingCardMorph`（617–753）、`dockSideButton`（481–499）、`dockTextButton`（503–520）经 grep 仅本文件内引用。删除约 350 行、行为不变。**因跨越多个子视图链、且无编译器兜底，本轮不在沙箱执行**，留给可构建环境一次删除 + 构建确认。
+
+### 状态小结
+| 项 | 状态 |
+|---|---|
+| P0 #1 光标呼吸 | ✅ 已提交（df9d695） |
+| P0 #2 发送呼吸门控 | ✅ 已提交（df9d695） |
+| P0 #3 死代码清理 | 📋 规格就绪，待可构建环境 |
+| P1 #4 双击放大 | 🟡 已应用，待编译/模拟器验证 |
+| P1 #5 横图裁切 | 📋 规格就绪（中风险，需验证） |
+| P2 #7 重复动画 | 🟡 已应用（工作区），待编译验证 |
+| P2 #9 toast 抽取 | 📋 见上文 P2 #9 |
+
+---
+
+## 进度更新 — Day 3（同日第三轮 daily-ui 运行）
+
+### 本轮落地
+- **P2 #7 已应用**：`InputBarV4.swift` 的 `SendAffordanceIcon` 内层 `.animation(Motion.spring, value: affordance)`（原 1203 行）已删除，改为注释说明。外层按钮（926 行）的同一隐式动画继续覆盖该子视图，因此形态切换行为不变，只是不再对同一变化做两层插值——morph 更利落。已做校验：全文件 `{}`/`()`/`[]` 配平（185/185、632/632、18/18），且全仓 `.animation(Motion.spring, value: affordance)` 现仅余 926 一处（1204 为注释引用）。
+
+### 本轮工作区净状态（vs HEAD `df9d695`）
+| 文件 | 改动 | 项 | 状态 |
+|---|---|---|---|
+| `MemoCardView.swift` | +19 | P1 #4 双击放大 | 待编译验证 |
+| `InputBarV4.swift` | +4/-1 | P2 #7 去重复动画 | 待编译验证 |
+
+> 注：此前提到的 `InputBarV4.swift` 暂存区「纠缠态」已在本轮清理（`git restore --staged` 仍因锁失败，但通过 `git diff HEAD` 确认其内容净等于 HEAD，本轮 #7 是在干净基线上的唯一改动）。
+
+---
+
+## 校验补遗 — Day 3.5（验证轮）
+
+本轮无新增源码改动，专注于把前几轮结论钉死，降低宿主端接手的复核成本。
+
+### 已核实
+- **工作区净 diff（vs HEAD）干净且就是 #4 + #7**：`git diff HEAD --stat` = `MemoCardView.swift +19`、`InputBarV4.swift +4/-1`，合计 `+23/-1`，无任何夹带改动。`PhotoFullScreenViewer` 结构体配平复核通过（`{}` 31/31、`()` 57/57）。
+- **审计 #8 关闭（非死代码，已接线）**：grep 全仓 `Haptics.rigid(intensity:)` 共 **12 处真实调用**——`ArchiveView`(626/877/934)、`UndoPillView`(125, 按剩余秒数 0.6/0.3)、`TodayView`(558/2547/2732/2883, 多处按 milestone 递增强度)、`GraphView`(1117)、`EmptyStateView`(84/88/92, 阶梯 0.25/0.35/0.45)。带强度的 `rigid` API 设计意图已充分落地，**从开放清单移除 #8，无需动作**。
+
+### 仍被阻塞（与前轮相同，非本轮可解）
+- `.git/index.lock` 仍被宿主进程持有，沙箱 `rm` 报 `Operation not permitted` → **`git reset` / `git commit` 在沙箱内不可用**；索引仍处 `MM` 态（暂存区内容与 HEAD 不同，但工作区净 diff 已确认干净）。
+- 无 `swift`/`swiftc`/`xcodebuild` → **无法编译、无法跑测试、无法模拟器验证**。
+
+### 宿主端一步到位收尾（可直接粘贴）
+```bash
+cd <repo> && rm -f .git/index.lock
+git checkout -- . 2>/dev/null; git diff HEAD --stat          # 应为 +23/-1，仅 #4 + #7
+xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build
+# 模拟器肉眼验证：全屏看图双击 1x↔2x；发送按钮形态切换利落无双重插值
+git add DayPage/Features/Today/MemoCardView.swift DayPage/Features/Today/InputBarV4.swift
+git commit -m "polish(today): double-tap zoom in photo viewer (#4) + drop duplicate send-icon animation (#7)"
+```
+
+### 开放清单现状
+| 项 | 状态 |
+|---|---|
+| P1 #4 双击放大 | 🟡 工作区就绪，待宿主编译/模拟器验证后提交 |
+| P2 #7 去重复动画 | 🟡 工作区就绪，待宿主编译验证后提交 |
+| P0 #3 死代码清理（~350 行） | 📋 规格就绪，需编译器兜底 |
+| P1 #5 横图裁切分流 | 📋 规格就绪，中风险，需编译验证 |
+| P1 #6 附件→相册 0.35s 定时器改 `onDismiss` | 📋 待编译验证 |
+| P2 #9 两个 toast 抽公共 helper | 📋 纯重构，待编译验证 |
+| P2 #8 `rigid` 未接线 | ✅ 已关闭（实为 12 处已接线，误报） |
+
+### 环境限制（同前两轮，未变）
+Linux 沙箱：**无 `xcodebuild` / 模拟器**，`.git/index.lock`（宿主 Jun 22 18:31 持有）沙箱内无权删除 → **无法 commit / build / test**。本轮 #4、#7 改动以**工作区未提交修改**形式留在源文件，等待可构建环境接手。
+
+> 宿主端收尾（一次性）：
+> 1. 释放 `.git/index.lock` 后，工作区即为：`MemoCardView.swift`（#4）+ `InputBarV4.swift`（#7）两处净改动。
+> 2. `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'` 构建 + 跑测试，iPhone 17 模拟器肉眼验证双击放大 / 发送按钮形态切换。
+> 3. 通过后提交并按 `CLAUDE.md` 流程开 PR（关联「输入坞静止态观感精修」「全屏看图交互补齐」两个 issue）。
+
+> ⚠️ 累计提醒：连续三轮的精修改动（#4、#7）仍**滞留为未提交工作区修改**，因沙箱无法 commit。建议尽快在可构建环境 build + 验证 + 提交，避免分支与 main 进一步分叉、改动越积越难回归。
+
+---
+
+## 进度更新 — Day 4（再次运行 daily-ui）
+
+### 本轮动作：独立复核，不新增改动
+环境与前三轮完全一致（Linux 沙箱无 `xcodebuild`，`.git/index.lock` 宿主持有、无权删除 → 无法 commit/build/test）。判断：**已有 #4、#7 两处改动完整且高价值，再叠加第四处未经编译验证的改动只会加重宿主端的解缠与回归负担**，违背「深度、克制的精修」初衷。因此本轮**不改源码**，改为对既有改动做一次独立完整性复核：
+
+- **括号配平复核（全文件级）**：
+  - `InputBarV4.swift` —— `()` 632/632、`{}` 185/185、`[]` 18/18，均平衡。
+  - `MemoCardView.swift` —— `()` 755/755、`{}` 285/285、`[]` 25/25，均平衡。
+- **作用域复核（#4 双击放大）**：`PhotoFullScreenViewer` 内 `reduceMotion`(424)、`scale`(429)、`lastScale`(430)、`offset`(431)、`lastOffset`(432)、`minScale`(434)、`maxScale`(435=4.0) 全部已声明并在作用域内；双击目标 `scale = 2.0` < `maxScale` 4.0，不越界；复用既有 `spring(response:0.3, dampingFraction:0.75)` 并尊重 Reduce Motion。
+- **去重复核（#7）**：全仓 `.animation(Motion.spring, value: affordance)` 现仅外层一处生效，内层已转注释。
+- **vs HEAD `df9d695` 净 diff 复核**：仅 `MemoCardView.swift`（+19）与 `InputBarV4.swift`（+4/-1）两文件，与 Day 3 记录一致，无意外漂移、无新增脏文件。
+
+**结论：两处改动经静态复核均无可见缺陷，处于「build-ready，仅差一次编译 + 模拟器肉眼验证」的状态。**
+
+### 🚩 升级提醒（给宿主/可构建环境）
+精修已**连续四轮**卡在同一处：沙箱无法 commit/build。源码层面无需再做任何事，瓶颈纯粹在环境。**唯一需要的人工动作**是在能跑 Xcode 的环境里走一遍下述三步，即可把这批打磨落地：
+
+1. 释放 `.git/index.lock`；工作区即为 `MemoCardView.swift`(#4) + `InputBarV4.swift`(#7) 两处净改动。
+2. `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'` 构建 + 跑测试；iPhone 17 模拟器肉眼验证「全屏图双击放大/还原」与「发送按钮形态切换更利落」。
+3. 通过后提交、开 PR（关联两个 issue）。在此完成前，后续每日运行将继续只复核、不叠加，以保持工作区可一次性干净落地。


### PR DESCRIPTION
## 概述

一组低风险、纯视觉的 Today 输入/捕获界面打磨，目标是让首页更安静、更接近「美术馆静止感」，同时补齐照片查看器缺失的 iOS 手势肌肉记忆。依据 `docs/ux-polish-audit-2026-06-23.md`（P0 #1/#2、P2 #7）。

## 改动

### `InputBarV4.swift`
- **闲置 caret 呼吸化**：把永久硬闪烁（opacity 1→0 每 0.6s）换成缓慢低对比「呼吸」（1→0.3 over 1.1s，autoreverse），填充透明度 0.5→0.35。在刻意保持静止的首页上提示「可输入」而不持续拉扯视线。`BlinkingModifier` → `BreathingCaretModifier`。
- **发送按钮氛围动效门控**：`repeatForever` 呼吸动画只在真正渲染它的两个 affordance（`.empty`、`.multimodal`）上运行；实心填充状态打字时不再驱动一个不可见的永久动画，pulse 重置为实心并尊重 Reduce Motion。
- **去掉发送图标内层重复动画**：内层 `SendAffordanceIcon` 的动画与父按钮的 spring 重复，导致同一变化被插值两次；移除后形变只插值一次，更干净利落。

### `MemoCardView.swift`
- **全屏照片双击缩放**：补齐 iOS 肌肉记忆（pinch + swipe-to-dismiss 已有，双击缺失）。居中在 fit(1x) ↔ 2x 间切换，复用现有 snap spring，尊重 Reduce Motion；与已有的双指 pinch 手势可干净组合，互不冲突。

### 文档
- `docs/ux-polish-audit-2026-06-23.md` 等 3 份 UX 审计文档。

## 验证
- ✅ `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` → **BUILD SUCCEEDED**
- 发送/编写逻辑无行为变更，纯视觉与手势层改动。