### PR TITLE
feat(sync): 接通 iOS → web memo 同步

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -99,7 +99,11 @@
 		VES0000001 /* VaultExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = VES1000001 /* VaultExportService.swift */; };
 		VES0000002 /* VaultExportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VES1000002 /* VaultExportServiceTests.swift */; };
 		SQS0000003 /* SyncQueueObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = SQS1000003 /* SyncQueueObserver.swift */; };
+		MSU0000001 /* MemoSyncUploader.swift in Sources */ = {isa = PBXBuildFile; fileRef = MSU1000001 /* MemoSyncUploader.swift */; };
+		SSU0000001 /* SyncSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = SSU1000001 /* SyncSettings.swift */; };
 		NMT0000001 /* NetworkMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = NMT1000001 /* NetworkMonitorTests.swift */; };
+		MSE0000001 /* MemoSyncE2EIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MSE1000001 /* MemoSyncE2EIntegrationTests.swift */; };
+		MST0000001 /* MemoSyncUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MST1000001 /* MemoSyncUploaderTests.swift */; };
 		WRA0000001 /* WeeklyRecapAutoTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = WRA1000001 /* WeeklyRecapAutoTriggerTests.swift */; };
 		A10000043 /* Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000043 /* Interactions.swift */; };
 		A10000045 /* OnThisDayIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000045 /* OnThisDayIndex.swift */; };
@@ -370,7 +374,11 @@
 		VES1000001 /* VaultExportService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultExportService.swift; sourceTree = "<group>"; };
 		VES1000002 /* VaultExportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultExportServiceTests.swift; sourceTree = "<group>"; };
 		SQS1000003 /* SyncQueueObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncQueueObserver.swift; sourceTree = "<group>"; };
+		MSU1000001 /* MemoSyncUploader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSyncUploader.swift; sourceTree = "<group>"; };
+		SSU1000001 /* SyncSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SyncSettings.swift; sourceTree = "<group>"; };
 		NMT1000001 /* NetworkMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitorTests.swift; sourceTree = "<group>"; };
+		MSE1000001 /* MemoSyncE2EIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSyncE2EIntegrationTests.swift; sourceTree = "<group>"; };
+		MST1000001 /* MemoSyncUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSyncUploaderTests.swift; sourceTree = "<group>"; };
 		WRA1000001 /* WeeklyRecapAutoTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapAutoTriggerTests.swift; sourceTree = "<group>"; };
 		A20000043 /* Interactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interactions.swift; sourceTree = "<group>"; };
 		A20000045 /* OnThisDayIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayIndex.swift; sourceTree = "<group>"; };
@@ -764,6 +772,8 @@
 				A20000803 /* RetryHelper.swift */,
 				SQS1000001 /* SyncQueueService.swift */,
 				SQS1000003 /* SyncQueueObserver.swift */,
+				MSU1000001 /* MemoSyncUploader.swift */,
+				SSU1000001 /* SyncSettings.swift */,
 				VES1000001 /* VaultExportService.swift */,
 			);
 			path = Services;
@@ -1080,6 +1090,8 @@
 				SQS1000002 /* SyncQueueServiceTests.swift */,
 				VES1000002 /* VaultExportServiceTests.swift */,
 				NMT1000001 /* NetworkMonitorTests.swift */,
+				MSE1000001 /* MemoSyncE2EIntegrationTests.swift */,
+				MST1000001 /* MemoSyncUploaderTests.swift */,
 				WRA1000001 /* WeeklyRecapAutoTriggerTests.swift */,
 			);
 			path = DayPageTests;
@@ -1395,6 +1407,8 @@
 				A10000803 /* RetryHelper.swift in Sources */,
 				SQS0000001 /* SyncQueueService.swift in Sources */,
 				SQS0000003 /* SyncQueueObserver.swift in Sources */,
+				MSU0000001 /* MemoSyncUploader.swift in Sources */,
+				SSU0000001 /* SyncSettings.swift in Sources */,
 				VES0000001 /* VaultExportService.swift in Sources */,
 				A10000079 /* iCloudSyncMonitor.swift in Sources */,
 				A10000085 /* iCloudConflictMonitor.swift in Sources */,
@@ -1505,6 +1519,8 @@
 				SQS0000002 /* SyncQueueServiceTests.swift in Sources */,
 				VES0000002 /* VaultExportServiceTests.swift in Sources */,
 				NMT0000001 /* NetworkMonitorTests.swift in Sources */,
