### PR TITLE
polish(ios/a11y): cleaner VoiceOver navigation through the sidebar drawer

### DIFF
--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -173,6 +173,10 @@ struct RootView: View {
                 .ignoresSafeArea()
                 .shadow(color: Color.black.opacity(0.10), radius: 20, x: 6, y: 0)
                 .offset(x: nav.isSidebarOpen ? 0 : -sidebarWidth)
+                // Take the panel out of the accessibility tree when it's off-
+                // screen, otherwise VoiceOver users can still focus Settings /
+                // Recent rows that are visually at negative x coordinates.
+                .accessibilityHidden(!nav.isSidebarOpen)
 
             // Right-side feedback panel — same scrim treatment as the sidebar
             // so both drawers feel like they belong to the same elevation tier.

--- a/DayPage/App/SidebarHeatmapView.swift
+++ b/DayPage/App/SidebarHeatmapView.swift
@@ -71,6 +71,13 @@ struct SidebarHeatmapView: View {
                 .accessibilityLabel(accessibilityText)
             grid
             footer
+                // Footer = LESS/MORE swatches + streak pill — the swatches are a
+                // pure legend (no signal beyond the accessibilityText already
+                // exposed by `header`), and the streak pill duplicates the
+                // streak phrase in `accessibilityText`. Hide the whole row from
+                // VoiceOver so users land on the next focusable element instead
+                // of trekking through 7+ decorative children.
+                .accessibilityHidden(true)
         }
         .padding(.init(top: 16, leading: 16, bottom: 14, trailing: 16))
         .background(
@@ -126,6 +133,11 @@ struct SidebarHeatmapView: View {
 
             VStack(alignment: .leading, spacing: 5) {
                 monthLabels(columns: columns)
+                    // MAR / APR / MAY are purely visual context for the grid —
+                    // each day cell already announces its own MMM-d in its
+                    // accessibilityLabel, so reading these labels aloud is
+                    // duplicative.
+                    .accessibilityHidden(true)
                 GeometryReader { geo in
                     let cell = cellSize(in: geo.size.width)
                     HStack(spacing: cellSpacing) {

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -128,6 +128,9 @@ struct SidebarView: View {
                 .font(DSType.mono10)
                 .tracking(2.0)
                 .foregroundColor(DSColor.inkMuted)
+                // Wordmark — purely decorative; VoiceOver users land on the
+                // close button and then go straight into the profile row.
+                .accessibilityHidden(true)
         }
         .padding(.horizontal, 20)
         .padding(.top, 58)
@@ -179,6 +182,15 @@ struct SidebarView: View {
         .buttonStyle(.plain)
         .padding(.horizontal, 20)
         .padding(.vertical, 10)
+        // Merge avatar + name + membership line into a single VoiceOver focus
+        // so the user hears "<name>, <membership>" once instead of three
+        // separate elements that read as "·, Local Account, LOCAL · TAP TO SYNC".
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(profileName), \(membershipLine)")
+        .accessibilityHint(sidebarVM.isLoggedIn
+            ? "Opens account details"
+            : "Opens sign-in"
+        )
     }
 
     private var profileName: String {
@@ -226,8 +238,10 @@ struct SidebarView: View {
                 )
             statDivider
             statCell(label: "DAILIES", value: "\(sidebarVM.totalPages)", unit: "COMPILED", first: false)
+                .accessibilityLabel("\(sidebarVM.totalPages) dailies compiled")
             statDivider
             statCell(label: "WORDS", value: formatWords(sidebarVM.totalWordCount), unit: "TOTAL", first: false)
+                .accessibilityLabel("\(sidebarVM.totalWordCount) words total")
         }
         .background(
             RoundedRectangle(cornerRadius: 14, style: .continuous)
@@ -256,6 +270,10 @@ struct SidebarView: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 14)
+        // Each stat cell reads as one focus (e.g. "STREAK 5 BEST 12") instead
+        // of three separate StaticText nodes. Call sites that need a richer
+        // phrase override via `.accessibilityLabel(...)`.
+        .accessibilityElement(children: .combine)
     }
 
     private var statDivider: some View {
@@ -263,6 +281,7 @@ struct SidebarView: View {
             .fill(DSColor.borderSubtle)
             .frame(width: 0.5)
             .padding(.vertical, 12)
+            .accessibilityHidden(true)
     }
 
     /// "58k" style compaction for the word stat.
@@ -382,6 +401,15 @@ struct SidebarView: View {
         }
         .disabled(disabled)
         .buttonStyle(.plain)
+        // Merge the amber strip + icon + label + "Post-MVP" badge into one
+        // focus, then announce the destination + selection state.
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(label)
+        .accessibilityHint(disabled
+            ? "Coming after MVP"
+            : (tab == .feedback ? "Opens feedback" : "Navigates to \(label)")
+        )
+        .accessibilityAddTraits(isActive ? [.isButton, .isSelected] : .isButton)
     }
 
     // MARK: - Recent Section
@@ -438,6 +466,11 @@ struct SidebarView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        // "Today, 3 entries" / "Apr 13, 1 entry" — one phrase, then trait.
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(Self.formatRowTitle(day.dateString)), \(day.memoCount) \(day.memoCount == 1 ? "entry" : "entries")")
+        .accessibilityHint("Opens this day in Archive")
+        .accessibilityAddTraits(.isButton)
     }
 
     private func sectionLabel(_ text: String) -> some View {
@@ -448,6 +481,9 @@ struct SidebarView: View {
             .textCase(.uppercase)
             .padding(.leading, 34)  // align with row text column (2 + 12 + 20)
             .padding(.bottom, 4)
+            // Use isHeader so VoiceOver rotor lists these as section titles
+            // rather than skipping them; users can jump between sections.
+            .accessibilityAddTraits(.isHeader)
     }
 
     // MARK: - Bottom Section
@@ -474,6 +510,10 @@ struct SidebarView: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Settings")
+            .accessibilityHint("Opens app settings")
+            .accessibilityAddTraits(.isButton)
 
             // Account (when logged in)
             if sidebarVM.isLoggedIn {
@@ -516,6 +556,10 @@ struct SidebarView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("Signed in as \(email)")
+        .accessibilityHint("Opens account details")
+        .accessibilityAddTraits(.isButton)
     }
 
     // MARK: - Date Formatting


### PR DESCRIPTION
## Summary

Tightens VoiceOver focus order through the sidebar drawer based on an `ios-simulator-skill accessibility_audit` run against the live app. The audit surfaced 151 `missing_traits` warnings on the sidebar screen and exposed that off-screen drawer rows (Settings at `x=-140`) were still focusable when the panel was closed.

**3 files, +60 lines, no layout changes** — purely a11y metadata + a11y-tree trim.

## Why

Today, VoiceOver users:
- Walk through the profile row as three separate elements (`·`, `Local Account`, `LOCAL · TAP TO SYNC`) instead of one focused phrase.
- Hear MAR/APR/MAY/JUN month rails they can't interact with — the heatmap header already announces its full state via `accessibilityText`.
- Hear LESS/MORE swatches and the streak pill twice (once as decoration, once via the heatmap's combined label).
- Can land on Settings / Recent rows while the drawer is shut (they live at negative-x offset but stay in the accessibility tree).

## What

**RootView.swift**
- `.accessibilityHidden(!nav.isSidebarOpen)` on the off-screen drawer panel.

**SidebarView.swift**
- `profileRow` → combine + `"<name>, <membership>"` label + hint
- `statCell` → `.accessibilityElement(children: .combine)` so each STREAK/DAILIES/WORDS triplet reads as one focus
- `statDivider` → hidden
- `navItem` → combine + label + hint + `.isButton` (with `.isSelected` when active)
- `recentRow` → combine + `"Today, 1 entry"` / `"Apr 13, 2 entries"` label + hint + `.isButton`
- `sectionLabel` → `.isHeader` (Recent / Support reachable via VoiceOver rotor)
- Settings row / accountRow → combine + label + hint + `.isButton`
- "DAYPAGE · 2026" wordmark → hidden

**SidebarHeatmapView.swift**
- Month-label rail (MAR/APR/MAY/JUN) → hidden
- Footer row (LESS/MORE swatches + streak pill) → hidden (redundant with `accessibilityText` already on the header)

## Test plan

- [x] `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` — succeeds
- [x] Visual diff vs. baseline screenshot — pixel-level identical sidebar
- [x] `accessibility_audit.py` re-run on the live sidebar — confirmed:
  - profileRow now reads as one element (`'Local Account, LOCAL · TAP TO SYNC'`) instead of three
  - sectionLabel "Recent" / "Support" now classified as `Heading`
  - recentRow uses `"Today, 1 entry"` format
- [ ] Manual VoiceOver test: open drawer → swipe through; close drawer → confirm Settings no longer reachable

🤖 Generated with [Claude Code](https://claude.com/claude-code)