### PR TITLE
feat(today): 抽屉 Liquid Glass morph 组 + 拖拽景深 + 长按 lift 圆角 (#812)

### DIFF
--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -277,6 +277,13 @@ struct SwipeableMemoCard: View {
         reduceMotion ? SwipePhysics.reducedSnap : SwipePhysics.snapSpring
     }
 
+    /// Contact-shadow opacity for the sliding card, 0 at rest → 0.16 at a
+    /// full reveal. Derived from |revealProgress| so it tracks the finger
+    /// frame-by-frame and both directions shade identically.
+    private var dragElevation: Double {
+        Double(min(0.16, abs(revealProgress) * 0.16))
+    }
+
     var body: some View {
         ZStack(alignment: .center) {
             // LAYER 1 (bottom): the card body — pure presentation. Navigation
@@ -287,6 +294,17 @@ struct SwipeableMemoCard: View {
                 .contentShape(Rectangle())
                 .scaleEffect(isPressed && !reduceMotion ? 0.985 : 1.0)
                 .animation(reduceMotion ? nil : Motion.spring, value: isPressed)
+                // Elevation while the drawer is exposed: a soft contact
+                // shadow fades in with revealProgress so the card reads as
+                // a sheet floating ABOVE the glass drawer (Liquid Glass
+                // layering physics), instead of two flat surfaces abutting.
+                // The trailing edge's shadow bleeds through the translucent
+                // glass, grounding the depth. Zeroed at rest — no cost to
+                // the settled timeline.
+                .shadow(
+                    color: Color.black.opacity(dragElevation),
+                    radius: 12, x: 0, y: 3
+                )
                 .offset(x: isSelectionMode ? 0 : currentOffset)
                 // UIKit pan + tap as an OVERLAY (not background): the
                 // recognizers' host must sit in the hit-test walk for touches
@@ -661,7 +679,39 @@ private struct SwipeActionPanel: View {
     /// "release to execute", mirroring Mail's full-swipe choreography.
     var commitArmed: Bool = false
 
+    /// Namespace for `glassEffectID` so the two action buttons' Liquid
+    /// Glass surfaces live in one morph group: when the commit layout
+    /// removes the secondary column, its glass is absorbed into the
+    /// expanding primary instead of vanishing in a layout jump.
+    @Namespace private var glassNamespace
+
     var body: some View {
+        glassGrouped {
+            panelColumns
+        }
+        .frame(width: max(SwipePhysics.panelWidth, revealWidth))
+        .frame(maxHeight: .infinity)
+        // Hide entirely when closed so VoiceOver doesn't announce hidden
+        // targets and a stray tap on the laid-out panel can't fire.
+        .opacity(progress > 0.02 ? 1 : 0)
+        .allowsHitTesting(progress > 0.02)
+        .accessibilityHidden(progress <= 0.02)
+    }
+
+    /// Apple's stated anti-pattern is sibling `glassEffect` views WITHOUT a
+    /// shared container — the container both batches the render pass and
+    /// enables morphing between the members. iOS 16–25 falls through to the
+    /// plain column stack (the material recipe there has nothing to morph).
+    @ViewBuilder
+    private func glassGrouped<C: View>(@ViewBuilder content: () -> C) -> some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer(spacing: 12.0, content: content)
+        } else {
+            content()
+        }
+    }
+
+    private var panelColumns: some View {
         HStack(spacing: 0) {
             // R3 — interleave a 1pt hairline between adjacent action columns
             // so the share/delete (or pin/more) boundary reads as two distinct
@@ -682,18 +732,12 @@ private struct SwipeActionPanel: View {
                     SwipeActionButton(
                         action: action,
                         progress: progress,
-                        fillsWidth: commitArmed && action.id == outerActionID
+                        fillsWidth: commitArmed && action.id == outerActionID,
+                        glassNamespace: glassNamespace
                     )
                 }
             }
         }
-        .frame(width: max(SwipePhysics.panelWidth, revealWidth))
-        .frame(maxHeight: .infinity)
-        // Hide entirely when closed so VoiceOver doesn't announce hidden
-        // targets and a stray tap on the laid-out panel can't fire.
-        .opacity(progress > 0.02 ? 1 : 0)
-        .allowsHitTesting(progress > 0.02)
-        .accessibilityHidden(progress <= 0.02)
     }
 
     /// The primary action — callers pass their arrays primary-first, and the
@@ -724,6 +768,11 @@ private struct SwipeActionButton: View {
     /// fill the whole drawer instead of its fixed 76pt column.
     var fillsWidth: Bool = false
 
+    /// Morph-group namespace owned by the enclosing SwipeActionPanel's
+    /// GlassEffectContainer. nil (or pre-iOS 26) renders plain glass with
+    /// no morph identity.
+    var glassNamespace: Namespace.ID? = nil
+
     @Environment(\.accessibilityReduceTransparency) private var reduceTransparency
 
     private let labelFadeStart: CGFloat = 0.30
@@ -739,6 +788,19 @@ private struct SwipeActionButton: View {
             .frame(width: fillsWidth ? nil : SwipePhysics.actionWidth)
             .frame(maxWidth: fillsWidth ? .infinity : nil)
             .frame(maxHeight: .infinity)
+            // iOS 26 glass goes HERE — on the sized content view, after the
+            // frame modifiers, per the canonical Liquid Glass pattern. The
+            // first cut applied it to a Color.clear member INSIDE the ZStack;
+            // once a GlassEffectContainer extracted that surface into the
+            // shared glass layer it composited OVER its ZStack siblings and
+            // the icon + label vanished. On the outer view the glass is the
+            // background and the labeled content is guaranteed above it.
+            .modifier(GlassTone26(
+                tint: baseColor.opacity(tintDepth),
+                id: action.id,
+                namespace: glassNamespace,
+                enabled: !reduceTransparency
+            ))
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
@@ -746,26 +808,27 @@ private struct SwipeActionButton: View {
         .accessibilityHint(action.a11yHint ?? "")
     }
 
+    /// Tone depth for the current reveal. Neutral tones keep a higher floor
+    /// so their pale surface stays legible; accent / destructive start lower
+    /// and deepen as the reveal progresses.
+    private var tintDepth: Double {
+        let floor: CGFloat = (action.tone == .neutral ? 0.78 : 0.42)
+        return Double(floor + (1 - floor) * min(1, progress))
+    }
+
     @ViewBuilder
     private var background: some View {
-        // Neutral tones keep a higher tint floor so their pale surface stays
-        // legible; accent / destructive start lower and deepen as revealed.
-        let floor: CGFloat = (action.tone == .neutral ? 0.78 : 0.42)
-        let tint = Double(floor + (1 - floor) * min(1, progress))
         if reduceTransparency {
             // Accessibility: opaque tone surface, no blur or refraction.
-            baseColor.opacity(max(tint, 0.96))
+            baseColor.opacity(max(tintDepth, 0.96))
         } else if #available(iOS 26.0, *) {
-            // Native Liquid Glass tinted with the deepening semantic tone.
-            // `.interactive()` adds the press-softening squish on touch.
-            Color.clear.glassEffect(
-                .regular.tint(baseColor.opacity(tint)).interactive(),
-                in: .rect
-            )
+            // Native Liquid Glass is applied by GlassTone26 on the outer
+            // view (see body) — no background member needed here.
+            Color.clear
         } else {
             ZStack {
                 Rectangle().fill(.ultraThinMaterial)
-                baseColor.opacity(tint)
+                baseColor.opacity(tintDepth)
             }
         }
     }
@@ -825,6 +888,35 @@ private struct SwipeActionButton: View {
     private var labelOpacity: Double {
         let clamped = max(0, min(1, (progress - labelFadeStart) / (1 - labelFadeStart)))
         return Double(clamped)
+    }
+}
+
+// MARK: - GlassTone26
+
+/// iOS 26 Liquid Glass base for a swipe action column: semantic-tone tinted,
+/// `.interactive()` for the press squish, enrolled in the enclosing
+/// GlassEffectContainer's morph group via `glassEffectID` so commit-arm
+/// absorbs the folding secondary column into the expanding primary.
+/// Inert pre-iOS 26 or when Reduce Transparency asks for the opaque path.
+private struct GlassTone26: ViewModifier {
+    let tint: Color
+    let id: SwipeAction.Kind
+    let namespace: Namespace.ID?
+    let enabled: Bool
+
+    func body(content: Content) -> some View {
+        if enabled, #available(iOS 26.0, *) {
+            if let ns = namespace {
+                content
+                    .glassEffect(.regular.tint(tint).interactive(), in: .rect)
+                    .glassEffectID(id, in: ns)
+            } else {
+                content
+                    .glassEffect(.regular.tint(tint).interactive(), in: .rect)
+            }
+        } else {
+            content
+        }
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -4034,6 +4034,17 @@ struct TimelineRow: View {
             cardStack
         } else {
             cardStack
+                // Long-press lift snapshot must share the card's 14pt
+                // continuous silhouette — without this the system clips the
+                // lift highlight to a square rect, flashing hard corners
+                // around a rounded card for the first frames of the pick-up.
+                .contentShape(
+                    .contextMenuPreview,
+                    RoundedRectangle(
+                        cornerRadius: SwipePhysics.cardCornerRadius,
+                        style: .continuous
+                    )
+                )
                 .contextMenu {
                     mergedMenuItems
                 } preview: {

--- a/docs/liquid-glass-vNext.md
+++ b/docs/liquid-glass-vNext.md
@@ -160,11 +160,14 @@ private struct NativeGlassModifier<S: Shape & InsettableShape>: ViewModifier {
 
 | 交互 | 实现 | 降级 |
 |---|---|---|
-| 左右滑动作抽屉 | `SwipeActionButton` 底面切原生 `.glassEffect(.regular.tint(语义色).interactive())`,语义色(琥珀/红/中性)随 reveal 进度加深,暖色氛围层透过玻璃折射 | iOS 16–25:原 ultraThinMaterial + tone tint;Reduce Transparency:不透明语义色 |
-| 全滑提交 | 越过 commit 线时最外侧按钮扩展填满抽屉 + SF Symbol `.bounce`(iOS 17+)+ rigid 触觉 | iOS 16 / Reduce Motion:仅布局扩展,无 bounce |
+| 左右滑动作抽屉 | `SwipeActionButton` 底面切原生 `.glassEffect(.regular.tint(语义色).interactive())`,语义色(琥珀/红/中性)随 reveal 进度加深,暖色氛围层透过玻璃折射;**R2(#812)**:两列按钮包进 `GlassEffectContainer` + `glassEffectID` 组成 morph 组,相邻玻璃液态融合 | iOS 16–25:原 ultraThinMaterial + tone tint;Reduce Transparency:不透明语义色 |
+| 全滑提交 | 越过 commit 线时最外侧按钮扩展填满抽屉 + SF Symbol `.bounce`(iOS 17+)+ rigid 触觉;**R2(#812)**:morph 组让次按钮玻璃被主按钮**液态吸收**而非布局跳变 | iOS 16 / Reduce Motion:仅布局扩展,无 bounce |
+| 拖拽景深 | **R2(#812)**:卡片滑开时随 `revealProgress` 渐入 contact shadow(≤0.16 · r12 · y3),卡片浮于玻璃抽屉之上,静止时零开销 | 各版本一致(纯 shadow) |
 | 点击进详情 | iOS 18+ `matchedTransitionSource` + `navigationTransition(.zoom)` —— 卡片放大成详情页(App Store 式 hero) | iOS 16–17:标准 push |
 | 按压反馈 | UIKit 触摸按压(0.06s)→ 卡片 0.985× 微缩(`Motion.spring`),滚动/滑动/长按夺走触摸的瞬间回弹 | Reduce Motion:无缩放 |
-| 长按菜单 | TimelineRow 单一合并菜单(置顶/双分享/复制文本/多选/删除)+ 卡片实景 preview | 系统行为 |
+| 长按菜单 | TimelineRow 单一合并菜单(置顶/双分享/复制文本/多选/删除)+ 卡片实景 preview;**R2(#812)**:`.contentShape(.contextMenuPreview, 14pt continuous)` 让 lift 高亮与卡片剪影一致,消除抬起帧的直角闪烁 | 系统行为 |
+
+**Liquid Glass 范式勘误(R2 实测,防回归)**:`glassEffect` 必须应用在**带内容的外层视图**上(frame 之后),不能作为 ZStack 里的 `Color.clear` 背景成员——一旦包进 `GlassEffectContainer`,背景成员的玻璃会被提取到容器共享层并压住 ZStack 兄弟内容(图标/文字整体消失,2026-07-05 模拟器实测)。正确写法见 `SwipeActionButton` 的 `GlassTone26` modifier。
 
 **手势仲裁勘误(重要,防回归)**:iOS 26 上 SwiftUI ScrollView 的滚动 pan 在**任意方向**都会 begin 并取消内容子树触摸;且 UIKit 对每次触摸只查询一次 `gestureRecognizerShouldBegin`(此时累计位移仅 ~1pt)。因此:
 1. 方向锁必须判 **velocity**(首查询即有效),不能判累计位移;


### PR DESCRIPTION
Closes #812。PR #809 之后的第二轮卡片交互打磨,三处全部在 iPhone 17 Pro (iOS 26.1) 模拟器实测截图验证。

## 改动

### 1. 抽屉玻璃 morph 组(iOS 26)
`SwipeActionPanel` 两列按钮包进 `GlassEffectContainer(spacing: 12)`,每个玻璃面 `glassEffectID` 入组:
- 相邻 share/delete(pin/more)玻璃液态融合
- full-swipe commit 的 expand-to-fill 变成**液态吸收**(次按钮玻璃并入主按钮),不再是布局跳变

**关键勘误(已写入 liquid-glass-vNext §3.3.5)**:`glassEffect` 必须应用在带内容的外层视图上(新 `GlassTone26` modifier,frame 之后)。第一版把它留在 ZStack 的 `Color.clear` 背景成员上,包进 Container 后玻璃被提取到共享层压住兄弟内容——图标/文字整体消失(实测截图抓到)。

### 2. 拖拽景深
卡片滑开时随 `revealProgress` 渐入 contact shadow(≤0.16 · r12 · y3),卡片浮在玻璃抽屉之上;静止时 opacity 0 零开销。

### 3. 长按 lift 剪影
`TimelineRow` 补 `.contentShape(.contextMenuPreview, 14pt continuous)`,长按抬起帧的系统高亮与卡片圆角一致,消除直角闪烁。

## 降级
iOS 16–25 ultraThinMaterial 配方不变;Reduce Transparency 不透明路径不变;Reduce Motion 不变。

## 验证
- `xcodebuild build` 0 error
- `SwipePolishContractTests` 16/16(GlassTone26 重构后复跑)
- 模拟器实测:左滑抽屉(图标+标签+hairline+玻璃色块 ✓)、全滑 commit 直达分享卡 sheet ✓、点击 zoom 进详情 ✓、长按圆角 lift + 合并菜单 ✓、卡缘 contact shadow 放大截图可见 ✓