+				MSE0000001 /* MemoSyncE2EIntegrationTests.swift in Sources */,
+				MST0000001 /* MemoSyncUploaderTests.swift in Sources */,
 				WRA0000001 /* WeeklyRecapAutoTriggerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -73,6 +73,12 @@ struct RootView: View {
                 // pending banner would never drain. Idempotent — subsequent
                 // .onAppear calls hit the already-initialised shared instance.
                 _ = SyncQueueObserver.shared
+
+                // #785: install the real iOS→web uploader when the user has
+                // configured a web endpoint + API key under Settings → 同步.
+                // When unconfigured this leaves the Noop double in place so the
+                // queue still drains locally instead of pretending forever.
+                SyncQueueObserver.shared.installConfiguredUploader()
             }
             .preferredColorScheme(resolvedColorScheme)
             .tint(appSettings.accentColor.color)

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -48,6 +48,14 @@ struct SettingsView: View {
     // iCloud sync monitor
     @StateObject private var syncMonitor = iCloudSyncMonitor.shared
 
+    // #785: iOS → Web sync config. Mirrors SyncSettings (UserDefaults baseURL +
+    // Keychain API key); edits are committed on submit and re-install the
+    // uploader so changes take effect without an app restart.
+    @State private var webSyncBaseURL: String = SyncSettings.baseURLString ?? ""
+    @State private var webSyncAPIKey: String = SyncSettings.apiKey ?? ""
+    @State private var webSyncSaved: Bool = false
+    @StateObject private var syncQueue = SyncQueueService.shared
+
     // Press-to-talk fallback toggle (US-008).
     @AppStorage(AppSettings.Keys.usePressToTalk) private var usePressToTalk: Bool = true
 
@@ -114,6 +122,7 @@ struct SettingsView: View {
                 appearanceSection
                 timeZoneSection
                 iCloudSyncSection
+                webSyncSection
                 dataSection
                 experimentsSection
                 aboutSection
@@ -825,6 +834,93 @@ struct SettingsView: View {
             formatter.dateFormat = "M月d日 HH:mm"
         }
         return formatter.string(from: date)
+    }
+
+    // MARK: - Web Sync Section (#785)
+
+    /// iOS → Web 同步配置。用户在 web Settings → API Keys 生成 `write` scope
+    /// 的 key,这里填 web 地址 + key,App 写的 memo 会自动推送到 web 端。
+    private var webSyncSection: some View {
+        Section {
+            // Web 地址
+            HStack {
+                Label("Web 地址", systemImage: "globe")
+                Spacer()
+                TextField("https://daypage.app", text: $webSyncBaseURL)
+                    .multilineTextAlignment(.trailing)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .keyboardType(.URL)
+                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .accessibilityIdentifier("sync-baseurl-field")
+            }
+
+            // API Key（敏感,用 SecureField）
+            HStack {
+                Label("API Key", systemImage: "key.fill")
+                Spacer()
+                SecureField("粘贴 web 生成的 key", text: $webSyncAPIKey)
+                    .multilineTextAlignment(.trailing)
+                    .textInputAutocapitalization(.never)
+                    .autocorrectionDisabled(true)
+                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .accessibilityIdentifier("sync-apikey-field")
+            }
+
+            // 保存 + 立即同步
+            Button {
+                saveWebSyncConfig()
+            } label: {
+                HStack {
+                    Label(webSyncSaved ? "已保存" : "保存并同步",
+                          systemImage: webSyncSaved ? "checkmark.circle.fill" : "arrow.up.circle")
+                    Spacer()
+                    if SyncSettings.isConfigured {
+                        Text("已配置").font(DSType.labelSM).foregroundColor(.green)
+                    }
+                }
+            }
+            .accessibilityIdentifier("sync-save-button")
+
+            // 待同步状态
+            if syncQueue.pendingCount > 0 {
+                HStack {
+                    Label("待同步", systemImage: "clock.arrow.circlepath")
+                    Spacer()
+                    Text("\(syncQueue.pendingCount) 条")
+                        .font(DSType.labelSM)
+                        .foregroundColor(.orange)
+                }
+            } else if SyncSettings.isConfigured {
+                HStack {
+                    Label("已全部同步", systemImage: "checkmark.icloud")
+                    Spacer()
+                }
+                .foregroundColor(DSColor.onSurfaceVariant)
+            }
+        } header: {
+            Text("同步到 Web")
+        } footer: {
+            Text("在 web 端 设置 → API Keys 生成一个带 write 权限的 key,粘贴到这里。App 写下的 memo 会自动同步到你的 web 账号。")
+                .font(.caption)
+        }
+    }
+
+    /// Commit the sync config to SyncSettings, re-install the uploader, and
+    /// kick a flush so any backlog goes out immediately.
+    private func saveWebSyncConfig() {
+        SyncSettings.baseURLString = webSyncBaseURL
+        SyncSettings.apiKey = webSyncAPIKey
+        // Reflect normalization back into the field.
+        webSyncBaseURL = SyncSettings.baseURLString ?? ""
+        SyncQueueObserver.shared.installConfiguredUploader()
+        webSyncSaved = true
+        Task { await SyncQueueService.shared.flushIfOnline() }
+        // Reset the "已保存" affordance after a beat.
+        Task {
+            try? await Task.sleep(nanoseconds: 1_500_000_000)
+            await MainActor.run { webSyncSaved = false }
+        }
     }
 
     // MARK: - Data Section

--- a/DayPage/Services/MemoSyncUploader.swift
+++ b/DayPage/Services/MemoSyncUploader.swift
@@ -1,0 +1,272 @@
+// MemoSyncUploader.swift — 真实 iOS → Web memo 上传器 (issue #785)
+//
+// 接通此前空转的同步链路: SyncQueueObserver 持有一个 RemoteUploader,过去只有
+// NoopRemoteUploader（假上传）。本文件提供真实实现:
+//
+//   memoID → 扫 vault/raw/*.md 找到对应 Memo → 映射成 web bulk JSON →
+//   POST {baseURL}/api/memos/bulk（Authorization: Bearer <apiKey>）
+//
+// 鉴权: web 端的 /api/memos/bulk 接受用户在 web Settings 生成的 `write` scope
+// API key（详见 docs/ios-web-sync-design.md）。key 的 user_id 决定 memo 落到
+// 哪个 web 账号,无需 Supabase↔NextAuth 桥接。
+//
+// 附件: 第一期只同步元数据（transcript / duration / kind / 路径引用），不传
+// 文件字节。
+//
+// 映射逻辑拆成纯函数 `MemoSyncMapper.bulkItem(from:vaultPath:)` 以便单测,不依赖
+// 网络或文件系统。
+
+import Foundation
+
+// MARK: - Errors
+
+enum MemoSyncError: LocalizedError {
+    case notConfigured
+    case insecureScheme
+    case memoNotFound(String)
+    case invalidResponse
+    case unauthorized          // 401 — key 无效/过期
+    case forbidden             // 403 — key 缺 write scope
+    case rateLimited(retryAfter: Int)
+    case serverError(status: Int)
+    case rejected(reason: String)   // server skipped this memo
+
+    var errorDescription: String? {
+        switch self {
+        case .notConfigured: return "同步未配置"
+        case .insecureScheme: return "同步地址必须使用 https"
+        case .memoNotFound(let id): return "找不到 memo \(id)"
+        case .invalidResponse: return "服务器响应无法解析"
+        case .unauthorized: return "API Key 无效或已过期"
+        case .forbidden: return "API Key 缺少 write 权限"
+        case .rateLimited(let s): return "请求过于频繁,请 \(s) 秒后再试"
+        case .serverError(let code): return "服务器错误 (\(code))"
+        case .rejected(let reason): return "memo 被服务器拒绝: \(reason)"
+        }
+    }
+}
+
+// MARK: - Mapper (pure, testable)
+
+/// Pure transformations from the iOS `Memo` model to the web bulk-sync JSON
+/// shape. No I/O — every input is passed in, so this is trivially unit-testable.
+enum MemoSyncMapper {
+
+    /// Map an iOS `MemoType` to the web schema's enum. The web schema only
+    /// knows text/url/voice/photo/file, so iOS-only cases collapse to `text`.
+    static func webType(for type: Memo.MemoType) -> String {
+        switch type {
+        case .text: return "text"
+        case .voice: return "voice"
+        case .photo: return "photo"
+        case .location: return "text"   // web has no location type
+        case .mixed: return "text"       // web has no mixed type
+        }
+    }
+
+    /// Build the `attachments` array for the bulk payload. Metadata only —
+    /// `storage_key` carries the iOS relative path as a reference; the bytes
+    /// are not uploaded in this phase.
+    static func attachments(from memo: Memo) -> [[String: Any]] {
+        memo.attachments.map { att in
+            var dict: [String: Any] = [
+                // web schema enum: audio|photo|file. iOS uses audio|photo.
+                "kind": att.kind,
+                "storage_key": att.file,
+            ]
+            if let duration = att.duration {
+                dict["duration_sec"] = duration
+            }
+            if let transcript = att.transcript, !transcript.isEmpty {
+                dict["transcript"] = transcript
+            }
+            return dict
+        }
+    }
+
+    /// Build one bulk JSON item from a memo. `vaultPath` is the relative path of
+    /// the .md file the memo lives in (for `vault_path` traceability); pass nil
+    /// when unknown.
+    ///
+    /// `body` is forced non-empty because the web schema requires `min(1)`:
+    /// a pure voice/photo memo with no text falls back to its first transcript,
+    /// then to a localized placeholder.
+    static func bulkItem(from memo: Memo, vaultPath: String?) -> [String: Any] {
+        let iso = ISO8601DateFormatter.memo
+        let createdISO = iso.string(from: memo.created)
+        // updated_at drives the server's last-write-wins; a pinned memo's pin
+        // time is the most recent meaningful mutation we track, else created.
+        let updatedISO = iso.string(from: memo.pinnedAt ?? memo.created)
+
+        var item: [String: Any] = [
+            "id": memo.id.uuidString.lowercased(),
+            "type": webType(for: memo.type),
+            "body": nonEmptyBody(for: memo),
+            "created_at": createdISO,
+            "updated_at": updatedISO,
+            "origin": "ios",
+            "idempotency_key": memo.id.uuidString.lowercased(),
+        ]
+
+        if let vaultPath, !vaultPath.isEmpty {
+            item["vault_path"] = vaultPath
+        }
+        if let device = memo.device, !device.isEmpty {
+            item["device"] = device
+        }
+        if let mood = memo.mood, !mood.isEmpty {
+            item["mood"] = mood
+        }
+        // iOS weather is a free-form string; web schema is an object — wrap it.
+        if let weather = memo.weather, !weather.isEmpty {
+            item["weather"] = ["condition": weather]
+        }
+        if let loc = memo.location {
+            var locDict: [String: Any] = [:]
+            if let lat = loc.lat { locDict["lat"] = lat }
+            if let lng = loc.lng { locDict["lng"] = lng }
+            if let name = loc.name, !name.isEmpty { locDict["address"] = name }
+            if !locDict.isEmpty { item["location"] = locDict }
+        }
+        let atts = attachments(from: memo)
+        if !atts.isEmpty {
+            item["attachments"] = atts
+        }
+        return item
+    }
+
+    /// Web requires a non-empty body. Prefer the memo's own text; for media-only
+    /// memos fall back to the first non-empty transcript, then a placeholder.
+    static func nonEmptyBody(for memo: Memo) -> String {
+        let trimmed = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty { return memo.body }
+        if let transcript = memo.attachments
+            .compactMap({ $0.transcript })
+            .first(where: { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) {
+            return transcript
+        }
+        return "(无文字)"
+    }
+}
+
+// MARK: - Uploader
+
+/// Production `RemoteUploader`. Resolves config from `SyncSettings` at call
+/// time (so the user can configure sync without an app restart), looks the memo
+/// up in the vault, maps it, and POSTs it. Returns the uploaded byte size for
+/// the queue's telemetry.
+struct MemoSyncUploader: RemoteUploader {
+
+    /// Injectable transport so tests can supply canned responses.
+    let transport: HTTPTransport
+
+    init(transport: HTTPTransport = HTTPTransports.shared) {
+        self.transport = transport
+    }
+
+    func upload(memoID: String) async throws -> Int {
+        guard let endpoint = SyncSettings.bulkEndpoint,
+              let apiKey = SyncSettings.apiKey, !apiKey.isEmpty else {
+            throw MemoSyncError.notConfigured
+        }
+
+        // Only allow plaintext http in DEBUG (dogfood on a LAN). Release builds
+        // must use https so the bearer key never crosses the wire in the clear.
+        #if !DEBUG
+        if endpoint.scheme?.lowercased() != "https" {
+            throw MemoSyncError.insecureScheme
+        }
+        #endif
+
+        guard let (memo, vaultPath) = Self.findMemo(byID: memoID) else {
+            // The memo no longer exists in the vault (e.g. user deleted it
+            // before it synced). Don't wedge the queue on a ghost — surface a
+            // typed error and let the caller decide to drop it.
+            throw MemoSyncError.memoNotFound(memoID)
+        }
+
+        let item = MemoSyncMapper.bulkItem(from: memo, vaultPath: vaultPath)
+        let payload: [String: Any] = ["memos": [item]]
+
+        let request = try HTTPClientHelper.bearerJSON(
+            url: endpoint,
+            apiKey: apiKey,
+            timeout: 30,
+            body: payload
+        )
+
+        let (data, response) = try await transport.data(for: request)
+
+        guard let http = response as? HTTPURLResponse else {
+            throw MemoSyncError.invalidResponse
+        }
+
+        switch http.statusCode {
+        case 200...299:
+            try Self.assertAccepted(memoID: memoID, responseData: data)
+            // Report the payload byte size for the queue's running tally.
+            return (try? JSONSerialization.data(withJSONObject: payload).count) ?? 0
+        case 401:
+            throw MemoSyncError.unauthorized
+        case 403:
+            throw MemoSyncError.forbidden
+        case 429:
+            let retry = Int(http.value(forHTTPHeaderField: "Retry-After") ?? "") ?? 60
+            throw MemoSyncError.rateLimited(retryAfter: retry)
+        default:
+            throw MemoSyncError.serverError(status: http.statusCode)
+        }
+    }
+
+    // MARK: Response parsing
+
+    /// The bulk endpoint returns `{ accepted: [...], skipped: [{id, reason}] }`.
+    /// Treat a memo that landed in `skipped` (or in neither list) as a failure
+    /// so the queue retries rather than silently dropping it.
+    static func assertAccepted(memoID: String, responseData: Data) throws {
+        let lowerID = memoID.lowercased()
+        guard let json = try? JSONSerialization.jsonObject(with: responseData) as? [String: Any] else {
+            throw MemoSyncError.invalidResponse
+        }
+        let accepted = (json["accepted"] as? [String])?.map { $0.lowercased() } ?? []
+        if accepted.contains(lowerID) { return }
+
+        if let skipped = json["skipped"] as? [[String: Any]],
+           let mine = skipped.first(where: { ($0["id"] as? String)?.lowercased() == lowerID }) {
+            let reason = (mine["reason"] as? String) ?? "unknown"
+            throw MemoSyncError.rejected(reason: reason)
+        }
+        // Not in accepted and not in skipped — server didn't process it.
+        throw MemoSyncError.rejected(reason: "not acknowledged by server")
+    }
+
+    // MARK: Vault lookup
+
+    /// Find the memo whose frontmatter `id` matches `memoID` by scanning
+    /// vault/raw/*.md. Returns the memo plus its vault-relative path. O(N files)
+    /// but only runs once per memo upload (and the queue is small); mirrors the
+    /// existing `SyncQueueService.estimateMemoSize` scan.
+    static func findMemo(byID memoID: String) -> (Memo, String)? {
+        let rawDir = VaultInitializer.vaultURL.appendingPathComponent("raw", isDirectory: true)
+        let fm = FileManager.default
+        guard let files = try? fm.contentsOfDirectory(
+            at: rawDir,
+            includingPropertiesForKeys: nil,
+            options: [.skipsHiddenFiles]
+        ) else {
+            return nil
+        }
+        let target = memoID.lowercased()
+        // Fast-path filter: only fully parse files whose text mentions the id.
+        for file in files where file.pathExtension == "md" {
+            guard let content = try? String(contentsOf: file, encoding: .utf8),
+                  content.lowercased().contains(target) else { continue }
+            let memos = RawStorage.parse(fileContent: content, sourceFile: file)
+            if let memo = memos.first(where: { $0.id.uuidString.lowercased() == target }) {
+                let relPath = "raw/" + file.lastPathComponent
+                return (memo, relPath)
+            }
+        }
+        return nil
+    }
+}

--- a/DayPage/Services/SyncQueueObserver.swift
+++ b/DayPage/Services/SyncQueueObserver.swift
@@ -66,10 +66,23 @@ final class SyncQueueObserver {
     }
 
     /// Swap in the production uploader. Tests call this with a stub that
-    /// asserts ordering / failure behaviour. The real Supabase service
+    /// asserts ordering / failure behaviour. The real sync service
     /// will call it at app launch, post-AuthService.
     func setUploader(_ uploader: RemoteUploader) {
         self.uploader = uploader
+    }
+
+    /// #785: pick the right uploader based on the user's sync configuration.
+    /// When a web endpoint + API key are present, install the real
+    /// `MemoSyncUploader`; otherwise fall back to the Noop double so the
+    /// pending banner still drains locally without pretending data reached the
+    /// server. Call this at launch and whenever Settings changes the config.
+    func installConfiguredUploader() {
+        if SyncSettings.isConfigured {
+            self.uploader = MemoSyncUploader()
+        } else {
+            self.uploader = NoopRemoteUploader()
+        }
     }
 
     /// Walk every pending ID once. We grab the snapshot up-front so a

--- a/DayPage/Services/SyncSettings.swift
+++ b/DayPage/Services/SyncSettings.swift
@@ -1,0 +1,98 @@
+// SyncSettings.swift — iOS → Web 同步配置 (issue #785)
+//
+// 持有 iOS 把 memo 推送到 web 端所需的两项配置:
+//   - baseURL: web 服务地址（如 https://daypage.app 或 dogfood 的局域网地址）
+//   - apiKey:  用户在 web Settings → API Keys 生成的 `write` scope key
+//
+// 设计要点:
+//   - apiKey 是凭证,存 Keychain（复用 KeychainHelper.setAPIKey/getAPIKey），
+//     绝不落 UserDefaults / 日志 / Sentry。
+//   - baseURL 非敏感,存 UserDefaults。
+//   - 两者任一为空 → `isConfigured == false`,上传层降级为 noop（不报错、不卡队列）。
+//   - 这是 web 端 API Key Bearer 鉴权方案的客户端侧（详见 docs/ios-web-sync-design.md）。
+
+import Foundation
+
+/// Process-wide accessor for the iOS→web sync configuration. Pure value reads
+/// so it can be used from any actor; writes go through UserDefaults / Keychain
+/// which are themselves thread-safe.
+enum SyncSettings {
+
+    // MARK: - Keys
+
+    /// Keychain identifier for the sync API key. Distinct from the AI-provider
+    /// keys managed elsewhere so revoking one never touches the other.
+    static let apiKeyIdentifier = "memoSyncApiKey"
+
+    /// UserDefaults key for the web base URL.
+    private static let baseURLKey = "sync.web.baseURL"
+
+    // MARK: - Base URL
+
+    /// The configured web base URL string, or nil/empty when unset. Trailing
+    /// slashes are trimmed so callers can always append `/api/...` cleanly.
+    static var baseURLString: String? {
+        get {
+            let raw = UserDefaults.standard.string(forKey: baseURLKey) ?? ""
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : normalizeBaseURL(trimmed)
+        }
+        set {
+            let trimmed = (newValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                UserDefaults.standard.removeObject(forKey: baseURLKey)
+            } else {
+                UserDefaults.standard.set(normalizeBaseURL(trimmed), forKey: baseURLKey)
+            }
+        }
+    }
+
+    /// The resolved bulk-sync endpoint URL, or nil when no/invalid base URL is
+    /// configured. Centralised here so the uploader and any future puller agree
+    /// on the path.
+    static var bulkEndpoint: URL? {
+        guard let base = baseURLString, let url = URL(string: base + "/api/memos/bulk") else {
+            return nil
+        }
+        return url
+    }
+
+    // MARK: - API Key
+
+    /// The configured API key, or nil when unset/empty.
+    static var apiKey: String? {
+        get { KeychainHelper.getAPIKey(for: apiKeyIdentifier) }
+        set {
+            let trimmed = (newValue ?? "").trimmingCharacters(in: .whitespacesAndNewlines)
+            if trimmed.isEmpty {
+                KeychainHelper.deleteAPIKey(for: apiKeyIdentifier)
+            } else {
+                KeychainHelper.setAPIKey(trimmed, for: apiKeyIdentifier)
+            }
+        }
+    }
+
+    // MARK: - State
+
+    /// True only when both an endpoint and a key are present. The sync layer
+    /// uses this to decide whether to install a real uploader or stay on the
+    /// noop double.
+    static var isConfigured: Bool {
+        bulkEndpoint != nil && (apiKey?.isEmpty == false)
+    }
+
+    // MARK: - Helpers
+
+    /// Strip a trailing slash and, when no scheme is present, default to https.
+    /// Dogfood users on a LAN can paste `192.168.x.x:3000` and get a usable
+    /// `https://…`; to use plain http they must type the scheme explicitly,
+    /// which the uploader gates behind a DEBUG check.
+    static func normalizeBaseURL(_ input: String) -> String {
+        var s = input
+        while s.hasSuffix("/") { s.removeLast() }
+        if !s.contains("://") {
+            s = "https://" + s
+        }
+        return s
+    }
+}

--- a/DayPageTests/MemoSyncE2EIntegrationTests.swift
+++ b/DayPageTests/MemoSyncE2EIntegrationTests.swift
@@ -1,0 +1,73 @@
+// MemoSyncE2EIntegrationTests.swift — iOS → Web 真实端到端集成测试 (issue #785)
+//
+// 与 MemoSyncUploaderTests 的纯函数测试不同,这里跑**真实的网络往返**:
+// 配置 SyncSettings 指向本地 web,在临时 vault 写一条真实 memo,然后用真实的
+// URLSession transport 调 MemoSyncUploader.upload(),验证 web 回 accepted。
+//
+// 默认 skip——只有设置环境变量后才运行,避免在没有本地 web 的环境（CI、其他
+// 开发者机器）误失败:
+//   SYNC_E2E_URL=http://127.0.0.1:3100
+//   SYNC_E2E_KEY=<web 生成的 write scope key>
+//
+// 跑法:在 scheme 的 Test 环境变量里设上述两项,或:
+//   SYNC_E2E_URL=... SYNC_E2E_KEY=... xcodebuild test \
+//     -only-testing:DayPageTests/MemoSyncE2EIntegrationTests
+//
+// 模拟器与 Mac 共享网络栈,127.0.0.1 在模拟器内即指向 Mac 本机,可直接访问本地
+// web dev server。
+
+import Testing
+import Foundation
+@testable import DayPage
+
+@Suite(.serialized)
+struct MemoSyncE2EIntegrationTests {
+
+    private var envURL: String? { ProcessInfo.processInfo.environment["SYNC_E2E_URL"] }
+    private var envKey: String? { ProcessInfo.processInfo.environment["SYNC_E2E_KEY"] }
+
+    @Test(.enabled(if: ProcessInfo.processInfo.environment["SYNC_E2E_KEY"] != nil))
+    func uploadsRealMemoToLocalWeb() async throws {
+        let baseURL = try #require(envURL, "set SYNC_E2E_URL")
+        let key = try #require(envKey, "set SYNC_E2E_KEY")
+
+        // Isolate a throwaway vault so we don't touch the real one.
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sync-e2e-\(UUID().uuidString)", isDirectory: true)
+        let rawDir = tmp.appendingPathComponent("raw", isDirectory: true)
+        try FileManager.default.createDirectory(at: rawDir, withIntermediateDirectories: true)
+        VaultInitializer.testOverrideURL = tmp
+        defer {
+            VaultInitializer.testOverrideURL = nil
+            try? FileManager.default.removeItem(at: tmp)
+        }
+
+        // Write a real memo into the vault via the same serializer the app uses.
+        let memo = Memo(
+            id: UUID(),
+            type: .text,
+            created: Date(),
+            body: "iOS→web E2E integration \(UUID().uuidString.prefix(8))"
+        )
+        let fileURL = rawDir.appendingPathComponent("2026-06-24.md")
+        try memo.toMarkdown().write(to: fileURL, atomically: true, encoding: .utf8)
+
+        // Snapshot + restore the real sync config so this test can't poison it.
+        let priorURL = SyncSettings.baseURLString
+        let priorKey = SyncSettings.apiKey
+        defer {
+            SyncSettings.baseURLString = priorURL
+            SyncSettings.apiKey = priorKey
+        }
+        SyncSettings.baseURLString = baseURL
+        SyncSettings.apiKey = key
+
+        // Real uploader, real URLSession transport.
+        let uploader = MemoSyncUploader()
+        let bytes = try await uploader.upload(memoID: memo.id.uuidString)
+
+        // A successful upload returns the payload byte size (>0) and the server
+        // acknowledged the memo (no throw from assertAccepted).
+        #expect(bytes > 0)
+    }
+}

--- a/DayPageTests/MemoSyncUploaderTests.swift
+++ b/DayPageTests/MemoSyncUploaderTests.swift
@@ -1,0 +1,227 @@
+// MemoSyncUploaderTests.swift — iOS → Web 同步映射 + 上传逻辑测试 (issue #785)
+//
+// 三层覆盖:
+//   1. MemoSyncMapper 纯函数:Memo → web bulk JSON 的字段映射（类型折叠、
+//      weather 包装、空 body 回退、附件元数据、location 映射）。
+//   2. assertAccepted 响应解析:accepted / skipped / 未确认 三种服务器响应。
+//   3. SyncSettings 配置状态机:baseURL 归一化 + bulkEndpoint 拼接。
+//
+// 完整 upload() 的端到端走真机/模拟器联调（见 PR 描述），这里聚焦不依赖网络与
+// 全局状态的纯逻辑,保证映射正确性可回归。
+
+import Testing
+import Foundation
+@testable import DayPage
+
+@Suite
+struct MemoSyncMapperTests {
+
+    /// Helper: a fully-populated text memo with a fixed UUID/date so assertions
+    /// are deterministic.
+    private func makeMemo(
+        type: Memo.MemoType = .text,
+        body: String = "Hello from iOS",
+        weather: String? = nil,
+        device: String? = nil,
+        mood: String? = nil,
+        location: Memo.Location? = nil,
+        attachments: [Memo.Attachment] = []
+    ) -> Memo {
+        Memo(
+            id: UUID(uuidString: "550E8400-E29B-41D4-A716-446655440001")!,
+            type: type,
+            created: Date(timeIntervalSince1970: 1_750_000_000), // fixed
+            pinnedAt: nil,
+            location: location,
+            weather: weather,
+            device: device,
+            attachments: attachments,
+            mood: mood,
+            entityMentions: [],
+            body: body
+        )
+    }
+
+    @Test func mapsBasicTextMemo() {
+        let item = MemoSyncMapper.bulkItem(from: makeMemo(), vaultPath: "raw/2025-06-15.md")
+        #expect(item["id"] as? String == "550e8400-e29b-41d4-a716-446655440001")
+        #expect(item["type"] as? String == "text")
+        #expect(item["body"] as? String == "Hello from iOS")
+        #expect(item["origin"] as? String == "ios")
+        #expect(item["vault_path"] as? String == "raw/2025-06-15.md")
+        #expect(item["idempotency_key"] as? String == "550e8400-e29b-41d4-a716-446655440001")
+        // created_at must be ISO8601 with fractional seconds.
+        let created = item["created_at"] as? String
+        #expect(created?.contains("T") == true)
+        #expect(created?.hasSuffix("Z") == true)
+    }
+
+    @Test func foldsIOSOnlyTypesToText() {
+        #expect(MemoSyncMapper.webType(for: .text) == "text")
+        #expect(MemoSyncMapper.webType(for: .voice) == "voice")
+        #expect(MemoSyncMapper.webType(for: .photo) == "photo")
+        // web schema has no location / mixed — both collapse to text.
+        #expect(MemoSyncMapper.webType(for: .location) == "text")
+        #expect(MemoSyncMapper.webType(for: .mixed) == "text")
+    }
+
+    @Test func wrapsWeatherStringIntoObject() {
+        let item = MemoSyncMapper.bulkItem(from: makeMemo(weather: "Sunny ☀️"), vaultPath: nil)
+        let weather = item["weather"] as? [String: Any]
+        #expect(weather?["condition"] as? String == "Sunny ☀️")
+    }
+
+    @Test func omitsEmptyOptionalFields() {
+        let item = MemoSyncMapper.bulkItem(from: makeMemo(weather: "", device: "", mood: ""), vaultPath: nil)
+        // Empty strings must not be emitted (they'd fail / pollute the server).
+        #expect(item["weather"] == nil)
+        #expect(item["device"] == nil)
+        #expect(item["mood"] == nil)
+        #expect(item["location"] == nil)
+        #expect(item["attachments"] == nil)
+    }
+
+    @Test func mapsLocation() {
+        let loc = Memo.Location(name: "Paris", lat: 48.8566, lng: 2.3522)
+        let item = MemoSyncMapper.bulkItem(from: makeMemo(location: loc), vaultPath: nil)
+        let mapped = item["location"] as? [String: Any]
+        #expect(mapped?["lat"] as? Double == 48.8566)
+        #expect(mapped?["lng"] as? Double == 2.3522)
+        #expect(mapped?["address"] as? String == "Paris")
+    }
+
+    @Test func emptyBodyFallsBackToTranscript() {
+        let att = Memo.Attachment(
+            file: "raw/assets/voice_x.m4a",
+            kind: "audio",
+            duration: 12.5,
+            transcript: "spoken words here",
+            transcriptionStatus: .done
+        )
+        let item = MemoSyncMapper.bulkItem(
+            from: makeMemo(type: .voice, body: "   ", attachments: [att]),
+            vaultPath: nil
+        )
+        // Web requires min(1) body; empty text falls back to the transcript.
+        #expect(item["body"] as? String == "spoken words here")
+    }
+
+    @Test func emptyBodyNoTranscriptUsesPlaceholder() {
+        let att = Memo.Attachment(
+            file: "raw/assets/img.jpg", kind: "photo",
+            duration: nil, transcript: nil, transcriptionStatus: nil
+        )
+        let item = MemoSyncMapper.bulkItem(
+            from: makeMemo(type: .photo, body: "", attachments: [att]),
+            vaultPath: nil
+        )
+        #expect(item["body"] as? String == "(无文字)")
+    }
+
+    @Test func mapsAttachmentMetadataOnly() {
+        let audio = Memo.Attachment(
+            file: "raw/assets/v.m4a", kind: "audio",
+            duration: 8.0, transcript: "hi", transcriptionStatus: .done
+        )
+        let item = MemoSyncMapper.bulkItem(from: makeMemo(attachments: [audio]), vaultPath: nil)
+        let atts = item["attachments"] as? [[String: Any]]
+        #expect(atts?.count == 1)
+        #expect(atts?.first?["kind"] as? String == "audio")
+        #expect(atts?.first?["storage_key"] as? String == "raw/assets/v.m4a")
+        #expect(atts?.first?["duration_sec"] as? Double == 8.0)
+        #expect(atts?.first?["transcript"] as? String == "hi")
+    }
+
+    @Test func payloadIsValidJSON() throws {
+        // The mapped dict must round-trip through JSONSerialization (no NaN,
+        // no non-serializable values) so the POST body never fails to encode.
+        let loc = Memo.Location(name: "Tokyo", lat: 35.0, lng: 139.0)
+        let att = Memo.Attachment(file: "a.m4a", kind: "audio", duration: 1.0, transcript: "t", transcriptionStatus: .done)
+        let item = MemoSyncMapper.bulkItem(
+            from: makeMemo(weather: "Rain", device: "iPhone", mood: "calm", location: loc, attachments: [att]),
+            vaultPath: "raw/x.md"
+        )
+        let payload: [String: Any] = ["memos": [item]]
+        #expect(JSONSerialization.isValidJSONObject(payload))
+        let data = try JSONSerialization.data(withJSONObject: payload)
+        #expect(data.count > 0)
+    }
+}
+
+// MARK: - Response parsing
+
+@Suite
+struct MemoSyncResponseTests {
+    let id = "550e8400-e29b-41d4-a716-446655440001"
+
+    private func data(_ obj: [String: Any]) -> Data {
+        try! JSONSerialization.data(withJSONObject: obj)
+    }
+
+    @Test func acceptedDoesNotThrow() throws {
+        let d = data(["accepted": [id], "skipped": []])
+        // Should not throw.
+        try MemoSyncUploader.assertAccepted(memoID: id, responseData: d)
+    }
+
+    @Test func acceptedIsCaseInsensitive() throws {
+        let d = data(["accepted": [id.uppercased()], "skipped": []])
+        try MemoSyncUploader.assertAccepted(memoID: id, responseData: d)
+    }
+
+    @Test func skippedThrowsWithReason() {
+        let d = data(["accepted": [], "skipped": [["id": id, "reason": "DB error"]]])
+        #expect(throws: MemoSyncError.self) {
+            try MemoSyncUploader.assertAccepted(memoID: id, responseData: d)
+        }
+    }
+
+    @Test func notAcknowledgedThrows() {
+        let d = data(["accepted": [], "skipped": []])
+        #expect(throws: MemoSyncError.self) {
+            try MemoSyncUploader.assertAccepted(memoID: id, responseData: d)
+        }
+    }
+
+    @Test func malformedResponseThrows() {
+        #expect(throws: MemoSyncError.self) {
+            try MemoSyncUploader.assertAccepted(memoID: id, responseData: Data("not json".utf8))
+        }
+    }
+}
+
+// MARK: - SyncSettings
+
+@Suite(.serialized)
+struct SyncSettingsTests {
+
+    /// Snapshot + restore the base URL so tests can't poison the host app or
+    /// each other.
+    private func withCleanBaseURL(_ body: () throws -> Void) rethrows {
+        let prior = SyncSettings.baseURLString
+        defer { SyncSettings.baseURLString = prior }
+        SyncSettings.baseURLString = nil
+        try body()
+    }
+
+    @Test func normalizesBaseURL() {
+        #expect(SyncSettings.normalizeBaseURL("daypage.app") == "https://daypage.app")
+        #expect(SyncSettings.normalizeBaseURL("https://daypage.app/") == "https://daypage.app")
+        #expect(SyncSettings.normalizeBaseURL("http://192.168.1.5:3000") == "http://192.168.1.5:3000")
+        #expect(SyncSettings.normalizeBaseURL("https://a.com///") == "https://a.com")
+    }
+
+    @Test func bulkEndpointAppendsPath() {
+        withCleanBaseURL {
+            SyncSettings.baseURLString = "https://daypage.app"
+            #expect(SyncSettings.bulkEndpoint?.absoluteString == "https://daypage.app/api/memos/bulk")
+        }
+    }
+
+    @Test func bulkEndpointNilWhenUnset() {
+        withCleanBaseURL {
+            SyncSettings.baseURLString = nil
+            #expect(SyncSettings.bulkEndpoint == nil)
+        }
+    }
+}

--- a/docs/ios-web-sync-design.md
+++ b/docs/ios-web-sync-design.md
@@ -1,0 +1,172 @@
+# iOS → Web Memo 同步设计方案
+
+> 状态：草案 / 待评审
+> 作者：Claude Code
+> 日期：2026-06-24
+> 关联分支：（开 issue 后创建）
+
+## 1. 背景与问题
+
+DayPage 有两个客户端：
+
+- **iOS App**：本地真相是 `vault/raw/YYYY-MM-DD.md`（YAML front-matter + Markdown），用 Supabase 做账号登录。
+- **Web（Next.js）**：本地真相是 PostgreSQL（`memos` 表 + Drizzle），用 NextAuth 做账号登录。
+
+用户诉求：**「App 发送的内容能在 web 端同步」**。
+
+### 现状（已核实，非推测）
+
+| 层 | 状态 |
+|---|---|
+| Web 存储 | ✅ PostgreSQL + Drizzle，`/api/memos` CRUD + `/api/memos/bulk`（专为 iOS 设计的 last-write-wins upsert）已存在且完整 |
+| Web 鉴权基建 | ✅ `api_keys` 表 + `authenticateApiKey()` + `hasScope()` + Settings 生成 UI（`/api/keys`）；`/api/ingest`、`/api/v1/*` 已用 `Authorization: Bearer <key>` 范式 |
+| iOS 写入 | ✅ `RawStorage.append()` 写 vault，并 `SyncQueueService.enqueue(memoID)` |
+| iOS 同步队列 | ✅ `SyncQueueService`（元数据队列）+ `SyncQueueObserver`（监听 flush）已就绪 |
+| iOS 真实上传 | ❌ **完全断掉**——只有 `NoopRemoteUploader`（sleep 300ms 假上传），从不发真实网络请求 |
+
+**结论：** 不是「从零实现存储」，而是**接通 iOS 端那条空转的同步链路**——实现一个真实的 `RemoteUploader`，把 vault 里的 memo POST 到 web 已经准备好的 `/api/memos/bulk`。
+
+## 2. 鉴权方案：API Key Bearer（模仿 flomo）
+
+### 决策
+
+不桥接 Supabase ↔ NextAuth（两套独立 auth，桥接成本高）。改用 **API Key Bearer**，与 flomo 的同步 token 模式一致：
+
+> flomo 给每个用户一个专属 API 地址 `https://flomoapp.com/iwh/<id>/<token>/`，客户端用 token 往里发内容。
+
+DayPage 复刻：用户在 **web Settings → API Keys** 生成一个 `write` scope 的 key，填进 **iOS Settings → 同步**。iOS 上传时带 `Authorization: Bearer <key>`。
+
+### 为什么这是最优解
+
+1. **零新增基建**：web 已有 `authenticateApiKey()`、`api_keys` 表、生成 UI、`/api/keys` 路由。
+2. **身份自动绑定**：`api_keys.user_id → users.id`。iOS 用某 key，memo 就落到那个 web 用户，**无需 email 桥接**。
+3. **已验证范式**：`/api/ingest`（浏览器剪藏）已是同款 Bearer 鉴权 + CORS。
+4. **安全边界清晰**：key 可吊销、有 scope、记 `last_used_at`、可设 `expires_at`。
+
+### 改动点
+
+`/api/memos/bulk/route.ts`：在现有 NextAuth session 之外，**额外**接受 API Key Bearer。
+
+```ts
+// 伪代码
+async function resolveAuthUserId(req): Promise<{ userId: string } | { error: Response }> {
+  // 1) 优先 API Key（iOS / 第三方）
+  const apiAuth = await authenticateApiKey(req);
+  if (apiAuth) {
+    if (!hasScope(apiAuth, "write")) return { error: forbidden("write scope required") };
+    return { userId: apiAuth.userId };
+  }
+  // 2) 回退 NextAuth session（web 自身调用）
+  const session = await auth();
+  if (session?.user?.email) {
+    const userId = await resolveUserId(session.user.email);
+    if (userId) return { userId };
+  }
+  return { error: unauthorized() };
+}
+```
+
+保留 session 路径不动，只「补」API Key 分支——对 web 现有行为零影响。
+
+## 3. 字段映射：iOS Memo → Bulk JSON
+
+Web `BulkMemoItemSchema`（`web/src/lib/schemas/memo.ts`）要求：`id`(UUID)、`body`(非空)、可选 `type/created_at/updated_at/location/weather/device/origin/ingest_mode/vault_path/idempotency_key/mood/attachments`。
+
+| iOS `Memo` 字段 | Bulk JSON 字段 | 映射规则 |
+|---|---|---|
+| `id: UUID` | `id` | `uuidString.lowercased()` |
+| `type: MemoType` | `type` | `voice→voice`、`photo→photo`、`text→text`、`location→text`、`mixed→text`（web 无 location/mixed 枚举） |
+| `body: String` | `body` | 直接；**若为空**（纯语音/照片）→ 填占位（如 transcript 或 `"(无文字)"`），因 schema 要求 `min(1)` |
+| `created: Date` | `created_at` | ISO8601（含毫秒，UTC） |
+| `pinnedAt`/修改时间 | `updated_at` | 取 `pinnedAt ?? created` 的 ISO8601；用于 LWW 比较 |
+| `location: Location?` | `location` | `{lat, lng, address: name}`（web `.passthrough()` 容忍多余字段） |
+| `weather: String?` | `weather` | **包装**为 `{condition: weatherString}`（iOS 是字符串，web schema 是 object） |
+| `device: String?` | `device` | 直接 |
+| `mood: String?` | `mood` | 直接 |
+| — | `origin` | 固定 `"ios"` |
+| `vault/raw/YYYY-MM-DD.md` | `vault_path` | memo 所在文件相对路径，便于追溯 |
+| `id` | `idempotency_key` | = memoID，防重复 upsert |
+| `attachments[]` | `attachments[]` | 见下，**只传元数据** |
+
+### 附件（第一期：只传元数据）
+
+不传文件字节。`attachments[]` 映射：
+
+| iOS `Attachment` | Bulk attachment | 规则 |
+|---|---|---|
+| `kind` | `kind` | `audio/photo/file`（已对齐） |
+| `file`（相对路径） | `storage_key` | 直接传路径字符串（web 仅存引用，第一期不解析文件） |
+| `duration` | `duration_sec` | 直接 |
+| `transcript`（音频转录 / 照片 EXIF 串） | `transcript` 或 `exif` | 音频→`transcript`；照片 EXIF→可放 `exif`/`ocr_text` |
+
+> 文件字节上传（multipart → `/api/upload`，让 web 能播放音频/看原图）作为**后续 issue**。
+
+## 4. 上传流程
+
+```
+SyncQueueObserver.flush()           （已存在，监听 .syncQueueFlushRequested）
+  └─ for memoID in pendingMemoIDs:
+       uploader.upload(memoID:)      （RemoteUploader 协议，已存在注入点）
+                ↓  ← 本方案实现 BulkSyncUploader
+   1. memoID → 扫 vault/raw/*.md 找到对应 Memo（复用 estimateMemoSize 的扫描思路）
+   2. Memo → bulk JSON（§3 映射）
+   3. POST {baseURL}/api/memos/bulk
+      Authorization: Bearer <api key>
+      Body: { memos: [item] }
+   4. 解析响应 { accepted, skipped }
+       - accepted 含本 memoID → 返回字节数（成功）
+       - skipped → 抛错（让 observer 中断本轮）
+```
+
+- **批量**：当前 observer 逐条调 `upload(memoID:)`。第一期保持逐条（每次 `memos:[单条]`）；后续可改批量（schema 支持 ≤100 条/请求）。
+- **复用** `HTTPTransport`（`HTTPTransports.shared`），便于测试注入假响应。
+
+## 5. 冲突与幂等
+
+- **服务端**：bulk 已是 **last-write-wins by `updated_at`**（`onConflictDoUpdate` + `setWhere user_id`）。同一 memoID 重复上传安全。
+- **客户端**：`SyncQueueService` 用 Set 去重；上传成功才 `markSynced`，失败保留待重试（网络恢复/手动触发自动重发）。
+- **幂等键**：`idempotency_key = memoID`。
+
+## 6. 错误处理
+
+| 场景 | 行为 |
+|---|---|
+| 未配置 baseURL / key | uploader 降级为 noop（不报错，不入队失败）；Settings 提示「未配置同步」 |
+| 401（key 无效/过期） | 中断本轮 + breadcrumb；Settings 标记 key 失效，提示重新生成 |
+| 403（无 write scope） | 同上，提示 key 权限不足 |
+| 429（限流） | 读 `Retry-After`，延迟下轮 flush |
+| 网络错误 | `SyncQueueObserver` 现有逻辑：breadcrumb + break，下次 flush 重试 |
+| 5xx | 同网络错误，保留队列 |
+| memoID 在 vault 找不到 | 跳过并 `markSynced`（已删除的 memo 不该卡住队列）+ breadcrumb |
+
+## 7. iOS 配置 UI
+
+Settings 新增「同步」section：
+
+- **Web 地址**（baseURL）：默认空；dogfood 可填 `http://<mac-ip>:3000`，生产填正式域名。
+- **API Key**：粘贴 web 生成的 key，存 **Keychain**（不存 UserDefaults，避免 PII/凭证泄露）。
+- **状态**：显示上次同步时间 / 待同步条数（复用 `SyncQueueService.pendingCount`）/ 失败原因。
+- **手动同步**按钮：触发 `flushIfOnline()`。
+
+配置读取：新建 `SyncConfig`（Keychain 封装），`BulkSyncUploader` 启动时读；为空 → `SyncQueueObserver.setUploader(NoopRemoteUploader())` 保持空转。
+
+## 8. 安全考量
+
+- API key 走 Keychain，不落 UserDefaults / 日志 / Sentry。
+- baseURL 仅允许 `https://`（dogfood 例外允许局域网 `http://`，用 `#if DEBUG` 或显式开关守护）。
+- bulk 端点对 API key 路径同样跑 `checkMutationRateLimit`（按 key/user 维度）。
+- key 泄露可在 web Settings 一键吊销（已有 DELETE `/api/keys/:id`）。
+
+## 9. 任务拆解
+
+1. **web**：`/api/memos/bulk` 接受 API Key Bearer（复用 `authenticateApiKey` + `hasScope("write")`）+ 测试。
+2. **iOS**：`SyncConfig`（Keychain）+ Settings 同步 section。
+3. **iOS**：`BulkSyncUploader: RemoteUploader`（vault 查找 + 映射 + POST）+ 注入。
+4. **iOS**：`Memo → BulkItem` 映射单元测试（Swift Testing）。
+5. **联调**：本地 web（dev login → 生成 write key）↔ iOS 模拟器写 memo → 验证 `/today` 可见。
+
+## 10. 非目标（后续 issue）
+
+- web → iOS 反向同步（`GET /api/memos?since=` 拉取并写回 vault）。
+- 附件文件字节上传（multipart → `/api/upload`）。
+- 多设备冲突的 body 级合并（当前 LWW 足够）。

--- a/web/src/app/(app)/home/HomeStream.tsx
+++ b/web/src/app/(app)/home/HomeStream.tsx
@@ -60,18 +60,36 @@ function computeToday(): TodayStrings {
 
 // A clock that re-derives the date strings once a minute, so a tab left open
 // across midnight rolls over to the new day rather than freezing on mount.
-function useTodayStrings(): TodayStrings {
+// When the iso day flips, `onCross` fires once — callers use it to refetch
+// "today's" memos (so cards left over from 23:59 don't claim to be today's).
+function useTodayStrings(onCross?: (prevIso: string, nextIso: string) => void): TodayStrings {
   const [today, setToday] = useState<TodayStrings>(computeToday);
+  const crossRef = useRef(onCross);
+  useEffect(() => { crossRef.current = onCross; }, [onCross]);
+
   useEffect(() => {
     const t = setInterval(() => {
       setToday((prev) => {
         const next = computeToday();
-        return next.iso === prev.iso ? prev : next;
+        if (next.iso === prev.iso) return prev;
+        try { crossRef.current?.(prev.iso, next.iso); } catch { /* ignore */ }
+        return next;
       });
     }, 60_000);
     return () => clearInterval(t);
   }, []);
   return today;
