### PR TITLE
feat: ios product-experience 100/100 + web/add v9 capture surface

### DIFF
--- a/web/e2e/add-v9.spec.ts
+++ b/web/e2e/add-v9.spec.ts
@@ -1,0 +1,177 @@
+/**
+ * DayPage v9 design contract tests — /add page.
+ *
+ * Locks down the six load-bearing pieces we shipped in the /add refactor
+ * (see docs/web-design-v9.md and this PR's commit body):
+ *   1. CaptureHero exists on /add with a Fraunces serif date + uppercase
+ *      mono-caps stats line.
+ *   2. Composer container reads with the v9 elevation tokens (--elev-flat
+ *      baseline, --elev-raise + accent ring on focus).
+ *   3. Composer placeholder is `此刻在想什么？` and hint copy references
+ *      "记下此刻，余下交给夜里" when focused-empty.
+ *   4. Primary CTA is the amber pill "收下" (not the old 28×28 send square).
+ *   5. Pipeline banner appears at most once on the page — every per-row
+ *      "编译服务未连接" leak from v8 is gone.
+ *   6. Ingest-mode pill uses the shared .chip--success / .chip--accent
+ *      tokens (i.e. LIGHT/FULL semantic pills), not hand-rolled colour.
+ *
+ * Usage:
+ *   BASE_URL=http://localhost:3000 pnpm exec playwright test \
+ *     e2e/add-v9.spec.ts --project=desktop-chrome
+ */
+import { test, expect, type Page } from "@playwright/test";
+
+// The project auth flow is the real /login form — dev seed user
+// `dev@daypage.local` gets a session cookie via `Dev login (no email)`.
+async function loginDev(page: Page) {
+  await page.goto("/login", { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "Dev login (no email)" }).click();
+  await page.waitForURL(/\/(home|today|add)/, { timeout: 15_000 }).catch(() => {
+    /* some flows land back on /login when session already exists — ignore */
+  });
+}
+
+test.describe("v9 design contract — /add", () => {
+  // Cold Turbopack routes on dev can take up to ~90s to compile /add on the
+  // first request (the app is 30+ routes and lazy-compiles). Give each test
+  // a generous 3-min budget rather than false-fail on first paint.
+  test.setTimeout(180_000);
+
+  test.beforeEach(async ({ page }) => {
+    await loginDev(page);
+    await page.goto("/add", { waitUntil: "domcontentloaded" });
+    // wait for hydrated composer — its testid renders client-side
+    await page.getByTestId("add-composer").waitFor({ state: "visible", timeout: 60_000 });
+    // Composer auto-focuses on mount when there's no localStorage draft
+    // (see Composer.tsx `queueMicrotask(() => taRef.current?.focus())`). To
+    // give every test a clean starting state, blur out to a neutral point
+    // and wait for the 180ms shadow transition to settle.
+    await page.mouse.click(2, 2);
+    await page.waitForTimeout(240);
+  });
+
+  // Contract #1 — CaptureHero (Fraunces + mono caps) is visible at the top
+  test("CaptureHero renders with Fraunces serif date + mono caps stats", async ({ page }) => {
+    const hero = page.getByTestId("capture-hero");
+    await expect(hero).toBeVisible();
+
+    // date uses Fraunces
+    const dateFontFamily = await hero.locator(".ds-home-hero__date").evaluate(
+      (el) => window.getComputedStyle(el).fontFamily,
+    );
+    expect(dateFontFamily.toLowerCase()).toContain("fraunces");
+
+    // stats line is mono-caps
+    const stats = hero.locator(".ds-home-hero__stats");
+    const statsTextTransform = await stats.evaluate(
+      (el) => window.getComputedStyle(el).textTransform,
+    );
+    expect(statsTextTransform).toBe("uppercase");
+
+    // ritual phrase is present verbatim
+    await expect(stats).toContainText("RAW · CAPTURE MOMENT");
+  });
+
+  // Contract #2 — Composer elevation tokens (flat baseline, raise on focus)
+  test("Composer boxShadow flips between flat baseline and lifted focus", async ({ page }) => {
+    const composer = page.getByTestId("add-composer");
+    await expect(composer).toBeVisible();
+
+    // The Composer auto-focuses on mount (Round 5 UX: "open page = already
+    // writing"). So we start in the focused state, blur out to sample the
+    // baseline, then focus back and sample the lifted state. This proves the
+    // two shadow tokens are wired up and different.
+    const textarea = composer.locator("textarea").first();
+
+    // Blur by clicking the body outside the composer (top-left corner is a
+    // safe empty area — the sidebar rail sits there but its own click
+    // handlers won't refocus the composer).
+    await page.mouse.click(2, 2);
+    await page.waitForTimeout(280);
+    await expect(composer).toHaveAttribute("data-focused", "false");
+    const baselineShadow = await composer.evaluate(
+      (el) => window.getComputedStyle(el).boxShadow,
+    );
+    expect(baselineShadow).not.toBe("none");
+    const baselineBorder = await composer.evaluate(
+      (el) => window.getComputedStyle(el).borderTopColor,
+    );
+
+    // Focus and re-sample.
+    await textarea.focus();
+    await page.waitForTimeout(280);
+    await expect(composer).toHaveAttribute("data-focused", "true");
+    const focusedShadow = await composer.evaluate(
+      (el) => window.getComputedStyle(el).boxShadow,
+    );
+    const focusedBorder = await composer.evaluate(
+      (el) => window.getComputedStyle(el).borderTopColor,
+    );
+
+    // Contract: BOTH boxShadow and border-color must change between the two
+    // states. Exact strings differ per browser / theme, so inequality is the
+    // stable assertion.
+    expect(focusedShadow).not.toBe(baselineShadow);
+    expect(focusedBorder).not.toBe(baselineBorder);
+  });
+
+  // Contract #3 — placeholder + hint copy
+  test("Composer placeholder is Chinese; focused-empty hint shows ritual phrase", async ({ page }) => {
+    const textarea = page.getByTestId("add-composer").locator("textarea").first();
+    await expect(textarea).toHaveAttribute("placeholder", "此刻在想什么？");
+
+    await textarea.focus();
+    const hint = page.getByTestId("composer-hint");
+    await expect(hint).toBeVisible();
+    await expect(hint).toContainText("记下此刻，余下交给夜里");
+  });
+
+  // Contract #4 — Send CTA is the "收下" pill (not the old 28×28 icon)
+  test("Send CTA is the amber '收下' pill with a rounded shape", async ({ page }) => {
+    const send = page.getByTestId("composer-send");
+    await expect(send).toBeVisible();
+    await expect(send).toContainText("收下");
+
+    const box = await send.boundingBox();
+    expect(box).not.toBeNull();
+    // v9 pill is 36px tall and >= 60px wide (icon + "收下" glyphs)
+    expect(box!.height).toBeGreaterThanOrEqual(32);
+    expect(box!.width).toBeGreaterThanOrEqual(60);
+
+    const radius = await send.evaluate(
+      (el) => window.getComputedStyle(el).borderRadius,
+    );
+    // 999px pill — parses to a very large pixel value in most browsers
+    expect(parseInt(radius, 10)).toBeGreaterThanOrEqual(16);
+  });
+
+  // Contract #5 — no per-row "编译服务未连接" leak
+  test("pipeline warning appears at most once (single banner, not per row)", async ({ page }) => {
+    const leakCount = await page
+      .getByText("编译服务未连接", { exact: false })
+      .count();
+    // Either the banner shows once (pipeline down) or not at all (pipeline
+    // up). Anything ≥ 2 means the old per-MemoRow debug string leaked back.
+    expect(leakCount).toBeLessThanOrEqual(1);
+
+    // And ABSOLUTELY no ops debug hint in any body copy on the page:
+    const debugLeak = await page.getByText("pnpm run dev:inngest", { exact: false }).count();
+    expect(debugLeak).toBe(0);
+  });
+
+  // Contract #6 — ingest-mode pill uses the semantic tokens
+  test("ingest-mode pill uses chip--success or chip--accent", async ({ page }) => {
+    // We only assert IF there's at least one recently-compiled row on this
+    // page. Fresh envs have none — we skip in that case rather than fail.
+    const pills = page.locator(".ds-add-mode-pill");
+    const count = await pills.count();
+    test.skip(count === 0, "no memos yet — nothing to pill");
+
+    for (let i = 0; i < count; i++) {
+      const cls = (await pills.nth(i).getAttribute("class")) ?? "";
+      const isSemantic =
+        cls.includes("chip--success") || cls.includes("chip--accent");
+      expect(isSemantic, `pill #${i} classes = ${cls}`).toBe(true);
+    }
+  });
+});

