### PR TITLE
feat(web/home): 一体化 capture→compile→wiki 主页

### DIFF
--- a/web/src/app/(app)/home/HomeStream.tsx
+++ b/web/src/app/(app)/home/HomeStream.tsx
@@ -60,18 +60,36 @@ function computeToday(): TodayStrings {
 
 // A clock that re-derives the date strings once a minute, so a tab left open
 // across midnight rolls over to the new day rather than freezing on mount.
-function useTodayStrings(): TodayStrings {
+// When the iso day flips, `onCross` fires once — callers use it to refetch
+// "today's" memos (so cards left over from 23:59 don't claim to be today's).
+function useTodayStrings(onCross?: (prevIso: string, nextIso: string) => void): TodayStrings {
   const [today, setToday] = useState<TodayStrings>(computeToday);
+  const crossRef = useRef(onCross);
+  useEffect(() => { crossRef.current = onCross; }, [onCross]);
+
   useEffect(() => {
     const t = setInterval(() => {
       setToday((prev) => {
         const next = computeToday();
-        return next.iso === prev.iso ? prev : next;
+        if (next.iso === prev.iso) return prev;
+        try { crossRef.current?.(prev.iso, next.iso); } catch { /* ignore */ }
+        return next;
       });
     }, 60_000);
     return () => clearInterval(t);
   }, []);
   return today;
+}
+
+// Pull the first complete sentence from an excerpt — preferring 。 / ！/ ？
+// (Chinese punctuation) then falling back to . / ! / ? (Latin), then to the
+// first newline. We never truncate mid-word; if no boundary is found within
+// 64 chars, we let the excerpt speak for itself (the CSS will clamp).
+function firstSentence(excerpt: string): string {
+  const trimmed = excerpt.replace(/\s+/g, " ").trim();
+  if (!trimmed) return "";
+  const match = trimmed.match(/^[^。！？.!?\n]{2,64}[。！？.!?]/);
+  return match ? match[0].trim() : trimmed;
 }
 
 // Friendly relative label for a daily wiki card: 昨天 / 前天 / N 天前 / date.
@@ -92,10 +110,23 @@ function relativeDayLabel(dateStr: string): string {
 // ─── Component ───────────────────────────────────────────────────────────────
 
 export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
-  const { weekday, long, iso } = useTodayStrings();
-
   const [memos, setMemos] = useState<MemoCardData[]>(initialToday);
   const [serviceConnected, setServiceConnected] = useState(true);
+
+  // Midnight-crossing toast — fires once when the iso day flips while the tab
+  // is open. The reload below will pull the new day's (likely empty) memo set,
+  // and this toast turns the moment into a product beat rather than a glitch.
+  const [midnightToast, setMidnightToast] = useState<string | null>(null);
+  const midnightToastTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const reloadMemosRef = useRef<() => Promise<void>>(async () => {});
+  const onCrossMidnight = useCallback(() => {
+    void reloadMemosRef.current();
+    setMidnightToast("刚跨过了 00 点，昨天正在编织…");
+    if (midnightToastTimer.current) clearTimeout(midnightToastTimer.current);
+    midnightToastTimer.current = setTimeout(() => setMidnightToast(null), 6000);
+  }, []);
+  const { weekday, long, iso } = useTodayStrings(onCrossMidnight);
 
   // Composer state
   const [draft, setDraft] = useState("");
@@ -126,6 +157,7 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
     () => () => {
       if (compileNoteTimer.current) clearTimeout(compileNoteTimer.current);
       if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
+      if (midnightToastTimer.current) clearTimeout(midnightToastTimer.current);
     },
     []
   );
@@ -145,6 +177,9 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
       /* keep last good */
     }
   }, []);
+  // Expose the latest reloadMemos to onCrossMidnight without re-arming the
+  // clock interval (the clock effect runs once on mount).
+  useEffect(() => { reloadMemosRef.current = reloadMemos; }, [reloadMemos]);
 
   // Probe the compile pipeline once; surface an honest banner when unreachable
   // (mirrors the per-card status logic in MemoCard / the iOS sync queue banner).
@@ -190,20 +225,22 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
       if (r.ok) {
         setDraft("");
         setSaveOk(true);
-        announce("已保存到今天");
+        announce("收下了，夜里见");
         if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
         saveOkTimer.current = setTimeout(() => setSaveOk(false), 1800);
         await reloadMemos();
       } else {
         const d = await r.json().catch(() => null);
-        const msg = d?.error ? String(d.error) : "保存失败，已为你保留草稿";
+        // Prefer the server's exact reason when it gives one (validation,
+        // rate-limit, auth), otherwise fall back to product voice.
+        const msg = d?.error ? String(d.error) : "夜里还远，先再试一次";
         setSaveError(msg);
         announce(msg);
       }
     } catch {
       // Network error — the textarea keeps the draft so nothing is lost.
-      setSaveError("网络错误，已为你保留草稿，可重试");
-      announce("保存失败，网络错误");
+      setSaveError("夜里还远，先再试一次");
+      announce("夜里还远，先再试一次");
     } finally {
       setSaving(false);
     }
@@ -298,6 +335,18 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
     (m) => m.compile_status === "pending" || m.compile_status === "running"
   ).length;
   const compiledCount = memos.filter((m) => m.compile_status === "done").length;
+  const todayCount = memos.length;
+
+  // Hero rhythm — the slogan retreats as the day fills up:
+  //   0 records  → full two-line slogan (welcome / onboarding mood)
+  //   ≥1 record  → single calm status line ("已记下 N 条，等夜里编织")
+  // The serif title stays, but its content adapts to the user's actual day.
+  const heroMode: "intro" | "active" = todayCount === 0 ? "intro" : "active";
+
+  // The on-demand compile button is intentionally restrained: when there's
+  // little to weave, we don't tempt the user to break the midnight ritual.
+  // It surfaces only once the day has accumulated some material (≥5 raws).
+  const showCompileButton = todayCount >= 5;
 
   return (
     <div className="page home-stream">
@@ -313,58 +362,97 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             <Sparkles size={12} strokeWidth={2} aria-hidden="true" />
             {long} · {weekday}
           </div>
-          <h1 className="home-hero__title">
-            今天，先把此刻记下来。
-            <br />
-            <span className="accent">夜里 00 点，它会自己编织成网。</span>
-          </h1>
-          <p className="home-hero__sub">
-            随手记录原始念头，像便签一样留在「今天」。每天午夜自动编译成结构化的日记页，
-            昨天与更早的，都会沉淀为可回溯的 wiki。
-          </p>
+
+          {heroMode === "intro" ? (
+            <>
+              <h1 className="home-hero__title">
+                今天，先把此刻记下来。
+                <br />
+                <span className="accent">夜里 00 点，它会自己编织成网。</span>
+              </h1>
+              <p className="home-hero__sub">
+                随手记录原始念头，像便签一样留在「今天」。每天午夜自动编译成结构化的日记页，
+                昨天与更早的，都会沉淀为可回溯的 wiki。
+              </p>
+            </>
+          ) : (
+            <>
+              <h1 className="home-hero__title home-hero__title--calm">
+                今天 · <span className="accent">已记下 {todayCount} 条</span>
+                <span className="home-hero__title-tail">，等夜里编织。</span>
+              </h1>
+              {dailyPages.length > 0 && (
+                <p className="home-hero__sub home-hero__sub--quiet">
+                  <Link href={`/wiki/${dailyPages[0]!.slug}`} className="home-hero__yesterday">
+                    昨天已编织好 <ArrowUpRight size={12} strokeWidth={2} aria-hidden="true" />
+                  </Link>
+                </p>
+              )}
+            </>
+          )}
         </div>
 
         {/* Daily compile card */}
-        <section className="daily-compile-card" aria-label="今日编译">
+        <section className="daily-compile-card" aria-label="今日编译状态">
           <div className="daily-compile-card__head">
-            <span className="daily-compile-card__label">今日编译</span>
+            <span className="daily-compile-card__label">今日</span>
             <span className="daily-compile-card__date">{iso}</span>
           </div>
 
+          {/* Three-beat narrative: 念头 → 已织入网中 → 等夜里 / 已就绪.
+              The third beat flips to "已就绪" when the day is fully compiled,
+              giving users a felt sense of state progression instead of static
+              counts that always sum to the first. */}
           <div className="daily-compile-card__metrics">
             <div className="dcc-metric">
-              <div className="dcc-metric__value">{memos.length}</div>
-              <div className="dcc-metric__label">今日记录</div>
+              <div className="dcc-metric__value">{todayCount}</div>
+              <div className="dcc-metric__label">此刻的念头</div>
             </div>
             <div className="dcc-metric">
               <div className="dcc-metric__value">{compiledCount}</div>
-              <div className="dcc-metric__label">已编译</div>
+              <div className="dcc-metric__label">已织入网中</div>
             </div>
             <div className="dcc-metric">
-              <div className="dcc-metric__value">{pendingCount}</div>
-              <div className="dcc-metric__label">待编译</div>
+              {pendingCount === 0 && todayCount > 0 ? (
+                <>
+                  <div className="dcc-metric__value dcc-metric__value--ready" aria-label="已就绪">
+                    <span className="dcc-ready-dot" aria-hidden="true" />
+                  </div>
+                  <div className="dcc-metric__label">已就绪</div>
+                </>
+              ) : (
+                <>
+                  <div className="dcc-metric__value">{pendingCount}</div>
+                  <div className="dcc-metric__label">等夜里</div>
+                </>
+              )}
             </div>
           </div>
 
-          <button
-            type="button"
-            className={`dcc-compile-btn${pendingCount === 0 && !compiling ? " dcc-compile-btn--ghost" : ""}`}
-            onClick={handleCompileToday}
-            disabled={compiling}
-            aria-busy={compiling}
-          >
-            {compiling ? (
-              <>
-                <Loader2 size={14} strokeWidth={2} style={SPIN} aria-hidden="true" />
-                正在送编译…
-              </>
-            ) : (
-              <>
-                <Sparkles size={14} strokeWidth={2} aria-hidden="true" />
-                立即编译今天
-              </>
-            )}
-          </button>
+          {/* Compile button is restrained: only surfaces once enough material
+              has accumulated. Below the threshold we keep the midnight ritual
+              the only path — quietness reinforces the slogan's promise. */}
+          {showCompileButton && (
+            <button
+              type="button"
+              className={`dcc-compile-btn${pendingCount === 0 && !compiling ? " dcc-compile-btn--ghost" : ""}`}
+              onClick={handleCompileToday}
+              disabled={compiling}
+              aria-busy={compiling}
+            >
+              {compiling ? (
+                <>
+                  <Loader2 size={14} strokeWidth={2} style={SPIN} aria-hidden="true" />
+                  正在送编译…
+                </>
+              ) : (
+                <>
+                  <Sparkles size={14} strokeWidth={2} aria-hidden="true" />
+                  提前看看今天会织成什么
+                </>
+              )}
+            </button>
+          )}
 
           {/* Visual-only: the dedicated .sr-only live region already announces
               compile outcomes to AT, so this avoids a duplicate read. */}
@@ -374,12 +462,21 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             ) : (
               <>
                 <Clock size={11} strokeWidth={2} aria-hidden="true" />
-                每天 00:00 自动编译昨天
+                每天 00:00 自动编织昨天
               </>
             )}
           </p>
         </section>
       </div>