+}
+
+// Pull the first complete sentence from an excerpt — preferring 。 / ！/ ？
+// (Chinese punctuation) then falling back to . / ! / ? (Latin), then to the
+// first newline. We never truncate mid-word; if no boundary is found within
+// 64 chars, we let the excerpt speak for itself (the CSS will clamp).
+function firstSentence(excerpt: string): string {
+  const trimmed = excerpt.replace(/\s+/g, " ").trim();
+  if (!trimmed) return "";
+  const match = trimmed.match(/^[^。！？.!?\n]{2,64}[。！？.!?]/);
+  return match ? match[0].trim() : trimmed;
 }
 
 // Friendly relative label for a daily wiki card: 昨天 / 前天 / N 天前 / date.
@@ -92,10 +110,23 @@ function relativeDayLabel(dateStr: string): string {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
-  const { weekday, long, iso } = useTodayStrings();
-
   const [memos, setMemos] = useState<MemoCardData[]>(initialToday);
   const [serviceConnected, setServiceConnected] = useState(true);
+
+  // Midnight-crossing toast — fires once when the iso day flips while the tab
+  // is open. The reload below will pull the new day's (likely empty) memo set,
+  // and this toast turns the moment into a product beat rather than a glitch.
+  const [midnightToast, setMidnightToast] = useState<string | null>(null);
+  const midnightToastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reloadMemosRef = useRef<() => Promise<void>>(async () => {});
+  const onCrossMidnight = useCallback(() => {
+    void reloadMemosRef.current();
+    setMidnightToast("刚跨过了 00 点，昨天正在编织…");
+    if (midnightToastTimer.current) clearTimeout(midnightToastTimer.current);
+    midnightToastTimer.current = setTimeout(() => setMidnightToast(null), 6000);
+  }, []);
+  const { weekday, long, iso } = useTodayStrings(onCrossMidnight);
 
   // Composer state
   const [draft, setDraft] = useState("");
@@ -126,6 +157,7 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
     () => () => {
       if (compileNoteTimer.current) clearTimeout(compileNoteTimer.current);
       if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
+      if (midnightToastTimer.current) clearTimeout(midnightToastTimer.current);
     },
     []
   );
