### PR TITLE
fix(today): 复活 iOS 26 上的卡片左右滑 + 四类交互 iOS 26 深度打磨

### DIFF
--- a/DayPage/Features/Today/HorizontalPanGesture.swift
+++ b/DayPage/Features/Today/HorizontalPanGesture.swift
@@ -12,12 +12,31 @@ import UIKit
 // arbitration never picks UIScrollView as the winner.
 //
 // UIKit's UIPanGestureRecognizer + UIGestureRecognizerDelegate solves this
-// natively. We override gestureRecognizerShouldBegin to return true ONLY
-// after the touch's translation passes a horizontal-dominance test. Until
-// then, UIScrollView's pan owns the touch and the timeline scrolls normally.
+// natively, via two cooperating rules (see Coordinator):
+//
+//  1. `shouldBeRequiredToFailBy` makes every other pan — the ScrollView's
+//     scroll pan in particular — WAIT until our pan resolves. Without it the
+//     scroller begins on any movement direction and cancels content touches,
+//     so our recognizer never even got its shouldBegin query.
+//  2. `gestureRecognizerShouldBegin` then judges direction ONCE, on velocity
+//     (fully formed at the first query, unlike accumulated translation):
+//     vertical-dominant → we fail instantly and the timeline scrolls;
+//     horizontal-dominant → we begin and own the touch.
+//
 // This mirrors iOS Mail / Reminders / Things 3 swipe-to-reveal behavior.
 
 struct HorizontalPanGesture: UIViewRepresentable {
+
+    /// Pure direction verdict behind the Coordinator's shouldBegin gate,
+    /// extracted so the contract is unit-testable without touch synthesis.
+    /// |vx| must dominate |vy| by `dominance` (1.2× — slightly more
+    /// permissive than Mail's 1.5× because our cards are wider and a
+    /// shallow horizontal flick should still register).
+    static func isHorizontalDominant(
+        vx: CGFloat, vy: CGFloat, dominance: CGFloat = 1.2
+    ) -> Bool {
+        abs(vx) > abs(vy) * dominance
+    }
 
     /// True while a confirmed horizontal pan is in progress. Use this to
     /// disable adjacent SwiftUI taps (NavigationLink) so finger-up after a
@@ -43,6 +62,14 @@ struct HorizontalPanGesture: UIViewRepresentable {
     /// route it back here, letting the parent drive programmatic navigation.
     /// nil means "no tap action" (e.g. the panel-close overlay).
     var onTap: (() -> Void)? = nil
+
+    /// Touch-down / touch-up press state, for the card's press-scale
+    /// feedback (UITableViewCell-highlight semantics). Driven by a zero-
+    /// distance long press that recognizes simultaneously with everything
+    /// and claims nothing: `true` shortly after the finger lands, `false`
+    /// on lift or the instant a scroll / swipe / context-menu interaction
+    /// takes the touch away. nil skips installing the extra recognizer.
+    var onPressChanged: ((Bool) -> Void)? = nil
 
     /// Hard-disable the recognizer (e.g. selection mode). When false the
     /// underlying recognizer reports isEnabled = false so it never even
@@ -79,6 +106,25 @@ struct HorizontalPanGesture: UIViewRepresentable {
         view.addGestureRecognizer(tap)
         context.coordinator.tapRecognizer = tap
 
+        // Press-state recognizer: a zero-ish-delay long press that merely
+        // REPORTS touch-down/up so SwiftUI can render the pressed scale.
+        // It recognizes simultaneously with everything (see the delegate's
+        // simultaneous rule), never cancels touches, and ends/cancels the
+        // moment the scroll, our pan, or the context-menu lift claims the
+        // touch — so the card un-presses exactly when it loses the finger.
+        if onPressChanged != nil {
+            let press = UILongPressGestureRecognizer(
+                target: context.coordinator,
+                action: #selector(Coordinator.handlePress(_:))
+            )
+            press.minimumPressDuration = 0.06
+            press.allowableMovement = .greatestFiniteMagnitude
+            press.cancelsTouchesInView = false
+            press.delegate = context.coordinator
+            view.addGestureRecognizer(press)
+            context.coordinator.pressRecognizer = press
+        }
+
         return view
     }
 
@@ -89,6 +135,7 @@ struct HorizontalPanGesture: UIViewRepresentable {
         // mode — selection-mode taps still need to toggle membership, which
         // the parent wires through onTap.
         context.coordinator.tapRecognizer?.isEnabled = (self.onTap != nil)
+        context.coordinator.pressRecognizer?.isEnabled = (self.onPressChanged != nil)
     }
 
     // MARK: Coordinator
@@ -97,26 +144,22 @@ struct HorizontalPanGesture: UIViewRepresentable {
         var parent: HorizontalPanGesture
         weak var recognizer: UIPanGestureRecognizer?
         weak var tapRecognizer: UITapGestureRecognizer?
-
-        // 6pt direction-lock: tightened from 10pt so UIKit's pan can enter
-        // Began before SwiftUI's ambient DragGestures (sidebar edge swipe,
-        // feedback-panel close) finish their own arbitration window. Still
-        // safely below UIScrollView's vertical pan threshold, so a slow
-        // vertical drag still hands ownership to the timeline scroll.
-        private let directionLockDistance: CGFloat = 6
-        // |dx| must dominate |dy| by 1.2× — slightly more permissive than
-        // Mail (1.5×) because our cards are wider and a shallow horizontal
-        // flick should still register.
-        private let horizontalDominance: CGFloat = 1.2
+        weak var pressRecognizer: UILongPressGestureRecognizer?
 
         init(parent: HorizontalPanGesture) {
             self.parent = parent
         }
 
-        // Critical: this gate gives UIScrollView its scroll back. UIKit
-        // calls this when the pan is about to transition from Possible to
-        // Began. Returning false keeps it Possible — UIScrollView's pan,
-        // which has no such gate, wins arbitration and the timeline scrolls.
+        // Direction lock. UIKit queries shouldBegin exactly ONCE per touch —
+        // at the pan's own internal hysteresis, where accumulated translation
+        // can still be tiny (observed 1.3pt live) — and a `false` verdict
+        // transitions the recognizer to .failed for the REST of the touch;
+        // it is never re-asked. The old translation gate (`dx >= 6pt`)
+        // therefore vetoed nearly every real swipe on its single query and
+        // the drawer never opened. Velocity is already fully formed at that
+        // first query (SwipeCellKit and UIKit's own table-cell swipe use the
+        // same velocity test), so one velocity comparison is enough to judge
+        // direction reliably at any drag speed.
         func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
             // This delegate serves BOTH recognizers on the host. The
             // direction-lock below must gate ONLY the pan — the guard's
@@ -126,10 +169,8 @@ struct HorizontalPanGesture: UIViewRepresentable {
             // tap still defers to the pan via require(toFail:).
             guard let pan = gestureRecognizer as? UIPanGestureRecognizer,
                   let view = pan.view else { return true }
-            let translation = pan.translation(in: view)
-            let dx = abs(translation.x)
-            let dy = abs(translation.y)
-            return dx >= directionLockDistance && dx > dy * horizontalDominance
+            let v = pan.velocity(in: view)
+            return HorizontalPanGesture.isHorizontalDominant(vx: v.x, vy: v.y)
         }
 
         // Coexist with UIScrollView's pan. Until our shouldBegin returns
@@ -138,6 +179,23 @@ struct HorizontalPanGesture: UIViewRepresentable {
         func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
                                shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
             true
+        }
+
+        // CRITICAL (iOS 26): make every OTHER pan — most importantly the
+        // ancestor ScrollView's scroll pan — wait for OUR pan to resolve
+        // first. Without this failure requirement the scroll pan begins on
+        // ANY direction of movement (SwiftUI's scroller is not direction-
+        // locked) and cancels content touches, so our recognizer's
+        // shouldBegin was never even queried — swipe-to-reveal was dead no
+        // matter what the direction-lock returned. With the requirement in
+        // place the arbitration becomes: vertical drag → our velocity gate
+        // fails the pan in one query → scroll proceeds (imperceptible
+        // delay); horizontal drag → our pan begins and the scroll pan stays
+        // blocked for the rest of the touch.
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                               shouldBeRequiredToFailBy other: UIGestureRecognizer) -> Bool {
+            guard gestureRecognizer is UIPanGestureRecognizer else { return false }
+            return other is UIPanGestureRecognizer && other !== gestureRecognizer
         }
 
         @objc func handlePan(_ recognizer: UIPanGestureRecognizer) {
@@ -168,6 +226,20 @@ struct HorizontalPanGesture: UIViewRepresentable {
         @objc func handleTap(_ recognizer: UITapGestureRecognizer) {
             guard recognizer.state == .ended else { return }
             parent.onTap?()
+        }
+
+        // Press-state reporter (see makeUIView). Pure observation — it
+        // triggers no action of its own, so every terminal state just
+        // clears the pressed flag.
+        @objc func handlePress(_ recognizer: UILongPressGestureRecognizer) {
+            switch recognizer.state {
+            case .began:
+                parent.onPressChanged?(true)
+            case .ended, .cancelled, .failed:
+                parent.onPressChanged?(false)
+            default:
+                break
+            }
         }
 
         // Let the tap coexist with the parent ScrollView's own recognizers so

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -29,7 +29,6 @@ struct MemoCardView: View {
     @State private var thumbnail: UIImage?
     @State private var downloadStates: [URL: AttachmentDownloadState] = [:]
     @State private var downloadTask: Task<Void, Never>? = nil
-    @State private var sharePayload: SharePayload? = nil
     @State private var showPhotoViewer: Bool = false
 
     /// Precise 24h time for the content-first card meta line (rendered as "15·23").
@@ -281,13 +280,9 @@ struct MemoCardView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 14)
                     .padding(.top, 12)
-                    .contextMenu {
-                        Button {
-                            UIPasteboard.general.string = bodyTrimmed
-                        } label: {
-                            Label("复制", systemImage: "doc.on.doc")
-                        }
-                    }
+                // NOTE: no contextMenu here. The swipe overlay above this
+                // card owns the long press, so an inner menu could never be
+                // summoned — Copy lives in TimelineRow's merged menu instead.
             }
 
             // Bottom meta row — content-first: only a quiet mono timestamp.
@@ -327,57 +322,11 @@ struct MemoCardView: View {
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .solidCard(cornerRadius: 14)
-        .contextMenu {
-            // Tap the button above for the smart default; long-press here to
-            // override the template or send plain text.
-            let shareText = shareableText
-            if !shareText.isEmpty {
-                ShareLink(item: shareText) {
-                    Label("分享文本", systemImage: "doc.plaintext")
-                }
-            }
-            Button {
-                sharePayload = .memo(MemoSnapshot.from(memo))
-            } label: {
-                Label("强制文字卡", systemImage: "rectangle.on.rectangle")
-            }
-            if memo.attachments.contains(where: { $0.kind == "photo" }),
-               let snap = PhotoSnapshot.from(memo) {
-                Button {
-                    sharePayload = .photo(snap)
-                } label: {
-                    Label("强制照片卡", systemImage: "photo.on.rectangle")
-                }
-            }
-            if memo.attachments.contains(where: { $0.kind == "audio" }),
-               let snap = VoiceSnapshot.from(memo) {
-                Button {
-                    sharePayload = .voice(snap)
-                } label: {
-                    Label("强制语音卡", systemImage: "mic.badge.plus")
-                }
-            }
-        }
-        .sheet(item: $sharePayload) { payload in
-            ShareCardSheet(payload: payload)
-        }
-    }
-
-    // MARK: - Share text
-
-    /// Builds a plain-text representation of the memo suitable for sharing.
-    /// Prefers the voice transcript when present; falls back to body text.
-    private var shareableText: String {
-        // For voice/mixed memos, use the transcript if available.
-        if let att = memo.attachments.first(where: { $0.kind == "audio" }),
-           let transcript = att.transcript, !transcript.isEmpty {
-            let body = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
-            if body.isEmpty || body == transcript {
-                return transcript
-            }
-            return "\(transcript)\n\n\(body)"
-        }
-        return memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        // 2026-07-05 (#808): the template-override contextMenu (分享文本 /
+        // 强制文字卡 / 强制照片卡 / 强制语音卡) and its sharePayload sheet were
+        // removed as dead code — the swipe overlay above this card owns the
+        // long press, so that menu was never reachable. Share flows live in
+        // the left-swipe action and TimelineRow's merged long-press menu.
     }
 
     // MARK: - Type chip

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -212,6 +212,12 @@ struct SwipeableMemoCard: View {
     // never routes to the detail page.
     @State private var isPanActive: Bool = false
 
+    // Touch-down press feedback (UITableViewCell-highlight semantics): the
+    // card settles to 0.985× while the finger rests on it and springs back
+    // on lift — or the instant the scroll / swipe / context-menu takes the
+    // touch. Suppressed under Reduce Motion.
+    @State private var isPressed: Bool = false
+
     // Tracks which threshold the live drag has already crossed so the
     // mid-drag haptic tick fires once per cross, not once per frame.
     @State private var armedSide: CardSwipeSide? = nil
@@ -279,6 +285,8 @@ struct SwipeableMemoCard: View {
             // because the pan host view hit-tests to self.
             MemoCardView(memo: memo, onDelete: onDelete)
                 .contentShape(Rectangle())
+                .scaleEffect(isPressed && !reduceMotion ? 0.985 : 1.0)
+                .animation(reduceMotion ? nil : Motion.spring, value: isPressed)
                 .offset(x: isSelectionMode ? 0 : currentOffset)
                 // UIKit pan + tap as an OVERLAY (not background): the
                 // recognizers' host must sit in the hit-test walk for touches
@@ -294,6 +302,11 @@ struct SwipeableMemoCard: View {
                         onEnded: handlePanEnded,
                         onCancelled: handlePanCancelled,
                         onTap: handleCardTap,
+                        onPressChanged: { pressed in
+                            // A confirmed swipe owns the touch — never show
+                            // the pressed dip while the drawer is moving.
+                            isPressed = pressed && !isPanActive
+                        },
                         isEnabled: !isSelectionMode
                     )
                 )
@@ -465,6 +478,9 @@ struct SwipeableMemoCard: View {
             didNotifyPeers = true
             NotificationCenter.default.post(name: .memoCardDidBeginSwipe, object: memo.id)
         }
+        // The swipe owns the touch now — release the press dip so the card
+        // doesn't ride the drawer at 0.985×.
+        if isPressed { isPressed = false }
         dragDelta = translation
         updateThresholdHaptics()
     }
@@ -695,8 +711,11 @@ private struct SwipeActionPanel: View {
 
 // MARK: - SwipeActionButton
 
-/// A single action column inside a panel. Frosted glass base + tone tint that
-/// deepens with reveal progress; icon scales up and label fades in past 0.30.
+/// A single action column inside a panel. On iOS 26 the base is native
+/// Liquid Glass (tinted with the action's semantic tone, deepening as the
+/// reveal progresses — the warm ambient canvas refracts through it); on
+/// iOS 16–25 it keeps the ultraThinMaterial + tone-tint recipe. Icon scales
+/// up and label fades in past 0.30 of the reveal.
 private struct SwipeActionButton: View {
 
     let action: SwipeAction
@@ -704,6 +723,8 @@ private struct SwipeActionButton: View {
     /// True while this button is the commit-armed primary: it stretches to
     /// fill the whole drawer instead of its fixed 76pt column.
     var fillsWidth: Bool = false
+
+    @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     private let labelFadeStart: CGFloat = 0.30
     private let iconScaleMin: CGFloat = 0.6
@@ -725,14 +746,27 @@ private struct SwipeActionButton: View {
         .accessibilityHint(action.a11yHint ?? "")
     }
 
+    @ViewBuilder
     private var background: some View {
         // Neutral tones keep a higher tint floor so their pale surface stays
         // legible; accent / destructive start lower and deepen as revealed.
         let floor: CGFloat = (action.tone == .neutral ? 0.78 : 0.42)
         let tint = Double(floor + (1 - floor) * min(1, progress))
-        return ZStack {
-            Rectangle().fill(.ultraThinMaterial)
-            baseColor.opacity(tint)
+        if reduceTransparency {
+            // Accessibility: opaque tone surface, no blur or refraction.
+            baseColor.opacity(max(tint, 0.96))
+        } else if #available(iOS 26.0, *) {
+            // Native Liquid Glass tinted with the deepening semantic tone.
+            // `.interactive()` adds the press-softening squish on touch.
+            Color.clear.glassEffect(
+                .regular.tint(baseColor.opacity(tint)).interactive(),
+                in: .rect
+            )
+        } else {
+            ZStack {
+                Rectangle().fill(.ultraThinMaterial)
+                baseColor.opacity(tint)
+            }
         }
     }
 
@@ -742,6 +776,10 @@ private struct SwipeActionButton: View {
                 .font(.system(size: 17, weight: .semibold))
                 .foregroundColor(foreground)
                 .scaleEffect(iconScale)
+                // Mail-style "release to execute" cue: the symbol bounces
+                // the moment the full-swipe commit arms (and re-bounces if
+                // the user slides back under the line and re-arms).
+                .modifier(CommitArmBounce(armed: fillsWidth))
 
             Text(action.label)
                 .font(.custom("Inter-Medium", size: 10.5))
@@ -787,6 +825,23 @@ private struct SwipeActionButton: View {
     private var labelOpacity: Double {
         let clamped = max(0, min(1, (progress - labelFadeStart) / (1 - labelFadeStart)))
         return Double(clamped)
+    }
+}
+
+// MARK: - CommitArmBounce
+
+/// One-shot symbol bounce when the full-swipe commit arms / re-arms.
+/// iOS 17+ only (`symbolEffect`); inert on iOS 16 and under Reduce Motion.
+private struct CommitArmBounce: ViewModifier {
+    let armed: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *), !reduceMotion {
+            content.symbolEffect(.bounce, options: .speed(1.3), value: armed)
+        } else {
+            content
+        }
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -186,6 +186,12 @@ struct TodayView: View {
     /// fires `onOpen`, which sets this id and drives `navigationDestination`.
     @State private var openedMemoID: UUID? = nil
 
+    /// iOS 18+ zoom transition: the tapped card is the `matchedTransitionSource`
+    /// and MemoDetailView zooms out of it (App Store / Photos-style hero).
+    /// iOS 16–17 keeps the plain push — see `CardZoomSource` /
+    /// `CardZoomDestination` at the bottom of this file.
+    @Namespace private var detailZoomNamespace
+
     /// v8 WriteSheet — bottom-sheet text composer opened from the dock's text
     /// affordance (composer.jsx:183). Routes saves through `submitCombinedMemo`
     /// (the same path the inline composer uses) via `draftText`.
@@ -794,6 +800,9 @@ struct TodayView: View {
                 if let id = openedMemoID,
                    let memo = viewModel.memos.first(where: { $0.id == id }) {
                     MemoDetailView(memo: memo, vm: viewModel)
+                        .modifier(CardZoomDestination(
+                            id: id, namespace: detailZoomNamespace
+                        ))
                 }
             }
     }
@@ -2987,6 +2996,11 @@ struct TodayView: View {
                             }
                         )
                         .offset(x: idx == 0 ? memoCardHintOffset : 0)
+                        // iOS 18+ hero zoom: this card is the source frame the
+                        // detail page grows out of (and shrinks back into).
+                        .modifier(CardZoomSource(
+                            id: memo.id, namespace: detailZoomNamespace
+                        ))
                         .onAppear {
                             guard idx == 0,
                                   !UserDefaults.standard.bool(forKey: AppSettings.Keys.memoSwipeHintShown),
@@ -4121,6 +4135,19 @@ struct TimelineRow: View {
                       systemImage: "quote.opening")
             }
         }
+        // Copy lived on a contextMenu INSIDE MemoCardView, which the swipe
+        // gesture's overlay shadowed — it could never be summoned. The merged
+        // menu is the single reachable long-press surface, so Copy belongs
+        // here. Voice memos with an empty body copy their transcript instead.
+        if !copyableText.isEmpty {
+            Button {
+                UIPasteboard.general.string = copyableText
+                Haptics.tapConfirm()
+            } label: {
+                Label(NSLocalizedString("memo.menu.copyText", comment: "contextMenu: copy memo text"),
+                      systemImage: "doc.on.doc")
+            }
+        }
         if let onEnterSelectionMode {
             Button {
                 onEnterSelectionMode()
@@ -4158,6 +4185,17 @@ struct TimelineRow: View {
             Button(NSLocalizedString("memo.swipe.delete", comment: "more dialog: delete memo"), role: .destructive) { onDelete() }
         }
         Button(NSLocalizedString("memo.menu.cancel", comment: "more dialog: cancel"), role: .cancel) { }
+    }
+
+    /// Text the long-press Copy action puts on the pasteboard: the visible
+    /// body, or — for voice memos whose body is empty — the transcript.
+    private var copyableText: String {
+        let body = memo.body.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !body.isEmpty { return body }
+        return memo.attachments
+            .first(where: { $0.kind == "audio" })?
+            .transcript?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
     }
 
     private var selectionIndicator: some View {
@@ -4200,6 +4238,42 @@ private struct NumericTextContentTransition: ViewModifier {
         } else {
             content
                 .contentTransition(.identity)
+        }
+    }
+}
+
+// MARK: - Card → Detail zoom transition (iOS 18+)
+//
+// The App Store / Photos-style hero: tapping a memo card zooms the detail
+// page out of the card frame and the back-swipe shrinks it back in. Both
+// halves must share one `Namespace` (owned by TodayView) and matching ids.
+// On iOS 16–17 both modifiers are inert and navigation keeps the standard
+// push — no behavioral change below the availability floor.
+
+/// Marks a timeline card as the zoom source for `memo.id`.
+struct CardZoomSource: ViewModifier {
+    let id: UUID
+    let namespace: Namespace.ID
+
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *) {
+            content.matchedTransitionSource(id: id, in: namespace)
+        } else {
+            content
+        }
+    }
+}
+
+/// Applies the zoom navigation transition to the pushed detail page.
+struct CardZoomDestination: ViewModifier {
+    let id: UUID
+    let namespace: Namespace.ID
+
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *) {
+            content.navigationTransition(.zoom(sourceID: id, in: namespace))
+        } else {
+            content
         }
     }
 }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -177,6 +177,7 @@
 /* Memo card long-press context menu / MORE dialog */
 "memo.menu.shareCard"   = "Share as Card";
 "memo.menu.shareQuote"  = "Share as Quote";
+"memo.menu.copyText"    = "Copy Text";
 "memo.menu.multiselect" = "Select Multiple";
 "memo.menu.cancel"      = "Cancel";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -177,6 +177,7 @@
 /* Memo card long-press context menu / MORE dialog */
 "memo.menu.shareCard"   = "分享为卡片";
 "memo.menu.shareQuote"  = "分享为引用";
+"memo.menu.copyText"    = "复制文本";
 "memo.menu.multiselect" = "多选";
 "memo.menu.cancel"      = "取消";
 

--- a/DayPageTests/SwipePolishContractTests.swift
+++ b/DayPageTests/SwipePolishContractTests.swift
@@ -96,6 +96,35 @@ struct SwipePolishContractTests {
         #expect(rawNeeded > 240 && rawNeeded < 270)
     }
 
+    // MARK: - Direction lock (velocity gate)
+    //
+    // Issue #808: UIKit consults gestureRecognizerShouldBegin exactly ONCE
+    // per touch, at the pan's own hysteresis where accumulated translation
+    // is still ~1pt. The old `dx >= 6pt` translation gate therefore failed
+    // the pan on its single query and swipe-to-reveal was dead. The gate
+    // now judges VELOCITY, which is fully formed at that first query —
+    // these tests lock in the velocity contract.
+
+    @Test("slow horizontal drags pass the direction gate")
+    func slowHorizontalDragPassesGate() {
+        // ~60pt/s is a very deliberate, slow swipe — must still open.
+        #expect(HorizontalPanGesture.isHorizontalDominant(vx: -60, vy: 0))
+        #expect(HorizontalPanGesture.isHorizontalDominant(vx: 60, vy: 10))
+    }
+
+    @Test("vertical and steep-diagonal drags fail the gate (scroll wins)")
+    func verticalDragFailsGate() {
+        #expect(!HorizontalPanGesture.isHorizontalDominant(vx: 0, vy: -300))
+        #expect(!HorizontalPanGesture.isHorizontalDominant(vx: 100, vy: 100))
+        // Exactly at the dominance boundary the scroll keeps ownership.
+        #expect(!HorizontalPanGesture.isHorizontalDominant(vx: 120, vy: 100))
+    }
+
+    @Test("shallow horizontal flick passes at the 1.2x dominance ratio")
+    func shallowFlickPassesGate() {
+        #expect(HorizontalPanGesture.isHorizontalDominant(vx: 121, vy: 100))
+    }
+
     // MARK: - LLMClient.Config public init is stable
 
     /// The 100-分 polish audit exposed that LLMClient.Config could not be

--- a/docs/liquid-glass-vNext.md
+++ b/docs/liquid-glass-vNext.md
@@ -154,6 +154,23 @@ private struct NativeGlassModifier<S: Shape & InsettableShape>: ViewModifier {
 - iOS 26 下:玻璃控件会**实时折射**这层光晕,产生「暖光在玻璃边缘流动」的高级感 — 这是免费赚到的效果
 - `AmberHalo` / `densityXXX` 热力图保留
 
+### 3.3.5 ✅ 卡片交互层(2026-07-05 落地,Issue #808)
+
+内容卡本体保持 SolidCard 白底(见 3.4),但卡片的**交互面**属于功能层,按以下分级用玻璃与原生过渡:
+
+| 交互 | 实现 | 降级 |
+|---|---|---|
+| 左右滑动作抽屉 | `SwipeActionButton` 底面切原生 `.glassEffect(.regular.tint(语义色).interactive())`,语义色(琥珀/红/中性)随 reveal 进度加深,暖色氛围层透过玻璃折射 | iOS 16–25:原 ultraThinMaterial + tone tint;Reduce Transparency:不透明语义色 |
+| 全滑提交 | 越过 commit 线时最外侧按钮扩展填满抽屉 + SF Symbol `.bounce`(iOS 17+)+ rigid 触觉 | iOS 16 / Reduce Motion:仅布局扩展,无 bounce |
+| 点击进详情 | iOS 18+ `matchedTransitionSource` + `navigationTransition(.zoom)` —— 卡片放大成详情页(App Store 式 hero) | iOS 16–17:标准 push |
+| 按压反馈 | UIKit 触摸按压(0.06s)→ 卡片 0.985× 微缩(`Motion.spring`),滚动/滑动/长按夺走触摸的瞬间回弹 | Reduce Motion:无缩放 |
+| 长按菜单 | TimelineRow 单一合并菜单(置顶/双分享/复制文本/多选/删除)+ 卡片实景 preview | 系统行为 |
+
+**手势仲裁勘误(重要,防回归)**:iOS 26 上 SwiftUI ScrollView 的滚动 pan 在**任意方向**都会 begin 并取消内容子树触摸;且 UIKit 对每次触摸只查询一次 `gestureRecognizerShouldBegin`(此时累计位移仅 ~1pt)。因此:
+1. 方向锁必须判 **velocity**(首查询即有效),不能判累计位移;
+2. 必须用 `shouldBeRequiredToFailBy` 让滚动 pan 等待卡片 pan 先决议。
+两者缺一,滑动抽屉在 iOS 26 上完全失效(2026-07-05 实测)。契约测试:`SwipePolishContractTests` "Direction lock (velocity gate)"。
+
 ### 3.4 ⚠️ 内容卡片 — 用户勾选了,但建议克制(附证据)
 
 **Apple 官方立场(HIG · Liquid Glass):**


### PR DESCRIPTION
Closes #808

## 问题

Today feed 卡片左右滑抽屉在 iOS 26 上**完全失效**（实测 iPhone 17 Pro / iOS 26.1 + NSLog 插桩证据链）：

1. iOS 26 上 SwiftUI ScrollView 的滚动 pan 在**任意方向**都会 begin 并取消内容子树触摸 → 我们的 pan 连 `gestureRecognizerShouldBegin` 查询都收不到（插桩 0 次）。
2. 即使被查询，UIKit 对每次触摸**只查询一次**——发生在累计位移仅 ~1.3pt 时。旧的 `dx >= 6pt` 位移方向锁在这唯一一次查询上必然返回 false → pan 直接 `.failed`，整个触摸周期不再重试。注释里"returning false keeps it Possible"的假设不成立。

## 修复（两者缺一不可，已实机验证）

- 方向锁改判 **velocity**（首查询即完全成形；SwipeCellKit / UIKit 表格滑动同款语义），抽出纯函数 `HorizontalPanGesture.isHorizontalDominant` 并加 3 个契约测试防回归。
- 新增 `shouldBeRequiredToFailBy`：滚动 pan 等待卡片 pan 先决议——竖滑一次查询即 fail（滚动照常，无感知延迟）；横滑我们先 begin（滚动整触摸被锁）。

## iOS 26 打磨（全部带 `#available` 守卫 + iOS 16 降级）

| 交互 | 改动 |
|---|---|
| 点击进详情 | iOS 18+ `matchedTransitionSource` + `navigationTransition(.zoom)` — 卡片放大成详情页的 hero 转场 |
| 滑动抽屉 | 按钮底面切原生 Liquid Glass（语义色 tint 随 reveal 加深 + `.interactive()` 按压软化）；iOS 16–25 保持 ultraThinMaterial 配方；Reduce Transparency 走不透明语义色 |
| 全滑提交 | commit armed 时 SF Symbol `.bounce`（iOS 17+，Reduce Motion 跳过） |
| 按压反馈 | UIKit 触摸按压 → 卡片 0.985× 微缩（`Motion.spring`），滚动/滑动/长按夺走触摸瞬间回弹 |
| 长按菜单 | 合并菜单新增 **复制文本**（语音 memo 无正文时复制转写）；移除 MemoCardView 内两个被手势 overlay 遮蔽、永远无法弹出的死 contextMenu |

设计文档同步：`docs/liquid-glass-vNext.md` 新增 §3.3.5 卡片交互层 + 手势仲裁勘误（防回归备忘）。

## 验证（iPhone 17 Pro · iOS 26.1 模拟器逐项截图）

- ✅ 左滑半开 → Delete + Share 玻璃抽屉；点击卡身关闭
- ✅ 右滑 → Pin + More
- ✅ 全滑越过 236pt 提交线 → 松手直接弹出"分享卡片"sheet
- ✅ 点击 → zoom hero 转场进详情（抓到转场中间帧：详情页带圆角缩小态从卡片长出）
- ✅ 长按 → 合并菜单（Pin / Share as Card / Share as Quote / **Copy Text** / Select Multiple / Delete）+ 卡片实景 preview
- ✅ 按压反馈：按住时卡片左缘 24→31px（0.985×），松手回弹（像素级测量）
- ✅ 竖直滚动 / 长按 / 点击与新 failure-requirement 无冲突
- ✅ `xcodebuild build` 0 error；`SwipePolishContractTests` 16/16 通过（含 3 个新 velocity 契约）

## 风险

- `shouldBeRequiredToFailBy` 只作用于 `UIPanGestureRecognizer` 同类；tap / long-press / contextMenu 交互不受影响（已逐项实测）。
- 侧栏左缘滑动手势起点在卡片区域外（x<20），不进入卡片 pan 的手势图，不受影响。
- TimelineSectionView 的历史行滑动复用同一 `HorizontalPanGesture`，自动获得修复。