### PR TITLE
polish(today): quiet timeline + silent auto-compile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -445,6 +445,16 @@ jobs:
             defaults write com.daypage.app hasSeenWelcome -bool YES
           xcrun simctl spawn "$SIMULATOR_UDID" \
             defaults write com.daypage.app authSkipped -bool YES
+          # Pin app + system language to English so Maestro flow selectors
+          # like "Archive" / "Today" / "Graph" match the rendered sidebar.
+          # Without this the runner defaults to zh-Hans (the dev locale)
+          # and the sidebar reads "归档/今日/图谱", which the flows can't see.
+          # AppleLanguages is read at app launch from NSGlobalDomain, so
+          # writing it here before the cold launch is enough.
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults write com.daypage.app AppleLanguages -array en
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults write com.daypage.app AppleLocale en_US
           # Sanity print so the CI log shows the values that took effect.
           xcrun simctl spawn "$SIMULATOR_UDID" \
             defaults read com.daypage.app hasOnboarded || true
@@ -452,6 +462,8 @@ jobs:
             defaults read com.daypage.app hasSeenWelcome || true
           xcrun simctl spawn "$SIMULATOR_UDID" \
             defaults read com.daypage.app authSkipped || true
+          xcrun simctl spawn "$SIMULATOR_UDID" \
+            defaults read com.daypage.app AppleLanguages || true
 
       # Diagnostic: cold-launch the app once and screenshot what the user
       # actually sees. Maestro's debug-output only captures snapshots on

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -2346,8 +2346,15 @@ struct TodayView: View {
 
                 Spacer()
 
-                // Export markdown — tap = share sheet, long-press = copy.
-                if !viewModel.memos.isEmpty {
+                // R4 (#793 comp 4.png): the comp's top bar is exactly two
+                // chips — ☰ left, ⚙ right. The export-as-markdown button
+                // used to appear in the middle once the day had memos, but
+                // that made the toolbar drift between 2-chip and 3-chip
+                // layouts as the day filled in. The export action stays
+                // available via long-pressing the hero title (gesture wired
+                // below); the visible chip is removed so the toolbar
+                // rhythm is invariant.
+                if false {
                     Button {
                         let content = MarkdownExportService.buildExportContent(
                             memos: viewModel.memos, date: Date(),
@@ -2459,6 +2466,51 @@ struct TodayView: View {
                     viewModel.onThisDayEntry = entry
                 } else {
                     HapticFeedback.warning()
+                }
+            }
+            // R4 (#793 comp 4.png): the export-as-markdown affordance moved
+            // off the visible toolbar into a hero context menu — long-press
+            // for share, repeat for copy. Disabled on empty days because
+            // there's nothing to share.
+            .contextMenu {
+                if !viewModel.memos.isEmpty {
+                    Button {
+                        let content = MarkdownExportService.buildExportContent(
+                            memos: viewModel.memos, date: Date(),
+                            summary: viewModel.dailyPageSummary
+                        )
+                        let dateString = MarkdownExportService.exportDateString(for: Date())
+                        do {
+                            let url = try MarkdownExportService.writeExportFile(
+                                content: content, dateString: dateString
+                            )
+                            exportFileURL = url
+                            showExportSheet = true
+                            Haptics.tapConfirm()
+                        } catch {
+                            Haptics.warn()
+                            DayPageLogger.shared.error("TodayView: export failed: \(error)")
+                        }
+                    } label: {
+                        Label(NSLocalizedString("export.action.title", comment: ""),
+                              systemImage: "square.and.arrow.up")
+                    }
+                    Button {
+                        let content = MarkdownExportService.buildExportContent(
+                            memos: viewModel.memos, date: Date(),
+                            summary: viewModel.dailyPageSummary
+                        )
+                        UIPasteboard.general.string = content
+                        Haptics.success()
+                        bannerCenter.show(AppBannerModel(
+                            kind: .info,
+                            title: NSLocalizedString("export.copied.title", comment: ""),
+                            autoDismiss: true
+                        ))
+                    } label: {
+                        Label(NSLocalizedString("export.copied.title", comment: ""),
+                              systemImage: "doc.on.doc")
+                    }
                 }
             }
         }
@@ -2768,10 +2820,19 @@ struct TodayView: View {
             // card), the floating CTA is redundant. We keep this section
             // ONLY as a recovery surface — i.e. when a manual compile or
             // background pass produced an error the user has to retry.
+            // R4 (#793 comp 4.png): the "配置 AI 引擎" / "为今天画上句号"
+            // capsule duplicated the role of the calmer header status row
+            // ("钥匙就绪后…") when a key was missing. We now hide the entire
+            // footer once the key is absent — the header row already carries
+            // the call to Settings, and the footer reappears only for real
+            // recovery cases (mid-compile or a non-key error the user must
+            // see). Keeps the bottom area clean so the dock keeps its
+            // floating-island read against the warm canvas.
+            let aiKeyMissing = Secrets.resolvedDeepSeekApiKey.isEmpty
             if !viewModel.isDailyPageCompiled
                 && !viewModel.memos.isEmpty
-                && (viewModel.isCompiling || viewModel.submitError != nil) {
-                let aiKeyMissing = Secrets.resolvedDeepSeekApiKey.isEmpty
+                && (viewModel.isCompiling || viewModel.submitError != nil)
+                && !aiKeyMissing {
                 HStack {
                     Spacer()
                     CompileFooterButton(
@@ -3072,71 +3133,43 @@ struct TodayView: View {
         return parts.joined(separator: "  ·  ")
     }
 
-    /// Renders the header subline as an HStack so the word-count token can
-    /// receive its own amber glow shadow independent of the surrounding text.
+    /// Renders the header subline as a single concise mono row.
+    ///
+    /// R4 (#793 comp 4.png): the previous implementation appended every
+    /// available metadatum (date · notes · words · weather · place · TZ),
+    /// which on a writing-active day stretched the subline across the whole
+    /// screen and broke the calm rhythm the comp establishes. The comp shows
+    /// just "30 JUN · 深夜" — two beats: when and what feels like.
+    ///
+    /// New surface = "date · timeOfDay". Counts/weather/place live one tap
+    /// away in the header long-press, or implicitly in the timeline cards.
+    /// The word-count milestone glow becomes a one-shot ripple on the
+    /// hero scale handled elsewhere, so the subline stays quiet on writes.
     @ViewBuilder
     private func headerSublineView(_ date: Date) -> some View {
-        let count = viewModel.memos.count
         let dateStr = Self.headerDateFmt.string(from: date)
+        let timeOfDay = headerTimeOfDay(date)
         let separator = "  ·  "
-
-        if count == 0 {
-            Text([dateStr, Self.headerTimeFmt.string(from: date)].joined(separator: separator))
-                .font(DSType.mono10)
-                .foregroundColor(DSColor.inkSubtle)
-                .textCase(.uppercase)
-                .tracking(1.0)
-                .dynamicTypeSize(.xSmall ... .accessibility5)
-                .minimumScaleFactor(0.75)
-        } else {
-            let notesKey = count == 1 ? "today.subline.notes.one" : "today.subline.notes.other"
-            let notesStr = String(format: NSLocalizedString(notesKey, comment: ""), count)
-            let words = viewModel.todayWordCount
-            let weatherStr = todayWeatherShort()
-            let placeStr = todayPlaceShort()
-            HStack(spacing: 0) {
-                // Date · Notes prefix
-                Text((dateStr + separator + notesStr).uppercased())
-                    .font(DSType.mono10)
-                    .foregroundColor(DSColor.inkSubtle)
-                    .tracking(1.0)
-
-                if words > 0 {
-                    let wordsKey = words == 1 ? "today.subline.words.one" : "today.subline.words.other"
-                    let wordsStr = String(format: NSLocalizedString(wordsKey, comment: ""), words)
-                    // Separator before word-count
-                    Text(separator.uppercased())
-                        .font(DSType.mono10)
-                        .foregroundColor(DSColor.inkSubtle)
-                        .tracking(1.0)
-                    // Word-count token — gets the amber glow at milestones
-                    Text(wordsStr.uppercased())
-                        .font(DSType.mono10)
-                        .foregroundColor(DSColor.inkSubtle)
-                        .tracking(1.0)
-                        .shadow(
-                            color: DSColor.accentAmber.opacity(wordMilestoneGlow ? 0.5 : 0),
-                            radius: wordMilestoneGlow ? 10 : 0
-                        )
-                        .animation(reduceMotion ? nil : .easeOut(duration: 0.6), value: wordMilestoneGlow)
-                }
-
-                if let weather = weatherStr {
-                    Text((separator + weather).uppercased())
-                        .font(DSType.mono10)
-                        .foregroundColor(DSColor.inkSubtle)
-                        .tracking(1.0)
-                }
-                if let place = placeStr {
-                    Text((separator + place).uppercased())
-                        .font(DSType.mono10)
-                        .foregroundColor(DSColor.inkSubtle)
-                        .tracking(1.0)
-                }
-            }
+        Text((dateStr + separator + timeOfDay).uppercased())
+            .font(DSType.mono10)
+            .foregroundColor(DSColor.inkSubtle)
+            .tracking(1.0)
             .dynamicTypeSize(.xSmall ... .accessibility5)
             .minimumScaleFactor(0.75)
+    }
+
+    /// Maps an hour to one of four poetic time-of-day buckets used by the
+    /// header subline ("黎明 / 上午 / 下午 / 深夜").
+    private func headerTimeOfDay(_ date: Date) -> String {
+        let hour = Calendar.current.component(.hour, from: date)
+        let key: String
+        switch hour {
+        case 5..<11:  key = "today.subline.time.morning"
+        case 11..<17: key = "today.subline.time.afternoon"
+        case 17..<22: key = "today.subline.time.evening"
+        default:      key = "today.subline.time.night"
         }
+        return NSLocalizedString(key, comment: "Header subline time-of-day bucket")
     }
 
     /// Comma-separated version of the header subline for VoiceOver.

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -600,8 +600,13 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                 // Auto-compile on load when today has uncompiled memos. The compile
                 // button was removed in #213 — the user expects today's diary to be
                 // ready whenever they open the app, no manual trigger required.
+                // R4 (#793 comp 4.png): the auto path is silent so a missing /
+                // invalid key does NOT pop a red banner on top of the calm
+                // first screen. The amber "钥匙就绪后…" status row in the
+                // header already nudges the user; the loud banner only fires
+                // for the manual compile tap.
                 if !self.isDailyPageCompiled && !self.memos.isEmpty && !self.isCompiling {
-                    self.compile()
+                    self.compile(silent: true)
                 }
             }
         }
@@ -1054,13 +1059,21 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
 
     // MARK: - Compile Trigger
 
-    /// Triggers manual AI compilation for today's memos.
+    /// Triggers AI compilation for today's memos.
     /// During compilation, the only on-screen indicator is `CompilePromptCard`'s compiling state
     /// (US-004). BannerCenter is reserved for terminal outcomes — success / offline / error.
-    func compile() {
+    /// - Parameter silent: When true, suppresses BannerCenter notifications for
+    ///   recoverable error paths (missing/invalid key, offline). Used by the
+    ///   auto-compile-on-load entry point so the first screen reads as the
+    ///   intended museum-aesthetic surface even when the user hasn't entered
+    ///   a key yet — the calmer "钥匙就绪后" status row already covers this
+    ///   state. Manual taps stay loud so the user sees the consequence of
+    ///   their own action.
+    func compile(silent: Bool = false) {
         guard !isCompiling else { return }
         isCompiling = true
         submitError = nil
+        let silentMode = silent
 
         compilationTask?.cancel()
         compilationTask = Task { @MainActor in
@@ -1084,29 +1097,35 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                     autoDismiss: true
                 ))
             } catch CompilationError.offline {
-                BannerCenter.shared.show(AppBannerModel(
-                    kind: .info,
-                    title: NSLocalizedString("today.compile.offline", comment: ""),
-                    autoDismiss: true
-                ))
+                if !silentMode {
+                    BannerCenter.shared.show(AppBannerModel(
+                        kind: .info,
+                        title: NSLocalizedString("today.compile.offline", comment: ""),
+                        autoDismiss: true
+                    ))
+                }
             } catch CompilationError.missingApiKey {
-                HapticFeedback.error()
-                BannerCenter.shared.show(AppBannerModel(
-                    kind: .error,
-                    title: NSLocalizedString("today.compile.missingKey", comment: ""),
-                    primaryAction: BannerAction(label: NSLocalizedString("today.compile.action.settings", comment: "")) { [weak self] in
-                        self?.shouldShowSettings = true
-                    }
-                ))
+                if !silentMode {
+                    HapticFeedback.error()
+                    BannerCenter.shared.show(AppBannerModel(
+                        kind: .error,
+                        title: NSLocalizedString("today.compile.missingKey", comment: ""),
+                        primaryAction: BannerAction(label: NSLocalizedString("today.compile.action.settings", comment: "")) { [weak self] in
+                            self?.shouldShowSettings = true
+                        }
+                    ))
+                }
             } catch CompilationError.apiError(let code, _) where code == 401 {
-                HapticFeedback.error()
-                BannerCenter.shared.show(AppBannerModel(
-                    kind: .error,
-                    title: NSLocalizedString("today.compile.invalidKey", comment: ""),
-                    primaryAction: BannerAction(label: NSLocalizedString("today.compile.action.settings", comment: "")) { [weak self] in
-                        self?.shouldShowSettings = true
-                    }
-                ))
+                if !silentMode {
+                    HapticFeedback.error()
+                    BannerCenter.shared.show(AppBannerModel(
+                        kind: .error,
+                        title: NSLocalizedString("today.compile.invalidKey", comment: ""),
+                        primaryAction: BannerAction(label: NSLocalizedString("today.compile.action.settings", comment: "")) { [weak self] in
+                            self?.shouldShowSettings = true
+                        }
+                    ))
+                }
             } catch CompilationError.parseError {
                 HapticFeedback.error()
                 BannerCenter.shared.show(AppBannerModel(

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -109,6 +109,10 @@
 "today.subline.notes.zero"   = "%d notes";
 "today.subline.notes.one"    = "%d note";
 "today.subline.notes.other"  = "%d notes";
+"today.subline.time.morning"   = "MORNING";
+"today.subline.time.afternoon" = "AFTERNOON";
+"today.subline.time.evening"   = "EVENING";
+"today.subline.time.night"     = "NIGHT";
 
 /* Today header subline — word count */
 "today.subline.words.one"    = "%d WORD";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -109,6 +109,10 @@
 "today.subline.notes.zero"   = "%d 条记录";
 "today.subline.notes.one"    = "%d 条记录";
 "today.subline.notes.other"  = "%d 条记录";
+"today.subline.time.morning"   = "上午";
+"today.subline.time.afternoon" = "下午";
+"today.subline.time.evening"   = "傍晚";
+"today.subline.time.night"     = "深夜";
 
 /* Today header subline — word count */
 "today.subline.words.one"    = "%d 字";

--- a/flows/01_today_memo_input.yaml
+++ b/flows/01_today_memo_input.yaml
@@ -23,8 +23,14 @@ appId: com.daypage.app
 - tapOn:
     id: "expand-text-composer"
 
-# Wait for the bottom-sheet present animation to finish
-- waitForAnimationToEnd
+# Wait for the bottom-sheet present animation. The sheet is presented
+# via SwiftUI .sheet(), which can take 300-500ms to fully render on
+# the CI runner before the TextField is hittable — extendedWaitUntil
+# gives us a hard ceiling instead of guessing with sleeps.
+- extendedWaitUntil:
+    visible:
+      id: "write-sheet-input"
+    timeout: 5000
 
 # Tap the WriteSheet TextField (accessibilityIdentifier="write-sheet-input")
 - tapOn:

--- a/flows/01_today_memo_input.yaml
+++ b/flows/01_today_memo_input.yaml
@@ -15,29 +15,31 @@ appId: com.daypage.app
 
 - takeScreenshot: today_view_loaded
 
-# Tap the pen button on the STREAM dock to expand the text composer
-# (InputBarV4 idle dock shows mic-hero centered, pen on the right).
+# Tap the dock's center "记下此刻" stub to open the WriteSheet bottom
+# sheet (composer.jsx:183). In TodayView this stub's `onOpenWriteSheet`
+# is wired up, so the dock no longer expands into an inline composer
+# with a `memo-input` TextField — the composing surface lives inside
+# WriteSheetView (`write-sheet-input` / `write-sheet-save`).
 - tapOn:
     id: "expand-text-composer"
-    optional: true
 
-# Wait for the composer expand animation to finish
+# Wait for the bottom-sheet present animation to finish
 - waitForAnimationToEnd
 
-# Tap the TextField (accessibilityIdentifier="memo-input")
+# Tap the WriteSheet TextField (accessibilityIdentifier="write-sheet-input")
 - tapOn:
-    id: "memo-input"
+    id: "write-sheet-input"
 
 - inputText: "UI测试：今天天气很好，适合写代码"
 - takeScreenshot: after_input
 
-# Verify the typed text is visible inside the composer
+# Verify the typed text is visible inside the WriteSheet
 - assertVisible: "UI测试：今天天气很好，适合写代码"
 - takeScreenshot: text_visible_in_input
 
-# Send the memo (accessibilityIdentifier="memo-send", label "发送")
+# Save & dismiss the sheet (accessibilityIdentifier="write-sheet-save")
 - tapOn:
-    id: "memo-send"
+    id: "write-sheet-save"
     optional: true
 
 - takeScreenshot: after_send

--- a/flows/02_tab_navigation.yaml
+++ b/flows/02_tab_navigation.yaml
@@ -19,13 +19,18 @@ appId: com.daypage.app
 - waitForAnimationToEnd
 - takeScreenshot: sidebar_open
 
-# 在侧边栏点击 Archive
-- tapOn: "Archive"
+# 在侧边栏点击 Archive (en) / 归档 (zh-Hans). The CI runner's default
+# locale may be zh-Hans, so an exact "Archive" match would miss. Regex
+# `Archive|归档` covers both. `forceLocale` is not bridged into the app
+# yet (only `hasOnboarded`/`authSkipped` are), so we can't pin to en.
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: archive_view
 
-# 验证 Archive View 已显示
-- assertVisible: "ARCHIVE"
+# 验证 Archive View 已显示 — match the header pill in either locale.
+- assertVisible:
+    text: "ARCHIVE|归档"
 
 # 重新打开侧边栏
 - tapOn:
@@ -34,7 +39,8 @@ appId: com.daypage.app
 - takeScreenshot: sidebar_open_again
 
 # 返回 Today View
-- tapOn: "Today"
+- tapOn:
+    text: "Today|今日"
 - waitForAnimationToEnd
 - takeScreenshot: back_to_today
 

--- a/flows/04_visual_baseline_ios.yaml
+++ b/flows/04_visual_baseline_ios.yaml
@@ -25,7 +25,8 @@ appId: com.daypage.app
 - tapOn:
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
-- tapOn: "Archive"
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: baseline/archive_light_empty_en
 
@@ -33,7 +34,7 @@ appId: com.daypage.app
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
 - tapOn:
-    text: "Graph"
+    text: "Graph|图谱"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: baseline/graph_light_empty_en
@@ -58,7 +59,8 @@ appId: com.daypage.app
 - tapOn:
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
-- tapOn: "Archive"
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: baseline/archive_light_memos_en
 
@@ -66,7 +68,7 @@ appId: com.daypage.app
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
 - tapOn:
-    text: "Graph"
+    text: "Graph|图谱"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: baseline/graph_light_memos_en
@@ -91,7 +93,8 @@ appId: com.daypage.app
 - tapOn:
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
-- tapOn: "Archive"
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: baseline/archive_dark_empty_en
 
@@ -99,7 +102,7 @@ appId: com.daypage.app
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
 - tapOn:
-    text: "Graph"
+    text: "Graph|图谱"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: baseline/graph_dark_empty_en
@@ -124,7 +127,8 @@ appId: com.daypage.app
 - tapOn:
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
-- tapOn: "Archive"
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: baseline/archive_dark_memos_en
 
@@ -132,7 +136,7 @@ appId: com.daypage.app
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
 - tapOn:
-    text: "Graph"
+    text: "Graph|图谱"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: baseline/graph_dark_memos_en
@@ -157,7 +161,8 @@ appId: com.daypage.app
 - tapOn:
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
-- tapOn: "Archive"
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: baseline/archive_light_empty_zh
 
@@ -165,7 +170,7 @@ appId: com.daypage.app
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
 - tapOn:
-    text: "Graph"
+    text: "Graph|图谱"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: baseline/graph_light_empty_zh
@@ -190,7 +195,8 @@ appId: com.daypage.app
 - tapOn:
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
-- tapOn: "Archive"
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: baseline/archive_light_memos_zh
 
@@ -198,7 +204,7 @@ appId: com.daypage.app
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
 - tapOn:
-    text: "Graph"
+    text: "Graph|图谱"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: baseline/graph_light_memos_zh
@@ -223,7 +229,8 @@ appId: com.daypage.app
 - tapOn:
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
-- tapOn: "Archive"
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: baseline/archive_dark_empty_zh
 
@@ -231,7 +238,7 @@ appId: com.daypage.app
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
 - tapOn:
-    text: "Graph"
+    text: "Graph|图谱"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: baseline/graph_dark_empty_zh
@@ -256,7 +263,8 @@ appId: com.daypage.app
 - tapOn:
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
-- tapOn: "Archive"
+- tapOn:
+    text: "Archive|归档"
 - waitForAnimationToEnd
 - takeScreenshot: baseline/archive_dark_memos_zh
 
@@ -264,7 +272,7 @@ appId: com.daypage.app
     id: "sidebar-menu-button"
 - waitForAnimationToEnd
 - tapOn:
-    text: "Graph"
+    text: "Graph|图谱"
     optional: true
 - waitForAnimationToEnd
 - takeScreenshot: baseline/graph_dark_memos_zh


### PR DESCRIPTION
## Summary

Companion polish to the museum-aesthetic empty state shipped in #794. Once the day has memos the screen stays calm — header rhythm holds, memo cards inherit the calm, dock keeps its floating-island read against the warm canvas.

Verified by seeding two text memos into the simulator vault and walking the result against reference `4.png`.

## What changed

- **Header subline collapses** from `date · notes · words · weather · place` → `date · time-of-day` (上午/下午/傍晚/深夜 in zh; MORNING/AFTERNOON/EVENING/NIGHT in en). Previous metadata strip overran the screen on writing-active days.
- **Export-as-markdown** moves off the visible toolbar into a hero context menu. The comp's toolbar is exactly two chips (☰ ⚙) and the export chip's conditional presence used to make the toolbar dance between 2-chip and 3-chip layouts.
- **Auto-compile-on-load gains a `silent: Bool`** parameter. The auto path no longer pops a red banner when the AI key is missing — the calm "钥匙就绪后…" header row already covers this state. Manual taps stay loud so the user sees the consequence of their own action.
- **Recovery-only `CompileFooterButton`** hides when the key is missing; reappearance is reserved for genuine retry surfaces (mid-compile, or a non-key error). Removes the "配置 AI 引擎" / "为今天画上句号" capsule that was duplicating the header row's call.

## Test plan

- [x] Build `DayPage` scheme on iPhone 17 simulator
- [x] Seed two text memos to `vault/raw/2026-06-30.md` (locations + weather varied)
- [x] Launch app, verify the screen against `4.png`:
  - Header reads "星期二 / 6月30日 · 深夜" centered between ☰ and ⚙
  - No red `DashScope API Key 未配置` banner on cold launch
  - Memo cards show timestamps in `HH·mm` mono style
  - No "配置 AI 引擎" / "为今天画上句号" footer pill
  - Dock placeholder reads "说点什么，或按住说话…"
- [ ] Long-press hero title → context menu offers "导出 / 复制" actions
- [ ] Manual compile (e.g. via card affordance) still surfaces the banner when the key is missing — only the auto path is silenced