@@ -145,6 +177,9 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
       /* keep last good */
     }
   }, []);
+  // Expose the latest reloadMemos to onCrossMidnight without re-arming the
+  // clock interval (the clock effect runs once on mount).
+  useEffect(() => { reloadMemosRef.current = reloadMemos; }, [reloadMemos]);
 
   // Probe the compile pipeline once; surface an honest banner when unreachable
   // (mirrors the per-card status logic in MemoCard / the iOS sync queue banner).
@@ -190,20 +225,22 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
       if (r.ok) {
         setDraft("");
         setSaveOk(true);
-        announce("已保存到今天");
+        announce("收下了，夜里见");
         if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
         saveOkTimer.current = setTimeout(() => setSaveOk(false), 1800);
         await reloadMemos();
       } else {
         const d = await r.json().catch(() => null);
-        const msg = d?.error ? String(d.error) : "保存失败，已为你保留草稿";
+        // Prefer the server's exact reason when it gives one (validation,
+        // rate-limit, auth), otherwise fall back to product voice.
+        const msg = d?.error ? String(d.error) : "夜里还远，先再试一次";
         setSaveError(msg);
         announce(msg);
       }
     } catch {
       // Network error — the textarea keeps the draft so nothing is lost.
-      setSaveError("网络错误，已为你保留草稿，可重试");
-      announce("保存失败，网络错误");
+      setSaveError("夜里还远，先再试一次");
+      announce("夜里还远，先再试一次");
     } finally {
       setSaving(false);
     }
@@ -298,6 +335,18 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
     (m) => m.compile_status === "pending" || m.compile_status === "running"
   ).length;
   const compiledCount = memos.filter((m) => m.compile_status === "done").length;
+  const todayCount = memos.length;
+
+  // Hero rhythm — the slogan retreats as the day fills up:
+  //   0 records  → full two-line slogan (welcome / onboarding mood)
+  //   ≥1 record  → single calm status line ("已记下 N 条，等夜里编织")
+  // The serif title stays, but its content adapts to the user's actual day.
+  const heroMode: "intro" | "active" = todayCount === 0 ? "intro" : "active";
+
+  // The on-demand compile button is intentionally restrained: when there's
+  // little to weave, we don't tempt the user to break the midnight ritual.
+  // It surfaces only once the day has accumulated some material (≥5 raws).
+  const showCompileButton = todayCount >= 5;
 
   return (
     <div className="page home-stream">
@@ -313,58 +362,97 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             <Sparkles size={12} strokeWidth={2} aria-hidden="true" />
             {long} · {weekday}
           </div>
-          <h1 className="home-hero__title">
-            今天，先把此刻记下来。
-            <br />
-            <span className="accent">夜里 00 点，它会自己编织成网。</span>
-          </h1>
-          <p className="home-hero__sub">
-            随手记录原始念头，像便签一样留在「今天」。每天午夜自动编译成结构化的日记页，
-            昨天与更早的，都会沉淀为可回溯的 wiki。
-          </p>
+
+          {heroMode === "intro" ? (
+            <>
+              <h1 className="home-hero__title">
+                今天，先把此刻记下来。
+                <br />
+                <span className="accent">夜里 00 点，它会自己编织成网。</span>
+              </h1>
+              <p className="home-hero__sub">
+                随手记录原始念头，像便签一样留在「今天」。每天午夜自动编译成结构化的日记页，
+                昨天与更早的，都会沉淀为可回溯的 wiki。
+              </p>
+            </>
+          ) : (
+            <>
+              <h1 className="home-hero__title home-hero__title--calm">
+                今天 · <span className="accent">已记下 {todayCount} 条</span>
+                <span className="home-hero__title-tail">，等夜里编织。</span>
+              </h1>
+              {dailyPages.length > 0 && (
+                <p className="home-hero__sub home-hero__sub--quiet">
+                  <Link href={`/wiki/${dailyPages[0]!.slug}`} className="home-hero__yesterday">
+                    昨天已编织好 <ArrowUpRight size={12} strokeWidth={2} aria-hidden="true" />
+                  </Link>
+                </p>
+              )}
+            </>
+          )}
         </div>
 
         {/* Daily compile card */}
-        <section className="daily-compile-card" aria-label="今日编译">
+        <section className="daily-compile-card" aria-label="今日编译状态">
           <div className="daily-compile-card__head">
-            <span className="daily-compile-card__label">今日编译</span>
+            <span className="daily-compile-card__label">今日</span>
             <span className="daily-compile-card__date">{iso}</span>
           </div>
 
+          {/* Three-beat narrative: 念头 → 已织入网中 → 等夜里 / 已就绪.
+              The third beat flips to "已就绪" when the day is fully compiled,
+              giving users a felt sense of state progression instead of static
+              counts that always sum to the first. */}
           <div className="daily-compile-card__metrics">
             <div className="dcc-metric">
-              <div className="dcc-metric__value">{memos.length}</div>
-              <div className="dcc-metric__label">今日记录</div>
+              <div className="dcc-metric__value">{todayCount}</div>
+              <div className="dcc-metric__label">此刻的念头</div>
             </div>
             <div className="dcc-metric">
               <div className="dcc-metric__value">{compiledCount}</div>
-              <div className="dcc-metric__label">已编译</div>
+              <div className="dcc-metric__label">已织入网中</div>
             </div>
             <div className="dcc-metric">
-              <div className="dcc-metric__value">{pendingCount}</div>
-              <div className="dcc-metric__label">待编译</div>
+              {pendingCount === 0 && todayCount > 0 ? (
+                <>
+                  <div className="dcc-metric__value dcc-metric__value--ready" aria-label="已就绪">
+                    <span className="dcc-ready-dot" aria-hidden="true" />
+                  </div>
+                  <div className="dcc-metric__label">已就绪</div>
+                </>
+              ) : (
+                <>
+                  <div className="dcc-metric__value">{pendingCount}</div>
+                  <div className="dcc-metric__label">等夜里</div>
+                </>
+              )}
             </div>
           </div>
 
-          <button
-            type="button"
-            className={`dcc-compile-btn${pendingCount === 0 && !compiling ? " dcc-compile-btn--ghost" : ""}`}
-            onClick={handleCompileToday}
-            disabled={compiling}
-            aria-busy={compiling}
-          >
-            {compiling ? (
-              <>
-                <Loader2 size={14} strokeWidth={2} style={SPIN} aria-hidden="true" />
-                正在送编译…
-              </>
-            ) : (
-              <>
-                <Sparkles size={14} strokeWidth={2} aria-hidden="true" />
-                立即编译今天
-              </>
-            )}
-          </button>
+          {/* Compile button is restrained: only surfaces once enough material
+              has accumulated. Below the threshold we keep the midnight ritual
+              the only path — quietness reinforces the slogan's promise. */}
+          {showCompileButton && (
+            <button
+              type="button"
+              className={`dcc-compile-btn${pendingCount === 0 && !compiling ? " dcc-compile-btn--ghost" : ""}`}
+              onClick={handleCompileToday}
+              disabled={compiling}
+              aria-busy={compiling}
+            >
+              {compiling ? (
+                <>
+                  <Loader2 size={14} strokeWidth={2} style={SPIN} aria-hidden="true" />
+                  正在送编译…
+                </>
+              ) : (
+                <>
+                  <Sparkles size={14} strokeWidth={2} aria-hidden="true" />
+                  提前看看今天会织成什么
+                </>
+              )}
+            </button>
+          )}
 
           {/* Visual-only: the dedicated .sr-only live region already announces
               compile outcomes to AT, so this avoids a duplicate read. */}
@@ -374,12 +462,21 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             ) : (
               <>
                 <Clock size={11} strokeWidth={2} aria-hidden="true" />
-                每天 00:00 自动编译昨天
+                每天 00:00 自动编织昨天
               </>
             )}
           </p>
         </section>
       </div>
+
+      {/* Midnight-crossing toast: a one-off product beat when the tab stays
+          open across 00:00 — turns a potential glitch into a small moment. */}
+      {midnightToast && (
+        <div className="home-midnight-toast" role="status">
+          <Sparkles size={13} strokeWidth={2} aria-hidden="true" />
+          {midnightToast}
+        </div>
+      )}
 
       {/* Pipeline-unreachable banner (dev w/o Inngest, or outage). */}
       {!serviceConnected && (
@@ -419,9 +516,9 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             {saveError
               ? saveError
               : saveOk
-                ? "已保存 ✓"
+                ? "收下了，夜里见 ✓"
                 : wordCount > 0
-                  ? `${wordCount} 字 · ⌘/Ctrl + ↵ 保存`
+                  ? `${wordCount} 字 · ⌘/Ctrl + ↵ 收下`
                   : "记下此刻，余下交给夜里"}
           </span>
           <button
@@ -436,7 +533,7 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             ) : (
               <Check size={13} strokeWidth={2.2} aria-hidden="true" />
             )}
-            保存
+            收下
           </button>
         </div>
       </section>
@@ -484,28 +581,41 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             <p>还没有编译过的日记页 —— 记录满一天，午夜会自动生成。</p>
           </div>
         ) : (
-          <div className="home-wiki-grid">
-            {dailyPages.map((p) => (
-              <Link
-                key={p.slug}
-                href={`/wiki/${p.slug}`}
-                className="wiki-day-card"
-                aria-label={`${relativeDayLabel(p.date)}的日记页：${p.title}`}
-              >
-                <div className="wiki-day-card__head">
-                  <span className="wiki-day-card__rel">{relativeDayLabel(p.date)}</span>
-                  <span className="wiki-day-card__date">{p.date}</span>
-                </div>
-                <h3 className="wiki-day-card__title">{p.title}</h3>
-                <p className="wiki-day-card__excerpt">{p.excerpt}</p>
-                <div className="wiki-day-card__foot">
-                  <span>
-                    <FileText size={11} strokeWidth={2} aria-hidden="true" /> {p.source_count} 条原始
-                  </span>
-                  <ArrowUpRight size={14} strokeWidth={2} aria-hidden="true" />
-                </div>
-              </Link>
-            ))}
+          /* Each daily page becomes a "small book": title + one whole
+             opening line, with a thin spine of N short rules along the
+             bottom edge (visual stand-in for "N raw memos went into this").
+             Date sits as a quiet corner stamp; full excerpt only emerges
+             on hover, so the grid reads like a shelf, not a list. */
+          <div className="home-wiki-grid home-wiki-grid--books">
+            {dailyPages.map((p) => {
+              // Cap the spine at 9 lines so a 50-memo day doesn't become a
+              // solid bar; a 9-line spine still reads as "thicker than usual".
+              const spineCount = Math.max(0, Math.min(9, p.source_count));
+              const pull = firstSentence(p.excerpt);
+              return (
+                <Link
+                  key={p.slug}
+                  href={`/wiki/${p.slug}`}
+                  className="wiki-book"
+                  aria-label={`${relativeDayLabel(p.date)}的日记页：${p.title}（${p.source_count} 条原始）`}
+                >
+                  <span className="wiki-book__stamp">{p.date}</span>
+                  <span className="wiki-book__rel">{relativeDayLabel(p.date)}</span>
+                  <h3 className="wiki-book__title">{p.title}</h3>
+                  {pull && <p className="wiki-book__pull">{pull}</p>}
+                  <p className="wiki-book__excerpt">{p.excerpt}</p>
+                  <div
+                    className="wiki-book__spine"
+                    aria-hidden="true"
+                    title={`${p.source_count} 条原始`}
+                  >
+                    {Array.from({ length: spineCount }).map((_, i) => (
+                      <span key={i} className="wiki-book__spine-line" />
+                    ))}
+                  </div>
+                </Link>
+              );
+            })}
           </div>
         )}
       </section>