+
+      {/* Midnight-crossing toast: a one-off product beat when the tab stays
+          open across 00:00 — turns a potential glitch into a small moment. */}
+      {midnightToast && (
+        <div className="home-midnight-toast" role="status">
+          <Sparkles size={13} strokeWidth={2} aria-hidden="true" />
+          {midnightToast}
+        </div>
+      )}
 
       {/* Pipeline-unreachable banner (dev w/o Inngest, or outage). */}
       {!serviceConnected && (
@@ -419,9 +516,9 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             {saveError
               ? saveError
               : saveOk
-                ? "已保存 ✓"
+                ? "收下了，夜里见 ✓"
                 : wordCount > 0
-                  ? `${wordCount} 字 · ⌘/Ctrl + ↵ 保存`
+                  ? `${wordCount} 字 · ⌘/Ctrl + ↵ 收下`
                   : "记下此刻，余下交给夜里"}
           </span>
           <button
@@ -436,7 +533,7 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             ) : (
               <Check size={13} strokeWidth={2.2} aria-hidden="true" />
             )}
-            保存
+            收下
           </button>
         </div>
       </section>
@@ -484,28 +581,41 @@ export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
             <p>还没有编译过的日记页 —— 记录满一天，午夜会自动生成。</p>
           </div>
         ) : (
-          <div className="home-wiki-grid">
-            {dailyPages.map((p) => (
-              <Link
-                key={p.slug}
-                href={`/wiki/${p.slug}`}
-                className="wiki-day-card"
-                aria-label={`${relativeDayLabel(p.date)}的日记页：${p.title}`}
-              >
-                <div className="wiki-day-card__head">
-                  <span className="wiki-day-card__rel">{relativeDayLabel(p.date)}</span>
-                  <span className="wiki-day-card__date">{p.date}</span>
-                </div>
-                <h3 className="wiki-day-card__title">{p.title}</h3>
-                <p className="wiki-day-card__excerpt">{p.excerpt}</p>
-                <div className="wiki-day-card__foot">
-                  <span>
-                    <FileText size={11} strokeWidth={2} aria-hidden="true" /> {p.source_count} 条原始
-                  </span>
-                  <ArrowUpRight size={14} strokeWidth={2} aria-hidden="true" />
-                </div>
-              </Link>
-            ))}
+          /* Each daily page becomes a "small book": title + one whole
+             opening line, with a thin spine of N short rules along the
+             bottom edge (visual stand-in for "N raw memos went into this").
+             Date sits as a quiet corner stamp; full excerpt only emerges
+             on hover, so the grid reads like a shelf, not a list. */
+          <div className="home-wiki-grid home-wiki-grid--books">
+            {dailyPages.map((p) => {
+              // Cap the spine at 9 lines so a 50-memo day doesn't become a
+              // solid bar; a 9-line spine still reads as "thicker than usual".
+              const spineCount = Math.max(0, Math.min(9, p.source_count));
+              const pull = firstSentence(p.excerpt);
+              return (
+                <Link
+                  key={p.slug}
+                  href={`/wiki/${p.slug}`}
+                  className="wiki-book"
+                  aria-label={`${relativeDayLabel(p.date)}的日记页：${p.title}（${p.source_count} 条原始）`}
+                >
+                  <span className="wiki-book__stamp">{p.date}</span>
+                  <span className="wiki-book__rel">{relativeDayLabel(p.date)}</span>
+                  <h3 className="wiki-book__title">{p.title}</h3>
+                  {pull && <p className="wiki-book__pull">{pull}</p>}
+                  <p className="wiki-book__excerpt">{p.excerpt}</p>
+                  <div
+                    className="wiki-book__spine"
+                    aria-hidden="true"
+                    title={`${p.source_count} 条原始`}
+                  >
+                    {Array.from({ length: spineCount }).map((_, i) => (
+                      <span key={i} className="wiki-book__spine-line" />
+                    ))}
+                  </div>
+                </Link>
+              );
+            })}
           </div>
         )}
       </section>