--- a/web/e2e/v9-design.spec.ts
+++ b/web/e2e/v9-design.spec.ts
@@ -10,13 +10,21 @@
  */
 import { test, expect } from "@playwright/test";
 
-async function loginDevBypass(page: import("@playwright/test").Page) {
-  await page.goto("/api/auth/dev-bypass", { waitUntil: "networkidle" });
+// The /api/auth/dev-bypass endpoint was removed during Round 5 refactor;
+// we now hit the real /login form's "Dev login (no email)" button to seed
+// the session. See web/tests/composer.spec.ts:20-21 for the same pattern.
+async function loginDev(page: import("@playwright/test").Page) {
+  await page.goto("/login", { waitUntil: "domcontentloaded" });
+  await page.getByRole("button", { name: "Dev login (no email)" }).click();
+  await page.waitForURL(/\/(home|today|add)/, { timeout: 15_000 }).catch(() => {
+    /* already-signed-in flows land back on /login — ignore */
+  });
 }
 
 test.describe("v9 design contract", () => {
+  test.setTimeout(180_000);
   test.beforeEach(async ({ page }) => {
-    await loginDevBypass(page);
+    await loginDev(page);
   });
 
   // Signature move: /home is the first port of call, and it must open with

--- a/web/playwright.e2e.config.ts
+++ b/web/playwright.e2e.config.ts
@@ -1,0 +1,25 @@
+// Slim Playwright config for the /e2e directory (design contract tests).
+// The default playwright.config.ts is scoped to /tests and stays that way;
+// this file lets us run the e2e contract suite (v9-design.spec.ts,
+// add-v9.spec.ts, visual-baseline.spec.ts) without cross-configuring the
+// main test harness.
+import { defineConfig, devices } from "@playwright/test";
+
+export default defineConfig({
+  testDir: "./e2e",
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: [["line"]],
+  use: {
+    baseURL: process.env.BASE_URL ?? "http://localhost:3000",
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
+  },
+  projects: [
+    {
+      name: "desktop-chrome",
+      use: { ...devices["Desktop Chrome"], viewport: { width: 1440, height: 900 } },
+    },
+  ],
+});

--- a/web/src/app/(app)/add/CaptureHero.tsx
+++ b/web/src/app/(app)/add/CaptureHero.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+// CaptureHero — v9 signature entrance for /add.
+//
+// Mirrors HomeHero on /home: a Fraunces serif date fades in from y+12 over
+// 360ms motion.island spring, backed by a mono-caps status line. This turns
+// /add from a bare textarea into a museum-restraint "capture the moment"
+// ritual entry. Plays once per session (SPA re-entry stays quiet) and
+// collapses to instant on prefers-reduced-motion.
+//
+// Design source: docs/web-design-v9.md §4 (adapted from HomeHero for the
+// raw-capture flow — instead of SOURCES/PAGES/THIS WEEK we surface
+// RAW · CAPTURE MOMENT and the current queue count so the entrance still
+// reads as a wall label, not a form header).
+
+import { motion, useReducedMotion } from "framer-motion";
+import { useEffect, useMemo, useState } from "react";
+
+interface CaptureHeroProps {
+  queueCount: number;
+  doneCount: number;
+}
+
+const PLAYED_KEY = "capture-hero-played";
+
+const MONTHS = [
+  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+] as const;
+const WEEKDAYS = ["SUN", "MON", "TUE", "WED", "THU", "FRI", "SAT"] as const;
+
+export function CaptureHero({ queueCount, doneCount }: CaptureHeroProps) {
+  const reduced = useReducedMotion();
+  const [shouldAnimate, setShouldAnimate] = useState(false);
+
+  // Compute date on the client so SSR/client match without hydration flicker.
+  // The hero renders the same textual date either way — we just tolerate a
+  // one-frame difference when the browser clock crosses midnight.
+  const { dateLabel, weekday } = useMemo(() => {
+    const d = new Date();
+    return {
+      dateLabel: `${d.getFullYear()} · ${MONTHS[d.getMonth()]} ${String(d.getDate()).padStart(2, "0")}`,
+      weekday: WEEKDAYS[d.getDay()] ?? "SUN",
+    };
+  }, []);
+
+  useEffect(() => {
+    try {
+      if (typeof window === "undefined") return;
+      if (sessionStorage.getItem(PLAYED_KEY)) return;
+      sessionStorage.setItem(PLAYED_KEY, "1");
+      setShouldAnimate(true);
+    } catch {
+      /* sessionStorage blocked — stay static */
+    }
+  }, []);
+
+  const animateIn = shouldAnimate && !reduced;
+
+  return (
+    <motion.header
+      initial={animateIn ? { opacity: 0, y: 12 } : false}
+      animate={animateIn ? { opacity: 1, y: 0 } : undefined}
+      transition={{ duration: 0.36, ease: [0.2, 0.8, 0.2, 1] }}
+      className="ds-home-hero ds-capture-hero"
+      data-testid="capture-hero"
+    >
+      <h1 className="ds-home-hero__date">{dateLabel}</h1>
+      <p className="ds-home-hero__stats">
+        <span>{weekday}</span>
+        <span aria-hidden="true">·</span>
+        <span>RAW · CAPTURE MOMENT</span>
+        <span aria-hidden="true">·</span>
+        <span>{queueCount} IN QUEUE</span>
+        <span aria-hidden="true">·</span>
+        <span>{doneCount} COMPILED</span>
+      </p>
+    </motion.header>
+  );
+}

--- a/web/src/app/(app)/add/CompileQueue.tsx
+++ b/web/src/app/(app)/add/CompileQueue.tsx
@@ -360,11 +360,14 @@ function MemoRow({
             </span>
           )}
         </div>
+        {/* v9 refactor: no more per-row "编译服务未连接" — a single banner
+            at the top of /add carries that signal (see
+            CompileServiceBanner). Rows here keep only the concrete state:
+            failure message when failed, live step when running, or a
+            terse "等待编译" fallback while pipeline is down. */}
         <div className="queue-item__sub">
           {memo.type} · {date}
-          {showDisconnected
-            ? " · 编译服务未连接（运行 pnpm run dev:inngest）"
-            : ""}
+          {showDisconnected ? " · 等待编译" : ""}
           {isFailed && errorMsg ? ` · ${errorMsg}` : ""}
           {isDone ? " · Compilation complete" : ""}
           {!isDone && !isFailed && !showDisconnected && step ? ` · ${step}` : ""}
@@ -391,6 +394,9 @@ function MemoRow({
         style={{ display: "flex", alignItems: "center", gap: "0.5rem" }}
         onClick={(e) => e.stopPropagation()}
       >
+        {/* v9 semantic pill — same tokens as RecentlyCompiled (light=success,
+            full=accent) so the queue -> compiled transition doesn't jump
+            visual language. chip--interactive still carries the switch UX. */}
         <button
           type="button"
           title={`Switch to ${nextMode.toUpperCase()} mode`}
@@ -400,14 +406,17 @@ function MemoRow({
             e.preventDefault();
             onSwitchMode(nextMode);
           }}
+          data-mode={currentMode}
           className={
             currentMode === "full"
-              ? "chip chip--accent chip--interactive"
-              : "chip chip--ghost chip--interactive"
+              ? "chip chip--accent chip--interactive ds-add-mode-pill"
+              : "chip chip--success chip--interactive ds-add-mode-pill"
           }
           style={{
             textTransform: "uppercase",
-            letterSpacing: "0.06em",
+            letterSpacing: "0.08em",
+            fontFamily: "var(--font-mono, monospace)",
+            fontWeight: 600,
             cursor: isDone ? "default" : "pointer",
             opacity: isSwitching ? 0.5 : 1,
           }}

--- a/web/src/app/(app)/add/CompileServiceBanner.tsx
+++ b/web/src/app/(app)/add/CompileServiceBanner.tsx
@@ -1,0 +1,42 @@
+"use client";
+
+// CompileServiceBanner — single-source pipeline health strip for /add.
+//
+// Before v9 refactor, every MemoRow in CompileQueue showed the raw string
+// "编译服务未连接（运行 pnpm run dev:inngest）" whenever Inngest was down.
+// That's ops debug leaked into a museum-restraint page, and it repeats up
+// to 20 times per screen. v9 collapses it into ONE amber banner at the
+// top of /add, matching /home's `.home-pipeline-warn` treatment. The
+// MemoRow subtitle drops the string entirely; the pending pill (see
+// CompileQueue.tsx) still says QUEUED so users can still triage rows.
+
+import { useQuery } from "@tanstack/react-query";
+import { AlertCircle } from "lucide-react";
+
+interface CompileStatusResponse {
+  connected: boolean;
+}
+
+async function fetchCompileServiceStatus(): Promise<CompileStatusResponse> {
+  const res = await fetch("/api/compile/status");
+  if (!res.ok) throw new Error("Failed to fetch compile status");
+  return res.json() as Promise<CompileStatusResponse>;
+}
+
+export function CompileServiceBanner() {
+  const { data } = useQuery<CompileStatusResponse>({
+    queryKey: ["compile", "service-status"],
+    queryFn: fetchCompileServiceStatus,
+    staleTime: 60_000,
+  });
+  // Optimistic: only show the banner once we're SURE the pipeline is down.
+  // A missing/failed status probe stays quiet — no false alarms in staging.
+  if (data?.connected !== false) return null;
+
+  return (
+    <div className="ds-add-pipeline-warn" role="status" data-testid="compile-service-banner">
+      <AlertCircle size={14} strokeWidth={2} aria-hidden="true" />
+      <span>编译服务未连接 —— 新记录会保存，但暂不会被编译。</span>
+    </div>
+  );
+}

--- a/web/src/app/(app)/add/Composer.tsx
+++ b/web/src/app/(app)/add/Composer.tsx
@@ -446,13 +446,20 @@ export function Composer() {
           : { scale: focused ? 1.0035 : 1, y: focused ? -1 : 0 }
       }
       transition={{ type: "spring", stiffness: 360, damping: 32, mass: 0.6 }}
+      data-testid="add-composer"
+      data-focused={focused ? "true" : "false"}
+      className="ds-add-composer"
       style={{
-        background: "var(--surface, #fff)",
-        border: `1px solid rgba(43, 40, 34, ${focused ? 0.12 : 0.08})`,
+        // v9: baseline reads at --elev-flat (0 1px 2px warm-brown 4%). On focus
+        // the composer steps forward to --elev-raise + an accent-soft outer
+        // ring, matching /home's .home-composer:focus-within cue so both
+        // capture surfaces share one "step onto the museum bench" moment.
+        background: "var(--surface-white, #fff)",
+        border: `1px solid ${focused ? "var(--accent-hover, #7A3F00)" : "var(--border-subtle, #EDE8DF)"}`,
         borderRadius: 12,
         boxShadow: focused
-          ? "0 4px 16px -8px rgba(43, 40, 34, 0.12)"
-          : "0 0 0 transparent",
+          ? "0 0 0 3px var(--accent-soft, #F5EDE3), var(--elev-raise, 0 2px 6px rgba(60,40,15,0.08), 0 12px 24px -12px rgba(60,40,15,0.14))"
+          : "var(--elev-flat, 0 1px 2px rgba(60,40,15,0.04))",
         transition: "border-color 180ms ease-out, box-shadow 180ms ease-out",
         overflow: "hidden",
       }}
@@ -507,7 +514,8 @@ export function Composer() {
               handleSubmit();
             }
           }}
-          placeholder="What's on your mind?"
+          placeholder="此刻在想什么？"
+          aria-label="记下此刻的念头"
           rows={3}
           style={{
             // field-sizing: content 让 textarea 跟随内容自适应（Chrome 123+ / Safari 17+）
@@ -766,7 +774,12 @@ export function Composer() {
 
         <div style={{ flex: 1 }} />
 
-        {/* 状态栏：错误 / hint / 字数 */}
+        {/* v9 状态栏：三态语气对齐 /home HomeStream Composer —
+              - 错误：'发送失败 · 点击重试'（保持红字点击重试）
+              - focus+可发送：'{N} 字 · ⌘/Ctrl + ↵ 收下'
+              - 有字数但未 focus：'{N} 字'
+              - 空+focus：'记下此刻，余下交给夜里'（新增静态 hint）
+              - 完全空：无 hint（首屏留白） */}
         {mutation.isError ? (
           <button
             type="button"
@@ -785,6 +798,7 @@ export function Composer() {
           </button>
         ) : focused && canSubmit ? (
           <span
+            data-testid="composer-hint"
             style={{
               fontSize: 11,
               fontFamily: "var(--font-mono, monospace)",
@@ -794,10 +808,24 @@ export function Composer() {
             }}
             aria-live="polite"
           >
-            {counts.words} 字 · {isMac ? "⌘↩" : "Ctrl+↩"} 发送
+            {counts.words} 字 · {isMac ? "⌘/Ctrl + ↵" : "Ctrl + ↵"} 收下
+          </span>
+        ) : focused && empty ? (
+          <span
+            data-testid="composer-hint"
+            style={{
+              fontSize: 11,
+              fontFamily: "var(--font-mono, monospace)",
+              color: "var(--fg-subtle, #888)",
+              letterSpacing: 0.2,
+              padding: "0 8px",
+            }}
+          >
+            记下此刻，余下交给夜里
           </span>
         ) : counts.chars > 0 ? (
           <span
+            data-testid="composer-hint"
             style={{
               fontSize: 11,
               fontFamily: "var(--font-mono, monospace)",
@@ -915,36 +943,56 @@ function SendButton({
   pending: boolean;
 }) {
   const reduced = useReducedMotion();
+  // v9 primary CTA — warm-brown accent pill, 36px pill height, "✓ 收下"
+  // label. Matches /home HomeStream `.home-composer__save` (same accent /
+  // hover / disabled tokens). While pending → "收纳中…" with a mono-caps
+  // rest state, so the button never loses text (SC 1.4.11 non-text
+  // contrast is fine — it's the accent-on-cream that carries the state).
   return (
     <motion.button
       type="button"
       onClick={onClick}
       disabled={disabled}
-      aria-label={pending ? "发送中" : "发送 (Cmd+Enter)"}
-      whileHover={reduced || disabled ? undefined : { scale: 1.06 }}
-      whileTap={reduced || disabled ? undefined : { scale: 0.92 }}
-      animate={
-        reduced
-          ? undefined
-          : pending
-            ? { rotate: [0, 8, -6, 0] }
-            : { rotate: 0 }
-      }
-      transition={{ type: "spring", stiffness: 480, damping: 18, mass: 0.5 }}
+      data-testid="composer-send"
+      aria-busy={pending}
+      aria-label={pending ? "收纳中" : "收下 (Cmd+Enter)"}
+      whileHover={reduced || disabled ? undefined : { scale: 1.02 }}
+      whileTap={reduced || disabled ? undefined : { scale: 0.96 }}
+      transition={{ type: "spring", stiffness: 480, damping: 22, mass: 0.5 }}
       style={{
-        width: 28,
-        height: 28,
+        height: 36,
+        padding: "0 16px",
         border: "none",
-        borderRadius: 7,
-        background: disabled ? "rgba(43, 40, 34, 0.06)" : "var(--accent, #5D3000)",
-        color: disabled ? "rgba(43, 40, 34, 0.25)" : "#FAF8F6",
+        borderRadius: 999,
         cursor: disabled ? "not-allowed" : "pointer",
+        background: disabled
+          ? "var(--surface-sunken, #F3F0EB)"
+          : "var(--accent, #5D3000)",
+        color: disabled ? "var(--fg-subtle, #A08A6E)" : "#FAF8F6",
         display: "inline-flex",
         alignItems: "center",
-        justifyContent: "center",
+        gap: 6,
+        fontFamily: "var(--font-body, system-ui)",
+        fontSize: 13,
+        fontWeight: 600,
+        letterSpacing: 0.2,
+        transition: "background 160ms ease-out, color 160ms ease-out",
       }}
     >
-      <Send size={12} strokeWidth={2.2} aria-hidden="true" />
+      {pending ? (
+        <span
+          aria-hidden="true"
+          style={{
+            display: "inline-flex",
+            animation: reduced ? undefined : "spin 0.9s linear infinite",
+          }}
+        >
+          <Send size={13} strokeWidth={2.2} />
+        </span>
+      ) : (
+        <Check size={13} strokeWidth={2.2} aria-hidden="true" />
+      )}
+      {pending ? "收纳中…" : "收下"}
     </motion.button>
   );
 }

--- a/web/src/app/(app)/add/RecentlyCompiled.tsx
+++ b/web/src/app/(app)/add/RecentlyCompiled.tsx
@@ -114,26 +114,23 @@ export function RecentlyCompiled({ initialMemos }: { initialMemos: Memo[] }) {
                 {memo.type} · {wc} words · {time}
               </p>
             </div>
+            {/* v9 semantic pill — light=success (quick pass), full=accent
+                (deep dive). Uses shared .chip--success/.chip--accent tokens
+                so dark mode + accessibility stay in one place. */}
             <span
-              className="chip"
+              className={
+                memo.ingest_mode === "full"
+                  ? "chip chip--accent ds-add-mode-pill"
+                  : "chip chip--success ds-add-mode-pill"
+              }
+              data-mode={memo.ingest_mode}
               style={{
                 fontSize: "0.6875rem",
                 flexShrink: 0,
                 textTransform: "uppercase",
-                letterSpacing: "0.06em",
-                background:
-                  memo.ingest_mode === "full"
-                    ? "var(--accent-soft, #eff6ff)"
-                    : "var(--surface-sunken, #fafaf9)",
-                color:
-                  memo.ingest_mode === "full"
-                    ? "var(--accent, #2563eb)"
-                    : "var(--fg-muted)",
-                border: `1px solid ${
-                  memo.ingest_mode === "full"
-                    ? "var(--accent-border, #bfdbfe)"
-                    : "var(--surface-border, #e5e4e0)"
-                }`,
+                letterSpacing: "0.08em",
+                fontFamily: "var(--font-mono, monospace)",
+                fontWeight: 600,
               }}
             >
               {memo.ingest_mode}

--- a/web/src/app/(app)/add/page.tsx
+++ b/web/src/app/(app)/add/page.tsx
@@ -1,3 +1,5 @@
+import { CaptureHero } from "./CaptureHero";
+import { CompileServiceBanner } from "./CompileServiceBanner";
 import { Composer } from "./Composer";
 import { CompileQueue, type Memo } from "./CompileQueue";
 import { RecentlyCompiled } from "./RecentlyCompiled";
@@ -87,9 +89,20 @@ export default async function AddPage() {
         gap: "2rem",
       }}
     >
-      {/* Composer 直接作为首屏主视觉 (Round 5)：删掉 hero headline 和长 sub
-          文案。只留一个极轻的 section label 作为页面身份指示，呼吸感留给 Composer
-          自己。Hero 文案的产品宣言转移到 Composer 自带的 placeholder 与 / 命令。 */}
+      {/* v9 signature entrance: Fraunces date + mono-caps ritual line.
+          Aligns /add with /home so the app has one gallery-front-desk
+          entry pattern instead of two. */}
+      <CaptureHero
+        queueCount={initialMemos.length}
+        doneCount={recentlyCompiled.length}
+      />
+
+      {/* Single, authoritative pipeline status banner. Mirrors the /home
+          `home-pipeline-warn` copy so users get the same signal in one
+          place instead of six per-row "编译服务未连接" repetitions. */}
+      <CompileServiceBanner />
+
+      {/* Composer — v9 elevation + warm-brown accent border on focus. */}
       <Composer />
 
       {/* Compile Queue */}

--- a/web/src/app/globals.css
+++ b/web/src/app/globals.css
@@ -1186,6 +1186,31 @@ mark.user-mark { background: var(--accent-soft); color: var(--fg-primary); borde
     padding: 28px 20px 24px;
   }
 }
+/* CaptureHero inherits the whole .ds-home-hero base and just tightens the
+   vertical padding — /add's card stack sits close, we don't want the ritual
+   date to open a huge gap above the composer. */
+.ds-capture-hero {
+  padding: 28px 8px 8px;
+}
+
+/* ---------- v9 Add /compile pipeline banner ---------- */
+/* Single-source pipeline health strip on /add. Same visual language as
+   /home's .home-pipeline-warn (amber accent-soft + accent-border), but a
+   dedicated class so /home and /add can drift independently if product
+   copy diverges later. */
+.ds-add-pipeline-warn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 11px 16px;
+  border-radius: 12px;
+  background: var(--accent-soft);
+  border: 0.5px solid var(--accent-border);
+  color: var(--accent);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+}
 
 /* ---------- v9 Glass Drawer (components/ui/Drawer.tsx) ---------- */
 /* Signature glass surface: 78% opacity + backdrop-blur 20px so the panel


### PR DESCRIPTION
## Summary
- **iOS product experience backlog · 20/20 → 100/100** (`7abc07d`): backlog + scorecard + Verification Gate A docs; SampleDataSeeder / OnboardingView / TodayFocusStore / CompilationService / DailyPage parser & summary + evidence tests; MemoDetailView / InputBarV4 / AttachmentMenuPopover polish; ArchiveView / SettingsView / SmartTemplateRow refinements; ErrorPresenter, InsightActionService, MarkdownExportService, LLMUsageTracker, WeeklyCompilationService adjustments; app-launched analytics wired end-to-end (Issue 18).
- **web/add v9 CLAUDE-aesthetic capture surface** (`d21d3fd`): CaptureHero ritual date, Composer warm-brown accent pill (\"✓ 收下\" / \"收纳中…\") + focus ring + Chinese copy + a11y labels, new CompileServiceBanner pipeline strip, CompileQueue/RecentlyCompiled visual sync, `ds-capture-hero` / `ds-add-pipeline-warn` tokens, add-v9 e2e spec + dedicated `playwright.e2e.config`.

## Test plan
- [ ] iOS: `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17' build` clean
- [ ] iOS: `xcodebuild test -scheme DayPage` (DayPageParserEvidenceTests + existing suites) green
- [ ] iOS: install on iPhone 17 sim, verify Onboarding → Today → sample data seeding, and `vault/_analytics/events.jsonl` records `app_launched`
- [ ] web: `pnpm -C web dev` and hit `/add` — hero date, focus ring, \"✓ 收下\" pill, empty hint, error state
- [ ] web: `pnpm -C web exec playwright test -c playwright.e2e.config.ts add-v9.spec.ts`
- [ ] web: keyboard-only + VoiceOver on `/add` composer (aria-label / aria-busy / aria-live all wired)