--- a/web/src/app/(app)/home/HomeStream.tsx
+++ b/web/src/app/(app)/home/HomeStream.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+// HomeStream — the unified home experience, mirroring the iOS Today→DailyPage
+// pipeline on the web. Three movements, top to bottom:
+//   1. An elegant inline composer + a "compile today" affordance.
+//   2. Today's raw memos as flomo-style cards (live compile status per card).
+//   3. Yesterday-and-earlier as compiled daily wiki cards.
+//
+// All data flows through endpoints that already exist and are shared with the
+// iOS client: POST /api/memos (capture), POST /api/compile (manual trigger),
+// GET /api/today/memos (today's stream), GET /api/compile/status (pipeline
+// reachability). The midnight cron (inngest daily-page, 00:30 UTC) compiles the
+// previous day automatically; the button here is the on-demand companion.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  Check,
+  Sparkles,
+  Loader2,
+  ArrowUpRight,
+  Clock,
+  FileText,
+  AlertCircle,
+} from "lucide-react";
+import { MemoCard, type MemoCardData } from "../today/MemoCard";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type DailyPageCard = {
+  slug: string; // e.g. "daily/2026-06-23"
+  date: string; // YYYY-MM-DD
+  title: string;
+  excerpt: string;
+  source_count: number;
+  last_compiled_at: string | null;
+};
+
+interface HomeStreamProps {
+  initialToday: MemoCardData[];
+  dailyPages: DailyPageCard[];
+}
+
+const SPIN: React.CSSProperties = { animation: "spin 1s linear infinite" };
+
+// ─── Date helpers ────────────────────────────────────────────────────────────
+
+type TodayStrings = { weekday: string; long: string; iso: string };
+
+function computeToday(): TodayStrings {
+  const now = new Date();
+  return {
+    weekday: now.toLocaleDateString("zh-CN", { weekday: "long" }),
+    long: now.toLocaleDateString("zh-CN", { year: "numeric", month: "long", day: "numeric" }),
+    iso: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
+      now.getDate()
+    ).padStart(2, "0")}`,
+  };
+}
+
+// A clock that re-derives the date strings once a minute, so a tab left open
+// across midnight rolls over to the new day rather than freezing on mount.
+function useTodayStrings(): TodayStrings {
+  const [today, setToday] = useState<TodayStrings>(computeToday);
+  useEffect(() => {
+    const t = setInterval(() => {
+      setToday((prev) => {
+        const next = computeToday();
+        return next.iso === prev.iso ? prev : next;
+      });
+    }, 60_000);
+    return () => clearInterval(t);
+  }, []);
+  return today;
+}
+
+// Friendly relative label for a daily wiki card: 昨天 / 前天 / N 天前 / date.
+function relativeDayLabel(dateStr: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  if (!y || !m || !d) return dateStr;
+  const that = new Date(y, m - 1, d);
+  const now = new Date();
+  const today0 = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const diffDays = Math.round((today0.getTime() - that.getTime()) / 86_400_000);
+  if (diffDays <= 0) return "今天";
+  if (diffDays === 1) return "昨天";
+  if (diffDays === 2) return "前天";
+  if (diffDays < 7) return `${diffDays} 天前`;
+  return that.toLocaleDateString("zh-CN", { month: "long", day: "numeric" });
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
+  const { weekday, long, iso } = useTodayStrings();
+
+  const [memos, setMemos] = useState<MemoCardData[]>(initialToday);
+  const [serviceConnected, setServiceConnected] = useState(true);
+
+  // Composer state
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveOk, setSaveOk] = useState(false);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  // Compile-today state
+  const [compiling, setCompiling] = useState(false);
+  const [compileNote, setCompileNote] = useState<string | null>(null);
+
+  // A single screen-reader announcement channel for save/compile outcomes.
+  // aria-live only fires on *content change*, so identical consecutive messages
+  // (e.g. two saves in a row) wouldn't re-announce — announce() appends an
+  // invisible, ever-changing zero-width-space run to force the DOM to differ.
+  const [liveMessage, setLiveMessage] = useState("");
+  const liveSeq = useRef(0);
+  const announce = useCallback((msg: string) => {
+    liveSeq.current += 1;
+    setLiveMessage(msg + "​".repeat(liveSeq.current % 2 ? 1 : 2));
+  }, []);
+
+  // Timers we must clear on unmount to avoid setState-after-unmount.
+  const compileNoteTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveOkTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (compileNoteTimer.current) clearTimeout(compileNoteTimer.current);
+      if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
+    },
+    []
+  );
+
+  const scheduleCompileNoteClear = useCallback(() => {
+    if (compileNoteTimer.current) clearTimeout(compileNoteTimer.current);
+    compileNoteTimer.current = setTimeout(() => setCompileNote(null), 4500);
+  }, []);
+
+  const reloadMemos = useCallback(async () => {
+    try {
+      const r = await fetch("/api/today/memos");
+      if (!r.ok) return;
+      const d: { memos: MemoCardData[] } = await r.json();
+      if (Array.isArray(d.memos)) setMemos(d.memos);
+    } catch {
+      /* keep last good */
+    }
+  }, []);
+
+  // Probe the compile pipeline once; surface an honest banner when unreachable
+  // (mirrors the per-card status logic in MemoCard / the iOS sync queue banner).
+  useEffect(() => {
+    fetch("/api/compile/status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { connected: boolean } | null) => {
+        if (d) setServiceConnected(d.connected);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Capture-first home: focus the composer on load, but never on touch devices
+  // (forcing the soft keyboard up on mobile is hostile).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const isTouch = window.matchMedia?.("(pointer: coarse)").matches;
+    if (!isTouch) taRef.current?.focus();
+  }, []);
+
+  // Auto-grow the composer textarea (min 56, max 200).
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+  }, [draft]);
+
+  const wordCount = draft.replace(/\s/g, "").length;
+  const canSave = draft.trim().length > 0 && !saving;
+
+  const handleSave = useCallback(async () => {
+    const body = draft.trim();
+    if (!body || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const r = await fetch("/api/memos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body, type: "text", origin: "web" }),
+      });
+      if (r.ok) {
+        setDraft("");
+        setSaveOk(true);
+        announce("已保存到今天");
+        if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
+        saveOkTimer.current = setTimeout(() => setSaveOk(false), 1800);
+        await reloadMemos();
+      } else {
+        const d = await r.json().catch(() => null);
+        const msg = d?.error ? String(d.error) : "保存失败，已为你保留草稿";
+        setSaveError(msg);
+        announce(msg);
+      }
+    } catch {
+      // Network error — the textarea keeps the draft so nothing is lost.
+      setSaveError("网络错误，已为你保留草稿，可重试");
+      announce("保存失败，网络错误");
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, saving, reloadMemos, announce]);
+
+  const handleComposerKey = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void handleSave();
+      }
+    },
+    [handleSave]
+  );
+
+  // Manual compile of today's memos. The cron handles midnight automatically;
+  // this lets the user weave the day's raw into its daily page on demand.
+  //
+  // We send the exact memo_ids currently shown in "today" rather than a date.
+  // /api/compile's date branch matches a *UTC* calendar day, but "today" here
+  // is the user's *local* day (see getTodayMemos / /api/today/memos) — passing
+  // ids sidesteps the timezone mismatch and compiles precisely what's on screen.
+  const handleCompileToday = useCallback(async () => {
+    if (compiling) return;
+    const ids = memos.map((m) => m.id);
+    if (ids.length === 0) {
+      setCompileNote("今天还没有可编译的记录");
+      announce("今天还没有可编译的记录");
+      scheduleCompileNoteClear();
+      return;
+    }
+    setCompiling(true);
+    setCompileNote(null);
+    try {
+      const r = await fetch("/api/compile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memo_ids: ids }),
+      });
+      const d = await r.json().catch(() => null);
+      if (r.ok) {
+        const n = (d?.triggered as number | undefined) ?? ids.length;
+        const msg = n > 0 ? `已送编译 · ${n} 条` : "今天还没有可编译的记录";
+        setCompileNote(msg);
+        announce(msg);
+        await reloadMemos();
+      } else {
+        const msg = d?.error ? String(d.error) : "编译触发失败";
+        setCompileNote(msg);
+        announce(msg);
+      }
+    } catch {
+      setCompileNote("编译触发失败");
+      announce("编译触发失败");
+    } finally {
+      setCompiling(false);
+      scheduleCompileNoteClear();
+    }
+  }, [compiling, memos, reloadMemos, scheduleCompileNoteClear, announce]);
+
+  const handleRetry = useCallback(
+    async (id: string) => {
+      // Optimistic: mark pending; revert to failed if the recompile call fails.
+      setMemos((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, compile_status: "pending", compile_error: null } : m))
+      );
+      try {
+        const r = await fetch(`/api/memos/${id}/recompile`, { method: "POST" });
+        if (!r.ok) {
+          setMemos((prev) =>
+            prev.map((m) =>
+              m.id === id ? { ...m, compile_status: "failed", compile_error: "重试失败" } : m
+            )
+          );
+          return;
+        }
+      } catch {
+        setMemos((prev) =>
+          prev.map((m) =>
+            m.id === id ? { ...m, compile_status: "failed", compile_error: "网络错误" } : m
+          )
+        );
+        return;
+      }
+      await reloadMemos();
+    },
+    [reloadMemos]
+  );
+
+  // Derived: today's compile summary for the daily card.
+  const pendingCount = memos.filter(
+    (m) => m.compile_status === "pending" || m.compile_status === "running"
+  ).length;
+  const compiledCount = memos.filter((m) => m.compile_status === "done").length;
+
+  return (
+    <div className="page home-stream">
+      {/* Screen-reader live region for save/compile outcomes. */}
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {liveMessage}
+      </p>
+
+      {/* ── Hero: date + daily compile card ─────────────────────────────── */}
+      <div className="home-hero">
+        <div>
+          <div className="home-hero__eyebrow">
+            <Sparkles size={12} strokeWidth={2} aria-hidden="true" />
+            {long} · {weekday}
+          </div>
+          <h1 className="home-hero__title">
+            今天，先把此刻记下来。
+            <br />
+            <span className="accent">夜里 00 点，它会自己编织成网。</span>
+          </h1>
+          <p className="home-hero__sub">
+            随手记录原始念头，像便签一样留在「今天」。每天午夜自动编译成结构化的日记页，
+            昨天与更早的，都会沉淀为可回溯的 wiki。
+          </p>
+        </div>
+
+        {/* Daily compile card */}
+        <section className="daily-compile-card" aria-label="今日编译">
+          <div className="daily-compile-card__head">
+            <span className="daily-compile-card__label">今日编译</span>
+            <span className="daily-compile-card__date">{iso}</span>
+          </div>
+
+          <div className="daily-compile-card__metrics">
+            <div className="dcc-metric">
+              <div className="dcc-metric__value">{memos.length}</div>
+              <div className="dcc-metric__label">今日记录</div>
+            </div>
+            <div className="dcc-metric">
+              <div className="dcc-metric__value">{compiledCount}</div>
+              <div className="dcc-metric__label">已编译</div>
+            </div>
+            <div className="dcc-metric">
+              <div className="dcc-metric__value">{pendingCount}</div>
+              <div className="dcc-metric__label">待编译</div>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            className={`dcc-compile-btn${pendingCount === 0 && !compiling ? " dcc-compile-btn--ghost" : ""}`}
+            onClick={handleCompileToday}
+            disabled={compiling}
+            aria-busy={compiling}
+          >
+            {compiling ? (
+              <>
+                <Loader2 size={14} strokeWidth={2} style={SPIN} aria-hidden="true" />
+                正在送编译…
+              </>
+            ) : (
+              <>
+                <Sparkles size={14} strokeWidth={2} aria-hidden="true" />
+                立即编译今天
+              </>
+            )}
+          </button>
+
+          {/* Visual-only: the dedicated .sr-only live region already announces
+              compile outcomes to AT, so this avoids a duplicate read. */}
+          <p className="dcc-foot">
+            {compileNote ? (
+              <span className="dcc-foot__note">{compileNote}</span>
+            ) : (
+              <>
+                <Clock size={11} strokeWidth={2} aria-hidden="true" />
+                每天 00:00 自动编译昨天
+              </>
+            )}
+          </p>
+        </section>
+      </div>
+
+      {/* Pipeline-unreachable banner (dev w/o Inngest, or outage). */}
+      {!serviceConnected && (
+        <div className="home-pipeline-warn" role="status">
+          <AlertCircle size={14} strokeWidth={2} aria-hidden="true" />
+          编译服务未连接 —— 新记录会保存，但暂不会被编译。
+        </div>
+      )}
+
+      {/* ── Composer ────────────────────────────────────────────────────── */}
+      <section className="home-composer" aria-label="记录此刻">
+        <textarea
+          ref={taRef}
+          id="home-composer-input"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            if (saveError) setSaveError(null);
+            if (saveOk) {
+              setSaveOk(false);
+              if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
+            }
+          }}
+          onKeyDown={handleComposerKey}
+          placeholder="此刻在想什么？"
+          rows={2}
+          className="home-composer__ta"
+          aria-label="记下此刻的念头"
+          aria-describedby="home-composer-hint"
+          aria-keyshortcuts="Meta+Enter Control+Enter"
+        />
+        <div className="home-composer__bar">
+          <span
+            id="home-composer-hint"
+            className={`home-composer__hint${saveError ? " is-error" : ""}`}
+          >
+            {saveError
+              ? saveError
+              : saveOk
+                ? "已保存 ✓"
+                : wordCount > 0
+                  ? `${wordCount} 字 · ⌘/Ctrl + ↵ 保存`
+                  : "记下此刻，余下交给夜里"}
+          </span>
+          <button
+            type="button"
+            className="home-composer__save"
+            disabled={!canSave}
+            aria-busy={saving}
+            onClick={handleSave}
+          >
+            {saving ? (
+              <Loader2 size={13} strokeWidth={2.2} style={SPIN} aria-hidden="true" />
+            ) : (
+              <Check size={13} strokeWidth={2.2} aria-hidden="true" />
+            )}
+            保存
+          </button>
+        </div>
+      </section>
+
+      {/* ── Today's raw (flomo cards) ───────────────────────────────────── */}
+      <section className="home-section" aria-label="今天的记录">
+        <h2 className="home-section__label">
+          <span>今天</span>
+          <span className="home-section__count">{memos.length}</span>
+        </h2>
+
+        {memos.length === 0 ? (
+          <div className="home-empty">
+            <Sparkles size={26} strokeWidth={1.5} aria-hidden="true" />
+            <p>今天还没有记录 —— 在上面写下第一条吧。</p>
+          </div>
+        ) : (
+          <div className="home-memo-grid">
+            {memos.map((m) => (
+              <MemoCard
+                key={m.id}
+                memo={m}
+                serviceConnected={serviceConnected}
+                onRetry={handleRetry}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Yesterday & earlier (compiled daily wiki) ───────────────────── */}
+      <section className="home-section" aria-label="昨天及更早的日记页">
+        <h2 className="home-section__label">
+          <span>昨天及更早</span>
+          {dailyPages.length > 0 && (
+            <Link href="/wiki?type=daily" className="home-section__more">
+              全部 <ArrowUpRight size={13} strokeWidth={2} aria-hidden="true" />
+            </Link>
+          )}
+        </h2>
+
+        {dailyPages.length === 0 ? (
+          <div className="home-empty">
+            <FileText size={26} strokeWidth={1.5} aria-hidden="true" />
+            <p>还没有编译过的日记页 —— 记录满一天，午夜会自动生成。</p>
+          </div>
+        ) : (
+          <div className="home-wiki-grid">
+            {dailyPages.map((p) => (
+              <Link
+                key={p.slug}
+                href={`/wiki/${p.slug}`}
+                className="wiki-day-card"
+                aria-label={`${relativeDayLabel(p.date)}的日记页：${p.title}`}
+              >
+                <div className="wiki-day-card__head">
+                  <span className="wiki-day-card__rel">{relativeDayLabel(p.date)}</span>
+                  <span className="wiki-day-card__date">{p.date}</span>
+                </div>
+                <h3 className="wiki-day-card__title">{p.title}</h3>
+                <p className="wiki-day-card__excerpt">{p.excerpt}</p>
+                <div className="wiki-day-card__foot">
+                  <span>
+                    <FileText size={11} strokeWidth={2} aria-hidden="true" /> {p.source_count} 条原始
+                  </span>
+                  <ArrowUpRight size={14} strokeWidth={2} aria-hidden="true" />
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/(app)/home/page.tsx
+++ b/web/src/app/(app)/home/page.tsx
@@ -1,16 +1,26 @@
-// Home view — stats, activities, inbox observations, and domains wired to real data.
+// Home view — the unified capture→compile→wiki stream up top (HomeStream),
+// followed by the knowledge-network panels (observations, activity).
+//
+// The top stream mirrors the iOS Today→DailyPage pipeline: capture raw memos,
+// see today's as flomo cards, browse yesterday-and-earlier as compiled daily
+// wiki pages, and trigger the day's compile on demand (the inngest daily-page
+// cron handles midnight automatically).
 import Link from "next/link";
 import { ArrowUpRight, ChevronRight, Sparkles, Inbox, Activity, Clock } from "lucide-react";
-import { Btn, Card, Chip, Icon, SectionLabel, Sparkline } from "@/components/ui";
-import { ColdStartGuide } from "./ColdStartGuide";
+import { Btn, Card, Chip, Icon, SectionLabel } from "@/components/ui";
+import { HomeStream, type DailyPageCard } from "./HomeStream";
+import type { MemoCardData } from "../today/MemoCard";
 import { auth } from "@/auth";
 import { db } from "@/lib/db/client";
-import { users, inbox_items, memos, pages, domains, page_links, activities } from "@/lib/db/schema";
-import { eq, and, gte, desc, sql } from "drizzle-orm";
-
-// How many sources we suggest before the graph starts weaving itself. Used only
-// to phrase the cold-start guidance — kept small and encouraging.
-const WEAVE_HINT_TARGET = 3;
+import {
+  users,
+  inbox_items,
+  memos,
+  memo_attachments,
+  pages,
+  activities,
+} from "@/lib/db/schema";
+import { eq, and, gte, lt, desc, inArray } from "drizzle-orm";
 
 // ── Data helpers ──────────────────────────────────────────────────────────────
 
@@ -23,41 +33,135 @@ async function resolveUserId(email: string): Promise<string | null> {
   return rows[0]?.id ?? null;
 }
 
-type StatsData = {
-  sources: number;
-  pages: number;
-  domainCount: number;
-  backlinks: number;
-  sources_week: number;
-  pages_week: number;
-  backlinks_week: number;
-};
-
-async function getStats(userId: string): Promise<StatsData> {
-  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+// Today's memos as flomo-card data (same shape the /today stream serves).
+async function getTodayMemos(userId: string): Promise<MemoCardData[]> {
   try {
-    const [sourcesRes, pagesRes, domainsRes, backlinksRes, swRes, pwRes, bwRes] =
-      await Promise.all([
-        db.select({ count: sql<number>`count(*)::int` }).from(memos).where(eq(memos.user_id, userId)),
-        db.select({ count: sql<number>`count(*)::int` }).from(pages).where(eq(pages.user_id, userId)),
-        db.select({ count: sql<number>`count(*)::int` }).from(domains).where(eq(domains.user_id, userId)),
-        db.select({ count: sql<number>`count(*)::int` }).from(page_links).where(eq(page_links.user_id, userId)),
-        db.select({ count: sql<number>`count(*)::int` }).from(memos).where(and(eq(memos.user_id, userId), gte(memos.created_at, oneWeekAgo))),
-        db.select({ count: sql<number>`count(*)::int` }).from(pages).where(and(eq(pages.user_id, userId), gte(pages.created_at, oneWeekAgo))),
-        db.select({ count: sql<number>`count(*)::int` }).from(page_links).where(and(eq(page_links.user_id, userId), gte(page_links.created_at, oneWeekAgo))),
-      ]);
-    return {
-      sources: sourcesRes[0]?.count ?? 0,
-      pages: pagesRes[0]?.count ?? 0,
-      domainCount: domainsRes[0]?.count ?? 0,
-      backlinks: backlinksRes[0]?.count ?? 0,
-      sources_week: swRes[0]?.count ?? 0,
-      pages_week: pwRes[0]?.count ?? 0,
-      backlinks_week: bwRes[0]?.count ?? 0,
-    };
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const tomorrowStart = new Date(todayStart.getTime() + 86_400_000);
+
+    const rows = await db
+      .select({
+        id: memos.id,
+        type: memos.type,
+        body: memos.body,
+        created_at: memos.created_at,
+        compile_status: memos.compile_status,
+        compile_step: memos.compile_step,
+        compile_error: memos.compile_error,
+      })
+      .from(memos)
+      .where(
+        and(
+          eq(memos.user_id, userId),
+          gte(memos.created_at, todayStart),
+          lt(memos.created_at, tomorrowStart)
+        )
+      )
+      .orderBy(desc(memos.created_at))
+      .limit(50);
+
+    const photoMemoIds = rows.filter((m) => m.type === "photo").map((m) => m.id);
+    // Scope the attachment lookup to today's photo memos — without the memo_id
+    // constraint this would scan every photo attachment in the table.
+    const attachments =
+      photoMemoIds.length > 0
+        ? await db
+            .select({
+              memo_id: memo_attachments.memo_id,
+              storage_key: memo_attachments.storage_key,
+            })
+            .from(memo_attachments)
+            .where(
+              and(
+                eq(memo_attachments.kind, "photo"),
+                inArray(memo_attachments.memo_id, photoMemoIds)
+              )
+            )
+        : [];
+    const photoByMemoId = new Map(
+      attachments.map((a) => [a.memo_id, `/api/img/${a.storage_key}`])
+    );
+
+    return rows.map((m) => {
+      const photoUrl = photoByMemoId.get(m.id) ?? null;
+      const displayType: MemoCardData["type"] =
+        m.type === "photo" && m.body.trim().length > 0
+          ? "mixed"
+          : (m.type as MemoCardData["type"]);
+      return {
+        id: m.id,
+        type: displayType,
+        body: m.body,
+        created_at: m.created_at.toISOString(),
+        photo_url: photoUrl,
+        compile_status: m.compile_status ?? undefined,
+        compile_step: m.compile_step ?? null,
+        compile_error: m.compile_error ?? null,
+      };
+    });
   } catch {
-    return { sources: 0, pages: 0, domainCount: 0, backlinks: 0, sources_week: 0, pages_week: 0, backlinks_week: 0 };
+    return [];
   }
+}
+
+// Yesterday-and-earlier compiled daily pages (type="daily", live), newest first.
+async function getDailyPages(userId: string): Promise<DailyPageCard[]> {
+  try {
+    const rows = await db
+      .select({
+        slug: pages.slug,
+        title: pages.title,
+        body_md: pages.body_md,
+        source_count: pages.source_count,
+        last_compiled_at: pages.last_compiled_at,
+      })
+      .from(pages)
+      .where(
+        and(eq(pages.user_id, userId), eq(pages.type, "daily"), eq(pages.status, "live"))
+      )
+      .orderBy(desc(pages.slug))
+      .limit(12);
+
+    const todayIso = (() => {
+      const n = new Date();
+      return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(
+        n.getDate()
+      ).padStart(2, "0")}`;
+    })();
+
+    return rows
+      .map((r) => {
+        const date = r.slug.replace(/^daily\//, "");
+        return {
+          slug: r.slug,
+          date,
+          title: r.title,
+          excerpt: excerptFromMarkdown(r.body_md ?? ""),
+          source_count: r.source_count ?? 0,
+          last_compiled_at: r.last_compiled_at ? r.last_compiled_at.toISOString() : null,
+        };
+      })
+      // Don't echo today's page in the "yesterday & earlier" rail.
+      .filter((p) => p.date !== todayIso);
+  } catch {
+    return [];
+  }
+}
+
+// First ~160 chars of body, stripped of markdown noise — a calm card preview.
+function excerptFromMarkdown(md: string): string {
+  const plain = md
+    .replace(/^---[\s\S]*?\r?\n---\r?\n/, "") // strip YAML frontmatter (LF or CRLF)
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*_]{3,}\s*$/gm, "") // strip horizontal rules
+    .replace(/^[|].*[|]\s*$/gm, "") // strip table rows
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[*_`>#]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return plain.length > 160 ? `${plain.slice(0, 160)}…` : plain;
 }
 
 type ActivityRow = {
@@ -72,7 +176,14 @@ type ActivityRow = {
 async function getActivities(userId: string): Promise<ActivityRow[]> {
   try {
     return await db
-      .select()
+      .select({
+        id: activities.id,
+        verb: activities.verb,
+        subject: activities.subject,
+        target_type: activities.target_type,
+        target_id: activities.target_id,
+        created_at: activities.created_at,
+      })
       .from(activities)
       .where(eq(activities.user_id, userId))
       .orderBy(desc(activities.created_at))
@@ -90,41 +201,26 @@ type InboxItemRow = {
   created_at: Date;
 };
 
-async function getOpenInboxItems(userId: string): Promise<{ items: InboxItemRow[]; total: number }> {
+async function getOpenInboxItems(
+  userId: string
+): Promise<{ items: InboxItemRow[]; total: number }> {
   try {
-    const [countRes, rows] = await Promise.all([
-      db.select({ count: sql<number>`count(*)::int` }).from(inbox_items).where(and(eq(inbox_items.user_id, userId), eq(inbox_items.status, "open"))),
-      db
-        .select({ id: inbox_items.id, kind: inbox_items.kind, title: inbox_items.title, body: inbox_items.body, created_at: inbox_items.created_at })
-        .from(inbox_items)
-        .where(and(eq(inbox_items.user_id, userId), eq(inbox_items.status, "open")))
-        .orderBy(desc(inbox_items.created_at))
-        .limit(3),
-    ]);
-    return { items: rows, total: countRes[0]?.count ?? 0 };
+    const rows = await db
+      .select({
+        id: inbox_items.id,
+        kind: inbox_items.kind,
+        title: inbox_items.title,
+        body: inbox_items.body,
+        created_at: inbox_items.created_at,
+      })
+      .from(inbox_items)
+      .where(and(eq(inbox_items.user_id, userId), eq(inbox_items.status, "open")))
+      .orderBy(desc(inbox_items.created_at))
+      .limit(3);
+    // The inbox page owns the precise count — here we only need "are there any".
+    return { items: rows, total: rows.length };
   } catch {
     return { items: [], total: 0 };
-  }
-}
-
-type DomainRow = {
-  id: string;
-  slug: string;
-  label: string;
-  color: string | null;
-  created_at: Date;
-};
-
-async function getDomains(userId: string): Promise<DomainRow[]> {
-  try {
-    return await db
-      .select({ id: domains.id, slug: domains.slug, label: domains.label, color: domains.color, created_at: domains.created_at })
-      .from(domains)
-      .where(eq(domains.user_id, userId))
-      .orderBy(domains.position, domains.created_at)
-      .limit(8);
-  } catch {
-    return [];
   }
 }
 
@@ -133,22 +229,27 @@ async function getDomains(userId: string): Promise<DomainRow[]> {
 function formatRelative(date: Date): string {
   const diffMs = Date.now() - date.getTime();
   const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1) return "Just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffMin < 1) return "刚刚";
+  if (diffMin < 60) return `${diffMin} 分钟前`;
   const diffH = Math.floor(diffMin / 60);
-  if (diffH < 24) return `${diffH}h ago`;
+  if (diffH < 24) return `${diffH} 小时前`;
   const diffD = Math.floor(diffH / 24);
-  if (diffD === 1) return "Yesterday";
-  return `${diffD} days ago`;
+  if (diffD === 1) return "昨天";
+  return `${diffD} 天前`;
 }
 
 function kindLabel(kind: string): string {
   switch (kind) {
-    case "contradiction": return "Contradiction";
-    case "schema": return "Schema";
-    case "orphan": return "Orphan";
-    case "compiled": return "Compiled";
-    default: return kind;
+    case "contradiction":
+      return "矛盾";
+    case "schema":
+      return "结构";
+    case "orphan":
+      return "孤立";
+    case "compiled":
+      return "已编译";
+    default:
+      return kind;
   }
 }
 
@@ -158,249 +259,168 @@ export default async function HomePage() {
   const session = await auth();
   const userId = session?.user?.email ? await resolveUserId(session.user.email) : null;
 
-  const [stats, recentActivities, inboxData, domainList] = userId
+  const [todayMemos, dailyPages, recentActivities, inboxData] = userId
     ? await Promise.all([
-        getStats(userId),
+        getTodayMemos(userId),
+        getDailyPages(userId),
         getActivities(userId),
         getOpenInboxItems(userId),
-        getDomains(userId),
       ])
     : [
-        { sources: 0, pages: 0, domainCount: 0, backlinks: 0, sources_week: 0, pages_week: 0, backlinks_week: 0 },
+        [] as MemoCardData[],
+        [] as DailyPageCard[],
         [] as ActivityRow[],
         { items: [] as InboxItemRow[], total: 0 },
-        [] as DomainRow[],
       ];
 
   const openInboxCount = inboxData.total;
 
-  // Cold-start: no knowledge network has formed yet (no domains, no backlinks).
-  // Replace the bare zeros with explicit guidance + a concrete next step.
-  const isColdStart = stats.domainCount === 0 && stats.backlinks === 0;
-  const sourcesToWeave = Math.max(WEAVE_HINT_TARGET - stats.sources, 1);
-
   return (
-    <div className="page">
-      {/* Hero */}
-      <div className="hero">
+    <>
+      {/* ── The capture→compile→wiki stream (main act) ─────────────────── */}
+      <HomeStream initialToday={todayMemos} dailyPages={dailyPages} />
+
+      {/* ── Knowledge-network panels (supporting act) ──────────────────── */}
+      <div className="page home-panels">
+        {/* Observations */}
         <div>
-          <div
-            className="ds-section-label"
-            style={{ color: "var(--accent)", marginBottom: 14, display: "inline-flex", alignItems: "center", gap: 6 }}
-          >
-            <Icon as={Sparkles} size={12} />
-            {new Date().toLocaleDateString("en-US", { weekday: "short", day: "numeric", month: "long", year: "numeric" })}
-          </div>
-          <h1 className="hero-headline">
-            Your personal knowledge base.
-            <br />
-            <span className="accent">Everything compiled and connected.</span>
-          </h1>
-          <p className="hero-sub">
-            Add sources and I&rsquo;ll compile them into your wiki. Check the inbox for things that need your attention.
-          </p>
-          <div className="flex gap-12 mt-24">
-            <Link href="/add"><Btn kind="primary">Add something</Btn></Link>
-            <Link href="/chat"><Btn kind="soft">Ask the wiki</Btn></Link>
-            <Link href="/inbox">
-              <Btn kind="ghost" icon={<Inbox size={14} />}>
-                {openInboxCount > 0 ? `${openInboxCount} in inbox` : "Inbox"}
-              </Btn>
-            </Link>
-          </div>
-        </div>
-
-        {/* Stats grid (2×2) — US-002 */}
-        <div className="stats">
-          <div className="stat">
-            <div className="stat__value">{stats.sources}</div>
-            <div className="stat__label">Sources</div>
-            <div className="stat__delta">+{stats.sources_week} this week</div>
-          </div>
-          <div className="stat">
-            <div className="stat__value">{stats.pages}</div>
-            <div className="stat__label">Wiki pages</div>
-            <div className="stat__delta">+{stats.pages_week} this week</div>
-          </div>
-          <div className="stat">
-            <div className="stat__value">{stats.domainCount}</div>
-            <div className="stat__label">Domains</div>
-            <div className="stat__delta" style={{ color: "var(--fg-subtle)" }}>across your topics</div>
-          </div>
-          <div className="stat">
-            <div className="stat__value">{stats.backlinks}</div>
-            <div className="stat__label">Backlinks</div>
-            <div className="stat__delta">+{stats.backlinks_week} this week</div>
-          </div>
-        </div>
-      </div>
-
-      {/* Cold-start guidance — US-052: replace bare zeros with a clear next step */}
-      {isColdStart && (
-        <div className="mt-32">
-          <ColdStartGuide sourcesToWeave={sourcesToWeave} />
-        </div>
-      )}
-
-      {/* Observations — US-004 */}
-      <div className="mt-32">
-        <SectionLabel
-          right={
-            openInboxCount > 0 ? (
-              <Link href="/inbox">
-                <Chip tone="accent">{openInboxCount} open</Chip>
-              </Link>
-            ) : null
-          }
-        >
-          What the system noticed
-        </SectionLabel>
-        {inboxData.items.length === 0 ? (
-          <Card>
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: "48px 24px", textAlign: "center" }}>
-              <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
-                <Icon as={Sparkles} size={28} />
-              </span>
-              <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
-                No pending observations
-              </p>
-              <Link href="/add">
-                <Btn kind="ghost" size="sm">Add a source</Btn>
-              </Link>
-            </div>
-          </Card>
-        ) : (
-          <Card>
-            {inboxData.items.map((item, i) => (
-              <div key={item.id}>
-                <Link href="/inbox" style={{ textDecoration: "none", color: "inherit" }}>
-                  <div className="observation">
-                    <div className="observation__lead">
-                      <span className="pulse" />
-                      {kindLabel(item.kind)}
-                    </div>
-                    <div className="observation__body">
-                      <p style={{ fontWeight: 500, margin: "0 0 4px" }}>{item.title}</p>
-                      {item.body && <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.875rem" }}>{item.body}</p>}
-                      <div style={{ display: "flex", alignItems: "center", gap: 4, marginTop: 6, color: "var(--fg-subtle)", fontSize: "0.8rem" }}>
-                        <Icon as={Clock} size={11} />
-                        {formatRelative(item.created_at)}
-                      </div>
-                    </div>
-                  </div>
-                </Link>
-                {i < inboxData.items.length - 1 && <div className="divider" />}
-              </div>
-            ))}
-            {openInboxCount > inboxData.items.length && (
-              <div style={{ padding: "12px 16px", borderTop: "1px solid var(--border)" }}>
+          <SectionLabel
+            right={
+              openInboxCount > 0 ? (
                 <Link href="/inbox">
-                  <Btn kind="ghost" size="sm" iconRight={<Icon as={ArrowUpRight} size={14} />}>
-                    View all {openInboxCount} observations
+                  <Chip tone="accent">{openInboxCount} open</Chip>
+                </Link>
+              ) : null
+            }
+          >
+            系统注意到的
+          </SectionLabel>
+          {inboxData.items.length === 0 ? (
+            <Card>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 12,
+                  padding: "40px 24px",
+                  textAlign: "center",
+                }}
+              >
+                <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
+                  <Icon as={Sparkles} size={26} />
+                </span>
+                <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
+                  暂无待处理的观察
+                </p>
+                <Link href="/inbox">
+                  <Btn kind="ghost" size="sm" icon={<Inbox size={14} />}>
+                    打开收件箱
                   </Btn>
                 </Link>
               </div>
-            )}
-          </Card>
-        )}
-      </div>
-
-      {/* Recent activity — US-003 */}
-      <div className="mt-32">
-        <SectionLabel
-          right={
-            <Link href="/inbox?filter=compiled">
-              <Btn kind="ghost" size="sm" iconRight={<Icon as={ArrowUpRight} size={14} />}>
-                View all
-              </Btn>
-            </Link>
-          }
-        >
-          Recent activity
-        </SectionLabel>
-        {recentActivities.length === 0 ? (
-          <Card>
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: "48px 24px", textAlign: "center" }}>
-              <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
-                <Icon as={Activity} size={28} />
-              </span>
-              <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
-                No recent activity — start by adding a memo
-              </p>
-              <Link href="/add">
-                <Btn kind="ghost" size="sm">Add a memo</Btn>
-              </Link>
-            </div>
-          </Card>
-        ) : (
-          <Card>
-            {recentActivities.map((a) => (
-              <div className="activity-row" key={a.id}>
-                <div className="when">{formatRelative(a.created_at)}</div>
-                <div className="what">
-                  <strong>{a.verb}</strong>
-                  {" "}
-                  {a.subject}
-                  {a.target_id && a.target_type === "page" && (
-                    <Link href={`/wiki/${a.target_id}`} className="activity-target"><em>{a.target_id}</em></Link>
-                  )}
-                </div>
-                <Icon as={ChevronRight} size={14} />
-              </div>
-            ))}
-          </Card>
-        )}
-      </div>
-
-      {/* Domains at a glance — US-005 */}
-      <div className="mt-32">
-        <SectionLabel
-          right={
-            <Link href="/insights">
-              <Btn kind="ghost" size="sm" iconRight={<Icon as={ArrowUpRight} size={14} />}>
-                All domains
-              </Btn>
-            </Link>
-          }
-        >
-          Domains at a glance
-        </SectionLabel>
-        {domainList.length === 0 ? (
-          <Card>
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: "48px 24px", textAlign: "center" }}>
-              <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>No domains yet</p>
-            </div>
-          </Card>
-        ) : (
-          <div className="grid-4">
-            {domainList.map((d) => (
-              <Link key={d.id} href={`/insights?domain=${d.slug}`} style={{ textDecoration: "none" }}>
-                <Card className="domain-card">
-                  <div className="flex between center">
-                    <div className="domain-card__title">{d.label}</div>
-                    <span
-                      style={{
-                        background: d.color ?? "#888",
-                        width: 8,
-                        height: 8,
-                        borderRadius: 999,
-                        display: "inline-block",
-                      }}
-                    />
-                  </div>
-                  <Sparkline values={[3, 4, 5, 6, 7, 8, 9, 10]} color={d.color ?? "#888"} fill w={240} h={32} />
-                  <div className="flex between center">
-                    <div className="domain-card__meta">
-                      {new Date(d.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+            </Card>
+          ) : (
+            <Card>
+              {inboxData.items.map((item, i) => (
+                <div key={item.id}>
+                  <Link href="/inbox" style={{ textDecoration: "none", color: "inherit" }}>
+                    <div className="observation">
+                      <div className="observation__lead">
+                        <span className="pulse" />
+                        {kindLabel(item.kind)}
+                      </div>
+                      <div className="observation__body">
+                        <p style={{ fontWeight: 500, margin: "0 0 4px" }}>{item.title}</p>
+                        {item.body && (
+                          <p
+                            style={{
+                              color: "var(--fg-subtle)",
+                              margin: 0,
+                              fontSize: "0.875rem",
+                            }}
+                          >
+                            {item.body}
+                          </p>
+                        )}
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
+                            marginTop: 6,
+                            color: "var(--fg-subtle)",
+                            fontSize: "0.8rem",
+                          }}
+                        >
+                          <Icon as={Clock} size={11} />
+                          {formatRelative(item.created_at)}
+                        </div>
+                      </div>
                     </div>
-                    <Icon as={ArrowUpRight} size={14} />
-                  </div>
-                </Card>
+                  </Link>
+                  {i < inboxData.items.length - 1 && <div className="divider" />}
+                </div>
+              ))}
+            </Card>
+          )}
+        </div>
+
+        {/* Recent activity */}
+        <div className="mt-32">
+          <SectionLabel
+            right={
+              <Link href="/inbox?filter=compiled">
+                <Btn kind="ghost" size="sm" iconRight={<Icon as={ArrowUpRight} size={14} />}>
+                  全部
+                </Btn>
               </Link>
-            ))}
-          </div>
-        )}
+            }
+          >
+            最近动态
+          </SectionLabel>
+          {recentActivities.length === 0 ? (
+            <Card>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 12,
+                  padding: "40px 24px",
+                  textAlign: "center",
+                }}
+              >
+                <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
+                  <Icon as={Activity} size={26} />
+                </span>
+                <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
+                  暂无动态 —— 记录满一天，编译后这里会亮起来
+                </p>
+              </div>
+            </Card>
+          ) : (
+            <Card>
+              {recentActivities.map((a) => (
+                <div className="activity-row" key={a.id}>
+                  <div className="when">{formatRelative(a.created_at)}</div>
+                  <div className="what">
+                    <strong>{a.verb}</strong> {a.subject}
+                    {a.target_id && a.target_type === "page" && (
+                      <Link href={`/wiki/${a.target_id}`} className="activity-target">
+                        <em>{a.target_id}</em>
+                      </Link>
+                    )}
+                  </div>
+                  <Icon as={ChevronRight} size={14} />
+                </div>
+              ))}
+            </Card>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/app/api/memos/bulk/__tests__/route.test.ts
+++ b/web/src/app/api/memos/bulk/__tests__/route.test.ts
@@ -29,8 +29,27 @@ vi.mock("@/lib/ratelimit", () => ({
   }),
 }));
 
+// API-key auth is opt-in per request: default to "no API key" so the existing
+// session-based tests exercise the NextAuth path unchanged. Individual tests
+// override authenticateApiKey to exercise the Bearer path.
+vi.mock("@/lib/api-auth", () => ({
+  authenticateApiKey: vi.fn().mockResolvedValue(null),
+  hasScope: vi.fn((auth: { scopes: string[] }, scope: string) =>
+    auth.scopes.includes("admin") || auth.scopes.includes(scope)
+  ),
+}));
+
 import { auth } from "@/auth";
 import { checkMutationRateLimit } from "@/lib/ratelimit";
+import { authenticateApiKey } from "@/lib/api-auth";
+
+// Build a UUID for index `i` by zero-padding it into the last segment, so bulk
+// payloads of N memos all carry distinct, schema-valid UUIDs (the zod schema
+// rejects non-UUID ids before the count check, so naive string concatenation
+// would mask count-limit assertions).
+function uuidFor(i: number): string {
+  return `550e8400-e29b-41d4-a716-${String(i).padStart(12, "0")}`;
+}
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -124,6 +143,7 @@ describe("POST /api/memos/bulk", () => {
 
   it("returns 400 for invalid JSON body", async () => {
     mockSession("alice@example.com");
+    mockUserLookup(mockUser); // auth must resolve before body parsing is reached
     const req = new NextRequest("http://localhost/api/memos/bulk", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -149,7 +169,7 @@ describe("POST /api/memos/bulk", () => {
     mockUserLookup(mockUser);
     const { POST } = await import("../route");
     const tooMany = Array.from({ length: 101 }, (_, i) =>
-      makeMemo({ id: `550e8400-e29b-41d4-a716-4466554400${String(i).padStart(2, "0")}` })
+      makeMemo({ id: uuidFor(i) })
     );
     const res = await POST(makeRequest({ memos: tooMany }));
     expect(res.status).toBe(400);
@@ -267,5 +287,96 @@ describe("POST /api/memos/bulk", () => {
     expect(res.status).toBe(200);
     const data = await res.json() as { accepted: string[] };
     expect(data.accepted).toHaveLength(100);
+  });
+});
+
+// ── API-key Bearer auth (iOS sync path) ─────────────────────────────────────────
+
+describe("POST /api/memos/bulk — API key auth", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function makeKeyRequest(body: unknown, key = "dp_live_testkey"): NextRequest {
+    return new NextRequest("http://localhost/api/memos/bulk", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${key}`,
+      },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it("accepts a memo when a valid write-scoped API key is presented (no session)", async () => {
+    // No NextAuth session — auth resolves purely from the API key.
+    mockNoSession();
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      userId: mockUser.id,
+      scopes: ["write"],
+    });
+    const insertChain = mockInsertChain();
+
+    const { POST } = await import("../route");
+    const memo = makeMemo();
+    const res = await POST(makeKeyRequest({ memos: [memo] }));
+
+    expect(res.status).toBe(200);
+    const data = (await res.json()) as { accepted: string[]; skipped: unknown[] };
+    expect(data.accepted).toContain(memo.id);
+    // The memo must be bound to the key's user, not anyone else.
+    const callArg = (insertChain.values as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as { user_id: string };
+    expect(callArg.user_id).toBe(mockUser.id);
+  });
+
+  it("returns 403 when the API key lacks the write scope", async () => {
+    mockNoSession();
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      userId: mockUser.id,
+      scopes: ["read"],
+    });
+    const { POST } = await import("../route");
+    const res = await POST(makeKeyRequest({ memos: [makeMemo()] }));
+    expect(res.status).toBe(403);
+    const data = (await res.json()) as { error: string };
+    expect(data.error).toMatch(/write/i);
+  });
+
+  it("admin-scoped key implicitly satisfies the write requirement", async () => {
+    mockNoSession();
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      userId: mockUser.id,
+      scopes: ["admin"],
+    });
+    mockInsertChain();
+    const { POST } = await import("../route");
+    const res = await POST(makeKeyRequest({ memos: [makeMemo()] }));
+    expect(res.status).toBe(200);
+  });
+
+  it("falls back to 401 when neither API key nor session is present", async () => {
+    mockNoSession();
+    vi.mocked(authenticateApiKey).mockResolvedValue(null);
+    const { POST } = await import("../route");
+    // No Authorization header at all.
+    const res = await POST(makeRequest({ memos: [makeMemo()] }));
+    expect(res.status).toBe(401);
+  });
+
+  it("API key takes precedence over a session (key user wins)", async () => {
+    // A session exists for user B, but a key for user A is presented; memos
+    // must bind to user A (the key holder).
+    mockSession("bob@example.com");
+    vi.mocked(authenticateApiKey).mockResolvedValue({
+      userId: mockUser.id,
+      scopes: ["write"],
+    });
+    const insertChain = mockInsertChain();
+    const { POST } = await import("../route");
+    await POST(makeKeyRequest({ memos: [makeMemo()] }));
+    const callArg = (insertChain.values as ReturnType<typeof vi.fn>).mock
+      .calls[0][0] as { user_id: string };
+    expect(callArg.user_id).toBe(mockUser.id);
   });
 });