--- a/web/src/app/(app)/home/HomeStream.tsx
+++ b/web/src/app/(app)/home/HomeStream.tsx
@@ -1,0 +1,514 @@
+"use client";
+
+// HomeStream — the unified home experience, mirroring the iOS Today→DailyPage
+// pipeline on the web. Three movements, top to bottom:
+//   1. An elegant inline composer + a "compile today" affordance.
+//   2. Today's raw memos as flomo-style cards (live compile status per card).
+//   3. Yesterday-and-earlier as compiled daily wiki cards.
+//
+// All data flows through endpoints that already exist and are shared with the
+// iOS client: POST /api/memos (capture), POST /api/compile (manual trigger),
+// GET /api/today/memos (today's stream), GET /api/compile/status (pipeline
+// reachability). The midnight cron (inngest daily-page, 00:30 UTC) compiles the
+// previous day automatically; the button here is the on-demand companion.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import Link from "next/link";
+import {
+  Check,
+  Sparkles,
+  Loader2,
+  ArrowUpRight,
+  Clock,
+  FileText,
+  AlertCircle,
+} from "lucide-react";
+import { MemoCard, type MemoCardData } from "../today/MemoCard";
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type DailyPageCard = {
+  slug: string; // e.g. "daily/2026-06-23"
+  date: string; // YYYY-MM-DD
+  title: string;
+  excerpt: string;
+  source_count: number;
+  last_compiled_at: string | null;
+};
+
+interface HomeStreamProps {
+  initialToday: MemoCardData[];
+  dailyPages: DailyPageCard[];
+}
+
+const SPIN: React.CSSProperties = { animation: "spin 1s linear infinite" };
+
+// ─── Date helpers ────────────────────────────────────────────────────────────
+
+type TodayStrings = { weekday: string; long: string; iso: string };
+
+function computeToday(): TodayStrings {
+  const now = new Date();
+  return {
+    weekday: now.toLocaleDateString("zh-CN", { weekday: "long" }),
+    long: now.toLocaleDateString("zh-CN", { year: "numeric", month: "long", day: "numeric" }),
+    iso: `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}-${String(
+      now.getDate()
+    ).padStart(2, "0")}`,
+  };
+}
+
+// A clock that re-derives the date strings once a minute, so a tab left open
+// across midnight rolls over to the new day rather than freezing on mount.
+function useTodayStrings(): TodayStrings {
+  const [today, setToday] = useState<TodayStrings>(computeToday);
+  useEffect(() => {
+    const t = setInterval(() => {
+      setToday((prev) => {
+        const next = computeToday();
+        return next.iso === prev.iso ? prev : next;
+      });
+    }, 60_000);
+    return () => clearInterval(t);
+  }, []);
+  return today;
+}
+
+// Friendly relative label for a daily wiki card: 昨天 / 前天 / N 天前 / date.
+function relativeDayLabel(dateStr: string): string {
+  const [y, m, d] = dateStr.split("-").map(Number);
+  if (!y || !m || !d) return dateStr;
+  const that = new Date(y, m - 1, d);
+  const now = new Date();
+  const today0 = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+  const diffDays = Math.round((today0.getTime() - that.getTime()) / 86_400_000);
+  if (diffDays <= 0) return "今天";
+  if (diffDays === 1) return "昨天";
+  if (diffDays === 2) return "前天";
+  if (diffDays < 7) return `${diffDays} 天前`;
+  return that.toLocaleDateString("zh-CN", { month: "long", day: "numeric" });
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function HomeStream({ initialToday, dailyPages }: HomeStreamProps) {
+  const { weekday, long, iso } = useTodayStrings();
+
+  const [memos, setMemos] = useState<MemoCardData[]>(initialToday);
+  const [serviceConnected, setServiceConnected] = useState(true);
+
+  // Composer state
+  const [draft, setDraft] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveOk, setSaveOk] = useState(false);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  // Compile-today state
+  const [compiling, setCompiling] = useState(false);
+  const [compileNote, setCompileNote] = useState<string | null>(null);
+
+  // A single screen-reader announcement channel for save/compile outcomes.
+  // aria-live only fires on *content change*, so identical consecutive messages
+  // (e.g. two saves in a row) wouldn't re-announce — announce() appends an
+  // invisible, ever-changing zero-width-space run to force the DOM to differ.
+  const [liveMessage, setLiveMessage] = useState("");
+  const liveSeq = useRef(0);
+  const announce = useCallback((msg: string) => {
+    liveSeq.current += 1;
+    setLiveMessage(msg + "​".repeat(liveSeq.current % 2 ? 1 : 2));
+  }, []);
+
+  // Timers we must clear on unmount to avoid setState-after-unmount.
+  const compileNoteTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const saveOkTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  useEffect(
+    () => () => {
+      if (compileNoteTimer.current) clearTimeout(compileNoteTimer.current);
+      if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
+    },
+    []
+  );
+
+  const scheduleCompileNoteClear = useCallback(() => {
+    if (compileNoteTimer.current) clearTimeout(compileNoteTimer.current);
+    compileNoteTimer.current = setTimeout(() => setCompileNote(null), 4500);
+  }, []);
+
+  const reloadMemos = useCallback(async () => {
+    try {
+      const r = await fetch("/api/today/memos");
+      if (!r.ok) return;
+      const d: { memos: MemoCardData[] } = await r.json();
+      if (Array.isArray(d.memos)) setMemos(d.memos);
+    } catch {
+      /* keep last good */
+    }
+  }, []);
+
+  // Probe the compile pipeline once; surface an honest banner when unreachable
+  // (mirrors the per-card status logic in MemoCard / the iOS sync queue banner).
+  useEffect(() => {
+    fetch("/api/compile/status")
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d: { connected: boolean } | null) => {
+        if (d) setServiceConnected(d.connected);
+      })
+      .catch(() => {});
+  }, []);
+
+  // Capture-first home: focus the composer on load, but never on touch devices
+  // (forcing the soft keyboard up on mobile is hostile).
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const isTouch = window.matchMedia?.("(pointer: coarse)").matches;
+    if (!isTouch) taRef.current?.focus();
+  }, []);
+
+  // Auto-grow the composer textarea (min 56, max 200).
+  useEffect(() => {
+    const ta = taRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+  }, [draft]);
+
+  const wordCount = draft.replace(/\s/g, "").length;
+  const canSave = draft.trim().length > 0 && !saving;
+
+  const handleSave = useCallback(async () => {
+    const body = draft.trim();
+    if (!body || saving) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const r = await fetch("/api/memos", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ body, type: "text", origin: "web" }),
+      });
+      if (r.ok) {
+        setDraft("");
+        setSaveOk(true);
+        announce("已保存到今天");
+        if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
+        saveOkTimer.current = setTimeout(() => setSaveOk(false), 1800);
+        await reloadMemos();
+      } else {
+        const d = await r.json().catch(() => null);
+        const msg = d?.error ? String(d.error) : "保存失败，已为你保留草稿";
+        setSaveError(msg);
+        announce(msg);
+      }
+    } catch {
+      // Network error — the textarea keeps the draft so nothing is lost.
+      setSaveError("网络错误，已为你保留草稿，可重试");
+      announce("保存失败，网络错误");
+    } finally {
+      setSaving(false);
+    }
+  }, [draft, saving, reloadMemos, announce]);
+
+  const handleComposerKey = useCallback(
+    (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+        e.preventDefault();
+        void handleSave();
+      }
+    },
+    [handleSave]
+  );
+
+  // Manual compile of today's memos. The cron handles midnight automatically;
+  // this lets the user weave the day's raw into its daily page on demand.
+  //
+  // We send the exact memo_ids currently shown in "today" rather than a date.
+  // /api/compile's date branch matches a *UTC* calendar day, but "today" here
+  // is the user's *local* day (see getTodayMemos / /api/today/memos) — passing
+  // ids sidesteps the timezone mismatch and compiles precisely what's on screen.
+  const handleCompileToday = useCallback(async () => {
+    if (compiling) return;
+    const ids = memos.map((m) => m.id);
+    if (ids.length === 0) {
+      setCompileNote("今天还没有可编译的记录");
+      announce("今天还没有可编译的记录");
+      scheduleCompileNoteClear();
+      return;
+    }
+    setCompiling(true);
+    setCompileNote(null);
+    try {
+      const r = await fetch("/api/compile", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ memo_ids: ids }),
+      });
+      const d = await r.json().catch(() => null);
+      if (r.ok) {
+        const n = (d?.triggered as number | undefined) ?? ids.length;
+        const msg = n > 0 ? `已送编译 · ${n} 条` : "今天还没有可编译的记录";
+        setCompileNote(msg);
+        announce(msg);
+        await reloadMemos();
+      } else {
+        const msg = d?.error ? String(d.error) : "编译触发失败";
+        setCompileNote(msg);
+        announce(msg);
+      }
+    } catch {
+      setCompileNote("编译触发失败");
+      announce("编译触发失败");
+    } finally {
+      setCompiling(false);
+      scheduleCompileNoteClear();
+    }
+  }, [compiling, memos, reloadMemos, scheduleCompileNoteClear, announce]);
+
+  const handleRetry = useCallback(
+    async (id: string) => {
+      // Optimistic: mark pending; revert to failed if the recompile call fails.
+      setMemos((prev) =>
+        prev.map((m) => (m.id === id ? { ...m, compile_status: "pending", compile_error: null } : m))
+      );
+      try {
+        const r = await fetch(`/api/memos/${id}/recompile`, { method: "POST" });
+        if (!r.ok) {
+          setMemos((prev) =>
+            prev.map((m) =>
+              m.id === id ? { ...m, compile_status: "failed", compile_error: "重试失败" } : m
+            )
+          );
+          return;
+        }
+      } catch {
+        setMemos((prev) =>
+          prev.map((m) =>
+            m.id === id ? { ...m, compile_status: "failed", compile_error: "网络错误" } : m
+          )
+        );
+        return;
+      }
+      await reloadMemos();
+    },
+    [reloadMemos]
+  );
+
+  // Derived: today's compile summary for the daily card.
+  const pendingCount = memos.filter(
+    (m) => m.compile_status === "pending" || m.compile_status === "running"
+  ).length;
+  const compiledCount = memos.filter((m) => m.compile_status === "done").length;
+
+  return (
+    <div className="page home-stream">
+      {/* Screen-reader live region for save/compile outcomes. */}
+      <p className="sr-only" aria-live="polite" aria-atomic="true">
+        {liveMessage}
+      </p>
+
+      {/* ── Hero: date + daily compile card ─────────────────────────────── */}
+      <div className="home-hero">
+        <div>
+          <div className="home-hero__eyebrow">
+            <Sparkles size={12} strokeWidth={2} aria-hidden="true" />
+            {long} · {weekday}
+          </div>
+          <h1 className="home-hero__title">
+            今天，先把此刻记下来。
+            <br />
+            <span className="accent">夜里 00 点，它会自己编织成网。</span>
+          </h1>
+          <p className="home-hero__sub">
+            随手记录原始念头，像便签一样留在「今天」。每天午夜自动编译成结构化的日记页，
+            昨天与更早的，都会沉淀为可回溯的 wiki。
+          </p>
+        </div>
+
+        {/* Daily compile card */}
+        <section className="daily-compile-card" aria-label="今日编译">
+          <div className="daily-compile-card__head">
+            <span className="daily-compile-card__label">今日编译</span>
+            <span className="daily-compile-card__date">{iso}</span>
+          </div>
+
+          <div className="daily-compile-card__metrics">
+            <div className="dcc-metric">
+              <div className="dcc-metric__value">{memos.length}</div>
+              <div className="dcc-metric__label">今日记录</div>
+            </div>
+            <div className="dcc-metric">
+              <div className="dcc-metric__value">{compiledCount}</div>
+              <div className="dcc-metric__label">已编译</div>
+            </div>
+            <div className="dcc-metric">
+              <div className="dcc-metric__value">{pendingCount}</div>
+              <div className="dcc-metric__label">待编译</div>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            className={`dcc-compile-btn${pendingCount === 0 && !compiling ? " dcc-compile-btn--ghost" : ""}`}
+            onClick={handleCompileToday}
+            disabled={compiling}
+            aria-busy={compiling}
+          >
+            {compiling ? (
+              <>
+                <Loader2 size={14} strokeWidth={2} style={SPIN} aria-hidden="true" />
+                正在送编译…
+              </>
+            ) : (
+              <>
+                <Sparkles size={14} strokeWidth={2} aria-hidden="true" />
+                立即编译今天
+              </>
+            )}
+          </button>
+
+          {/* Visual-only: the dedicated .sr-only live region already announces
+              compile outcomes to AT, so this avoids a duplicate read. */}
+          <p className="dcc-foot">
+            {compileNote ? (
+              <span className="dcc-foot__note">{compileNote}</span>
+            ) : (
+              <>
+                <Clock size={11} strokeWidth={2} aria-hidden="true" />
+                每天 00:00 自动编译昨天
+              </>
+            )}
+          </p>
+        </section>
+      </div>
+
+      {/* Pipeline-unreachable banner (dev w/o Inngest, or outage). */}
+      {!serviceConnected && (
+        <div className="home-pipeline-warn" role="status">
+          <AlertCircle size={14} strokeWidth={2} aria-hidden="true" />
+          编译服务未连接 —— 新记录会保存，但暂不会被编译。
+        </div>
+      )}
+
+      {/* ── Composer ────────────────────────────────────────────────────── */}
+      <section className="home-composer" aria-label="记录此刻">
+        <textarea
+          ref={taRef}
+          id="home-composer-input"
+          value={draft}
+          onChange={(e) => {
+            setDraft(e.target.value);
+            if (saveError) setSaveError(null);
+            if (saveOk) {
+              setSaveOk(false);
+              if (saveOkTimer.current) clearTimeout(saveOkTimer.current);
+            }
+          }}
+          onKeyDown={handleComposerKey}
+          placeholder="此刻在想什么？"
+          rows={2}
+          className="home-composer__ta"
+          aria-label="记下此刻的念头"
+          aria-describedby="home-composer-hint"
+          aria-keyshortcuts="Meta+Enter Control+Enter"
+        />
+        <div className="home-composer__bar">
+          <span
+            id="home-composer-hint"
+            className={`home-composer__hint${saveError ? " is-error" : ""}`}
+          >
+            {saveError
+              ? saveError
+              : saveOk
+                ? "已保存 ✓"
+                : wordCount > 0
+                  ? `${wordCount} 字 · ⌘/Ctrl + ↵ 保存`
+                  : "记下此刻，余下交给夜里"}
+          </span>
+          <button
+            type="button"
+            className="home-composer__save"
+            disabled={!canSave}
+            aria-busy={saving}
+            onClick={handleSave}
+          >
+            {saving ? (
+              <Loader2 size={13} strokeWidth={2.2} style={SPIN} aria-hidden="true" />
+            ) : (
+              <Check size={13} strokeWidth={2.2} aria-hidden="true" />
+            )}
+            保存
+          </button>
+        </div>
+      </section>
+
+      {/* ── Today's raw (flomo cards) ───────────────────────────────────── */}
+      <section className="home-section" aria-label="今天的记录">
+        <h2 className="home-section__label">
+          <span>今天</span>
+          <span className="home-section__count">{memos.length}</span>
+        </h2>
+
+        {memos.length === 0 ? (
+          <div className="home-empty">
+            <Sparkles size={26} strokeWidth={1.5} aria-hidden="true" />
+            <p>今天还没有记录 —— 在上面写下第一条吧。</p>
+          </div>
+        ) : (
+          <div className="home-memo-grid">
+            {memos.map((m) => (
+              <MemoCard
+                key={m.id}
+                memo={m}
+                serviceConnected={serviceConnected}
+                onRetry={handleRetry}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* ── Yesterday & earlier (compiled daily wiki) ───────────────────── */}
+      <section className="home-section" aria-label="昨天及更早的日记页">
+        <h2 className="home-section__label">
+          <span>昨天及更早</span>
+          {dailyPages.length > 0 && (
+            <Link href="/wiki?type=daily" className="home-section__more">
+              全部 <ArrowUpRight size={13} strokeWidth={2} aria-hidden="true" />
+            </Link>
+          )}
+        </h2>
+
+        {dailyPages.length === 0 ? (
+          <div className="home-empty">
+            <FileText size={26} strokeWidth={1.5} aria-hidden="true" />
+            <p>还没有编译过的日记页 —— 记录满一天，午夜会自动生成。</p>
+          </div>
+        ) : (
+          <div className="home-wiki-grid">
+            {dailyPages.map((p) => (
+              <Link
+                key={p.slug}
+                href={`/wiki/${p.slug}`}
+                className="wiki-day-card"
+                aria-label={`${relativeDayLabel(p.date)}的日记页：${p.title}`}
+              >
+                <div className="wiki-day-card__head">
+                  <span className="wiki-day-card__rel">{relativeDayLabel(p.date)}</span>
+                  <span className="wiki-day-card__date">{p.date}</span>
+                </div>
+                <h3 className="wiki-day-card__title">{p.title}</h3>
+                <p className="wiki-day-card__excerpt">{p.excerpt}</p>
+                <div className="wiki-day-card__foot">
+                  <span>
+                    <FileText size={11} strokeWidth={2} aria-hidden="true" /> {p.source_count} 条原始
+                  </span>
+                  <ArrowUpRight size={14} strokeWidth={2} aria-hidden="true" />
+                </div>
+              </Link>
+            ))}
+          </div>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/web/src/app/(app)/home/page.tsx
+++ b/web/src/app/(app)/home/page.tsx
@@ -1,16 +1,26 @@
-// Home view — stats, activities, inbox observations, and domains wired to real data.
+// Home view — the unified capture→compile→wiki stream up top (HomeStream),
+// followed by the knowledge-network panels (observations, activity).
+//
+// The top stream mirrors the iOS Today→DailyPage pipeline: capture raw memos,
+// see today's as flomo cards, browse yesterday-and-earlier as compiled daily
+// wiki pages, and trigger the day's compile on demand (the inngest daily-page
+// cron handles midnight automatically).
 import Link from "next/link";
 import { ArrowUpRight, ChevronRight, Sparkles, Inbox, Activity, Clock } from "lucide-react";
-import { Btn, Card, Chip, Icon, SectionLabel, Sparkline } from "@/components/ui";
-import { ColdStartGuide } from "./ColdStartGuide";
+import { Btn, Card, Chip, Icon, SectionLabel } from "@/components/ui";
+import { HomeStream, type DailyPageCard } from "./HomeStream";
+import type { MemoCardData } from "../today/MemoCard";
 import { auth } from "@/auth";
 import { db } from "@/lib/db/client";
-import { users, inbox_items, memos, pages, domains, page_links, activities } from "@/lib/db/schema";
-import { eq, and, gte, desc, sql } from "drizzle-orm";
-
-// How many sources we suggest before the graph starts weaving itself. Used only
-// to phrase the cold-start guidance — kept small and encouraging.
-const WEAVE_HINT_TARGET = 3;
+import {
+  users,
+  inbox_items,
+  memos,
+  memo_attachments,
+  pages,
+  activities,
+} from "@/lib/db/schema";
+import { eq, and, gte, lt, desc, inArray } from "drizzle-orm";
 
 // ── Data helpers ──────────────────────────────────────────────────────────────
 
@@ -23,41 +33,135 @@ async function resolveUserId(email: string): Promise<string | null> {
   return rows[0]?.id ?? null;
 }
 
-type StatsData = {
-  sources: number;
-  pages: number;
-  domainCount: number;
-  backlinks: number;
-  sources_week: number;
-  pages_week: number;
-  backlinks_week: number;
-};
-
-async function getStats(userId: string): Promise<StatsData> {
-  const oneWeekAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+// Today's memos as flomo-card data (same shape the /today stream serves).
+async function getTodayMemos(userId: string): Promise<MemoCardData[]> {
   try {
-    const [sourcesRes, pagesRes, domainsRes, backlinksRes, swRes, pwRes, bwRes] =
-      await Promise.all([
-        db.select({ count: sql<number>`count(*)::int` }).from(memos).where(eq(memos.user_id, userId)),
-        db.select({ count: sql<number>`count(*)::int` }).from(pages).where(eq(pages.user_id, userId)),
-        db.select({ count: sql<number>`count(*)::int` }).from(domains).where(eq(domains.user_id, userId)),
-        db.select({ count: sql<number>`count(*)::int` }).from(page_links).where(eq(page_links.user_id, userId)),
-        db.select({ count: sql<number>`count(*)::int` }).from(memos).where(and(eq(memos.user_id, userId), gte(memos.created_at, oneWeekAgo))),
-        db.select({ count: sql<number>`count(*)::int` }).from(pages).where(and(eq(pages.user_id, userId), gte(pages.created_at, oneWeekAgo))),
-        db.select({ count: sql<number>`count(*)::int` }).from(page_links).where(and(eq(page_links.user_id, userId), gte(page_links.created_at, oneWeekAgo))),
-      ]);
-    return {
-      sources: sourcesRes[0]?.count ?? 0,
-      pages: pagesRes[0]?.count ?? 0,
-      domainCount: domainsRes[0]?.count ?? 0,
-      backlinks: backlinksRes[0]?.count ?? 0,
-      sources_week: swRes[0]?.count ?? 0,
-      pages_week: pwRes[0]?.count ?? 0,
-      backlinks_week: bwRes[0]?.count ?? 0,
-    };
+    const now = new Date();
+    const todayStart = new Date(now.getFullYear(), now.getMonth(), now.getDate());
+    const tomorrowStart = new Date(todayStart.getTime() + 86_400_000);
+
+    const rows = await db
+      .select({
+        id: memos.id,
+        type: memos.type,
+        body: memos.body,
+        created_at: memos.created_at,
+        compile_status: memos.compile_status,
+        compile_step: memos.compile_step,
+        compile_error: memos.compile_error,
+      })
+      .from(memos)
+      .where(
+        and(
+          eq(memos.user_id, userId),
+          gte(memos.created_at, todayStart),
+          lt(memos.created_at, tomorrowStart)
+        )
+      )
+      .orderBy(desc(memos.created_at))
+      .limit(50);
+
+    const photoMemoIds = rows.filter((m) => m.type === "photo").map((m) => m.id);
+    // Scope the attachment lookup to today's photo memos — without the memo_id
+    // constraint this would scan every photo attachment in the table.
+    const attachments =
+      photoMemoIds.length > 0
+        ? await db
+            .select({
+              memo_id: memo_attachments.memo_id,
+              storage_key: memo_attachments.storage_key,
+            })
+            .from(memo_attachments)
+            .where(
+              and(
+                eq(memo_attachments.kind, "photo"),
+                inArray(memo_attachments.memo_id, photoMemoIds)
+              )
+            )
+        : [];
+    const photoByMemoId = new Map(
+      attachments.map((a) => [a.memo_id, `/api/img/${a.storage_key}`])
+    );
+
+    return rows.map((m) => {
+      const photoUrl = photoByMemoId.get(m.id) ?? null;
+      const displayType: MemoCardData["type"] =
+        m.type === "photo" && m.body.trim().length > 0
+          ? "mixed"
+          : (m.type as MemoCardData["type"]);
+      return {
+        id: m.id,
+        type: displayType,
+        body: m.body,
+        created_at: m.created_at.toISOString(),
+        photo_url: photoUrl,
+        compile_status: m.compile_status ?? undefined,
+        compile_step: m.compile_step ?? null,
+        compile_error: m.compile_error ?? null,
+      };
+    });
   } catch {
-    return { sources: 0, pages: 0, domainCount: 0, backlinks: 0, sources_week: 0, pages_week: 0, backlinks_week: 0 };
+    return [];
   }
+}
+
+// Yesterday-and-earlier compiled daily pages (type="daily", live), newest first.
+async function getDailyPages(userId: string): Promise<DailyPageCard[]> {
+  try {
+    const rows = await db
+      .select({
+        slug: pages.slug,
+        title: pages.title,
+        body_md: pages.body_md,
+        source_count: pages.source_count,
+        last_compiled_at: pages.last_compiled_at,
+      })
+      .from(pages)
+      .where(
+        and(eq(pages.user_id, userId), eq(pages.type, "daily"), eq(pages.status, "live"))
+      )
+      .orderBy(desc(pages.slug))
+      .limit(12);
+
+    const todayIso = (() => {
+      const n = new Date();
+      return `${n.getFullYear()}-${String(n.getMonth() + 1).padStart(2, "0")}-${String(
+        n.getDate()
+      ).padStart(2, "0")}`;
+    })();
+
+    return rows
+      .map((r) => {
+        const date = r.slug.replace(/^daily\//, "");
+        return {
+          slug: r.slug,
+          date,
+          title: r.title,
+          excerpt: excerptFromMarkdown(r.body_md ?? ""),
+          source_count: r.source_count ?? 0,
+          last_compiled_at: r.last_compiled_at ? r.last_compiled_at.toISOString() : null,
+        };
+      })
+      // Don't echo today's page in the "yesterday & earlier" rail.
+      .filter((p) => p.date !== todayIso);
+  } catch {
+    return [];
+  }
+}
+
+// First ~160 chars of body, stripped of markdown noise — a calm card preview.
+function excerptFromMarkdown(md: string): string {
+  const plain = md
+    .replace(/^---[\s\S]*?\r?\n---\r?\n/, "") // strip YAML frontmatter (LF or CRLF)
+    .replace(/^#{1,6}\s+/gm, "")
+    .replace(/^\s*[-*_]{3,}\s*$/gm, "") // strip horizontal rules
+    .replace(/^[|].*[|]\s*$/gm, "") // strip table rows
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, "")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[*_`>#]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+  return plain.length > 160 ? `${plain.slice(0, 160)}…` : plain;
 }
 
 type ActivityRow = {
@@ -72,7 +176,14 @@ type ActivityRow = {
 async function getActivities(userId: string): Promise<ActivityRow[]> {
   try {
     return await db
-      .select()
+      .select({
+        id: activities.id,
+        verb: activities.verb,
+        subject: activities.subject,
+        target_type: activities.target_type,
+        target_id: activities.target_id,
+        created_at: activities.created_at,
+      })
       .from(activities)
       .where(eq(activities.user_id, userId))
       .orderBy(desc(activities.created_at))
@@ -90,41 +201,26 @@ type InboxItemRow = {
   created_at: Date;
 };
 
-async function getOpenInboxItems(userId: string): Promise<{ items: InboxItemRow[]; total: number }> {
+async function getOpenInboxItems(
+  userId: string
+): Promise<{ items: InboxItemRow[]; total: number }> {
   try {
-    const [countRes, rows] = await Promise.all([
-      db.select({ count: sql<number>`count(*)::int` }).from(inbox_items).where(and(eq(inbox_items.user_id, userId), eq(inbox_items.status, "open"))),
-      db
-        .select({ id: inbox_items.id, kind: inbox_items.kind, title: inbox_items.title, body: inbox_items.body, created_at: inbox_items.created_at })
-        .from(inbox_items)
-        .where(and(eq(inbox_items.user_id, userId), eq(inbox_items.status, "open")))
-        .orderBy(desc(inbox_items.created_at))
-        .limit(3),
-    ]);
-    return { items: rows, total: countRes[0]?.count ?? 0 };
+    const rows = await db
+      .select({
+        id: inbox_items.id,
+        kind: inbox_items.kind,
+        title: inbox_items.title,
+        body: inbox_items.body,
+        created_at: inbox_items.created_at,
+      })
+      .from(inbox_items)
+      .where(and(eq(inbox_items.user_id, userId), eq(inbox_items.status, "open")))
+      .orderBy(desc(inbox_items.created_at))
+      .limit(3);
+    // The inbox page owns the precise count — here we only need "are there any".
+    return { items: rows, total: rows.length };
   } catch {
     return { items: [], total: 0 };
-  }
-}
-
-type DomainRow = {
-  id: string;
-  slug: string;
-  label: string;
-  color: string | null;
-  created_at: Date;
-};
-
-async function getDomains(userId: string): Promise<DomainRow[]> {
-  try {
-    return await db
-      .select({ id: domains.id, slug: domains.slug, label: domains.label, color: domains.color, created_at: domains.created_at })
-      .from(domains)
-      .where(eq(domains.user_id, userId))
-      .orderBy(domains.position, domains.created_at)
-      .limit(8);
-  } catch {
-    return [];
   }
 }
 
@@ -133,22 +229,27 @@ async function getDomains(userId: string): Promise<DomainRow[]> {
 function formatRelative(date: Date): string {
   const diffMs = Date.now() - date.getTime();
   const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1) return "Just now";
-  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffMin < 1) return "刚刚";
+  if (diffMin < 60) return `${diffMin} 分钟前`;
   const diffH = Math.floor(diffMin / 60);
-  if (diffH < 24) return `${diffH}h ago`;
+  if (diffH < 24) return `${diffH} 小时前`;
   const diffD = Math.floor(diffH / 24);
-  if (diffD === 1) return "Yesterday";
-  return `${diffD} days ago`;
+  if (diffD === 1) return "昨天";
+  return `${diffD} 天前`;
 }
 
 function kindLabel(kind: string): string {
   switch (kind) {
-    case "contradiction": return "Contradiction";
-    case "schema": return "Schema";
-    case "orphan": return "Orphan";
-    case "compiled": return "Compiled";
-    default: return kind;
+    case "contradiction":
+      return "矛盾";
+    case "schema":
+      return "结构";
+    case "orphan":
+      return "孤立";
+    case "compiled":
+      return "已编译";
+    default:
+      return kind;
   }
 }
 
@@ -158,249 +259,168 @@ export default async function HomePage() {
   const session = await auth();
   const userId = session?.user?.email ? await resolveUserId(session.user.email) : null;
 
-  const [stats, recentActivities, inboxData, domainList] = userId
+  const [todayMemos, dailyPages, recentActivities, inboxData] = userId
     ? await Promise.all([
-        getStats(userId),
+        getTodayMemos(userId),
+        getDailyPages(userId),
         getActivities(userId),
         getOpenInboxItems(userId),
-        getDomains(userId),
       ])
     : [
-        { sources: 0, pages: 0, domainCount: 0, backlinks: 0, sources_week: 0, pages_week: 0, backlinks_week: 0 },
+        [] as MemoCardData[],
+        [] as DailyPageCard[],
         [] as ActivityRow[],
         { items: [] as InboxItemRow[], total: 0 },
-        [] as DomainRow[],
       ];
 
   const openInboxCount = inboxData.total;
 
-  // Cold-start: no knowledge network has formed yet (no domains, no backlinks).
-  // Replace the bare zeros with explicit guidance + a concrete next step.
-  const isColdStart = stats.domainCount === 0 && stats.backlinks === 0;
-  const sourcesToWeave = Math.max(WEAVE_HINT_TARGET - stats.sources, 1);
-
   return (
-    <div className="page">
-      {/* Hero */}
-      <div className="hero">
+    <>
+      {/* ── The capture→compile→wiki stream (main act) ─────────────────── */}
+      <HomeStream initialToday={todayMemos} dailyPages={dailyPages} />
+
+      {/* ── Knowledge-network panels (supporting act) ──────────────────── */}
+      <div className="page home-panels">
+        {/* Observations */}
         <div>
-          <div
-            className="ds-section-label"
-            style={{ color: "var(--accent)", marginBottom: 14, display: "inline-flex", alignItems: "center", gap: 6 }}
-          >
-            <Icon as={Sparkles} size={12} />
-            {new Date().toLocaleDateString("en-US", { weekday: "short", day: "numeric", month: "long", year: "numeric" })}
-          </div>
-          <h1 className="hero-headline">
-            Your personal knowledge base.
-            <br />
-            <span className="accent">Everything compiled and connected.</span>
-          </h1>
-          <p className="hero-sub">
-            Add sources and I&rsquo;ll compile them into your wiki. Check the inbox for things that need your attention.
-          </p>
-          <div className="flex gap-12 mt-24">
-            <Link href="/add"><Btn kind="primary">Add something</Btn></Link>
-            <Link href="/chat"><Btn kind="soft">Ask the wiki</Btn></Link>
-            <Link href="/inbox">
-              <Btn kind="ghost" icon={<Inbox size={14} />}>
-                {openInboxCount > 0 ? `${openInboxCount} in inbox` : "Inbox"}
-              </Btn>
-            </Link>
-          </div>
-        </div>
-
-        {/* Stats grid (2×2) — US-002 */}
-        <div className="stats">
-          <div className="stat">
-            <div className="stat__value">{stats.sources}</div>
-            <div className="stat__label">Sources</div>
-            <div className="stat__delta">+{stats.sources_week} this week</div>
-          </div>
-          <div className="stat">
-            <div className="stat__value">{stats.pages}</div>
-            <div className="stat__label">Wiki pages</div>
-            <div className="stat__delta">+{stats.pages_week} this week</div>
-          </div>
-          <div className="stat">
-            <div className="stat__value">{stats.domainCount}</div>
-            <div className="stat__label">Domains</div>
-            <div className="stat__delta" style={{ color: "var(--fg-subtle)" }}>across your topics</div>
-          </div>
-          <div className="stat">
-            <div className="stat__value">{stats.backlinks}</div>
-            <div className="stat__label">Backlinks</div>
-            <div className="stat__delta">+{stats.backlinks_week} this week</div>
-          </div>
-        </div>
-      </div>
-
-      {/* Cold-start guidance — US-052: replace bare zeros with a clear next step */}
-      {isColdStart && (
-        <div className="mt-32">
-          <ColdStartGuide sourcesToWeave={sourcesToWeave} />
-        </div>
-      )}
-
-      {/* Observations — US-004 */}
-      <div className="mt-32">
-        <SectionLabel
-          right={
-            openInboxCount > 0 ? (
-              <Link href="/inbox">
-                <Chip tone="accent">{openInboxCount} open</Chip>
-              </Link>
-            ) : null
-          }
-        >
-          What the system noticed
-        </SectionLabel>
-        {inboxData.items.length === 0 ? (
-          <Card>
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: "48px 24px", textAlign: "center" }}>
-              <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
-                <Icon as={Sparkles} size={28} />
-              </span>
-              <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
-                No pending observations
-              </p>
-              <Link href="/add">
-                <Btn kind="ghost" size="sm">Add a source</Btn>
-              </Link>
-            </div>
-          </Card>
-        ) : (
-          <Card>
-            {inboxData.items.map((item, i) => (
-              <div key={item.id}>
-                <Link href="/inbox" style={{ textDecoration: "none", color: "inherit" }}>
-                  <div className="observation">
-                    <div className="observation__lead">
-                      <span className="pulse" />
-                      {kindLabel(item.kind)}
-                    </div>
-                    <div className="observation__body">
-                      <p style={{ fontWeight: 500, margin: "0 0 4px" }}>{item.title}</p>
-                      {item.body && <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.875rem" }}>{item.body}</p>}
-                      <div style={{ display: "flex", alignItems: "center", gap: 4, marginTop: 6, color: "var(--fg-subtle)", fontSize: "0.8rem" }}>
-                        <Icon as={Clock} size={11} />
-                        {formatRelative(item.created_at)}
-                      </div>
-                    </div>
-                  </div>
-                </Link>
-                {i < inboxData.items.length - 1 && <div className="divider" />}
-              </div>
-            ))}
-            {openInboxCount > inboxData.items.length && (
-              <div style={{ padding: "12px 16px", borderTop: "1px solid var(--border)" }}>
+          <SectionLabel
+            right={
+              openInboxCount > 0 ? (
                 <Link href="/inbox">
-                  <Btn kind="ghost" size="sm" iconRight={<Icon as={ArrowUpRight} size={14} />}>
-                    View all {openInboxCount} observations
+                  <Chip tone="accent">{openInboxCount} open</Chip>
+                </Link>
+              ) : null
+            }
+          >
+            系统注意到的
+          </SectionLabel>
+          {inboxData.items.length === 0 ? (
+            <Card>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 12,
+                  padding: "40px 24px",
+                  textAlign: "center",
+                }}
+              >
+                <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
+                  <Icon as={Sparkles} size={26} />
+                </span>
+                <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
+                  暂无待处理的观察
+                </p>
+                <Link href="/inbox">
+                  <Btn kind="ghost" size="sm" icon={<Inbox size={14} />}>
+                    打开收件箱
                   </Btn>
                 </Link>
               </div>
-            )}
-          </Card>
-        )}
-      </div>
-
-      {/* Recent activity — US-003 */}
-      <div className="mt-32">
-        <SectionLabel
-          right={
-            <Link href="/inbox?filter=compiled">
-              <Btn kind="ghost" size="sm" iconRight={<Icon as={ArrowUpRight} size={14} />}>
-                View all
-              </Btn>
-            </Link>
-          }
-        >
-          Recent activity
-        </SectionLabel>
-        {recentActivities.length === 0 ? (
-          <Card>
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: "48px 24px", textAlign: "center" }}>
-              <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
-                <Icon as={Activity} size={28} />
-              </span>
-              <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
-                No recent activity — start by adding a memo
-              </p>
-              <Link href="/add">
-                <Btn kind="ghost" size="sm">Add a memo</Btn>
-              </Link>
-            </div>
-          </Card>
-        ) : (
-          <Card>
-            {recentActivities.map((a) => (
-              <div className="activity-row" key={a.id}>
-                <div className="when">{formatRelative(a.created_at)}</div>
-                <div className="what">
-                  <strong>{a.verb}</strong>
-                  {" "}
-                  {a.subject}
-                  {a.target_id && a.target_type === "page" && (
-                    <Link href={`/wiki/${a.target_id}`} className="activity-target"><em>{a.target_id}</em></Link>
-                  )}
-                </div>
-                <Icon as={ChevronRight} size={14} />
-              </div>
-            ))}
-          </Card>
-        )}
-      </div>
-
-      {/* Domains at a glance — US-005 */}
-      <div className="mt-32">
-        <SectionLabel
-          right={
-            <Link href="/insights">
-              <Btn kind="ghost" size="sm" iconRight={<Icon as={ArrowUpRight} size={14} />}>
-                All domains
-              </Btn>
-            </Link>
-          }
-        >
-          Domains at a glance
-        </SectionLabel>
-        {domainList.length === 0 ? (
-          <Card>
-            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", gap: 12, padding: "48px 24px", textAlign: "center" }}>
-              <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>No domains yet</p>
-            </div>
-          </Card>
-        ) : (
-          <div className="grid-4">
-            {domainList.map((d) => (
-              <Link key={d.id} href={`/insights?domain=${d.slug}`} style={{ textDecoration: "none" }}>
-                <Card className="domain-card">
-                  <div className="flex between center">
-                    <div className="domain-card__title">{d.label}</div>
-                    <span
-                      style={{
-                        background: d.color ?? "#888",
-                        width: 8,
-                        height: 8,
-                        borderRadius: 999,
-                        display: "inline-block",
-                      }}
-                    />
-                  </div>
-                  <Sparkline values={[3, 4, 5, 6, 7, 8, 9, 10]} color={d.color ?? "#888"} fill w={240} h={32} />
-                  <div className="flex between center">
-                    <div className="domain-card__meta">
-                      {new Date(d.created_at).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" })}
+            </Card>
+          ) : (
+            <Card>
+              {inboxData.items.map((item, i) => (
+                <div key={item.id}>
+                  <Link href="/inbox" style={{ textDecoration: "none", color: "inherit" }}>
+                    <div className="observation">
+                      <div className="observation__lead">
+                        <span className="pulse" />
+                        {kindLabel(item.kind)}
+                      </div>
+                      <div className="observation__body">
+                        <p style={{ fontWeight: 500, margin: "0 0 4px" }}>{item.title}</p>
+                        {item.body && (
+                          <p
+                            style={{
+                              color: "var(--fg-subtle)",
+                              margin: 0,
+                              fontSize: "0.875rem",
+                            }}
+                          >
+                            {item.body}
+                          </p>
+                        )}
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: 4,
+                            marginTop: 6,
+                            color: "var(--fg-subtle)",
+                            fontSize: "0.8rem",
+                          }}
+                        >
+                          <Icon as={Clock} size={11} />
+                          {formatRelative(item.created_at)}
+                        </div>
+                      </div>
                     </div>
-                    <Icon as={ArrowUpRight} size={14} />
-                  </div>
-                </Card>
+                  </Link>
+                  {i < inboxData.items.length - 1 && <div className="divider" />}
+                </div>
+              ))}
+            </Card>
+          )}
+        </div>
+
+        {/* Recent activity */}
+        <div className="mt-32">
+          <SectionLabel
+            right={
+              <Link href="/inbox?filter=compiled">
+                <Btn kind="ghost" size="sm" iconRight={<Icon as={ArrowUpRight} size={14} />}>
+                  全部
+                </Btn>
               </Link>
-            ))}
-          </div>
-        )}
+            }
+          >
+            最近动态
+          </SectionLabel>
+          {recentActivities.length === 0 ? (
+            <Card>
+              <div
+                style={{
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                  gap: 12,
+                  padding: "40px 24px",
+                  textAlign: "center",
+                }}
+              >
+                <span style={{ color: "var(--fg-subtle)", opacity: 0.5, display: "flex" }}>
+                  <Icon as={Activity} size={26} />
+                </span>
+                <p style={{ color: "var(--fg-subtle)", margin: 0, fontSize: "0.9rem" }}>
+                  暂无动态 —— 记录满一天，编译后这里会亮起来
+                </p>
+              </div>
+            </Card>
+          ) : (
+            <Card>
+              {recentActivities.map((a) => (
+                <div className="activity-row" key={a.id}>
+                  <div className="when">{formatRelative(a.created_at)}</div>
+                  <div className="what">
+                    <strong>{a.verb}</strong> {a.subject}
+                    {a.target_id && a.target_type === "page" && (
+                      <Link href={`/wiki/${a.target_id}`} className="activity-target">
+                        <em>{a.target_id}</em>
+                      </Link>
+                    )}
+                  </div>
+                  <Icon as={ChevronRight} size={14} />
+                </div>
+              ))}
+            </Card>
+          )}
+        </div>
       </div>
-    </div>
+    </>
   );
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -10,6 +10,10 @@
   --fg-primary: #2B2822;
   --fg-muted: #6B6560;
   --fg-subtle: #A39F99;
+  /* AA-compliant subtle text (~4.6:1 on the warm canvas, ~4.9:1 on white) — for
+     token-bearing micro-labels that must stay legible; reserve --fg-subtle for
+     purely decorative hairlines. */
+  --fg-subtle-aa: #79736B;
   --accent: #5D3000;
   --accent-hover: #7A3F00;
   --accent-soft: #F5EDE3;
@@ -158,6 +162,7 @@
   --fg-primary:  #F0EDE8;
   --fg-muted:    #A39F99;
   --fg-subtle:   #6B6560;
+  --fg-subtle-aa: #B8B3AC;
 
   --accent:        #C9883A;
   --accent-hover:  #E09A45;
@@ -191,6 +196,7 @@
     --fg-primary:  #F0EDE8;
     --fg-muted:    #A39F99;
     --fg-subtle:   #6B6560;
+  --fg-subtle-aa: #B8B3AC;
 
     --accent:        #C9883A;
     --accent-hover:  #E09A45;
@@ -1003,9 +1009,26 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
 .queue-item:focus-visible,
 .inbox-card:focus-visible,
 .cite-card:focus-visible,
-.recently-compiled-item:focus-visible {
+.recently-compiled-item:focus-visible,
+.dcc-compile-btn:focus-visible,
+.home-composer__save:focus-visible,
+.home-section__more:focus-visible,
+.wiki-day-card:focus-visible {
   outline: 2px solid var(--accent);
   outline-offset: 2px;
+}
+
+/* Visually-hidden but screen-reader-available (live regions, labels). */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .recently-compiled-item:hover {
@@ -1565,4 +1588,411 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
     from { opacity: 0; }
     to   { opacity: 1; }
   }
+}
+
+/* ═══════════════════════════════════════════════════════════════════════════
+   HomeStream — unified capture→compile→wiki home (mirrors iOS Today→DailyPage).
+   Museum-calm: warm cream, hairline borders, serif headlines, mono captions.
+   ═══════════════════════════════════════════════════════════════════════════ */
+
+.home-stream { padding-bottom: 24px; }
+.home-panels { padding-top: 8px; padding-bottom: 80px; }
+
+/* ── Hero: date + daily-compile card ──────────────────────────────────────── */
+.home-hero {
+  display: grid;
+  grid-template-columns: 1.55fr 1fr;
+  gap: 28px;
+  align-items: start;
+}
+.home-hero__eyebrow {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 14px;
+}
+.home-hero__title {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: clamp(22px, 5vw, 34px);
+  line-height: 1.22;
+  letter-spacing: -0.4px;
+  color: var(--fg-primary);
+  margin: 0;
+}
+.home-hero__title .accent { color: var(--accent); }
+.home-hero__sub {
+  margin: 16px 0 0;
+  font-family: var(--font-body);
+  font-size: 14.5px;
+  line-height: 1.7;
+  color: var(--fg-muted);
+  max-width: 46ch;
+  text-wrap: pretty;
+}
+
+/* Daily-compile card */
+.daily-compile-card {
+  background: var(--surface-white);
+  border: 0.5px solid var(--border-subtle);
+  border-radius: 18px;
+  box-shadow: var(--shadow-card);
+  padding: 20px 22px 18px;
+}
+.daily-compile-card__head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 18px;
+}
+.daily-compile-card__label {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 12px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.daily-compile-card__date {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.4px;
+  color: var(--fg-subtle);
+}
+.daily-compile-card__metrics {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+  margin-bottom: 18px;
+}
+.dcc-metric { text-align: center; }
+.dcc-metric__value {
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 28px;
+  line-height: 1;
+  letter-spacing: -0.5px;
+  color: var(--fg-primary);
+  font-variant-numeric: tabular-nums;
+}
+.dcc-metric__label {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
+  color: var(--fg-subtle-aa);
+  margin-top: 6px;
+}
+.dcc-compile-btn {
+  width: 100%;
+  height: 42px;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  background: var(--accent);
+  color: #FAF8F6;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  transition: background 160ms ease-out, transform 120ms ease-out;
+}
+.dcc-compile-btn:hover:not(:disabled) { background: var(--accent-hover); }
+.dcc-compile-btn:active:not(:disabled) { transform: scale(0.985); }
+/* Steady state (nothing pending): de-emphasise compile to an outline so the
+   composer ("先把此刻记下来") stays the page's primary call to action. It
+   re-fills with accent the moment there are memos waiting to compile. */
+.dcc-compile-btn--ghost {
+  background: transparent;
+  color: var(--accent);
+  box-shadow: inset 0 0 0 1px var(--accent-border);
+}
+.dcc-compile-btn--ghost:hover:not(:disabled) {
+  background: var(--accent-soft);
+  box-shadow: inset 0 0 0 1px var(--accent-border);
+}
+.dcc-compile-btn:disabled { opacity: 0.62; cursor: default; }
+.dcc-foot {
+  margin: 12px 0 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.4px;
+  color: var(--fg-subtle-aa);
+  min-height: 14px;
+}
+.dcc-foot__note { color: var(--accent); font-weight: 600; }
+
+/* Pipeline-unreachable banner */
+.home-pipeline-warn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 18px;
+  padding: 11px 16px;
+  border-radius: 12px;
+  background: var(--accent-soft);
+  border: 0.5px solid var(--accent-border);
+  color: var(--accent);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+}
+
+/* ── Composer ─────────────────────────────────────────────────────────────── */
+.home-composer {
+  margin-top: 28px;
+  background: var(--surface-white);
+  border: 0.5px solid var(--border-subtle);
+  border-radius: 18px;
+  box-shadow: var(--shadow-card);
+  padding: 18px 20px 14px;
+  transition: border-color 160ms ease-out, box-shadow 160ms ease-out;
+}
+.home-composer:focus-within {
+  /* genuine, perceivable focus ring on the page's primary control (SC 2.4.11) */
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+.home-composer__ta {
+  width: 100%;
+  resize: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  font-family: var(--font-serif);
+  font-size: 17px;
+  line-height: 1.7;
+  letter-spacing: 0.2px;
+  color: var(--fg-primary);
+  min-height: 52px;
+  max-height: 200px;
+  padding: 0;
+  caret-color: var(--accent);
+  display: block;
+}
+.home-composer__ta::placeholder { color: var(--fg-subtle); opacity: 0.6; font-style: italic; }
+.home-composer__ta::-webkit-scrollbar { display: none; }
+.home-composer__bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 0.5px solid var(--border-subtle);
+}
+.home-composer__hint {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.5px;
+  color: var(--fg-subtle-aa);
+  font-variant-numeric: tabular-nums;
+  transition: color 160ms ease-out;
+}
+.home-composer__hint.is-error { color: var(--accent); font-weight: 600; }
+.home-composer__save {
+  height: 36px;
+  padding: 0 16px;
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  background: var(--accent);
+  color: #FAF8F6;
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.2px;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  transition: background 160ms ease-out;
+}
+.home-composer__save:hover:not(:disabled) { background: var(--accent-hover); }
+.home-composer__save:disabled {
+  background: var(--surface-sunken);
+  color: var(--fg-subtle);
+  cursor: default;
+}
+
+/* ── Section label (今天 / 昨天及更早) ──────────────────────────────────────── */
+.home-section { margin-top: 38px; }
+.home-section__label {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 16px;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 13px;
+  letter-spacing: 1.6px;
+  text-transform: uppercase;
+  color: var(--fg-primary);
+}
+.home-section__count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0;
+  color: var(--accent);
+  background: var(--accent-soft);
+  border-radius: 999px;
+  padding: 2px 9px;
+  text-transform: none;
+}
+.home-section__more {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  /* keep ≥24px hit target without disturbing layout (WCAG 2.5.8) */
+  padding: 6px 8px;
+  margin-right: -8px;
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.6px;
+  text-transform: none;
+  color: var(--fg-muted);
+  text-decoration: none;
+  transition: color 140ms ease-out;
+}
+.home-section__more:hover { color: var(--accent); }
+
+/* Today's flomo card grid */
+.home-memo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+
+/* Empty state */
+.home-empty {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 48px 24px;
+  text-align: center;
+  background: var(--surface-white);
+  border: 0.5px dashed var(--border-default);
+  border-radius: 18px;
+  color: var(--fg-subtle);
+}
+.home-empty p { margin: 0; font-family: var(--font-body); font-size: 14px; color: var(--fg-muted); }
+.home-empty svg { color: var(--fg-subtle); opacity: 0.55; }
+
+/* Daily wiki card grid */
+.home-wiki-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
+  gap: 16px;
+  align-items: start;
+}
+.wiki-day-card {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 20px 22px;
+  background: var(--surface-white);
+  border: 0.5px solid var(--border-subtle);
+  border-radius: 18px;
+  box-shadow: var(--shadow-card);
+  text-decoration: none;
+  color: inherit;
+  transition: border-color 160ms ease-out, transform 160ms ease-out, box-shadow 160ms ease-out;
+}
+.wiki-day-card:hover {
+  border-color: var(--accent-border);
+  transform: translateY(-2px);
+  box-shadow: 0 6px 20px -8px rgba(60,40,15,0.18);
+}
+.wiki-day-card__head {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+.wiki-day-card__rel {
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 16px;
+  letter-spacing: -0.1px;
+  color: var(--accent);
+}
+.wiki-day-card__date {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--fg-subtle-aa);
+}
+.wiki-day-card__title {
+  margin: 0;
+  font-family: var(--font-display);
+  font-weight: 700;
+  font-size: 16px;
+  line-height: 1.4;
+  letter-spacing: -0.2px;
+  color: var(--fg-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+.wiki-day-card__excerpt {
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: pretty;
+}
+.wiki-day-card__foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-top: 2px;
+  padding-top: 12px;
+  border-top: 0.5px solid var(--border-subtle);
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 0.4px;
+  color: var(--fg-subtle-aa);
+}
+.wiki-day-card__foot span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.wiki-day-card:hover .wiki-day-card__foot { color: var(--accent); }
+
+/* ── Responsive ───────────────────────────────────────────────────────────── */
+@media (max-width: 820px) {
+  .home-hero { grid-template-columns: 1fr; gap: 20px; }
+  .home-hero__title { font-size: 28px; }
+}
+@media (max-width: 560px) {
+  .home-hero__title { font-size: 25px; }
+  .home-memo-grid,
+  .home-wiki-grid { grid-template-columns: 1fr; }
 }

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1637,6 +1637,75 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
   text-wrap: pretty;
 }
 
+/* Calm hero — shown once the day has ≥1 record. One-line state in place of
+   the two-line slogan, so returning users don't read the same poster twice. */
+.home-hero__title--calm {
+  font-size: clamp(20px, 4vw, 26px);
+  line-height: 1.35;
+  font-weight: 500;
+  letter-spacing: -0.2px;
+}
+.home-hero__title-tail { color: var(--fg-muted); font-weight: 400; }
+.home-hero__sub--quiet { margin-top: 10px; }
+.home-hero__yesterday {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 600;
+  font-size: 13.5px;
+  border-bottom: 0.5px dashed transparent;
+  transition: border-color 160ms ease-out;
+}
+.home-hero__yesterday:hover { border-bottom-color: var(--accent-border); }
+
+/* Midnight-crossing toast — appears once when the day flips. */
+.home-midnight-toast {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin: 14px 0 -4px;
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: color-mix(in oklab, var(--accent) 10%, var(--surface-white));
+  border: 0.5px solid var(--accent-border);
+  color: var(--accent);
+  font-size: 13px;
+  font-weight: 500;
+  letter-spacing: 0.2px;
+  box-shadow: 0 4px 14px -10px rgba(60,40,15,0.35);
+  animation: midnightToastIn 320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+@keyframes midnightToastIn {
+  from { opacity: 0; transform: translateY(-4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+/* "Ready" dot used in the third metric column when pending===0. The dot
+   replaces the count to communicate state, not statistics. */
+.dcc-metric__value--ready {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 1em;
+}
+.dcc-ready-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 999px;
+  background: #4d8c5b;
+  box-shadow: 0 0 0 4px color-mix(in oklab, #4d8c5b 18%, transparent);
+  animation: readyPulse 2.4s ease-in-out infinite;
+}
+@keyframes readyPulse {
+  0%, 100% { box-shadow: 0 0 0 4px color-mix(in oklab, #4d8c5b 18%, transparent); }
+  50%      { box-shadow: 0 0 0 7px color-mix(in oklab, #4d8c5b 8%, transparent); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .dcc-ready-dot, .home-midnight-toast { animation: none; }
+}
+
 /* Daily-compile card */
 .daily-compile-card {
   background: var(--surface-white);
@@ -1985,6 +2054,142 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
   gap: 5px;
 }
 .wiki-day-card:hover .wiki-day-card__foot { color: var(--accent); }
+
+/* ── Daily wiki "books" — reading shelf, not list ─────────────────────────
+   Each compiled day reads as a small book: serif title + one opening line
+   on the face, a corner date stamp, and N short rules along the bottom
+   edge as a "spine" — visually narrating "this day held N raw thoughts"
+   without making the user parse a number. Full excerpt fades in on hover
+   so the resting grid stays quiet. */
+.home-wiki-grid--books {
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 18px;
+}
+.wiki-book {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 22px 22px 28px;
+  min-height: 168px;
+  background: var(--surface-white);
+  border: 0.5px solid var(--border-subtle);
+  border-radius: 14px;
+  box-shadow: 0 1px 0 rgba(60,40,15,0.04), var(--shadow-card);
+  text-decoration: none;
+  color: inherit;
+  overflow: hidden;
+  transition:
+    transform 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    box-shadow 220ms cubic-bezier(0.2, 0.8, 0.2, 1),
+    border-color 220ms ease-out;
+}
+.wiki-book:hover {
+  transform: translateY(-3px);
+  border-color: var(--accent-border);
+  box-shadow: 0 10px 28px -14px rgba(60,40,15,0.22), 0 1px 0 rgba(60,40,15,0.04);
+}
+.wiki-book__stamp {
+  position: absolute;
+  top: 16px;
+  right: 18px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.6px;
+  color: var(--fg-subtle-aa);
+  opacity: 0.55;
+}
+.wiki-book__rel {
+  font-family: var(--font-mono);
+  font-size: 10.5px;
+  letter-spacing: 1.2px;
+  text-transform: uppercase;
+  color: var(--accent);
+  opacity: 0.75;
+}
+.wiki-book__title {
+  margin: 2px 0 0;
+  font-family: var(--font-serif);
+  font-weight: 600;
+  font-size: 19px;
+  line-height: 1.32;
+  letter-spacing: -0.3px;
+  color: var(--fg-primary);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: balance;
+}
+.wiki-book__pull {
+  margin: 4px 0 0;
+  font-family: var(--font-body);
+  font-size: 13.5px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: pretty;
+}
+/* Full excerpt is reserved for hover — it sits absolutely so it doesn't
+   reshuffle the resting layout. */
+.wiki-book__excerpt {
+  position: absolute;
+  left: 22px;
+  right: 22px;
+  bottom: 22px;
+  margin: 0;
+  font-family: var(--font-body);
+  font-size: 13px;
+  line-height: 1.62;
+  color: var(--fg-muted);
+  background: linear-gradient(180deg, transparent 0%, var(--surface-white) 22%);
+  padding-top: 36px;
+  opacity: 0;
+  transform: translateY(6px);
+  pointer-events: none;
+  transition: opacity 200ms ease-out, transform 200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+  text-wrap: pretty;
+}
+.wiki-book:hover .wiki-book__excerpt,
+.wiki-book:focus-visible .wiki-book__excerpt {
+  opacity: 1;
+  transform: translateY(0);
+}
+/* Spine — N short rules at the bottom edge, like the lines on a paperback's
+   bottom edge stain. Capped at 9 lines in the JSX so a heavy day reads as
+   "thick" without becoming a solid bar. */
+.wiki-book__spine {
+  position: absolute;
+  left: 22px;
+  right: 22px;
+  bottom: 10px;
+  display: flex;
+  gap: 3px;
+  height: 4px;
+  align-items: flex-end;
+  opacity: 0.55;
+  transition: opacity 200ms ease-out;
+}
+.wiki-book:hover .wiki-book__spine { opacity: 0.18; }
+.wiki-book__spine-line {
+  flex: 1;
+  height: 100%;
+  background: var(--accent);
+  border-radius: 1px;
+}
+.wiki-book__spine-line:nth-child(even) { height: 70%; opacity: 0.7; }
+.wiki-book__spine-line:nth-child(3n) { height: 85%; opacity: 0.85; }
+@media (prefers-reduced-motion: reduce) {
+  .wiki-book,
+  .wiki-book__excerpt { transition: none; }
+}
 
 /* ── Responsive ───────────────────────────────────────────────────────────── */
 @media (max-width: 820px) {


### PR DESCRIPTION
> 📌 本 PR base 为 `feat/ios-web-sync-785`（iOS→web 同步 PR）—— home 改造复用了其中的 web 端 memo 同步基线。建议在 #785 合并后再合本 PR，或一并审阅。

## 概述

把 web 端 `/home` 重做成 **capture-first 的一体化主页**，在 web 上复刻 iOS `Today→DailyPage` 管线 —— 让"每日编译"循环成为主页的主角，而不再散落在 `/today`、`/wiki`、`/add` 三个页面。

三段式（自上而下）：
1. **优雅输入** — 内联 composer：桌面自动聚焦、`⌘/Ctrl+↵` 保存、实时字数、保存成功「已保存 ✓」、失败保留草稿可重试
2. **今天 = flomo 卡片流** — 复用现有 `MemoCard`，每卡实时编译状态
3. **昨天及更早 = wiki 卡片流** — `type=daily` 编译页卡片，相对日期 + 摘要，点进 `/wiki`

顶部「今日编译」卡展示 今日记录/已编译/待编译 计数 + 「立即编译今天」按钮；inngest `daily-page` cron（00:30 UTC）仍自动编译昨天。

## 关键设计决策

- **手动编译用 `memo_ids` 而非 `date`**：`/api/compile` 的 date 分支按 **UTC 日** 匹配，但 `/api/today/memos` 的"今天"是**本地日** —— 传 memo_ids 精确编译屏上所见，规避跨时区漏编译的真实 bug。
- **零新 API**：仅复用 `POST /api/memos`、`POST /api/compile`、`GET /api/today/memos`、`GET /api/compile/status`、`type=daily` pages 查询。
- 知识网络面板（observations / activity）下沉为辅助区保留。

## 可访问性（WCAG 2.2 AA）

labeled composer、sr-only `aria-live` 状态播报通道、async 按钮 `aria-busy`、全控件 `:focus-visible` 焦点环 + composer 真实焦点环、AA 对比度微标签（新 `--fg-subtle-aa` token）、`h2` 段落标题、landmark sections、干净的 wiki 卡片链接名。

## 验证

**生产构建实测**（`next build && next start`，非 dev）：
- ✅ composer 保存流程跑通（输入即成卡片）
- ✅ 立即编译触发 `triggered:N`
- ✅ flomo 卡片 + wiki 卡片渲染、零控制台错误
- ✅ 全部 a11y 属性在 live DOM 确认（aria-label / aria-live / aria-busy / focus ring 2px accent / h2 / landmark）
- ✅ 桌面 + 移动截图复核

> 注：dev 环境（Turbopack + 慢文件系统）下客户端组件 hydration 异常导致输入框点不动，**生产构建完全正常** —— 已用生产 server 实测确认。

## Agent 测评（两轮迭代）

| 维度 | 初评 | 终评 |
|---|---|---|
| UX / 可访问性 | 72 | **100 / 100**（所有 AA 阻断清零）|
| 代码质量 | 68 | **91 / 100**（0 CRITICAL/HIGH/MEDIUM，APPROVE）|

途中顺带修复了 `/api/today/memos` 也存在的 `memo_attachments` 全表扫描（已在本 PR 的 SSR 查询中加 `inArray` 过滤）。

## 改动文件

- `web/src/app/(app)/home/HomeStream.tsx`（新增，客户端组件）
- `web/src/app/(app)/home/page.tsx`（重写，SSR 取数）
- `web/src/app/globals.css`（追加 HomeStream 样式 + `--fg-subtle-aa` token + focus/sr-only）