### PR TITLE
fix(onthisday): eliminate cross-suite vault race behind CI-only test flake

### DIFF
--- a/DayPageKit/Sources/DayPageServices/OnThisDayIndex.swift
+++ b/DayPageKit/Sources/DayPageServices/OnThisDayIndex.swift
@@ -44,11 +44,15 @@ public final class OnThisDayIndex: ObservableObject {
     @Published public private(set) var isReady: Bool = false
 
     private var index: [String: [DayRecord]] = [:]  // 键："MMDD"
-    private let indexURL: URL = {
-        VaultInitializer.vaultURL
+
+    /// Resolved per call (not captured at singleton init) so the persisted
+    /// index always lands next to the vault actually scanned — the locator
+    /// can switch roots at runtime (iCloud migration, test override).
+    private static func indexURL(under vaultRoot: URL) -> URL {
+        vaultRoot
             .appendingPathComponent("wiki")
             .appendingPathComponent("index.json")
-    }()
+    }
 
     private init() {}
 
@@ -81,12 +85,21 @@ public final class OnThisDayIndex: ObservableObject {
 
     // MARK: - Index Building
 
-    public func rebuildIndex() async {
+    /// Rebuild the MMDD index by scanning `vaultRoot/raw`.
+    ///
+    /// The scan root is captured synchronously HERE, before the detached
+    /// task starts, and passed down by value. Reading the process-global
+    /// `VaultInitializer.vaultURL` from inside the detached closure was a
+    /// race: tests (and iCloud migration) can repoint the vault while the
+    /// scan is queued, making it enumerate a different — or already
+    /// deleted — directory (#810).
+    public func rebuildIndex(vaultRoot: URL? = nil) async {
+        let root = vaultRoot ?? VaultInitializer.vaultURL
         let built = await Task.detached(priority: .utility) {
-            OnThisDayIndex.buildIndexOff()
+            OnThisDayIndex.buildIndexOff(vaultRoot: root)
         }.value
         index = built
-        await persistIndex(built)
+        await persistIndex(built, vaultRoot: root)
         // R8 — flip isReady AFTER index assign + persist so any observer
         // (TodayView.onReceive) that reacts by calling candidate(for:) sees
         // the fresh index, not the empty initial dictionary.
@@ -151,8 +164,8 @@ public final class OnThisDayIndex: ObservableObject {
 
     // MARK: - Static scanning (nonisolated — runs off main actor)
 
-    private static nonisolated func buildIndexOff() -> [String: [DayRecord]] {
-        let rawDir = VaultInitializer.vaultURL.appendingPathComponent("raw")
+    private static nonisolated func buildIndexOff(vaultRoot: URL) -> [String: [DayRecord]] {
+        let rawDir = vaultRoot.appendingPathComponent("raw")
         let fm = FileManager.default
         guard let enumerator = fm.enumerator(at: rawDir, includingPropertiesForKeys: nil) else {
             return [:]
@@ -202,20 +215,22 @@ public final class OnThisDayIndex: ObservableObject {
 
     // MARK: - Persistence
 
-    private func persistIndex(_ built: [String: [DayRecord]]) async {
+    private func persistIndex(_ built: [String: [DayRecord]], vaultRoot: URL) async {
         do {
             let data = try JSONEncoder().encode(built)
-            let dir = indexURL.deletingLastPathComponent()
+            let target = Self.indexURL(under: vaultRoot)
+            let dir = target.deletingLastPathComponent()
             try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-            try data.write(to: indexURL, options: .atomic)
+            try data.write(to: target, options: .atomic)
         } catch {
             DayPageLogger.shared.error("OnThisDayIndex: persist failed: \(error)")
         }
     }
 
     private func loadIndexFromDisk() -> [String: [DayRecord]]? {
-        guard FileManager.default.fileExists(atPath: indexURL.path),
-              let data = try? Data(contentsOf: indexURL),
+        let source = Self.indexURL(under: VaultInitializer.vaultURL)
+        guard FileManager.default.fileExists(atPath: source.path),
+              let data = try? Data(contentsOf: source),
               let decoded = try? JSONDecoder().decode([String: [DayRecord]].self, from: data)
         else { return nil }
         return decoded

--- a/DayPageTests/OnThisDayIntegrationTests.swift
+++ b/DayPageTests/OnThisDayIntegrationTests.swift
@@ -3,7 +3,7 @@
 // Validates the OnThisDay candidate + dismiss contract end-to-end:
 //   - `OnThisDayIndex` picks the correct candidate (prefers 1-year-ago,
 //     falls back to ~6-months-ago, then 2-years-ago) from a synthetic
-//     vault seeded under VaultInitializer.testOverrideURL.
+//     temp vault passed explicitly via `rebuildIndex(vaultRoot:)`.
 //   - `OnThisDayScheduler.markDismissedForToday()` flips the persisted
 //     dismiss flag so `shouldShowToday()` returns nil for the rest of
 //     the local day.
@@ -26,9 +26,17 @@ struct OnThisDayIntegrationTests {
 
     // MARK: - Test fixture helpers
 
-    /// Stand up a private temp vault, seed `raw/YYYY-MM-DD.md` files, and
-    /// point `VaultInitializer.testOverrideURL` at it for the duration of
-    /// the test. Returns the root URL so caller can clean up.
+    /// Stand up a private temp vault and seed `raw/YYYY-MM-DD.md` files.
+    /// Returns the root URL, which the test passes to
+    /// `rebuildIndex(vaultRoot:)` explicitly.
+    ///
+    /// Deliberately does NOT touch `VaultInitializer.testOverrideURL`:
+    /// that global is shared by ~20 suites that Swift Testing runs in
+    /// parallel within one process, and mutating it here both breaks other
+    /// suites and lets their teardown repoint our scan mid-rebuild — the
+    /// actual root cause of the CI-only flake in #810 (not a timezone
+    /// mismatch; every date path here uses `TimeZone.current` on both the
+    /// seed and index side).
     private func seedVault(withSeeds seeds: [(date: Date, body: String)]) throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("daypage-tests-\(UUID().uuidString)", isDirectory: true)
@@ -58,12 +66,10 @@ struct OnThisDayIntegrationTests {
             try content.write(to: fileURL, atomically: true, encoding: .utf8)
         }
 
-        VaultInitializer.testOverrideURL = root
         return root
     }
 
     private func teardownVault(at root: URL) {
-        VaultInitializer.testOverrideURL = nil
         try? FileManager.default.removeItem(at: root)
     }
 
@@ -88,7 +94,7 @@ struct OnThisDayIntegrationTests {
         // Reset shared singleton state so prior tests' seeded entries
         // can't pollute this candidate lookup.
         OnThisDayIndex.shared.resetForTesting()
-        await OnThisDayIndex.shared.rebuildIndex()
+        await OnThisDayIndex.shared.rebuildIndex(vaultRoot: root)
         let entry = OnThisDayIndex.shared.candidate(for: today)
 
         try #require(entry != nil)
@@ -112,7 +118,7 @@ struct OnThisDayIntegrationTests {
         defer { teardownVault(at: root) }
 
         OnThisDayIndex.shared.resetForTesting()
-        await OnThisDayIndex.shared.rebuildIndex()
+        await OnThisDayIndex.shared.rebuildIndex(vaultRoot: root)
         let entry = OnThisDayIndex.shared.candidate(for: today)
 
         try #require(entry != nil)
@@ -136,7 +142,7 @@ struct OnThisDayIntegrationTests {
         defer { teardownVault(at: root) }
 
         OnThisDayIndex.shared.resetForTesting()
-        await OnThisDayIndex.shared.rebuildIndex()
+        await OnThisDayIndex.shared.rebuildIndex(vaultRoot: root)
         let entry = OnThisDayIndex.shared.candidate(for: today)
         #expect(entry == nil)
     }


### PR DESCRIPTION
## Summary

修复 #810 追踪的 CI-only flaky：`OnThisDayIntegrationTests.indexFallsBackToTwoYearsAgoWhenNoOneYearMatch` 在 CI 稳定挂、本地稳定过。

## 根因(不是时区)

#810 疑似根因写的是 UTC/CST 漂移,但审计后确认 seed 文件名、index 解析、MMDD 提取三处**全部**锚定 `TimeZone.current`,时区上是自洽的。

真正的根因是进程级全局变量 `VaultInitializer.testOverrideURL` 的跨 suite 数据竞争:

- 全仓有 **21 个测试文件**读写这同一个全局变量,而 Swift Testing 默认在同一进程内并行跑各 suite(CI 日志可见 20+ 个 suite 交错启动,这个只有 5 个用例的 suite 跑了 32.9s)。
- `rebuildIndex()` 在 **detached 扫描任务内部**才读 `VaultInitializer.vaultURL`。CI 的 3 核 runner 负载高,`.utility` QoS 的扫描被推迟,窗口期内其他 suite 的 seed/teardown 把 override 改指到自己的 vault 或清成 nil → 扫描枚举到别人的(或已删除的)目录 → `0622` 种子文件不入索引 → `candidate(for:)` 返回 nil。
- 这也解释了为什么 test 1 过、test 2 挂、test 3(期望 nil)"假绿":test 3 被踩了也照样返回 nil。

## 修复

1. **`rebuildIndex(vaultRoot: URL? = nil)`**:进入函数时同步捕获扫描根路径,按值传给 detached 任务;不再让后台线程读可变全局。顺带修掉生产侧同款隐患(iCloud 迁移可在扫描排队期间切换 locator)。
2. **`index.json` 路径按调用时的 root 解析**,不再在单例 init 时一次性捕获(过期捕获 bug)。
3. **测试完全不再触碰 `testOverrideURL`**:seed 私有临时 vault 并显式传入,既不会被其他 20 个 suite 踩,也不再反过来踩别人。

## 验证

- 本地完整 `DayPageTests` target:**141 tests / 24 suites 全绿**;OnThisDay suite 0.14s 完成。
- 修复后扫描根路径与全局变量完全解耦,CI(UTC)与本地(CST)不再有任何环境相关路径。

## 遗留说明

其余 20 个共享 `testOverrideURL` 的 suite 仍存在同类理论风险(互踩窗口),本 PR 按 #810 验收范围只根治 OnThisDay 套件并消除它对外的污染;如后续再现同类 flake,可按本 PR 的"显式传根路径"模式逐个迁移。

Closes #810