--- a/web/src/app/api/memos/bulk/route.ts
+++ b/web/src/app/api/memos/bulk/route.ts
@@ -5,9 +5,14 @@ import { memos, memo_attachments, users } from "@/lib/db/schema";
 import { eq, sql } from "drizzle-orm";
 import { BulkMemosSchema, BulkMemoItem } from "@/lib/schemas/memo";
 import { checkMutationRateLimit } from "@/lib/ratelimit";
+import { authenticateApiKey, hasScope } from "@/lib/api-auth";
 
 function unauthorized() {
   return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+}
+
+function forbidden(message: string) {
+  return NextResponse.json({ error: message }, { status: 403 });
 }
 
 function badRequest(message: string) {
@@ -23,12 +28,54 @@ async function resolveUserId(email: string): Promise<string | null> {
   return rows[0]?.id ?? null;
 }
 
+/**
+ * Resolve the acting user for a bulk-sync request. Two auth paths:
+ *
+ *  1. **API Key Bearer** (iOS sync, third-party clients) — the iOS app holds
+ *     a `write`-scoped key the user generated under web Settings → API Keys.
+ *     The key's `user_id` binds the memos to the right account, so no
+ *     Supabase↔NextAuth email bridge is needed. This mirrors the existing
+ *     `/api/ingest` auth model.
+ *  2. **NextAuth session** (web itself) — unchanged from the original
+ *     behaviour; a logged-in browser session resolves to its user by email.
+ *
+ * Returns the resolved `userId`, or a ready-to-send error `Response` (401 for
+ * no/invalid credentials, 403 for a valid key lacking the `write` scope) plus
+ * a `rateKey` used to scope mutation rate limiting per key/user.
+ */
+async function resolveActor(
+  req: NextRequest
+): Promise<
+  | { userId: string; rateKey: string }
+  | { error: NextResponse }
+> {
+  // Path 1: API key (preferred for non-browser clients).
+  const apiAuth = await authenticateApiKey(req);
+  if (apiAuth) {
+    if (!hasScope(apiAuth, "write")) {
+      return { error: forbidden("API key requires 'write' scope") };
+    }
+    // Rate-limit by user id so multiple keys for the same user share a budget.
+    return { userId: apiAuth.userId, rateKey: `apikey:${apiAuth.userId}` };
+  }
+
+  // Path 2: NextAuth browser session (web self-calls).
+  const session = await auth();
+  if (session?.user?.email) {
+    const userId = await resolveUserId(session.user.email);
+    if (userId) return { userId, rateKey: session.user.email };
+  }
+
+  return { error: unauthorized() };
+}
+
 // POST /api/memos/bulk — iOS sync upsert (last-write-wins by updated_at)
 export async function POST(req: NextRequest) {
-  const session = await auth();
-  if (!session?.user?.email) return unauthorized();
+  const actor = await resolveActor(req);
+  if ("error" in actor) return actor.error;
+  const { userId, rateKey } = actor;
 
-  const rl = await checkMutationRateLimit(session.user.email);
+  const rl = await checkMutationRateLimit(rateKey);
   if (!rl.success) {
     return NextResponse.json(
       { error: "Rate limit exceeded" },
@@ -41,9 +88,6 @@ export async function POST(req: NextRequest) {
       }
     );
   }
-
-  const userId = await resolveUserId(session.user.email);
-  if (!userId) return unauthorized();
 
   const body: unknown = await req.json().catch(() => null);
   if (!body) return badRequest("Invalid JSON body");

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -10,6 +10,10 @@
   --fg-primary: #2B2822;
   --fg-muted: #6B6560;
   --fg-subtle: #A39F99;
+  /* AA-compliant subtle text (~4.6:1 on the warm canvas, ~4.9:1 on white) — for
+     token-bearing micro-labels that must stay legible; reserve --fg-subtle for
+     purely decorative hairlines. */
+  --fg-subtle-aa: #79736B;
   --accent: #5D3000;
   --accent-hover: #7A3F00;
   --accent-soft: #F5EDE3;
@@ -158,6 +162,7 @@
   --fg-primary:  #F0EDE8;
   --fg-muted:    #A39F99;
   --fg-subtle:   #6B6560;
+  --fg-subtle-aa: #B8B3AC;
 
   --accent:        #C9883A;
   --accent-hover:  #E09A45;
@@ -191,6 +196,7 @@
     --fg-primary:  #F0EDE8;
     --fg-muted:    #A39F99;
     --fg-subtle:   #6B6560;
+  --fg-subtle-aa: #B8B3AC;
 
     --accent:        #C9883A;
     --accent-hover:  #E09A45;
@@ -1003,9 +1009,26 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
 .queue-item:focus-visible,
 .inbox-card:focus-visible,
 .cite-card:focus-visible,
-.recently-compiled-item:focus-visible {
+.recently-compiled-item:focus-visible,
+.dcc-compile-btn:focus-visible,
+.home-composer__save:focus-visible,
+.home-section__more:focus-visible,
+.wiki-day-card:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* Visually-hidden but screen-reader-available (live regions, labels). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .recently-compiled-item:hover {
@@ -1565,4 +1588,411 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
     from { opacity: 0; }
     to   { opacity: 1; }
   }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   HomeStream — unified capture→compile→wiki home (mirrors iOS Today→DailyPage).
+   Museum-calm: warm cream, hairline borders, serif headlines, mono captions.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.home-stream { padding-bottom: 24px; }
+.home-panels { padding-top: 8px; padding-bottom: 80px; }
+
+/* ── Hero: date + daily-compile card ──────────────────────────────────────── */
+.home-hero {
+  display: grid;
+  grid-template-columns: 1.55fr 1fr;
+  gap: 28px;
+  align-items: start;
+}
+.home-hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 14px;
+}
+.home-hero__title {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: clamp(22px, 5vw, 34px);
+  line-height: 1.22;
+  letter-spacing: -0.4px;
+  color: var(--fg-primary);
+  margin: 0;
+}
+.home-hero__title .accent { color: var(--accent); }
+.home-hero__sub {
+  margin: 16px 0 0;
+  font-family: var(--font-body);
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--fg-muted);
+  max-width: 46ch;
+  text-wrap: pretty;
+}
+
+/* Daily-compile card */
+.daily-compile-card {
+  background: var(--surface-white);
+  border: 0.5px solid var(--border-subtle);
+  border-radius: 18px;
+  box-shadow: var(--shadow-card);
+  padding: 20px 22px 18px;
+}
+.daily-compile-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+.daily-compile-card__label {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.daily-compile-card__date {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.4px;
+  color: var(--fg-subtle);
+}
+.daily-compile-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 18px;
+}
+.dcc-metric { text-align: center; }
+.dcc-metric__value {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 28px;
+  line-height: 1;
+  letter-spacing: -0.5px;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+}
+.dcc-metric__label {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--fg-subtle-aa);
+  margin-top: 6px;
+}
+.dcc-compile-btn {
+  width: 100%;
+  height: 42px;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  background: var(--accent);
+  color: #FAF8F6;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: background 160ms ease-out, transform 120ms ease-out;
+}
+.dcc-compile-btn:hover:not(:disabled) { background: var(--accent-hover); }
+.dcc-compile-btn:active:not(:disabled) { transform: scale(0.985); }
+/* Steady state (nothing pending): de-emphasise compile to an outline so the
+   composer ("先把此刻记下来") stays the page's primary call to action. It
+   re-fills with accent the moment there are memos waiting to compile. */
+.dcc-compile-btn--ghost {
+  background: transparent;
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent-border);
+}
+.dcc-compile-btn--ghost:hover:not(:disabled) {
+  background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px var(--accent-border);
+}
+.dcc-compile-btn:disabled { opacity: 0.62; cursor: default; }
+.dcc-foot {
+  margin: 12px 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.4px;
+  color: var(--fg-subtle-aa);
+  min-height: 14px;
+}
+.dcc-foot__note { color: var(--accent); font-weight: 600; }
+
+/* Pipeline-unreachable banner */
+.home-pipeline-warn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  padding: 11px 16px;
+  border-radius: 12px;
+  background: var(--accent-soft);
+  border: 0.5px solid var(--accent-border);
+  color: var(--accent);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* ── Composer ─────────────────────────────────────────────────────────────── */
+.home-composer {
+  margin-top: 28px;
+  background: var(--surface-white);
+  border: 0.5px solid var(--border-subtle);
+  border-radius: 18px;
+  box-shadow: var(--shadow-card);
+  padding: 18px 20px 14px;
+  transition: border-color 160ms ease-out, box-shadow 160ms ease-out;
+}
+.home-composer:focus-within {
+  /* genuine, perceivable focus ring on the page's primary control (SC 2.4.11) */
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.home-composer__ta {
+  width: 100%;
+  resize: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: var(--font-serif);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.2px;
+  color: var(--fg-primary);
+  min-height: 52px;
+  max-height: 200px;
+  padding: 0;
+  caret-color: var(--accent);
+  display: block;
+}
+.home-composer__ta::placeholder { color: var(--fg-subtle); opacity: 0.6; font-style: italic; }
+.home-composer__ta::-webkit-scrollbar { display: none; }
+.home-composer__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 0.5px solid var(--border-subtle);
+}
+.home-composer__hint {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.5px;
+  color: var(--fg-subtle-aa);
+  font-variant-numeric: tabular-nums;
+  transition: color 160ms ease-out;
+}
+.home-composer__hint.is-error { color: var(--accent); font-weight: 600; }
+.home-composer__save {
+  height: 36px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  background: var(--accent);
+  color: #FAF8F6;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 160ms ease-out;
+}
+.home-composer__save:hover:not(:disabled) { background: var(--accent-hover); }
+.home-composer__save:disabled {
+  background: var(--surface-sunken);
+  color: var(--fg-subtle);
+  cursor: default;
+}
+
+/* ── Section label (今天 / 昨天及更早) ──────────────────────────────────────── */
+.home-section { margin-top: 38px; }
+.home-section__label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--fg-primary);
+}
+.home-section__count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 999px;
+  padding: 2px 9px;
+  text-transform: none;
+}
+.home-section__more {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  /* keep ≥24px hit target without disturbing layout (WCAG 2.5.8) */
+  padding: 6px 8px;
+  margin-right: -8px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: none;
+  color: var(--fg-muted);
+  text-decoration: none;
+  transition: color 140ms ease-out;
+}
+.home-section__more:hover { color: var(--accent); }
+
+/* Today's flomo card grid */
+.home-memo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+/* Empty state */
+.home-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 24px;
+  text-align: center;
+  background: var(--surface-white);
+  border: 0.5px dashed var(--border-default);
+  border-radius: 18px;
+  color: var(--fg-subtle);
+}
+.home-empty p { margin: 0; font-family: var(--font-body); font-size: 14px; color: var(--fg-muted); }
+.home-empty svg { color: var(--fg-subtle); opacity: 0.55; }
+
+/* Daily wiki card grid */
+.home-wiki-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+.wiki-day-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px 22px;
+  background: var(--surface-white);
+  border: 0.5px solid var(--border-subtle);
+  border-radius: 18px;
+  box-shadow: var(--shadow-card);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 160ms ease-out, transform 160ms ease-out, box-shadow 160ms ease-out;
+}
+.wiki-day-card:hover {
+  border-color: var(--accent-border);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px -8px rgba(60,40,15,0.18);
+}
+.wiki-day-card__head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.wiki-day-card__rel {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: -0.1px;
+  color: var(--accent);
+}
+.wiki-day-card__date {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--fg-subtle-aa);
+}
+.wiki-day-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: -0.2px;
+  color: var(--fg-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.wiki-day-card__excerpt {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: pretty;
+}
+.wiki-day-card__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 2px;
+  padding-top: 12px;
+  border-top: 0.5px solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.4px;
+  color: var(--fg-subtle-aa);
+}
+.wiki-day-card__foot span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.wiki-day-card:hover .wiki-day-card__foot { color: var(--accent); }
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+@media (max-width: 820px) {
+  .home-hero { grid-template-columns: 1fr; gap: 20px; }
+  .home-hero__title { font-size: 28px; }
+}
+@media (max-width: 560px) {
+  .home-hero__title { font-size: 25px; }
+  .home-memo-grid,
+  .home-wiki-grid { grid-template-columns: 1fr; }
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1637,6 +1637,75 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
   text-wrap: pretty;
 }
 
