### PR TITLE
fix(today): 卡片点击进详情根因修复 + 四交互满分打磨 (#806)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,6 +87,7 @@ DayPage/
 - `.openMemo` / `.openEntityPage` — DayPageApp.swift（R8 跨页跳转规范）
 - `.vaultConflictResolved` — ConflictMerger.swift（R4 iCloud 冲突 banner）
 - `.rawStorageDidWrite` — RawStorage.swift
+- `.memoCardDidBeginSwipe` — SwipeableMemoCard.swift（同屏仅一张卡开抽屉，Mail 语义）
 
 ### 测试覆盖矩阵 (9 个 suite, 55 个 case)
 - MemoYAMLTests (R1) — yamlQuote 转义 round-trip 8 case

--- a/DayPage/Features/Today/HorizontalPanGesture.swift
+++ b/DayPage/Features/Today/HorizontalPanGesture.swift
@@ -118,8 +118,14 @@ struct HorizontalPanGesture: UIViewRepresentable {
         // Began. Returning false keeps it Possible — UIScrollView's pan,
         // which has no such gate, wins arbitration and the timeline scrolls.
         func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            // This delegate serves BOTH recognizers on the host. The
+            // direction-lock below must gate ONLY the pan — the guard's
+            // failed cast used to return false for the tap recognizer,
+            // which silently vetoed every card tap (detail navigation
+            // never fired). Non-pan recognizers may always begin; the
+            // tap still defers to the pan via require(toFail:).
             guard let pan = gestureRecognizer as? UIPanGestureRecognizer,
-                  let view = pan.view else { return false }
+                  let view = pan.view else { return true }
             let translation = pan.translation(in: view)
             let dx = abs(translation.x)
             let dy = abs(translation.y)

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -11,11 +11,18 @@ import DayPageServices
 //   peek      — finger moves but the action is not yet committable.
 //   reveal    — the user has crossed the open threshold; icon + label sit on
 //                a settled panel; releasing snaps the panel open.
-//   rubber    — drag continues past the panel; resistance grows with distance.
+//   overdrag  — drag continues past the panel with light damping; the drawer
+//                keeps hugging the card edge on its way to the commit line.
+//   commit    — past commitThreshold the outermost action expands to fill
+//                the drawer; releasing executes it directly (Mail-style).
 //
 // Tuned against Apple Mail / Notes / Reminders for snappy attack and minimal
 // overshoot, while keeping the panel surface visually quiet at small offsets.
-private enum SwipePhysics {
+//
+// Internal (not fileprivate) so SwipeSnapLogic below and the
+// SwipePolishContractTests suite can assert against the real tokens
+// instead of re-hardcoding literals.
+enum SwipePhysics {
 
     /// Width of one action button inside a side panel.
     static let actionWidth: CGFloat = 76
@@ -43,10 +50,24 @@ private enum SwipePhysics {
     /// Velocity past which a flick alone closes the panel.
     static let velocityClose: CGFloat = 500
 
-    /// Resistance coefficient applied to drag past the panel edge. 0.25 is
-    /// firmer than the previous 0.35 so the limit reads as a real wall while
-    /// still allowing a tactile overdrag.
-    static let rubberBand: CGFloat = 0.25
+    /// Damping applied to drag travel past the panel edge. Unlike the old
+    /// 0.25 rubber wall, 0.85 keeps the card following the finger — the
+    /// overdrag is now a doorway to the full-swipe commit, not a dead end.
+    /// Mail tracks 1:1 here; a light 15% drag keeps some tactile weight.
+    static let overdragDamping: CGFloat = 0.85
+
+    /// Visual offset past which releasing the finger commits the OUTERMOST
+    /// action directly (trailing → share, leading → pin), Mail-style.
+    /// 236pt ≈ 65% of the 362pt card, requiring ~250pt of finger travel
+    /// through the damped zone — a deliberate, uncancellable-feeling pull
+    /// that is still comfortably reachable one-handed.
+    static let commitThreshold: CGFloat = 236
+
+    /// Corner radius of MemoCardView's `.solidCard(cornerRadius: 14)`
+    /// surface. The drawer container clips to the same continuous shape so
+    /// revealed action panels share the card's silhouette instead of
+    /// poking square corners out of a rounded card.
+    static let cardCornerRadius: CGFloat = 14
 
     /// Spring used for snap-open / snap-close. Delegated to the shared
     /// `Motion.panel` token (0.32s response, 0.85 damping) so drawer motion
@@ -67,6 +88,65 @@ private enum SwipePhysics {
     static let actionCommitDelay: TimeInterval = 0.36
 }
 
+// MARK: - CardSwipeSide / SwipeSnapLogic
+
+/// Which drawer a swipe reveals. Internal so the pure snap-resolution logic
+/// (and its tests) can speak the same vocabulary as the view.
+enum CardSwipeSide: Equatable {
+    case leading, trailing
+}
+
+/// Pure release-decision for the swipe gesture, extracted from the view so
+/// the whole state machine is unit-testable without touch synthesis.
+///
+/// Inputs are the values available at finger-lift; the output says where the
+/// card should settle — including the Mail-style full-swipe commit that
+/// executes the outermost action when the drag "冲高" past commitThreshold.
+enum SwipeSnapLogic {
+
+    enum Resolution: Equatable {
+        case open(CardSwipeSide)
+        case close
+        /// Execute the OUTERMOST action of the given side immediately
+        /// (trailing → share, leading → pin). Fired only from a full swipe.
+        case commitOuter(CardSwipeSide)
+    }
+
+    /// - Parameters:
+    ///   - revealed: the side that was settled open when the drag began.
+    ///   - visualOffset: damped on-screen offset at release (currentOffset).
+    ///   - dx: raw drag translation relative to the drag start.
+    ///   - velocity: horizontal velocity in pt/s at release.
+    static func resolve(
+        revealed: CardSwipeSide?,
+        visualOffset: CGFloat,
+        dx: CGFloat,
+        velocity: CGFloat
+    ) -> Resolution {
+        // Full-swipe commit wins over every other rule: once the card has
+        // been pulled past the commit line the release means "do it now".
+        // Deliberately translation-only — a flick's velocity alone must
+        // never commit an action the finger didn't travel for.
+        if visualOffset <= -SwipePhysics.commitThreshold { return .commitOuter(.trailing) }
+        if visualOffset >= SwipePhysics.commitThreshold { return .commitOuter(.leading) }
+
+        let openT = SwipePhysics.openThreshold
+        let closeT = SwipePhysics.closeThreshold
+        let vOpen = SwipePhysics.velocityOpen
+        let vClose = SwipePhysics.velocityClose
+        switch revealed {
+        case nil:
+            if      dx < -openT || velocity < -vOpen { return .open(.trailing) }
+            else if dx >  openT || velocity >  vOpen { return .open(.leading)  }
+            else                                     { return .close           }
+        case .trailing:
+            return (dx > closeT || velocity > vClose) ? .close : .open(.trailing)
+        case .leading:
+            return (dx < -closeT || velocity < -vClose) ? .close : .open(.leading)
+        }
+    }
+}
+
 // MARK: - SwipeableMemoCard
 //
 // iOS-native swipe-to-reveal wrapper around MemoCardView, built on a UIKit
@@ -84,10 +164,12 @@ private enum SwipePhysics {
 //
 // Gesture model:
 //  - settledOffset is the resting position; dragDelta rides on top 1:1.
-//  - Rubber-band resistance beyond ±panelW gives tactile limit feedback.
-//  - Velocity-aware snap: a flick opens/closes even with small translation.
-//  - Threshold-cross haptic tick fires during the drag (not just at button
-//    tap), matching the Apple Notes "you've armed an action" feel.
+//  - Past ±panelW the drag keeps following with light damping toward the
+//    full-swipe commit line (see SwipePhysics.commitThreshold).
+//  - Velocity-aware snap: a flick opens/closes even with small translation —
+//    but only real finger travel (never velocity) can trigger a commit.
+//  - Threshold-cross haptic ticks escalate during the drag: soft (armed) →
+//    light (fully revealed) → rigid (commit armed), Apple Notes-style.
 //
 // Why no SwiftUI DragGesture: SwiftUI's DragGesture + simultaneousGesture
 // activates on the very first touch event and cannot relinquish gesture
@@ -132,30 +214,40 @@ struct SwipeableMemoCard: View {
 
     // Tracks which threshold the live drag has already crossed so the
     // mid-drag haptic tick fires once per cross, not once per frame.
-    @State private var armedSide: Side? = nil
+    @State private var armedSide: CardSwipeSide? = nil
 
     // R3 — fires a stronger "fully revealed" light-impact tick the first
     // time the user pulls the panel all the way open (≥ panelWidth) within
     // a single drag. Distinct from the early `armedSide` tick (which fires
     // at openThreshold to signal "release-to-arm"). Resets when the drag
     // ends or the drag direction flips.
-    @State private var fullyRevealedSide: Side? = nil
+    @State private var fullyRevealedSide: CardSwipeSide? = nil
+
+    // Full-swipe commit arming: non-nil once the live drag has pulled the
+    // card past SwipePhysics.commitThreshold. Drives the outermost button's
+    // expand-to-fill choreography and the rigid "about to execute" haptic.
+    @State private var commitArmedSide: CardSwipeSide? = nil
+
+    // One drawer at a time: set after this card announces its own drag via
+    // .memoCardDidBeginSwipe so peers can close, reset on lift/cancel.
+    @State private var didNotifyPeers: Bool = false
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    fileprivate enum Side { case leading, trailing }
-
-    private var revealedSide: Side? {
+    private var revealedSide: CardSwipeSide? {
         if settledOffset < -1 { return .trailing }
         if settledOffset > 1  { return .leading }
         return nil
     }
 
+    // Sign contract (relied on by revealProgress AND the per-side
+    // revealWidth passed to each SwipeActionPanel): POSITIVE offset =
+    // leading (right-swipe) reveal, NEGATIVE = trailing (left-swipe).
     private var currentOffset: CGFloat {
         let raw = settledOffset + dragDelta
         let w = SwipePhysics.panelWidth
-        if raw > w  { return w  + (raw - w)  * SwipePhysics.rubberBand }
-        if raw < -w { return -w + (raw + w)  * SwipePhysics.rubberBand }
+        if raw > w  { return w  + (raw - w)  * SwipePhysics.overdragDamping }
+        if raw < -w { return -w + (raw + w)  * SwipePhysics.overdragDamping }
         return raw
     }
 
@@ -219,18 +311,25 @@ struct SwipeableMemoCard: View {
                 SwipeActionPanel(
                     actions: leadingActions,
                     edge: .leading,
-                    progress: max(0, revealProgress)
+                    progress: max(0, revealProgress),
+                    revealWidth: max(SwipePhysics.panelWidth, currentOffset),
+                    commitArmed: commitArmedSide == .leading
                 )
                 Spacer(minLength: 0)
                 SwipeActionPanel(
                     actions: trailingActions,
                     edge: .trailing,
-                    progress: max(0, -revealProgress)
+                    progress: max(0, -revealProgress),
+                    revealWidth: max(SwipePhysics.panelWidth, -currentOffset),
+                    commitArmed: commitArmedSide == .trailing
                 )
             }
             .allowsHitTesting(revealedSide != nil && !isSelectionMode)
         }
-        .clipped()
+        // Same continuous corner as MemoCardView's solidCard surface, so a
+        // revealed drawer inherits the card's silhouette (the old .clipped()
+        // let the panels poke square corners out of a 14pt-rounded card).
+        .clipShape(RoundedRectangle(cornerRadius: SwipePhysics.cardCornerRadius, style: .continuous))
         // R3→2026-07-04: the long-press contextMenu moved UP to TimelineRow.
         // Two nested contextMenus (this one + TimelineRow's share/select
         // menu) meant the inner one shadowed the outer — TimelineRow now
@@ -247,9 +346,21 @@ struct SwipeableMemoCard: View {
         // gestures don't reach the close overlay. Force-close on transition
         // so the card is visually flush when selection chrome appears.
         .onChange(of: isSelectionMode) { newValue in
-            if newValue, revealedSide != nil {
-                snapClose()
+            if newValue {
+                // Also disarm any in-flight commit layout: entering selection
+                // mode during the brief post-commit settle window must never
+                // leave the expanded single-button drawer frozen on screen.
+                commitArmedSide = nil
+                if revealedSide != nil {
+                    snapClose()
+                }
             }
+        }
+        // Mail semantics: starting a swipe on any card closes every other
+        // card's drawer, so at most one drawer is ever open on screen.
+        .onReceive(NotificationCenter.default.publisher(for: .memoCardDidBeginSwipe)) { note in
+            guard let other = note.object as? UUID, other != memo.id else { return }
+            if revealedSide != nil { snapClose() }
         }
     }
 
@@ -350,15 +461,53 @@ struct SwipeableMemoCard: View {
     // horizontal and we can apply translation 1:1.
 
     private func handlePanChanged(_ translation: CGFloat) {
+        if !didNotifyPeers {
+            didNotifyPeers = true
+            NotificationCenter.default.post(name: .memoCardDidBeginSwipe, object: memo.id)
+        }
         dragDelta = translation
         updateThresholdHaptics()
     }
 
     private func handlePanEnded(_ translation: CGFloat, _ velocity: CGFloat) {
-        dragDelta = 0
-        decideSnap(dx: translation, velocity: velocity)
+        // Resolve on the pre-release visual offset — dragDelta must still be
+        // live here so the full-swipe commit sees how far the card really was.
+        let visualOffset = currentOffset
+        let resolution = SwipeSnapLogic.resolve(
+            revealed: revealedSide,
+            visualOffset: visualOffset,
+            dx: translation,
+            velocity: velocity
+        )
         armedSide = nil
         fullyRevealedSide = nil
+        didNotifyPeers = false
+
+        switch resolution {
+        case .open(let side):
+            dragDelta = 0
+            commitArmedSide = nil
+            snapOpen(side)
+        case .close:
+            dragDelta = 0
+            commitArmedSide = nil
+            snapClose()
+        case .commitOuter(let side):
+            // Hand the live drag offset to settledOffset before zeroing the
+            // delta — same composed value, so no visual jump — then run the
+            // OUTERMOST action (trailing → share, leading → pin). run()
+            // already carries the haptic + animated close + settle delay.
+            settledOffset = visualOffset
+            dragDelta = 0
+            let outer = (side == .trailing ? trailingActions : leadingActions).first
+            outer?.run()
+            // Keep the expanded single-button layout through the close
+            // animation so the drawer doesn't pop back to two columns
+            // mid-flight; clear once the panel is visually flush.
+            DispatchQueue.main.asyncAfter(deadline: .now() + SwipePhysics.actionCommitDelay) {
+                commitArmedSide = nil
+            }
+        }
     }
 
     private func handlePanCancelled() {
@@ -366,6 +515,8 @@ struct SwipeableMemoCard: View {
         dragDelta = 0
         armedSide = nil
         fullyRevealedSide = nil
+        didNotifyPeers = false
+        commitArmedSide = nil
     }
 
     /// Fires a soft tick the first time a drag crosses the open threshold
@@ -374,7 +525,7 @@ struct SwipeableMemoCard: View {
     /// user "release now and the action will fire."
     private func updateThresholdHaptics() {
         let offset = currentOffset
-        let armingSide: Side?
+        let armingSide: CardSwipeSide?
         if offset > SwipePhysics.openThreshold {
             armingSide = .leading
         } else if offset < -SwipePhysics.openThreshold {
@@ -391,7 +542,7 @@ struct SwipeableMemoCard: View {
         // confirmable "drawer fully out" cue distinct from the early
         // armed-at-threshold tick. UIImpactFeedbackGenerator(.light) via
         // Haptics.light() keeps the impact crisp without being shouty.
-        let fullSide: Side?
+        let fullSide: CardSwipeSide?
         if offset >= SwipePhysics.panelWidth {
             fullSide = .leading
         } else if offset <= -SwipePhysics.panelWidth {
@@ -403,33 +554,36 @@ struct SwipeableMemoCard: View {
             fullyRevealedSide = fullSide
             if fullSide != nil { Haptics.light() }
         }
+
+        // Full-swipe commit arming — the third and strongest tick. Crossing
+        // commitThreshold expands the outermost button to fill the drawer
+        // (release now = execute); sliding back under it collapses the
+        // layout with a light disarm tick, exactly like Mail's arm/disarm.
+        let commitSide: CardSwipeSide?
+        if offset >= SwipePhysics.commitThreshold {
+            commitSide = .leading
+        } else if offset <= -SwipePhysics.commitThreshold {
+            commitSide = .trailing
+        } else {
+            commitSide = nil
+        }
+        if commitSide != commitArmedSide {
+            let animation: Animation? = reduceMotion ? nil : SwipePhysics.snapSpring
+            withAnimation(animation) { commitArmedSide = commitSide }
+            if commitSide != nil {
+                Haptics.rigid(intensity: 0.8)
+            } else {
+                Haptics.light()
+            }
+        }
     }
 
     // MARK: - Snap Logic
     //
-    // dx is always relative to the drag start position (not screen zero).
-    // When trailing panel is open (settledOffset = -panelW), a rightward drag
-    // produces dx > 0, which correctly triggers snapClose via the first branch.
-    // No coordinate transform needed — this is the fix for the "can't close" bug.
+    // Release resolution lives in SwipeSnapLogic (pure, unit-tested);
+    // these two just animate the card to the resolved resting position.
 
-    private func decideSnap(dx: CGFloat, velocity: CGFloat) {
-        let openT = SwipePhysics.openThreshold
-        let closeT = SwipePhysics.closeThreshold
-        let vOpen = SwipePhysics.velocityOpen
-        let vClose = SwipePhysics.velocityClose
-        switch revealedSide {
-        case nil:
-            if      dx < -openT || velocity < -vOpen  { snapOpen(.trailing) }
-            else if dx >  openT || velocity >  vOpen  { snapOpen(.leading)  }
-            else                                       { snapClose()         }
-        case .trailing:
-            (dx > closeT || velocity > vClose) ? snapClose() : snapOpen(.trailing)
-        case .leading:
-            (dx < -closeT || velocity < -vClose) ? snapClose() : snapOpen(.leading)
-        }
-    }
-
-    private func snapOpen(_ side: Side) {
+    private func snapOpen(_ side: CardSwipeSide) {
         let target: CGFloat = side == .trailing ? -SwipePhysics.panelWidth : SwipePhysics.panelWidth
         withAnimation(snapAnimation) { settledOffset = target }
         HapticFeedback.light()
@@ -482,6 +636,14 @@ private struct SwipeActionPanel: View {
     let actions: [SwipeAction]
     let edge: Edge
     let progress: CGFloat
+    /// Live drawer width. Tracks the (damped) finger past panelWidth so the
+    /// panel's inner edge always hugs the card edge during an overdrag —
+    /// with the old fixed width a full swipe opened a bare gap between them.
+    var revealWidth: CGFloat = SwipePhysics.panelWidth
+    /// Full-swipe commit armed: the outermost (primary) action expands to
+    /// fill the whole drawer and the secondary column folds away, signalling
+    /// "release to execute", mirroring Mail's full-swipe choreography.
+    var commitArmed: Bool = false
 
     var body: some View {
         HStack(spacing: 0) {
@@ -489,9 +651,10 @@ private struct SwipeActionPanel: View {
             // so the share/delete (or pin/more) boundary reads as two distinct
             // tap targets rather than a single colored slab. `inkFaint` is the
             // same low-opacity ink token used by other DS rules and keeps the
-            // divider readable in both schemes.
+            // divider readable in both schemes. Folded away while the commit
+            // layout has a single full-width button.
             ForEach(Array(orderedActions.enumerated()), id: \.element.id) { index, action in
-                if index > 0 {
+                if index > 0 && !commitArmed {
                     Rectangle()
                         .fill(DSColor.inkFaint)
                         .frame(width: 1)
@@ -499,10 +662,16 @@ private struct SwipeActionPanel: View {
                         .opacity(progress > 0.02 ? 1 : 0)
                         .allowsHitTesting(false)
                 }
-                SwipeActionButton(action: action, progress: progress)
+                if !commitArmed || action.id == outerActionID {
+                    SwipeActionButton(
+                        action: action,
+                        progress: progress,
+                        fillsWidth: commitArmed && action.id == outerActionID
+                    )
+                }
             }
         }
-        .frame(width: SwipePhysics.panelWidth)
+        .frame(width: max(SwipePhysics.panelWidth, revealWidth))
         .frame(maxHeight: .infinity)
         // Hide entirely when closed so VoiceOver doesn't announce hidden
         // targets and a stray tap on the laid-out panel can't fire.
@@ -510,6 +679,10 @@ private struct SwipeActionPanel: View {
         .allowsHitTesting(progress > 0.02)
         .accessibilityHidden(progress <= 0.02)
     }
+
+    /// The primary action — callers pass their arrays primary-first, and the
+    /// primary always sits at the drawer's outer (screen-edge) side.
+    private var outerActionID: SwipeAction.Kind? { actions.first?.id }
 
     /// Leading panel grows from the left edge, so its primary action should be
     /// outermost (left). Trailing panel grows from the right edge, primary
@@ -528,6 +701,9 @@ private struct SwipeActionButton: View {
 
     let action: SwipeAction
     let progress: CGFloat
+    /// True while this button is the commit-armed primary: it stretches to
+    /// fill the whole drawer instead of its fixed 76pt column.
+    var fillsWidth: Bool = false
 
     private let labelFadeStart: CGFloat = 0.30
     private let iconScaleMin: CGFloat = 0.6
@@ -539,7 +715,8 @@ private struct SwipeActionButton: View {
                 background
                 content
             }
-            .frame(width: SwipePhysics.actionWidth)
+            .frame(width: fillsWidth ? nil : SwipePhysics.actionWidth)
+            .frame(maxWidth: fillsWidth ? .infinity : nil)
             .frame(maxHeight: .infinity)
             .contentShape(Rectangle())
         }
@@ -611,4 +788,13 @@ private struct SwipeActionButton: View {
         let clamped = max(0, min(1, (progress - labelFadeStart) / (1 - labelFadeStart)))
         return Double(clamped)
     }
+}
+
+// MARK: - Notification.Name
+
+extension Notification.Name {
+    /// Posted (object: Memo.id as UUID) the moment a card's horizontal pan
+    /// starts moving. Every other SwipeableMemoCard closes its drawer on
+    /// receipt, so at most one drawer is open at a time (Mail semantics).
+    static let memoCardDidBeginSwipe = Notification.Name("memoCardDidBeginSwipe")
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -2978,7 +2978,13 @@ struct TodayView: View {
                                     }
                                 }
                             },
-                            onOpen: { openedMemoID = memo.id }
+                            onOpen: {
+                                // Same confirm tick the timeline rows play on
+                                // open, so tap-into-detail feels identical
+                                // across today's cards and historical rows.
+                                Haptics.tapConfirm()
+                                openedMemoID = memo.id
+                            }
                         )
                         .offset(x: idx == 0 ? memoCardHintOffset : 0)
                         .onAppear {
@@ -4071,7 +4077,11 @@ struct TimelineRow: View {
         }
         // Right-swipe MORE → fuller action set (pin / quote / delete) kept
         // out of the card's resting chrome per the content-first redesign.
-        .confirmationDialog("更多", isPresented: $showMoreActions, titleVisibility: .hidden) {
+        .confirmationDialog(
+            NSLocalizedString("memo.swipe.more", comment: "more dialog title"),
+            isPresented: $showMoreActions,
+            titleVisibility: .hidden
+        ) {
             moreActionsButtons
         }
     }
@@ -4099,21 +4109,24 @@ struct TimelineRow: View {
             Button {
                 onShare()
             } label: {
-                Label("分享为卡片", systemImage: "square.and.arrow.up.on.square")
+                Label(NSLocalizedString("memo.menu.shareCard", comment: "contextMenu: share memo as card"),
+                      systemImage: "square.and.arrow.up.on.square")
             }
         }
         if let onShareAsQuote {
             Button {
                 onShareAsQuote()
             } label: {
-                Label("分享为引用", systemImage: "quote.opening")
+                Label(NSLocalizedString("memo.menu.shareQuote", comment: "contextMenu: share memo as quote"),
+                      systemImage: "quote.opening")
             }
         }
         if let onEnterSelectionMode {
             Button {
                 onEnterSelectionMode()
             } label: {
-                Label("多选", systemImage: "checkmark.circle")
+                Label(NSLocalizedString("memo.menu.multiselect", comment: "contextMenu: enter multi-select mode"),
+                      systemImage: "checkmark.circle")
             }
         }
         if let onDelete {
@@ -4131,18 +4144,20 @@ struct TimelineRow: View {
     @ViewBuilder
     private var moreActionsButtons: some View {
         if let onPin {
-            Button(memo.pinnedAt != nil ? "取消置顶" : "置顶") { onPin() }
+            Button(memo.pinnedAt != nil
+                ? NSLocalizedString("memo.swipe.unpin", comment: "more dialog: unpin memo")
+                : NSLocalizedString("memo.swipe.pin", comment: "more dialog: pin memo")) { onPin() }
         }
         if let onShareAsQuote {
-            Button("分享为引用") { onShareAsQuote() }
+            Button(NSLocalizedString("memo.menu.shareQuote", comment: "more dialog: share as quote")) { onShareAsQuote() }
         }
         if let onEnterSelectionMode {
-            Button("多选") { onEnterSelectionMode() }
+            Button(NSLocalizedString("memo.menu.multiselect", comment: "more dialog: multi-select")) { onEnterSelectionMode() }
         }
         if let onDelete {
-            Button("删除", role: .destructive) { onDelete() }
+            Button(NSLocalizedString("memo.swipe.delete", comment: "more dialog: delete memo"), role: .destructive) { onDelete() }
         }
-        Button("取消", role: .cancel) { }
+        Button(NSLocalizedString("memo.menu.cancel", comment: "more dialog: cancel"), role: .cancel) { }
     }
 
     private var selectionIndicator: some View {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -174,6 +174,12 @@
 "memo.swipe.share"  = "Share";
 "memo.swipe.delete" = "Delete";
 
+/* Memo card long-press context menu / MORE dialog */
+"memo.menu.shareCard"   = "Share as Card";
+"memo.menu.shareQuote"  = "Share as Quote";
+"memo.menu.multiselect" = "Select Multiple";
+"memo.menu.cancel"      = "Cancel";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "Recompile";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -174,6 +174,12 @@
 "memo.swipe.share"  = "分享";
 "memo.swipe.delete" = "删除";
 
+/* Memo card long-press context menu / MORE dialog */
+"memo.menu.shareCard"   = "分享为卡片";
+"memo.menu.shareQuote"  = "分享为引用";
+"memo.menu.multiselect" = "多选";
+"memo.menu.cancel"      = "取消";
+
 /* DailyPage swipe action */
 "today.action.recompile"     = "重新编译";
 

--- a/DayPageTests/SwipePolishContractTests.swift
+++ b/DayPageTests/SwipePolishContractTests.swift
@@ -22,13 +22,78 @@ struct SwipePolishContractTests {
     /// response so the parent's action (share sheet / delete dialog) never
     /// animates in over an open drawer. 0.36 gives a 40ms settle margin.
     ///
-    /// This test is a sentinel — SwipePhysics is fileprivate, so we lock
-    /// the contract via the literal that both call-sites (SwipeableMemoCard,
-    /// TimelineSectionView) now share.
+    /// SwipePhysics is internal since the full-swipe-commit work, so this
+    /// asserts the real token instead of a mirrored literal.
     @Test("actionCommitDelay matches Motion.panel response + settle")
     func actionCommitDelayIsSynced() {
-        let expected: TimeInterval = 0.36
-        #expect(expected == 0.36, "SwipePhysics.actionCommitDelay must stay ≥ Motion.panel.response(0.32) + 40ms")
+        #expect(SwipePhysics.actionCommitDelay == 0.36, "SwipePhysics.actionCommitDelay must stay ≥ Motion.panel.response(0.32) + 40ms")
+    }
+
+    // MARK: - SwipeSnapLogic release resolution (full-swipe commit)
+
+    /// 冲高过 commitThreshold 后松手 = 直接执行最外侧动作：左滑(trailing)
+    /// 提交分享，右滑(leading) 提交置顶。这是 Mail 式 full-swipe 的核心契约。
+    @Test("release past commitThreshold commits the outer action")
+    func fullSwipeCommitsOuterAction() {
+        let c = SwipePhysics.commitThreshold
+        #expect(SwipeSnapLogic.resolve(revealed: nil, visualOffset: -c - 1, dx: -300, velocity: 0)
+                == .commitOuter(.trailing))
+        #expect(SwipeSnapLogic.resolve(revealed: nil, visualOffset: c + 1, dx: 300, velocity: 0)
+                == .commitOuter(.leading))
+        // Commit also works when the drawer was already open before the drag.
+        #expect(SwipeSnapLogic.resolve(revealed: .trailing, visualOffset: -c - 10, dx: -120, velocity: 0)
+                == .commitOuter(.trailing))
+    }
+
+    /// 高速甩动绝不能触发 commit——commit 只认手指真实走过的位移，
+    /// 防止一次猛甩误执行分享/置顶。
+    @Test("velocity alone never commits")
+    func velocityAloneNeverCommits() {
+        let r = SwipeSnapLogic.resolve(revealed: nil, visualOffset: -80, dx: -80, velocity: -6000)
+        #expect(r == .open(.trailing))
+    }
+
+    /// 自信的半滑打开抽屉；犹豫的轻扫弹回关闭（openThreshold=40 的两侧）。
+    @Test("half-swipe opens, hesitant brush closes")
+    func halfSwipeOpensBrushCloses() {
+        let t = SwipePhysics.openThreshold
+        #expect(SwipeSnapLogic.resolve(revealed: nil, visualOffset: -(t + 1), dx: -(t + 1), velocity: 0)
+                == .open(.trailing))
+        #expect(SwipeSnapLogic.resolve(revealed: nil, visualOffset: t + 1, dx: t + 1, velocity: 0)
+                == .open(.leading))
+        #expect(SwipeSnapLogic.resolve(revealed: nil, visualOffset: -(t - 20), dx: -(t - 20), velocity: 0)
+                == .close)
+    }
+
+    /// 小位移大速度的 flick 也能开（velocityOpen=600 之外）。
+    @Test("flick velocity opens with tiny translation")
+    func flickOpens() {
+        #expect(SwipeSnapLogic.resolve(revealed: nil, visualOffset: -10, dx: -10, velocity: -(SwipePhysics.velocityOpen + 100))
+                == .open(.trailing))
+    }
+
+    /// 已打开的抽屉：反向拖 > closeThreshold 或反向 flick 关闭；
+    /// 原地小抖动保持打开。
+    @Test("open drawer closes on reverse drag or flick, stays on jitter")
+    func openDrawerCloseRules() {
+        let closeT = SwipePhysics.closeThreshold
+        #expect(SwipeSnapLogic.resolve(revealed: .trailing, visualOffset: -120, dx: closeT + 6, velocity: 0)
+                == .close)
+        #expect(SwipeSnapLogic.resolve(revealed: .trailing, visualOffset: -140, dx: 10, velocity: SwipePhysics.velocityClose + 100)
+                == .close)
+        #expect(SwipeSnapLogic.resolve(revealed: .trailing, visualOffset: -150, dx: -5, velocity: 0)
+                == .open(.trailing))
+        #expect(SwipeSnapLogic.resolve(revealed: .leading, visualOffset: 120, dx: -(closeT + 6), velocity: 0)
+                == .close)
+    }
+
+    /// commit 需要的真实手指行程（阻尼区按 overdragDamping 换算）落在
+    /// 单手可达且不会误触的窗口内（240–270pt @ 402pt 屏）。
+    @Test("commit requires deliberate finger travel")
+    func commitTravelIsDeliberate() {
+        let rawNeeded = SwipePhysics.panelWidth
+            + (SwipePhysics.commitThreshold - SwipePhysics.panelWidth) / SwipePhysics.overdragDamping
+        #expect(rawNeeded > 240 && rawNeeded < 270)
     }
 
     // MARK: - LLMClient.Config public init is stable


### PR DESCRIPTION
# fix(today): 卡片点击进详情根因修复 + 四交互满分打磨（长按/左滑/右滑/点击）

## Summary

真实模拟器体验驱动（iPhone 17 / iOS 26.4，idb HID 注入逐项实测）的 Today 今日卡片交互修复与深度打磨：修掉"点击卡片永远进不了详情页"的手势根因 bug，并把左滑/右滑升级为 Mail 式 full-swipe commit（冲高直接执行），统一长按菜单语言、抽屉圆角与触感语言。

Closes #806

## What changed

### P0 根因修复：卡片单击从未生效
`HorizontalPanGesture.Coordinator` 同时是 pan 和 tap 两个 recognizer 的 delegate。`gestureRecognizerShouldBegin` 的方向锁 guard（`as? UIPanGestureRecognizer`）对 tap recognizer 转换失败后返回 `false`，导致 **UITapGestureRecognizer 永远不被允许开始**——"点击进详情"整条链路（今日卡片 + 历史时间轴行共用组件）从未触发。NSLog 插桩证实 handleTap 零命中。修复后非 pan recognizer 一律放行（tap 仍经 `require(toFail: pan)` 让位于滑动）。

### Full-swipe commit（冲高直接执行，Mail 语义）
- `rubberBand(0.25)` 死墙 → `overdragDamping(0.85)`：过面板后卡片继续跟手，通往 `commitThreshold(236pt)`
- 新增纯函数 `SwipeSnapLogic.resolve`：**commit 只认手指真实位移，velocity 再大也不 commit**（防甩动误执行）
- 左滑冲高松手 → 直接弹分享卡片；右滑冲高松手 → 置顶/取消置顶。破坏性的删除在内侧列，永远不会被 full-swipe 误触
- commit 装填时最外侧按钮扩展占满抽屉（`SwipeActionPanel.commitArmed`），三级触感递进：soft(armed) → light(fully revealed) → rigid(commit armed)，滑回撤防有 light 解除 tick
- 抽屉宽度 `revealWidth` 跟手，overdrag 时面板内缘始终贴住卡片边缘（旧实现会露出空隙）

### 满分细节
- 抽屉容器 `.clipped()` → `.clipShape(RoundedRectangle(14, continuous))`，与 MemoCardView `solidCard` 同轮廓——露出的抽屉不再是直角色块
- 单抽屉互斥：`.memoCardDidBeginSwipe` 通知（已登记 CLAUDE.md 中心化清单），滑新卡自动关旧卡
- 长按菜单中英混排修复：`分享为卡片/分享为引用/多选/取消` 走 `memo.menu.*` 新 key（zh-Hans + en 双表），en locale 下全英文
- 点击进详情补 `Haptics.tapConfirm()`，与历史时间轴行触感一致

## Why this approach
- commit 阈值走视觉位移而非 raw 位移：与用户看到的一致；236pt ≈ 卡宽 65%，阻尼区换算后需 ~251pt 真实指程——单手可达但绝不误触（有单测锁定该几何）
- 决策逻辑抽成 `SwipeSnapLogic` 纯函数：手势状态机首次可单测，6 个新测试覆盖 commit/open/close/flick/jitter 全分支
- 测试加在既有 `SwipePolishContractTests.swift`：DayPage 是显式 pbxproj，避免新文件登记风险

## Quality gates
- [x] `xcodebuild build` ✅
- [x] 全量 `xcodebuild test` ✅（含 SwipePolish 13/13，其中 6 个新增）
- [x] 模拟器实测（idb + 截图断言）：
  - 点击卡片 → MemoDetailView ✅（修复前 3 次复现均无反应）
  - 长按 → 预览 + 全英文菜单（en locale）✅
  - 左滑 reveal 圆角 ✅ / 左滑冲高 → 分享卡片页直开 ✅
  - 右滑 reveal ✅ / 右滑冲高 → vault YAML 写入 `pinned_at` ✅
  - 点卡片关抽屉 ✅ / 双卡抽屉互斥 ✅
- [x] Evaluator 独立评审：45/50，**零 MUST-FIX**，全部扣分项被评审员明确判定为非阻塞理论边缘情况；其中 2 条一行建议（选择模式清零 commitArmedSide、currentOffset 符号契约注释）已在本 PR 顺手落实

## 已知范围外事项（评审员要求显式记录）
- `TimelineDayRow`（历史时间轴行，TimelineSwipePhysics）的滑动物理**未**同步升级为 full-swipe-commit，仍是旧 rubber-band 模型——两组件仅共享 HorizontalPanGesture host，本次 P0 点击修复对其同样生效，但 commit 体验统一留待后续
- `SwipeableMemoCard` 的 `.accessibilityAction` label 为历史遗留英文硬编码，未来统一本地化

## Test plan
- [ ] 真机：四种交互手感复核（触感三级递进、commit 扩展动画）
- [ ] Reduce Motion 开启时的降级曲线
- [ ] zh-Hans locale 菜单全中文复核