+/* Calm hero — shown once the day has ≥1 record. One-line state in place of
+   the two-line slogan, so returning users don't read the same poster twice. */
+.home-hero__title--calm {
+  font-size: clamp(20px, 4vw, 26px);
+  line-height: 1.35;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+}
+.home-hero__title-tail { color: var(--fg-muted); font-weight: 400; }
+.home-hero__sub--quiet { margin-top: 10px; }
+.home-hero__yesterday {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 13.5px;
+  border-bottom: 0.5px dashed transparent;
+  transition: border-color 160ms ease-out;
+}
+.home-hero__yesterday:hover { border-bottom-color: var(--accent-border); }
+
+/* Midnight-crossing toast — appears once when the day flips. */
+.home-midnight-toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin: 14px 0 -4px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 10%, var(--surface-white));
+  border: 0.5px solid var(--accent-border);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  box-shadow: 0 4px 14px -10px rgba(60,40,15,0.35);
+  animation: midnightToastIn 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@keyframes midnightToastIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* "Ready" dot used in the third metric column when pending===0. The dot
+   replaces the count to communicate state, not statistics. */
+.dcc-metric__value--ready {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1em;
+}
+.dcc-ready-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #4d8c5b;
+  box-shadow: 0 0 0 4px color-mix(in oklab, #4d8c5b 18%, transparent);
+  animation: readyPulse 2.4s ease-in-out infinite;
+}
+@keyframes readyPulse {
+  0%, 100% { box-shadow: 0 0 0 4px color-mix(in oklab, #4d8c5b 18%, transparent); }
+  50%      { box-shadow: 0 0 0 7px color-mix(in oklab, #4d8c5b 8%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dcc-ready-dot, .home-midnight-toast { animation: none; }
+}
+
 /* Daily-compile card */
 .daily-compile-card {
   background: var(--surface-white);
@@ -1985,6 +2054,142 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
   gap: 5px;
 }
 .wiki-day-card:hover .wiki-day-card__foot { color: var(--accent); }
+
+/* ── Daily wiki "books" — reading shelf, not list ─────────────────────────
+   Each compiled day reads as a small book: serif title + one opening line
+   on the face, a corner date stamp, and N short rules along the bottom
+   edge as a "spine" — visually narrating "this day held N raw thoughts"
+   without making the user parse a number. Full excerpt fades in on hover
+   so the resting grid stays quiet. */
+.home-wiki-grid--books {
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 18px;
+}
+.wiki-book {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 22px 22px 28px;
+  min-height: 168px;
+  background: var(--surface-white);
+  border: 0.5px solid var(--border-subtle);
+  border-radius: 14px;
+  box-shadow: 0 1px 0 rgba(60,40,15,0.04), var(--shadow-card);
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+  transition:
+    transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 220ms ease-out;
+}
+.wiki-book:hover {
+  transform: translateY(-3px);
+  border-color: var(--accent-border);
+  box-shadow: 0 10px 28px -14px rgba(60,40,15,0.22), 0 1px 0 rgba(60,40,15,0.04);
+}
+.wiki-book__stamp {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  color: var(--fg-subtle-aa);
+  opacity: 0.55;
+}
+.wiki-book__rel {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0.75;
+}
+.wiki-book__title {
+  margin: 2px 0 0;
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 19px;
+  line-height: 1.32;
+  letter-spacing: -0.3px;
+  color: var(--fg-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: balance;
+}
+.wiki-book__pull {
+  margin: 4px 0 0;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: pretty;
+}
+/* Full excerpt is reserved for hover — it sits absolutely so it doesn't
+   reshuffle the resting layout. */
+.wiki-book__excerpt {
+  position: absolute;
+  left: 22px;
+  right: 22px;
+  bottom: 22px;
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.62;
+  color: var(--fg-muted);
+  background: linear-gradient(180deg, transparent 0%, var(--surface-white) 22%);
+  padding-top: 36px;
+  opacity: 0;
+  transform: translateY(6px);
+  pointer-events: none;
+  transition: opacity 200ms ease-out, transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: pretty;
+}
+.wiki-book:hover .wiki-book__excerpt,
+.wiki-book:focus-visible .wiki-book__excerpt {
+  opacity: 1;
+  transform: translateY(0);
+}
+/* Spine — N short rules at the bottom edge, like the lines on a paperback's
+   bottom edge stain. Capped at 9 lines in the JSX so a heavy day reads as
+   "thick" without becoming a solid bar. */
+.wiki-book__spine {
+  position: absolute;
+  left: 22px;
+  right: 22px;
+  bottom: 10px;
+  display: flex;
+  gap: 3px;
+  height: 4px;
+  align-items: flex-end;
+  opacity: 0.55;
+  transition: opacity 200ms ease-out;
+}
+.wiki-book:hover .wiki-book__spine { opacity: 0.18; }
+.wiki-book__spine-line {
+  flex: 1;
+  height: 100%;
+  background: var(--accent);
+  border-radius: 1px;
+}
+.wiki-book__spine-line:nth-child(even) { height: 70%; opacity: 0.7; }
+.wiki-book__spine-line:nth-child(3n) { height: 85%; opacity: 0.85; }
+@media (prefers-reduced-motion: reduce) {
+  .wiki-book,
+  .wiki-book__excerpt { transition: none; }
+}
 
 /* ── Responsive ───────────────────────────────────────────────────────────── */
 @media (max-width: 820px) {


### PR DESCRIPTION
## 目标

接通 iOS → web memo 同步。此前 iOS 的 `RemoteUploader` 只有 `NoopRemoteUploader`（假上传,从不发真实网络请求），同步队列空转——App 写的 memo 永远到不了 web。

Closes #785

## 改了什么

### Web（鉴权,最小改动）
- `/api/memos/bulk` 在 NextAuth session 之外**额外接受 API Key Bearer**（复用现成 `authenticateApiKey` + `hasScope("write")`），与 `/api/ingest` 同款范式。现有 session 路径行为不变。
- key 的 `user_id` 自动绑定 memo 归属,**无需 Supabase↔NextAuth 桥接**。

### iOS
- **`SyncSettings`**：baseURL（UserDefaults）+ apiKey（Keychain）+ `isConfigured` 门控 + baseURL 归一化。
- **`MemoSyncMapper`**（纯函数）：`Memo` → web bulk JSON（类型折叠、weather 包成 object、空 body 回退 transcript/占位、附件只传元数据、location 映射）。
- **`MemoSyncUploader`**：memoID → 扫 vault 找 Memo → POST → 解析 accepted/skipped；401/403/429/5xx 分类错误；Release 强制 https。
- **`SyncQueueObserver.installConfiguredUploader()`**：按配置注入真实 uploader 或保持 Noop（启动 + Settings 保存后调用）。
- **Settings「同步到 Web」section**：web 地址 + API key（SecureField）+ 待同步状态 + 保存即同步。

## 鉴权方案（模仿 flomo）

用户在 web Settings → API Keys 生成 `write` scope key，填进 iOS Settings → 同步。与 flomo 的同步 token 模式一致。

## 测试（真实验证）

| 项 | 结果 |
|---|---|
| web bulk 测试 | ✅ 17/17（修 2 个预先存在的脆弱用例 + 新增 5 个 API key 用例） |
| web 真实 curl | ✅ 无 key→401 / 假 key→401 / write→200 落库 / read→403 / 幂等 / LWW |
| iOS 同步单测 | ✅ 18/18（mapper / 响应解析 / settings） |
| **iOS 真实 E2E** | ✅ 模拟器进程内真实 URLSession POST → memo 落库（`origin=ios`），DB + web 日志双向对齐 |
| iOS 完整套件 | ✅ 167 XCTest + 125 Swift Testing,0 失败,无回归 |

`MemoSyncE2EIntegrationTests` 由环境变量 `SYNC_E2E_URL` / `SYNC_E2E_KEY` 门控（用 `TEST_RUNNER_` 前缀传入模拟器测试进程），CI/无 web 环境自动 skip。

## 非目标（后续 issue）

- web → iOS 反向同步（拉取写回 vault）
- 附件文件字节上传（multipart → `/api/upload`）

设计详见 `docs/ios-web-sync-design.md`。
