### PR TITLE
feat(ux): 体验总攻 — 跟手性/触感/签名时刻/设计语言收敛 (#816)

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0AA94A9D087DA366336C8480 /* DayPageServices in Frameworks */ = {isa = PBXBuildFile; productRef = 160D427C0AE7DAC5724A134F /* DayPageServices */; };
 		14188AFE740A834ADF7A41F4 /* DayPageWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B2DFF2B446D2F0AC8DE530A1 /* DayPageWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		1530E7C28C23499CFC14C498 /* HapticFeedback.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB12D96218034D3E4555B8AA /* HapticFeedback.swift */; };
+		1530E7C28C23499CFC14C499 /* SignatureHaptics.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB12D96218034D3E4555B8AB /* SignatureHaptics.swift */; };
 		1700091E891D56C434E3221E /* MacRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15CC12840AD6E5CF8621F34C /* MacRootView.swift */; };
 		17B5829B738952DA183B1B90 /* DailyPageMetadataEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CF7E0148C3A6933A903247D /* DailyPageMetadataEditView.swift */; };
 		1BA5F2B78351EFB69F085A65 /* AskPastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1681BDF1E5113769618DA9B0 /* AskPastView.swift */; };
@@ -387,6 +388,7 @@
 		B93ED807E07C2171E9F4234B /* RecordingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingView.swift; sourceTree = "<group>"; };
 		BAC7527E8128E6A865349FB9 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		BB12D96218034D3E4555B8AA /* HapticFeedback.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HapticFeedback.swift; sourceTree = "<group>"; };
+		BB12D96218034D3E4555B8AB /* SignatureHaptics.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SignatureHaptics.swift; sourceTree = "<group>"; };
 		BFC2FE3353FDB07872B77D65 /* MacKitSecretsProvider.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacKitSecretsProvider.swift; sourceTree = "<group>"; };
 		BGC1000002 /* BackgroundCompilationServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackgroundCompilationServiceTests.swift; sourceTree = "<group>"; };
 		C551D36362FF97C44EB4D5DE /* SidebarHeatmapView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SidebarHeatmapView.swift; sourceTree = "<group>"; };
@@ -738,6 +740,7 @@
 				A20000070 /* AuthService.swift */,
 				A20000095 /* ComposerContextProvider.swift */,
 				BB12D96218034D3E4555B8AA /* HapticFeedback.swift */,
+				BB12D96218034D3E4555B8AB /* SignatureHaptics.swift */,
 				AC8043A3D3371852ACB3D6F3 /* MarkdownExportService.swift */,
 				I280000002 /* InsightActionService.swift */,
 			);
@@ -1467,6 +1470,7 @@
 				4A862A4AB3CC3961B771EBC5 /* InputBarTutorialOverlay.swift in Sources */,
 				3C0AE791CCB255E33198C9F9 /* UndoPillView.swift in Sources */,
 				1530E7C28C23499CFC14C498 /* HapticFeedback.swift in Sources */,
+				1530E7C28C23499CFC14C499 /* SignatureHaptics.swift in Sources */,
 				F69AA7BDCB1C041959C26EB4 /* ShareCardSystem.swift in Sources */,
 				C80B52CC8945CDC4EE87DCBB /* PosterTemplates.swift in Sources */,
 				F66780AF157611A4283937FE /* MemoListSkeleton.swift in Sources */,

--- a/DayPage/App/AppNavigationModel.swift
+++ b/DayPage/App/AppNavigationModel.swift
@@ -66,21 +66,35 @@ final class AppNavigationModel: ObservableObject {
         }
     }
 
+    // Drawer settle uses Motion.panel (spring) instead of Motion.slide
+    // (timing curve): springs merge & retarget when interrupted, so a
+    // mid-flight reversal (finger catches the drawer) keeps its velocity
+    // instead of hard-cutting. Haptics fire only on actual state changes so
+    // programmatic re-closes (e.g. navigate while already closed) stay silent.
     func openSidebar() {
-        withAnimation(Motion.slide) {
+        guard !isSidebarOpen else { return }
+        Haptics.soft()
+        withAnimation(Motion.respectReduceMotion(Motion.panel)) {
             isSidebarOpen = true
         }
     }
 
-    func closeSidebar() {
-        withAnimation(Motion.slide) {
+    func closeSidebar(haptic: Bool = true) {
+        guard isSidebarOpen else { return }
+        if haptic { Haptics.soft() }
+        withAnimation(Motion.respectReduceMotion(Motion.panel)) {
             isSidebarOpen = false
         }
     }
 
     func navigate(to tab: AppTab) {
-        selectedTab = tab
-        closeSidebar()
+        if selectedTab != tab {
+            Haptics.selection()
+            selectedTab = tab
+        }
+        // Drawer close is implied by the tab selection tick — a second
+        // impact here would read as a double-buzz.
+        closeSidebar(haptic: false)
     }
 
     /// Switch to Archive and ask ArchiveView to open the DayDetailView for the
@@ -100,14 +114,18 @@ final class AppNavigationModel: ObservableObject {
     }
 
     func openFeedbackPanel() {
-        closeSidebar()
-        withAnimation(Motion.slide) {
+        closeSidebar(haptic: false)
+        guard !isFeedbackPanelOpen else { return }
+        Haptics.soft()
+        withAnimation(Motion.respectReduceMotion(Motion.panel)) {
             isFeedbackPanelOpen = true
         }
     }
 
     func closeFeedbackPanel() {
-        withAnimation(Motion.slide) {
+        guard isFeedbackPanelOpen else { return }
+        Haptics.soft()
+        withAnimation(Motion.respectReduceMotion(Motion.panel)) {
             isFeedbackPanelOpen = false
         }
     }

--- a/DayPage/App/DSTokens.swift
+++ b/DayPage/App/DSTokens.swift
@@ -4,61 +4,162 @@
 // Source of truth: design-tokens/tokens.json
 
 import SwiftUI
+import UIKit
 
 enum DSTokens {
     static let version = "9.0.0"
 
     enum Colors {
-        /// #FAF8F6
-        static let bgWarm = Color(red: 0.9803921568627451, green: 0.9725490196078431, blue: 0.9647058823529412)
-        /// #FFFFFF
-        static let surfaceWhite = Color(red: 1.0, green: 1.0, blue: 1.0)
-        /// #F3F0EB
-        static let surfaceSunken = Color(red: 0.9529411764705882, green: 0.9411764705882353, blue: 0.9215686274509803)
-        /// #2B2822
-        static let fgPrimary = Color(red: 0.16862745098039217, green: 0.1568627450980392, blue: 0.13333333333333333)
-        /// #6B6560
-        static let fgMuted = Color(red: 0.4196078431372549, green: 0.396078431372549, blue: 0.3764705882352941)
-        /// #A39F99
-        static let fgSubtle = Color(red: 0.6392156862745098, green: 0.6235294117647059, blue: 0.6)
-        /// #7A7269
-        static let fgSubtleAa = Color(red: 0.47843137254901963, green: 0.4470588235294118, blue: 0.4117647058823529)
-        /// #5D3000
-        static let accent = Color(red: 0.36470588235294116, green: 0.18823529411764706, blue: 0.0)
-        /// #7A3F00
-        static let accentHover = Color(red: 0.47843137254901963, green: 0.24705882352941178, blue: 0.0)
-        /// #F5EDE3
-        static let accentSoft = Color(red: 0.9607843137254902, green: 0.9294117647058824, blue: 0.8901960784313725)
-        /// #E8DCCA
-        static let accentBorder = Color(red: 0.9098039215686274, green: 0.8627450980392157, blue: 0.792156862745098)
-        /// #EDE8DF
-        static let borderSubtle = Color(red: 0.9294117647058824, green: 0.9098039215686274, blue: 0.8745098039215686)
-        /// #D6CEC0
-        static let borderDefault = Color(red: 0.8392156862745098, green: 0.807843137254902, blue: 0.7529411764705882)
-        /// #4C7A3F
-        static let success = Color(red: 0.2980392156862745, green: 0.47843137254901963, blue: 0.24705882352941178)
-        /// #EBF3E5
-        static let successSoft = Color(red: 0.9215686274509803, green: 0.9529411764705882, blue: 0.8980392156862745)
-        /// #A66A00
-        static let warning = Color(red: 0.6509803921568628, green: 0.41568627450980394, blue: 0.0)
-        /// #F8ECD6
-        static let warningSoft = Color(red: 0.9725490196078431, green: 0.9254901960784314, blue: 0.8392156862745098)
-        /// #A23A2E
-        static let error = Color(red: 0.6352941176470588, green: 0.22745098039215686, blue: 0.1803921568627451)
-        /// #F5E1DC
-        static let errorSoft = Color(red: 0.9607843137254902, green: 0.8823529411764706, blue: 0.8627450980392157)
-        /// #F0EBE3
-        static let heatmapEmpty = Color(red: 0.9411764705882353, green: 0.9215686274509803, blue: 0.8901960784313725)
-        /// #E6D9C3
-        static let heatmapLow = Color(red: 0.9019607843137255, green: 0.8509803921568627, blue: 0.7647058823529411)
-        /// #C9A677
-        static let heatmapMid = Color(red: 0.788235294117647, green: 0.6509803921568628, blue: 0.4666666666666667)
-        /// #5D3000
-        static let heatmapHigh = Color(red: 0.36470588235294116, green: 0.18823529411764706, blue: 0.0)
-        /// #E36B4A
-        static let recordingRed = Color(red: 0.8901960784313725, green: 0.4196078431372549, blue: 0.2901960784313726)
-        /// #2D1E0C
-        static let recordingBg = Color(red: 0.17647058823529413, green: 0.11764705882352941, blue: 0.047058823529411764)
+        /// light #FAF8F6 / dark #1A1814
+        static let bgWarm = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.10196078431372549, green: 0.09411764705882353, blue: 0.0784313725490196, alpha: 1.0)
+                : UIColor(red: 0.9803921568627451, green: 0.9725490196078431, blue: 0.9647058823529412, alpha: 1.0)
+        })
+        /// light #FFFFFF / dark #1F1C18
+        static let surfaceWhite = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.12156862745098039, green: 0.10980392156862745, blue: 0.09411764705882353, alpha: 1.0)
+                : UIColor(red: 1.0, green: 1.0, blue: 1.0, alpha: 1.0)
+        })
+        /// light #F3F0EB / dark #252118
+        static let surfaceSunken = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.1450980392156863, green: 0.12941176470588237, blue: 0.09411764705882353, alpha: 1.0)
+                : UIColor(red: 0.9529411764705882, green: 0.9411764705882353, blue: 0.9215686274509803, alpha: 1.0)
+        })
+        /// light #2B2822 / dark #F0EDE8
+        static let fgPrimary = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.9411764705882353, green: 0.9294117647058824, blue: 0.9098039215686274, alpha: 1.0)
+                : UIColor(red: 0.16862745098039217, green: 0.1568627450980392, blue: 0.13333333333333333, alpha: 1.0)
+        })
+        /// light #6B6560 / dark #A39F99
+        static let fgMuted = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.6392156862745098, green: 0.6235294117647059, blue: 0.6, alpha: 1.0)
+                : UIColor(red: 0.4196078431372549, green: 0.396078431372549, blue: 0.3764705882352941, alpha: 1.0)
+        })
+        /// light #A39F99 / dark #6B6560
+        static let fgSubtle = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.4196078431372549, green: 0.396078431372549, blue: 0.3764705882352941, alpha: 1.0)
+                : UIColor(red: 0.6392156862745098, green: 0.6235294117647059, blue: 0.6, alpha: 1.0)
+        })
+        /// light #7A7269 / dark #B8B3AC
+        static let fgSubtleAa = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.7215686274509804, green: 0.7019607843137254, blue: 0.6745098039215687, alpha: 1.0)
+                : UIColor(red: 0.47843137254901963, green: 0.4470588235294118, blue: 0.4117647058823529, alpha: 1.0)
+        })
+        /// light #5D3000 / dark #C9883A
+        static let accent = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.788235294117647, green: 0.5333333333333333, blue: 0.22745098039215686, alpha: 1.0)
+                : UIColor(red: 0.36470588235294116, green: 0.18823529411764706, blue: 0.0, alpha: 1.0)
+        })
+        /// light #7A3F00 / dark #E09A45
+        static let accentHover = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.8784313725490196, green: 0.6039215686274509, blue: 0.27058823529411763, alpha: 1.0)
+                : UIColor(red: 0.47843137254901963, green: 0.24705882352941178, blue: 0.0, alpha: 1.0)
+        })
+        /// light #F5EDE3 / dark #2A1F0E
+        static let accentSoft = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.16470588235294117, green: 0.12156862745098039, blue: 0.054901960784313725, alpha: 1.0)
+                : UIColor(red: 0.9607843137254902, green: 0.9294117647058824, blue: 0.8901960784313725, alpha: 1.0)
+        })
+        /// light #E8DCCA / dark #3D2E14
+        static let accentBorder = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.23921568627450981, green: 0.1803921568627451, blue: 0.0784313725490196, alpha: 1.0)
+                : UIColor(red: 0.9098039215686274, green: 0.8627450980392157, blue: 0.792156862745098, alpha: 1.0)
+        })
+        /// light #EDE8DF / dark #2A2620
+        static let borderSubtle = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.16470588235294117, green: 0.14901960784313725, blue: 0.12549019607843137, alpha: 1.0)
+                : UIColor(red: 0.9294117647058824, green: 0.9098039215686274, blue: 0.8745098039215686, alpha: 1.0)
+        })
+        /// light #D6CEC0 / dark #38332A
+        static let borderDefault = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.2196078431372549, green: 0.2, blue: 0.16470588235294117, alpha: 1.0)
+                : UIColor(red: 0.8392156862745098, green: 0.807843137254902, blue: 0.7529411764705882, alpha: 1.0)
+        })
+        /// light #4C7A3F / dark #6AAF5A
+        static let success = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.41568627450980394, green: 0.6862745098039216, blue: 0.35294117647058826, alpha: 1.0)
+                : UIColor(red: 0.2980392156862745, green: 0.47843137254901963, blue: 0.24705882352941178, alpha: 1.0)
+        })
+        /// light #EBF3E5 / dark #1B2E18
+        static let successSoft = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.10588235294117647, green: 0.1803921568627451, blue: 0.09411764705882353, alpha: 1.0)
+                : UIColor(red: 0.9215686274509803, green: 0.9529411764705882, blue: 0.8980392156862745, alpha: 1.0)
+        })
+        /// light #A66A00 / dark #D4940A
+        static let warning = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.8313725490196079, green: 0.5803921568627451, blue: 0.0392156862745098, alpha: 1.0)
+                : UIColor(red: 0.6509803921568628, green: 0.41568627450980394, blue: 0.0, alpha: 1.0)
+        })
+        /// light #F8ECD6 / dark #2E2210
+        static let warningSoft = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.1803921568627451, green: 0.13333333333333333, blue: 0.06274509803921569, alpha: 1.0)
+                : UIColor(red: 0.9725490196078431, green: 0.9254901960784314, blue: 0.8392156862745098, alpha: 1.0)
+        })
+        /// light #A23A2E / dark #D4524A
+        static let error = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.8313725490196079, green: 0.3215686274509804, blue: 0.2901960784313726, alpha: 1.0)
+                : UIColor(red: 0.6352941176470588, green: 0.22745098039215686, blue: 0.1803921568627451, alpha: 1.0)
+        })
+        /// light #F5E1DC / dark #2E1210
+        static let errorSoft = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.1803921568627451, green: 0.07058823529411765, blue: 0.06274509803921569, alpha: 1.0)
+                : UIColor(red: 0.9607843137254902, green: 0.8823529411764706, blue: 0.8627450980392157, alpha: 1.0)
+        })
+        /// light #F0EBE3 / dark #252118
+        static let heatmapEmpty = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.1450980392156863, green: 0.12941176470588237, blue: 0.09411764705882353, alpha: 1.0)
+                : UIColor(red: 0.9411764705882353, green: 0.9215686274509803, blue: 0.8901960784313725, alpha: 1.0)
+        })
+        /// light #E6D9C3 / dark #3D2E14
+        static let heatmapLow = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.23921568627450981, green: 0.1803921568627451, blue: 0.0784313725490196, alpha: 1.0)
+                : UIColor(red: 0.9019607843137255, green: 0.8509803921568627, blue: 0.7647058823529411, alpha: 1.0)
+        })
+        /// light #C9A677 / dark #724C1E
+        static let heatmapMid = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.4470588235294118, green: 0.2980392156862745, blue: 0.11764705882352941, alpha: 1.0)
+                : UIColor(red: 0.788235294117647, green: 0.6509803921568628, blue: 0.4666666666666667, alpha: 1.0)
+        })
+        /// light #5D3000 / dark #E0A04C
+        static let heatmapHigh = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.8784313725490196, green: 0.6274509803921569, blue: 0.2980392156862745, alpha: 1.0)
+                : UIColor(red: 0.36470588235294116, green: 0.18823529411764706, blue: 0.0, alpha: 1.0)
+        })
+        /// light #E36B4A / dark #E36B4A
+        static let recordingRed = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.8901960784313725, green: 0.4196078431372549, blue: 0.2901960784313726, alpha: 1.0)
+                : UIColor(red: 0.8901960784313725, green: 0.4196078431372549, blue: 0.2901960784313726, alpha: 1.0)
+        })
+        /// light #2D1E0C / dark #2D1E0C
+        static let recordingBg = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.17647058823529413, green: 0.11764705882352941, blue: 0.047058823529411764, alpha: 1.0)
+                : UIColor(red: 0.17647058823529413, green: 0.11764705882352941, blue: 0.047058823529411764, alpha: 1.0)
+        })
     }
 
     enum Fonts {
@@ -122,6 +223,15 @@ enum DSTokens {
         static let raise = "0 2px 6px rgba(60,40,15,0.08), 0 12px 24px -12px rgba(60,40,15,0.14)"
         /// CSS reference: 0 2px 6px rgba(60,40,15,0.10), 0 24px 48px -16px rgba(60,40,15,0.28)
         static let float = "0 2px 6px rgba(60,40,15,0.10), 0 24px 48px -16px rgba(60,40,15,0.28)"
+
+        // Dark-scheme shadow references — black-based, higher opacity
+        // (warm-ink shadows disappear on dark canvases).
+        /// CSS reference (dark): 0 1px 2px rgba(0,0,0,0.24)
+        static let flatDark = "0 1px 2px rgba(0,0,0,0.24)"
+        /// CSS reference (dark): 0 2px 6px rgba(0,0,0,0.32), 0 12px 24px -12px rgba(0,0,0,0.42)
+        static let raiseDark = "0 2px 6px rgba(0,0,0,0.32), 0 12px 24px -12px rgba(0,0,0,0.42)"
+        /// CSS reference (dark): 0 2px 6px rgba(0,0,0,0.36), 0 24px 48px -16px rgba(0,0,0,0.55)
+        static let floatDark = "0 2px 6px rgba(0,0,0,0.36), 0 24px 48px -16px rgba(0,0,0,0.55)"
     }
 
     enum Spacing {

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -134,6 +134,42 @@ struct RootView: View {
     // SwipeableMemoCard and effectively froze left/right swipe-to-reveal.
     private let edgeSwipeWidth: CGFloat = 20
 
+    // MARK: - Interactive drawer drag
+
+    /// Non-nil while a finger is actively dragging the sidebar — from the
+    /// edge strip (opening) or the scrim (closing). Drives 1:1 tracking so
+    /// the drawer follows the finger instead of playing a canned animation
+    /// after the gesture ends.
+    @State private var sidebarDragTranslation: CGFloat? = nil
+
+    /// Current drawer x-offset: settled base plus live drag, clamped to the
+    /// drawer's travel range (it can never overshoot fully-open).
+    private var sidebarOffset: CGFloat {
+        let base: CGFloat = nav.isSidebarOpen ? 0 : -sidebarWidth
+        guard let drag = sidebarDragTranslation else { return base }
+        return min(0, max(-sidebarWidth, base + drag))
+    }
+
+    /// 0 = fully closed, 1 = fully open. Lets the scrim's opacity track the
+    /// finger during a drag instead of snapping on state change.
+    private var sidebarProgress: CGFloat {
+        1 + sidebarOffset / sidebarWidth
+    }
+
+    /// Resolves a finished drawer drag: commit toward whichever side the
+    /// *predicted* resting offset (translation + flick momentum) lands on.
+    /// The settle runs on Motion.panel so it inherits gesture velocity.
+    private func settleSidebar(predictedTranslation: CGFloat) {
+        guard sidebarDragTranslation != nil else { return }
+        let base: CGFloat = nav.isSidebarOpen ? 0 : -sidebarWidth
+        let projected = min(0, max(-sidebarWidth, base + predictedTranslation))
+        let shouldOpen = projected > -sidebarWidth / 2
+        withAnimation(Motion.respectReduceMotion(Motion.panel)) {
+            sidebarDragTranslation = nil
+        }
+        if shouldOpen { nav.openSidebar() } else { nav.closeSidebar() }
+    }
+
     private var mainContent: some View {
         ZStack(alignment: .leading) {
             // Persistent tab hosts — three pages stay alive to preserve
@@ -162,15 +198,27 @@ struct RootView: View {
             // sidebar offset) animates on the same render pass.
             .animation(Motion.fade, value: nav.selectedTab)
 
-            // 背景遮罩 — 点击或左滑关闭
-            if nav.isSidebarOpen {
-                Color.black.opacity(0.28)
+            // 背景遮罩 — 点击关闭；左滑时 1:1 跟手拖回抽屉。
+            // Mounted while dragging too, so the scrim fades in under the
+            // finger during an edge-swipe open instead of popping at the end.
+            if nav.isSidebarOpen || sidebarDragTranslation != nil {
+                Color.black.opacity(0.28 * sidebarProgress)
                     .ignoresSafeArea()
                     .onTapGesture { nav.closeSidebar() }
                     .gesture(
-                        DragGesture(minimumDistance: 20)
+                        DragGesture(minimumDistance: 10)
+                            .onChanged { value in
+                                // Only engage on a leftward pull (closing);
+                                // once engaged, keep tracking both directions.
+                                if sidebarDragTranslation == nil {
+                                    guard value.translation.width < 0 else { return }
+                                }
+                                sidebarDragTranslation = value.translation.width
+                            }
                             .onEnded { value in
-                                if value.translation.width < -30 { nav.closeSidebar() }
+                                settleSidebar(
+                                    predictedTranslation: value.predictedEndTranslation.width
+                                )
                             }
                     )
                     .transition(.opacity)
@@ -182,7 +230,7 @@ struct RootView: View {
                 .frame(maxHeight: .infinity)
                 .ignoresSafeArea()
                 .shadow(color: Color.black.opacity(0.10), radius: 20, x: 6, y: 0)
-                .offset(x: nav.isSidebarOpen ? 0 : -sidebarWidth)
+                .offset(x: sidebarOffset)
                 // Take the panel out of the accessibility tree when it's off-
                 // screen, otherwise VoiceOver users can still focus Settings /
                 // Recent rows that are visually at negative x coordinates.
@@ -248,11 +296,22 @@ struct RootView: View {
                     .contentShape(Rectangle())
                     .simultaneousGesture(
                         DragGesture(minimumDistance: 12, coordinateSpace: .local)
+                            .onChanged { value in
+                                // Engage only once horizontal dominance is
+                                // established on a rightward pull, so vertical
+                                // timeline scroll starting near the edge never
+                                // drags the drawer. After engaging, track 1:1.
+                                if sidebarDragTranslation == nil {
+                                    let dx = value.translation.width
+                                    let dy = value.translation.height
+                                    guard dx > 0, abs(dx) > abs(dy) * 1.2 else { return }
+                                }
+                                sidebarDragTranslation = value.translation.width
+                            }
                             .onEnded { value in
-                                let dx = value.translation.width
-                                let dy = value.translation.height
-                                guard abs(dx) > abs(dy) * 1.2 else { return }
-                                if dx > 30 { nav.openSidebar() }
+                                settleSidebar(
+                                    predictedTranslation: value.predictedEndTranslation.width
+                                )
                             }
                     )
                     .allowsHitTesting(true)

--- a/DayPage/App/SidebarHeatmapView.swift
+++ b/DayPage/App/SidebarHeatmapView.swift
@@ -228,7 +228,7 @@ struct SidebarHeatmapView: View {
                 )
                 .overlay(
                     RoundedRectangle(cornerRadius: 2.5, style: .continuous)
-                        .strokeBorder(isToday ? DSColor.accentAmber : .clear, lineWidth: 1)
+                        .strokeBorder(isToday ? DSColor.accentOnBg : .clear, lineWidth: 1)
                 )
                 .shadow(
                     color: isToday && firstEntryGlow ? DSColor.accentAmber.opacity(0.55) : .clear,

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -415,7 +415,7 @@ struct SidebarView: View {
             HStack(spacing: 12) {
                 // Left amber accent strip
                 RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(isActive ? DSColor.amberAccent : Color.clear)
+                    .fill(isActive ? DSColor.accentOnBg : Color.clear)
                     .frame(width: 2, height: 20)
 
                 Image(systemName: icon)
@@ -423,7 +423,7 @@ struct SidebarView: View {
                     .frame(width: 20)
                     .foregroundColor(
                         disabled ? DSColor.inkSubtle
-                        : isActive ? DSColor.amberAccent
+                        : isActive ? DSColor.accentOnBg
                         : DSColor.inkMuted
                     )
 
@@ -491,7 +491,7 @@ struct SidebarView: View {
                 Image(systemName: "circle.fill")
                     .font(.system(size: 6))
                     .frame(width: 20)
-                    .foregroundColor(DSColor.amberAccent.opacity(0.75))
+                    .foregroundColor(DSColor.accentOnBg.opacity(0.75))
 
                 VStack(alignment: .leading, spacing: 1) {
                     Text(Self.formatRowTitle(day.dateString))
@@ -594,7 +594,7 @@ struct SidebarView: View {
                         .overlay(Circle().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
                     Text(initial)
                         .font(DSType.labelSM)
-                        .foregroundColor(DSColor.amberDeep)
+                        .foregroundColor(DSColor.accentOnBg)
                 }
                 .frame(width: 20)
                 Text(email)

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -255,11 +255,11 @@ struct SidebarView: View {
                 .accessibilityLabel("\(sidebarVM.totalWordCount) words total")
         }
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                 .fill(DSColor.surfaceWhite)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                 .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
         )
         .shadow(color: Color.black.opacity(0.04), radius: 1, x: 0, y: 1)

--- a/DayPage/Components/GlassErrorBanner.swift
+++ b/DayPage/Components/GlassErrorBanner.swift
@@ -270,7 +270,7 @@ struct GlassErrorBannerOverlayModifier: ViewModifier {
                 .zIndex(200)
             }
         }
-        .animation(.spring(response: 0.55, dampingFraction: 0.88), value: stack.items.map(\.id))
+        .animation(Motion.bannerSlide, value: stack.items.map(\.id))
     }
 }
 

--- a/DayPage/Components/GlassErrorBanner.swift
+++ b/DayPage/Components/GlassErrorBanner.swift
@@ -110,6 +110,7 @@ struct GlassErrorBanner: View {
         HStack(alignment: .top, spacing: 12) {
             icon
                 .font(.system(size: 18, weight: .semibold))
+                .symbolRenderingMode(.hierarchical)
                 .foregroundColor(DSColor.errorRed)
                 .frame(width: 24, height: 24)
 

--- a/DayPage/Components/PillSegmentedControl.swift
+++ b/DayPage/Components/PillSegmentedControl.swift
@@ -49,7 +49,7 @@ struct PillSegmentedControl<ID: Hashable>: View {
         return Button {
             guard !isSelected else { return }
             Haptics.soft()
-            withAnimation(reduceMotion ? nil : .spring(response: 0.32, dampingFraction: 0.86)) {
+            withAnimation(reduceMotion ? nil : Motion.panel) {
                 selection = segment.id
             }
             onSelect?(segment.id)

--- a/DayPage/Components/PillSegmentedControl.swift
+++ b/DayPage/Components/PillSegmentedControl.swift
@@ -57,7 +57,7 @@ struct PillSegmentedControl<ID: Hashable>: View {
             Text(segment.label)
                 .font(.custom("Inter-Medium", size: 13))
                 .fontWeight(isSelected ? .semibold : .medium)
-                .foregroundColor(isSelected ? DSColor.accentAmber : DSColor.inkMuted)
+                .foregroundColor(isSelected ? DSColor.accentOnBg : DSColor.inkMuted)
                 .lineLimit(1)
                 .padding(.vertical, 7)
                 .frame(maxWidth: .infinity)

--- a/DayPage/DesignSystem/Components.swift
+++ b/DayPage/DesignSystem/Components.swift
@@ -49,7 +49,7 @@ struct WikilinkText: View {
     var body: some View {
         Text(text)
             .bodySMStyle()
-            .foregroundColor(DSColor.amberAccent)
+            .foregroundColor(DSColor.accentOnBg)
             .onTapGesture { onTap?() }
     }
 }
@@ -102,7 +102,7 @@ struct WikilinkBodyText: View {
             var part = AttributedString(seg.content)
             if seg.isLink {
                 part.font = .custom("Inter-Medium", size: 15)
-                part.foregroundColor = DSColor.amberAccent
+                part.foregroundColor = DSColor.accentOnBg
                 // Percent-encode the slug into the URL host so tapping routes to this specific entity.
                 let encoded = seg.inner.addingPercentEncoding(withAllowedCharacters: .urlHostAllowed) ?? seg.inner
                 part.link = URL(string: "wikilink://\(encoded)")

--- a/DayPage/DesignSystem/DSBanner.swift
+++ b/DayPage/DesignSystem/DSBanner.swift
@@ -32,11 +32,11 @@ enum DSBannerKind {
 
     fileprivate var tint: Color {
         switch self {
-        case .info:    return DSColor.amberAccent
+        case .info:    return DSColor.accentOnBg
         case .success: return DSColor.successGreen
         case .warning: return DSColor.warningAmber
         case .error:   return DSColor.errorRed
-        case .loading: return DSColor.amberAccent
+        case .loading: return DSColor.accentOnBg
         }
     }
 
@@ -115,6 +115,7 @@ struct DSBanner: View {
             if let sym = kind.systemImage {
                 Image(systemName: sym)
                     .font(.system(size: 16))
+                    .symbolRenderingMode(.hierarchical)
                     .foregroundColor(kind.tint)
                     .frame(width: 18, height: 18)
             }

--- a/DayPage/DesignSystem/DSButton.swift
+++ b/DayPage/DesignSystem/DSButton.swift
@@ -58,7 +58,7 @@ struct DSPrimaryButtonStyle: ButtonStyle {
                     .fill(isEnabled ? DSColor.amberDeep : DSColor.inkSubtle)
             )
             .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
-            .animation(Motion.respectReduceMotion(.spring(response: 0.25, dampingFraction: 0.85)),
+            .animation(Motion.respectReduceMotion(Motion.press),
                        value: configuration.isPressed)
             .contentShape(Rectangle())
     }
@@ -83,7 +83,7 @@ struct DSSecondaryButtonStyle: ButtonStyle {
             .dpGlass(.control, in: RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
             .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
             .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
-            .animation(Motion.respectReduceMotion(.spring(response: 0.25, dampingFraction: 0.85)),
+            .animation(Motion.respectReduceMotion(Motion.press),
                        value: configuration.isPressed)
             .contentShape(Rectangle())
     }
@@ -125,7 +125,7 @@ struct DSDestructiveButtonStyle: ButtonStyle {
                     .fill(isEnabled ? DSColor.errorRed : DSColor.inkSubtle)
             )
             .scaleEffect(configuration.isPressed ? 0.97 : 1.0)
-            .animation(Motion.respectReduceMotion(.spring(response: 0.25, dampingFraction: 0.85)),
+            .animation(Motion.respectReduceMotion(Motion.press),
                        value: configuration.isPressed)
             .contentShape(Rectangle())
     }
@@ -142,7 +142,7 @@ struct DSIconChipButtonStyle: ButtonStyle {
         configuration.label
             .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
             .opacity(configuration.isPressed ? 0.75 : 1.0)
-            .animation(Motion.respectReduceMotion(.spring(response: 0.25, dampingFraction: 0.85)),
+            .animation(Motion.respectReduceMotion(Motion.press),
                        value: configuration.isPressed)
     }
 }

--- a/DayPage/DesignSystem/DSButton.swift
+++ b/DayPage/DesignSystem/DSButton.swift
@@ -131,6 +131,22 @@ struct DSDestructiveButtonStyle: ButtonStyle {
     }
 }
 
+// MARK: - Icon chip (36pt circular glass toolbar buttons)
+
+/// Press feedback for the circular glass icon chips in toolbars (☰ / 🔍).
+/// The chip itself (glassSurface + Circle clip) is drawn by the label;
+/// this style only adds the touch response: a small scale dip plus an
+/// ink deepen so every tap reads as acknowledged.
+struct DSIconChipButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.92 : 1.0)
+            .opacity(configuration.isPressed ? 0.75 : 1.0)
+            .animation(Motion.respectReduceMotion(.spring(response: 0.25, dampingFraction: 0.85)),
+                       value: configuration.isPressed)
+    }
+}
+
 // MARK: - ButtonStyle sugar
 
 extension ButtonStyle where Self == DSPrimaryButtonStyle {
@@ -151,4 +167,8 @@ extension ButtonStyle where Self == DSGhostButtonStyle {
 extension ButtonStyle where Self == DSDestructiveButtonStyle {
     static var dsDestructive: DSDestructiveButtonStyle { .init() }
     static func dsDestructive(size: DSButtonSize) -> DSDestructiveButtonStyle { .init(size: size) }
+}
+
+extension ButtonStyle where Self == DSIconChipButtonStyle {
+    static var dsIconChip: DSIconChipButtonStyle { .init() }
 }

--- a/DayPage/DesignSystem/DSButton.swift
+++ b/DayPage/DesignSystem/DSButton.swift
@@ -99,7 +99,7 @@ struct DSGhostButtonStyle: ButtonStyle {
         configuration.label
             .font(size.font)
             .foregroundColor(isEnabled
-                ? (configuration.isPressed ? DSColor.amberAccent : DSColor.inkMuted)
+                ? (configuration.isPressed ? DSColor.accentOnBg : DSColor.inkMuted)
                 : DSColor.inkSubtle)
             .frame(minHeight: 44)
             .padding(.horizontal, size.horizontalPadding)

--- a/DayPage/DesignSystem/DSPicker.swift
+++ b/DayPage/DesignSystem/DSPicker.swift
@@ -54,7 +54,7 @@ struct DSPicker<Value: Hashable, Label: View>: View {
         VStack(spacing: 0) {
             // Header row — tappable, surfaces the selected value.
             Button {
-                withAnimation(.spring(response: 0.35, dampingFraction: 0.85)) {
+                withAnimation(Motion.spring) {
                     isExpanded.toggle()
                 }
             } label: {

--- a/DayPage/DesignSystem/DSPicker.swift
+++ b/DayPage/DesignSystem/DSPicker.swift
@@ -89,7 +89,7 @@ struct DSPicker<Value: Hashable, Label: View>: View {
                             Spacer()
                             if option.value == selection {
                                 Image(systemName: "checkmark")
-                                    .foregroundColor(DSColor.amberAccent)
+                                    .foregroundColor(DSColor.accentOnBg)
                             }
                         }
                         .padding(.horizontal, 16)
@@ -108,7 +108,7 @@ struct DSPicker<Value: Hashable, Label: View>: View {
         .background(.ultraThinMaterial)
         .overlay(
             RoundedRectangle(cornerRadius: 14)
-                .strokeBorder(DSColor.amberAccent.opacity(0.25), lineWidth: 0.75)
+                .strokeBorder(DSColor.accentOnBg.opacity(0.25), lineWidth: 0.75)
         )
         .clipShape(RoundedRectangle(cornerRadius: 14))
     }

--- a/DayPage/DesignSystem/Elevation.swift
+++ b/DayPage/DesignSystem/Elevation.swift
@@ -10,21 +10,31 @@ import SwiftUI
 //   .glass     → default Liquid Glass card shadow (matches v4 spec)
 //   .floating  → sheets, drawers, modals — stronger drop
 //
-// All tiers share the same warm ink color (#2D1E0A) used by GlassSurface.swift.
+// Light scheme shares the warm ink color (#2D1E0A) used by GlassSurface.swift.
+// Dark scheme switches to black at higher opacity (tokens.json dark.elevation):
+// warm-brown shadows are invisible against dark charcoal canvases.
 
 enum DSElevation {
     case flat
     case glass
     case floating
-
-    // Warm ink — matches the #2D1E0A used by GlassSurface.swift shadows.
-    fileprivate var inkColor: Color {
-        Color(.sRGB, red: 45/255, green: 30/255, blue: 10/255, opacity: 1.0)
-    }
 }
 
 struct ElevationModifier: ViewModifier {
     let tier: DSElevation
+    @Environment(\.colorScheme) private var colorScheme
+
+    // Warm ink in light mode; pure black in dark mode.
+    private var ink: Color {
+        colorScheme == .dark
+            ? .black
+            : Color(.sRGB, red: 45/255, green: 30/255, blue: 10/255, opacity: 1.0)
+    }
+
+    // Dark canvases swallow low-opacity shadows — boost per dark.elevation.
+    private func alpha(_ light: Double, _ dark: Double) -> Double {
+        colorScheme == .dark ? dark : light
+    }
 
     func body(content: Content) -> some View {
         switch tier {
@@ -33,13 +43,13 @@ struct ElevationModifier: ViewModifier {
         case .glass:
             // Matches LiquidGlassCard's existing two-layer ambient shadow.
             content
-                .shadow(color: tier.inkColor.opacity(0.04), radius: 1,  x: 0, y: 1)
-                .shadow(color: tier.inkColor.opacity(0.08), radius: 24, x: 0, y: 8)
+                .shadow(color: ink.opacity(alpha(0.04, 0.32)), radius: 1,  x: 0, y: 1)
+                .shadow(color: ink.opacity(alpha(0.08, 0.42)), radius: 24, x: 0, y: 8)
         case .floating:
             // Stronger lift for sheets/drawers — used by Sidebar and Feedback panel.
             content
-                .shadow(color: tier.inkColor.opacity(0.06), radius: 2,  x: 0, y: 1)
-                .shadow(color: tier.inkColor.opacity(0.14), radius: 32, x: 0, y: 12)
+                .shadow(color: ink.opacity(alpha(0.06, 0.36)), radius: 2,  x: 0, y: 1)
+                .shadow(color: ink.opacity(alpha(0.14, 0.55)), radius: 32, x: 0, y: 12)
         }
     }
 }

--- a/DayPage/DesignSystem/Haptics.swift
+++ b/DayPage/DesignSystem/Haptics.swift
@@ -12,6 +12,9 @@ enum Haptics {
     static func warn()       { HapticFeedback.warning() }
     // Success chime for completed async operations (compilation, upload).
     static func success()    { HapticFeedback.success() }
+    // Selection tick for moving between discrete options (tabs, segmented
+    // controls, calendar cells) — the system scrubbing feel, not an impact.
+    static func selection()  { HapticFeedback.selection() }
 
     // MARK: - 5-Level Composer Haptic Ladder
 

--- a/DayPage/DesignSystem/Interactions.swift
+++ b/DayPage/DesignSystem/Interactions.swift
@@ -18,9 +18,9 @@ struct PressableCardModifier: ViewModifier {
             .scaleEffect((!reduceMotion && isPressed) ? 0.98 : 1.0)
             .overlay(
                 Color.black.opacity(isPressed ? 0.04 : 0)
-                    .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
             )
-            .animation(reduceMotion ? nil : .spring(response: 0.25, dampingFraction: 0.8), value: isPressed)
+            .animation(reduceMotion ? nil : Motion.press, value: isPressed)
             .onLongPressGesture(minimumDuration: 0.0, maximumDistance: .infinity) {
                 // 轻触动作由 MemoCardView 内部的 .onTapGesture 处理
                 // 此处不执行任何操作

--- a/DayPage/DesignSystem/Motion.swift
+++ b/DayPage/DesignSystem/Motion.swift
@@ -19,6 +19,10 @@ enum Motion {
     static let slide: Animation = .timingCurve(0.2, 0.8, 0.2, 1, duration: 0.28)
     // Interactive controls with elastic settle (buttons, toggles).
     static let spring: Animation = .spring(response: 0.35, dampingFraction: 0.8)
+    // Press feedback on buttons/chips — quick settle, no visible wobble.
+    // Previously duplicated inline as spring(0.25, 0.8–0.85) across
+    // DSButton / PressableCardModifier.
+    static let press: Animation = .spring(response: 0.25, dampingFraction: 0.85)
     // Panel / card entrance that scales or rises into place (recording panel,
     // popovers, send-confirm settle). Slightly snappier than `spring`. Pair with
     // `.dsAnimation(Motion.panel, value:)` so translation/scale honors Reduce Motion.

--- a/DayPage/DesignSystem/Spacing.swift
+++ b/DayPage/DesignSystem/Spacing.swift
@@ -47,11 +47,4 @@ enum DSSpacing {
     static let iconLabel:  CGFloat = sm       // 8
     /// Bottom safe-area cushion above the home indicator.
     static let bottomDock: CGFloat = lg       // 16
-
-    // MARK: - Legacy aliases (kept for compile compatibility — DO NOT use in new code)
-
-    /// - Deprecated: Use `DSRadius.lg`.
-    static let radiusCard: CGFloat = 12
-    /// - Deprecated: Use `DSRadius.sm`.
-    static let radiusSmall: CGFloat = 8
 }

--- a/DayPage/DesignSystem/Surfaces.swift
+++ b/DayPage/DesignSystem/Surfaces.swift
@@ -34,7 +34,7 @@ enum GlassTone {
 /// Layers: warm tint → ultraThinMaterial (blur 28, saturate 160 %)
 /// → top inner highlight → 0.5 pt hairline → soft drop-shadow stack.
 struct LiquidGlassCard: ViewModifier {
-    var cornerRadius: CGFloat = 18
+    var cornerRadius: CGFloat = DSRadius.lg
     var tone: GlassTone = .std
 
     private var shape: RoundedRectangle {
@@ -87,7 +87,7 @@ struct LiquidGlassCard: ViewModifier {
 /// cards so the content (text + photo) reads cleanly against the warm canvas.
 /// Matches the design token: surface-white #FFF, radius 14, hairline border.
 struct SolidCard: ViewModifier {
-    var cornerRadius: CGFloat = 14
+    var cornerRadius: CGFloat = DSRadius.md
 
     func body(content: Content) -> some View {
         content
@@ -113,7 +113,7 @@ struct SolidCard: ViewModifier {
 struct LiquidGlassPill: ViewModifier {
     func body(content: Content) -> some View {
         content
-            .modifier(LiquidGlassCard(cornerRadius: 999, tone: .hi))
+            .modifier(LiquidGlassCard(cornerRadius: DSRadius.pill, tone: .hi))
     }
 }
 
@@ -133,7 +133,7 @@ struct LiquidGlassPanel: ViewModifier {
 
 extension View {
     /// iOS 26-style Liquid Glass card — the default card surface.
-    func liquidGlassCard(cornerRadius: CGFloat = 18, tone: GlassTone = .std) -> some View {
+    func liquidGlassCard(cornerRadius: CGFloat = DSRadius.lg, tone: GlassTone = .std) -> some View {
         modifier(LiquidGlassCard(cornerRadius: cornerRadius, tone: tone))
     }
 
@@ -148,7 +148,7 @@ extension View {
     }
 
     /// Museum-aesthetic content-first white card (surface-white + hairline).
-    func solidCard(cornerRadius: CGFloat = 14) -> some View {
+    func solidCard(cornerRadius: CGFloat = DSRadius.md) -> some View {
         modifier(SolidCard(cornerRadius: cornerRadius))
     }
 }

--- a/DayPage/DesignSystem/Typography.swift
+++ b/DayPage/DesignSystem/Typography.swift
@@ -71,16 +71,29 @@ enum DSFonts {
 
     // MARK: - Resolved Font Helpers (with system fallbacks)
 
-    static func spaceGrotesk(size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .custom(headline, size: size).weight(weight)
+    /// Pass `relativeTo:` to make the returned font track Dynamic Type — the
+    /// point size is treated as the value at the default (.large) content size
+    /// and scales with the given text style. `nil` keeps the fixed-size
+    /// behaviour for legacy call sites.
+    static func spaceGrotesk(size: CGFloat, weight: Font.Weight = .regular, relativeTo textStyle: Font.TextStyle? = nil) -> Font {
+        if let textStyle {
+            return Font.custom(headline, size: size, relativeTo: textStyle).weight(weight)
+        }
+        return .custom(headline, size: size).weight(weight)
     }
 
-    static func inter(size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .custom(body, size: size).weight(weight)
+    static func inter(size: CGFloat, weight: Font.Weight = .regular, relativeTo textStyle: Font.TextStyle? = nil) -> Font {
+        if let textStyle {
+            return Font.custom(body, size: size, relativeTo: textStyle).weight(weight)
+        }
+        return .custom(body, size: size).weight(weight)
     }
 
-    static func jetBrainsMono(size: CGFloat, weight: Font.Weight = .regular) -> Font {
-        .custom(mono, size: size).weight(weight)
+    static func jetBrainsMono(size: CGFloat, weight: Font.Weight = .regular, relativeTo textStyle: Font.TextStyle? = nil) -> Font {
+        if let textStyle {
+            return Font.custom(mono, size: size, relativeTo: textStyle).weight(weight)
+        }
+        return .custom(mono, size: size).weight(weight)
     }
 
     // MARK: - Cascading Serif (Source Serif 4 + Source Han Serif SC)
@@ -91,7 +104,29 @@ enum DSFonts {
     ///     (Source Han Serif SC has no italic face; iOS renders CJK in upright style even
     ///      when italic is requested — this is the standard platform behaviour for CJK fonts.)
     /// Falls back to the system serif design if any required font face is absent from the bundle.
-    static func serif(size: CGFloat, weight: Font.Weight = .regular, italic: Bool = false) -> Font {
+    ///
+    /// Dynamic Type: fonts built from a concrete `UIFont` do not scale on their
+    /// own (unlike `Font.custom(_:size:relativeTo:)`), so when `relativeTo:` is
+    /// given we scale the point size through `UIFontMetrics` at resolution time.
+    /// The serif `DSType` levels are computed properties so they re-resolve
+    /// whenever a view body re-evaluates after a size-category change.
+    /// `maxSize` caps that scaling for display-size levels, mirroring the
+    /// `.accessibility1` clamp the sans-serif display modifiers apply.
+    static func serif(
+        size: CGFloat,
+        weight: Font.Weight = .regular,
+        italic: Bool = false,
+        relativeTo textStyle: Font.TextStyle? = nil,
+        maxSize: CGFloat? = nil
+    ) -> Font {
+        var size = size
+        if let textStyle {
+            size = UIFontMetrics(forTextStyle: textStyle.uiTextStyle).scaledValue(for: size)
+            if let maxSize {
+                size = min(size, maxSize)
+            }
+        }
+
         // PostScript name mapping for the primary Latin face.
         let latinPS: String
         if italic {
@@ -130,73 +165,107 @@ enum DSFonts {
     }
 }
 
+// MARK: - Font.TextStyle Bridging
+
+private extension Font.TextStyle {
+    /// UIKit counterpart, used to drive `UIFontMetrics` for UIFont-backed
+    /// (cascading serif) fonts that cannot use `Font.custom(relativeTo:)`.
+    var uiTextStyle: UIFont.TextStyle {
+        switch self {
+        case .largeTitle:  return .largeTitle
+        case .title:       return .title1
+        case .title2:      return .title2
+        case .title3:      return .title3
+        case .headline:    return .headline
+        case .subheadline: return .subheadline
+        case .body:        return .body
+        case .callout:     return .callout
+        case .footnote:    return .footnote
+        case .caption:     return .caption1
+        case .caption2:    return .caption2
+        @unknown default:  return .body
+        }
+    }
+}
+
 // MARK: - Typography Levels
 
+/// Every level anchors to the system text style closest to its semantic role
+/// (`relativeTo:`), so custom fonts scale with Dynamic Type: display/hero →
+/// `.largeTitle`, section headers → `.title`/`.title2`/`.title3`, emphasized
+/// 18pt copy → `.headline`, running text → `.body`/`.subheadline`, and
+/// captions/labels/mono chips → `.footnote`/`.caption`/`.caption2`. The point
+/// size is the design value at the default (.large) content size. Serif
+/// levels are computed properties because their UIFont cascade resolves the
+/// scaled size eagerly (see `DSFonts.serif`).
 enum DSType {
     // Display-LG: 56 / Space Grotesk 700 uppercase
-    static let displayLG: Font = DSFonts.spaceGrotesk(size: 56, weight: .bold)
+    static let displayLG: Font = DSFonts.spaceGrotesk(size: 56, weight: .bold, relativeTo: .largeTitle)
 
     // H1: 32 / Space Grotesk 700
-    static let h1: Font = DSFonts.spaceGrotesk(size: 32, weight: .bold)
+    static let h1: Font = DSFonts.spaceGrotesk(size: 32, weight: .bold, relativeTo: .largeTitle)
 
     // H2: 22 / Space Grotesk SemiBold
-    static let h2: Font = DSFonts.spaceGrotesk(size: 22, weight: .semibold)
+    static let h2: Font = DSFonts.spaceGrotesk(size: 22, weight: .semibold, relativeTo: .title2)
 
     // Headline-MD: 24 / Space Grotesk 700 uppercase
-    static let headlineMD: Font = DSFonts.spaceGrotesk(size: 24, weight: .bold)
+    static let headlineMD: Font = DSFonts.spaceGrotesk(size: 24, weight: .bold, relativeTo: .title)
 
     // Headline-Caps: 18 / Space Grotesk 700 uppercase (tracking widest)
-    static let headlineCaps: Font = DSFonts.spaceGrotesk(size: 18, weight: .bold)
+    static let headlineCaps: Font = DSFonts.spaceGrotesk(size: 18, weight: .bold, relativeTo: .headline)
 
     // Section-Label: 13 / Space Grotesk 700 uppercase
-    static let sectionLabel: Font = DSFonts.spaceGrotesk(size: 13, weight: .bold)
+    static let sectionLabel: Font = DSFonts.spaceGrotesk(size: 13, weight: .bold, relativeTo: .footnote)
 
     // Title-SM: 20 / Inter 600
-    static let titleSM: Font = DSFonts.inter(size: 20, weight: .semibold)
+    static let titleSM: Font = DSFonts.inter(size: 20, weight: .semibold, relativeTo: .title3)
 
     // Body-MD: 16 / Inter 400
-    static let bodyMD: Font = DSFonts.inter(size: 16, weight: .regular)
+    static let bodyMD: Font = DSFonts.inter(size: 16, weight: .regular, relativeTo: .body)
 
     // Body-SM: 14 / Inter 400
-    static let bodySM: Font = DSFonts.inter(size: 14, weight: .regular)
+    static let bodySM: Font = DSFonts.inter(size: 14, weight: .regular, relativeTo: .subheadline)
 
     // Caption: 13 / Inter Medium
-    static let caption: Font = DSFonts.inter(size: 13, weight: .medium)
+    static let caption: Font = DSFonts.inter(size: 13, weight: .medium, relativeTo: .footnote)
 
     // Label: 11 / Space Grotesk Bold uppercase
-    static let label: Font = DSFonts.spaceGrotesk(size: 11, weight: .bold)
+    static let label: Font = DSFonts.spaceGrotesk(size: 11, weight: .bold, relativeTo: .caption2)
 
     // Label-SM: 12 / Inter 500
-    static let labelSM: Font = DSFonts.inter(size: 12, weight: .medium)
+    static let labelSM: Font = DSFonts.inter(size: 12, weight: .medium, relativeTo: .caption)
 
     // Label-XS: 10 / Inter 500 or JetBrains Mono
-    static let labelXS: Font = DSFonts.inter(size: 10, weight: .medium)
+    static let labelXS: Font = DSFonts.inter(size: 10, weight: .medium, relativeTo: .caption2)
 
     // Mono-11: 11 / JetBrains Mono 500 uppercase (chips, timestamps)
-    static let mono11: Font = DSFonts.jetBrainsMono(size: 11, weight: .medium)
+    static let mono11: Font = DSFonts.jetBrainsMono(size: 11, weight: .medium, relativeTo: .caption2)
 
     // Mono-10: 10 / JetBrains Mono 400 uppercase
-    static let mono10: Font = DSFonts.jetBrainsMono(size: 10, weight: .regular)
+    static let mono10: Font = DSFonts.jetBrainsMono(size: 10, weight: .regular, relativeTo: .caption2)
 
     // Mono-9: 9 / JetBrains Mono 400 uppercase (badges)
-    static let mono9: Font = DSFonts.jetBrainsMono(size: 9, weight: .regular)
+    static let mono9: Font = DSFonts.jetBrainsMono(size: 9, weight: .regular, relativeTo: .caption2)
 
     // MARK: - V4 Liquid Glass Serif Levels
+    // Computed (not stored) so UIFontMetrics re-resolves on size-category
+    // changes. Display levels carry a `maxSize` cap ≈ the .accessibility1
+    // scale of their anchor style, matching the sans-serif display clamp.
 
     /// Serif body 16pt — memo card body copy.
-    static let serifBody16: Font = DSFonts.serif(size: 16, weight: .regular)
+    static var serifBody16: Font { DSFonts.serif(size: 16, weight: .regular, relativeTo: .body) }
     /// Serif body 18pt — Daily Page card lead summary.
-    static let serifBody18: Font = DSFonts.serif(size: 18, weight: .regular)
+    static var serifBody18: Font { DSFonts.serif(size: 18, weight: .regular, relativeTo: .headline) }
     /// Serif body 20pt — quoted voice transcript.
-    static let serifBody20: Font = DSFonts.serif(size: 20, weight: .regular)
+    static var serifBody20: Font { DSFonts.serif(size: 20, weight: .regular, relativeTo: .title3) }
     /// Serif italic 18pt — voice-memo "quote" style.
-    static let serifQuote: Font = DSFonts.serif(size: 18, italic: true)
+    static var serifQuote: Font { DSFonts.serif(size: 18, italic: true, relativeTo: .headline) }
     /// Serif display 28pt — Today header date.
-    static let serifDisplay28: Font = DSFonts.serif(size: 28, weight: .semibold)
+    static var serifDisplay28: Font { DSFonts.serif(size: 28, weight: .semibold, relativeTo: .title, maxSize: 34) }
     /// Serif display 32pt — sidebar date / large headers.
-    static let serifDisplay32: Font = DSFonts.serif(size: 32, weight: .semibold)
+    static var serifDisplay32: Font { DSFonts.serif(size: 32, weight: .semibold, relativeTo: .largeTitle, maxSize: 41) }
     /// Serif display 56pt — Today hero date title (museum-aesthetic, always-on).
-    static let serifDisplay56: Font = DSFonts.serif(size: 56, weight: .semibold)
+    static var serifDisplay56: Font { DSFonts.serif(size: 56, weight: .semibold, relativeTo: .largeTitle, maxSize: 72) }
 }
 
 // MARK: - View Modifiers
@@ -237,6 +306,10 @@ struct DisplayLGModifier: ViewModifier {
             .font(DSType.displayLG)
             .textCase(.uppercase)
             .tracking(1)
+            // Display sizes explode at accessibility categories — clamp one
+            // notch tighter than H1/H2 (.accessibility2).
+            .dynamicTypeSize(.xSmall ... .accessibility1)
+            .minimumScaleFactor(0.80)
     }
 }
 
@@ -278,11 +351,13 @@ struct BodyMDModifier: ViewModifier {
     @ObservedObject private var appSettings = AppSettings.shared
 
     func body(content: Content) -> some View {
+        // fontSizeAdjust.delta shifts the base size *before* Dynamic Type
+        // scaling — the two mechanisms compose (relativeTo scales `adjusted`).
         let baseSize: CGFloat = 16
         let adjusted = baseSize + appSettings.fontSizeAdjust.delta
         let spacing = max(0, 4 + appSettings.cardDensity.lineSpacingDelta)
         content
-            .font(DSFonts.inter(size: adjusted, weight: .regular))
+            .font(DSFonts.inter(size: adjusted, weight: .regular, relativeTo: .body))
             .lineSpacing(spacing)
             .dynamicTypeSize(.xSmall ... .xxxLarge)
             .minimumScaleFactor(0.85)
@@ -293,11 +368,12 @@ struct BodySMModifier: ViewModifier {
     @ObservedObject private var appSettings = AppSettings.shared
 
     func body(content: Content) -> some View {
+        // Same composition as BodyMDModifier: delta first, then Dynamic Type.
         let baseSize: CGFloat = 14
         let adjusted = baseSize + appSettings.fontSizeAdjust.delta
         let spacing = max(0, 3 + appSettings.cardDensity.lineSpacingDelta)
         content
-            .font(DSFonts.inter(size: adjusted, weight: .regular))
+            .font(DSFonts.inter(size: adjusted, weight: .regular, relativeTo: .subheadline))
             .lineSpacing(spacing)
             .dynamicTypeSize(.xSmall ... .xxxLarge)
             .minimumScaleFactor(0.85)
@@ -322,7 +398,7 @@ struct MonoLabelModifier: ViewModifier {
     let size: CGFloat
     func body(content: Content) -> some View {
         content
-            .font(DSFonts.jetBrainsMono(size: size, weight: .medium))
+            .font(DSFonts.jetBrainsMono(size: size, weight: .medium, relativeTo: .caption2))
             .textCase(.uppercase)
             .tracking(0.5)
     }

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -604,7 +604,7 @@ struct ArchiveView: View {
                                     Spacer()
                                     VStack(spacing: 8) {
                                         ProgressView()
-                                            .tint(DSColor.amberAccent)
+                                            .tint(DSColor.accentOnBg)
                                         Text(NSLocalizedString("archive.loading_month", comment: ""))
                                             .font(DSType.mono9)
                                             .foregroundColor(DSColor.inkSubtle)
@@ -1103,7 +1103,7 @@ struct ArchiveView: View {
 
             // Today dot sits on the amber today-cell fill — onAmber instead
             // of pure white so dark mode keeps the warm-cream language.
-            let dotColor: Color = isToday ? DSColor.onAmber : DSColor.amberAccent
+            let dotColor: Color = isToday ? DSColor.onAmber : DSColor.accentOnBg
 
             Button(action: {
                 Haptics.tapConfirm()
@@ -1372,7 +1372,7 @@ struct ArchiveView: View {
             HStack(alignment: .firstTextBaseline, spacing: 4) {
                 Text(value)
                     .font(DSType.serifDisplay32)
-                    .foregroundColor(accentPrimary ? DSColor.amberDeep : DSColor.inkPrimary)
+                    .foregroundColor(accentPrimary ? DSColor.accentOnBg : DSColor.inkPrimary)
                     .lineLimit(1)
                     .minimumScaleFactor(0.5)
                 if let unit {
@@ -1574,7 +1574,7 @@ struct ArchiveView: View {
         VStack(alignment: .center, spacing: 4) {
             Text(value)
                 .font(DSType.serifDisplay28)
-                .foregroundColor(accent ? DSColor.amberDeep : DSColor.inkPrimary)
+                .foregroundColor(accent ? DSColor.accentOnBg : DSColor.inkPrimary)
                 .lineLimit(1)
                 .minimumScaleFactor(0.5)
             Text(label)
@@ -1620,8 +1620,9 @@ struct ArchiveView: View {
         let title = NSLocalizedString("weekly.recap.entrycard.title", comment: "")
 
         return HStack(alignment: .center, spacing: 14) {
-            Text("📅")
-                .font(.system(size: 28))
+            Image(systemName: "calendar")
+                .font(.system(size: 20, weight: .medium))
+                .foregroundColor(DSColor.accentOnBg)
             VStack(alignment: .leading, spacing: 4) {
                 Text(title)
                     .font(DSType.titleSM)

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -1110,16 +1110,16 @@ struct ArchiveView: View {
                 handleDateTap(dateStr: dateStr)
             }) {
                 ZStack(alignment: .topLeading) {
-                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    RoundedRectangle(cornerRadius: DSRadius.xs, style: .continuous)
                         .fill(fillColor)
                         .overlay(
-                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            RoundedRectangle(cornerRadius: DSRadius.xs, style: .continuous)
                                 .stroke(isToday ? DSColor.amberAccent : DSColor.glassRim,
                                         lineWidth: isToday ? 1.5 : 0.5)
                         )
 
                     if isToday && !reduceMotion {
-                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        RoundedRectangle(cornerRadius: DSRadius.xs, style: .continuous)
                             .stroke(DSColor.amberAccent, lineWidth: 1.5)
                             .opacity(todayPulse ? 1.0 : 0.4)
                             .shadow(color: DSColor.amberAccent.opacity(todayPulse ? 0.6 : 0.2), radius: todayPulse ? 6 : 2)
@@ -1147,7 +1147,7 @@ struct ArchiveView: View {
             .accessibilityValue(viewModel.dayStats[dateStr]?.densityLevel.label ?? "")
             .accessibilityHint("双击打开当天详情")
         } else {
-            RoundedRectangle(cornerRadius: 6, style: .continuous)
+            RoundedRectangle(cornerRadius: DSRadius.xs, style: .continuous)
                 .fill(Color.clear)
                 .aspectRatio(1, contentMode: .fit)
                 .frame(maxWidth: .infinity)
@@ -1269,7 +1269,7 @@ struct ArchiveView: View {
                                 }
                                 .padding(.horizontal, 14)
                                 .padding(.vertical, 10)
-                                .liquidGlassCard(cornerRadius: 10)
+                                .liquidGlassCard(cornerRadius: DSRadius.sm)
                             }
                             .buttonStyle(.plain)
                             .accessibilityLabel(formatArchiveDate(stats.dateString))
@@ -1562,7 +1562,7 @@ struct ArchiveView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 16)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .liquidGlassCard(cornerRadius: DSSpacing.radiusCard)
+        .liquidGlassCard(cornerRadius: DSRadius.md)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel(String(
             format: NSLocalizedString("archive.list.digest.a11y", comment: "Month digest summary"),
@@ -1639,7 +1639,7 @@ struct ArchiveView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .liquidGlassCard(cornerRadius: DSSpacing.radiusCard)
+        .liquidGlassCard(cornerRadius: DSRadius.md)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(title), \(isoWeek)")
         .accessibilityHint(NSLocalizedString("weekly.recap.entrycard.hint", comment: ""))
@@ -1716,7 +1716,7 @@ struct ArchiveView: View {
             }
             .padding(DSSpacing.cardGap)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .liquidGlassCard(cornerRadius: DSSpacing.radiusCard)
+            .liquidGlassCard(cornerRadius: DSRadius.md)
             .pressableCard()
         }
         .buttonStyle(.plain)

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -35,9 +35,23 @@ struct DayDetailView: View {
     /// transition. `.forward` = moved to a later day, `.backward` = earlier.
     private enum PageDirection { case forward, backward }
 
+    /// Live state of an in-flight page drag. `isEngaged` latches once the drag
+    /// is dominantly horizontal so a finger that later wanders vertically keeps
+    /// tracking instead of dropping the page mid-gesture.
+    private struct PageDragState: Equatable {
+        var isEngaged = false
+        var offset: CGFloat = 0
+    }
+
     @State private var state: LoadState = .loading
     @State private var hasRawFile: Bool = false
     @State private var selectedTab: Tab = .daily
+
+    /// Finger-tracked horizontal offset for interactive paging. `@GestureState`
+    /// auto-resets when the gesture ends or is cancelled; the reset transaction
+    /// springs the page back to rest (near-instant under Reduce Motion).
+    @GestureState(resetTransaction: Transaction(animation: Motion.respectReduceMotion(Motion.spring)))
+    private var pageDrag = PageDragState()
 
     /// The day actually on screen. Initialised to `dateString`, then advanced /
     /// rewound by `go(_:)`. Re-running `load()` keyed on this value lets a
@@ -74,10 +88,15 @@ struct DayDetailView: View {
                 // distinct subtree and runs the directional slide transition.
                 .id(currentDate)
                 .transition(dayTransition)
+                // Finger-tracked paging: 1:1 while paging is possible in the
+                // drag direction, rubber-banded at the bounds (see gesture).
+                .offset(x: pageDrag.offset)
             }
-            // Horizontal swipe to page between days. High distance + low-ish
-            // height tolerance keeps it from stealing vertical scrolls inside
-            // the daily/raw content.
+            // Interactive horizontal paging between days: the page follows the
+            // finger once the drag is dominantly sideways, rubber-bands at the
+            // bounds, and commits on distance or flick. `simultaneousGesture`
+            // + the dominance gate keep vertical scrolls inside the daily/raw
+            // content untouched.
             .simultaneousGesture(pageSwipeGesture)
             .navigationTitle(formattedTitle)
             .navigationBarTitleDisplayMode(.inline)
@@ -126,6 +145,12 @@ struct DayDetailView: View {
     /// Forward paging is allowed only while we're strictly before today.
     private var canGoForward: Bool { currentDate < todayString }
 
+    /// Backward paging is allowed whenever a valid previous calendar day
+    /// exists — the same bounds check `go(.backward)` performs.
+    private var canGoBackward: Bool {
+        Self.steppedDate(from: currentDate, forward: false) != nil
+    }
+
     /// Slide the incoming day in from the side it came from; fade only when the
     /// user has Reduce Motion on.
     private var dayTransition: AnyTransition {
@@ -138,17 +163,39 @@ struct DayDetailView: View {
         )
     }
 
+    /// Rubber-band factor applied when dragging toward a bound that cannot page.
+    private static let boundsResistance: CGFloat = 0.3
+
     private var pageSwipeGesture: some Gesture {
         DragGesture(minimumDistance: 24)
-            .onEnded { value in
-                // Treat as horizontal only when the drag is dominantly sideways.
-                guard abs(value.translation.width) > abs(value.translation.height) * 1.5,
-                      abs(value.translation.width) > 60 else { return }
-                if value.translation.width < 0 {
-                    go(.forward)   // drag left → next (later) day
-                } else {
-                    go(.backward)  // drag right → previous (earlier) day
+            .updating($pageDrag) { value, drag, _ in
+                // Engage only once the drag is dominantly sideways, so we never
+                // fight vertical scrolling inside the daily/raw content; after
+                // that, latch and follow the finger for the rest of the gesture.
+                if !drag.isEngaged {
+                    guard abs(value.translation.width) > abs(value.translation.height) * 1.5 else { return }
+                    drag.isEngaged = true
                 }
+                let translation = value.translation.width
+                // drag left → forward (later day); drag right → backward.
+                let canPage = translation < 0 ? canGoForward : canGoBackward
+                drag.offset = canPage ? translation : translation * Self.boundsResistance
+            }
+            .onEnded { value in
+                // Same horizontal-dominance guard as tracking: an end that never
+                // engaged (vertical scroll) must stay a no-op.
+                guard abs(value.translation.width) > abs(value.translation.height) * 1.5 else { return }
+                let screenWidth = UIScreen.main.bounds.width
+                let translation = value.translation.width
+                // `value.velocity` is iOS 17+; the predicted overshoot is the
+                // deceleration-projected distance, so a projection past half the
+                // screen reads as a decisive flick even from a short drag.
+                let projected = value.predictedEndTranslation.width
+                let commit = abs(translation) > screenWidth / 3 || abs(projected) > screenWidth / 2
+                guard commit else { return }  // @GestureState springs offset back to 0
+                // `go(_:)` re-checks the bounds itself, so a committed drag at a
+                // bound stays the same silent no-op as before.
+                go(translation < 0 ? .forward : .backward)
             }
     }
 
@@ -165,7 +212,9 @@ struct DayDetailView: View {
 
         Haptics.soft()
         lastDirection = direction
-        withAnimation(reduceMotion ? nil : Motion.slide) {
+        // Spring (not a fixed timing curve) so a finger-tracked commit settles
+        // with continuous-feeling velocity instead of restarting from zero.
+        withAnimation(reduceMotion ? nil : Motion.spring) {
             state = .loading        // show the loader while the next day resolves
             currentDate = nextString
         }

--- a/DayPage/Features/Archive/WeeklyRecapDetailView.swift
+++ b/DayPage/Features/Archive/WeeklyRecapDetailView.swift
@@ -94,9 +94,14 @@ struct WeeklyRecapDetailView: View {
             ?? WeeklyCompilationService.isoWeekKey(for: referenceDate)
 
         return VStack(alignment: .leading, spacing: 6) {
-            Text("📅 \(NSLocalizedString("weekly.recap.title", comment: ""))")
-                .font(DSType.headlineMD)
-                .foregroundColor(DSColor.inkPrimary)
+            HStack(spacing: 8) {
+                Image(systemName: "calendar")
+                    .font(.system(size: 18, weight: .medium))
+                    .foregroundColor(DSColor.accentOnBg)
+                Text(NSLocalizedString("weekly.recap.title", comment: ""))
+                    .font(DSType.headlineMD)
+                    .foregroundColor(DSColor.inkPrimary)
+            }
             Text("\(isoWeek) · \(rangeText)")
                 .font(DSType.mono11)
                 .foregroundColor(DSColor.inkSubtle)
@@ -141,7 +146,7 @@ struct WeeklyRecapDetailView: View {
             } label: {
                 Text(NSLocalizedString("weekly.recap.refresh", comment: ""))
                     .font(DSType.labelSM)
-                    .foregroundColor(DSColor.amberAccent)
+                    .foregroundColor(DSColor.accentOnBg)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 8)
                     .overlay(
@@ -196,7 +201,7 @@ struct WeeklyRecapDetailView: View {
                         } label: {
                             Text(kw)
                                 .font(DSType.bodyMD)
-                                .foregroundColor(DSColor.amberAccent)
+                                .foregroundColor(DSColor.accentOnBg)
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 6)
                                 .background(
@@ -250,7 +255,7 @@ struct WeeklyRecapDetailView: View {
                 HStack(alignment: .top, spacing: 10) {
                     Image(systemName: "mappin")
                         .font(.system(size: 16))
-                        .foregroundColor(DSColor.amberAccent)
+                        .foregroundColor(DSColor.accentOnBg)
                         .padding(.top, 2)
                     Text(text.isEmpty ? "—" : text)
                         .font(DSType.bodyMD)
@@ -279,7 +284,7 @@ struct WeeklyRecapDetailView: View {
                 HStack(alignment: .top, spacing: 8) {
                     Text("✦")
                         .font(DSType.bodyMD)
-                        .foregroundColor(DSColor.amberAccent)
+                        .foregroundColor(DSColor.accentOnBg)
                     Text(items[idx])
                         .font(DSType.bodyMD)
                         .foregroundColor(DSColor.inkPrimary)
@@ -334,7 +339,7 @@ struct WeeklyRecapDetailView: View {
             } label: {
                 Text(NSLocalizedString("weekly.recap.refresh", comment: ""))
                     .font(DSType.labelSM)
-                    .foregroundColor(DSColor.amberAccent)
+                    .foregroundColor(DSColor.accentOnBg)
                     .padding(.horizontal, 20)
                     .padding(.vertical, 10)
                     .overlay(
@@ -403,7 +408,7 @@ struct WeeklyRecapDetailView: View {
                 } label: {
                     Text(NSLocalizedString("weekly.recap.refresh", comment: ""))
                         .font(DSType.labelSM)
-                        .foregroundColor(DSColor.amberAccent)
+                        .foregroundColor(DSColor.accentOnBg)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 8)
                         .overlay(

--- a/DayPage/Features/Archive/WeeklyRecapDetailView.swift
+++ b/DayPage/Features/Archive/WeeklyRecapDetailView.swift
@@ -343,7 +343,7 @@ struct WeeklyRecapDetailView: View {
                     .padding(.horizontal, 20)
                     .padding(.vertical, 10)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous)
                             .stroke(DSColor.amberRim, lineWidth: 1)
                     )
             }

--- a/DayPage/Features/Archive/YearMonthPicker.swift
+++ b/DayPage/Features/Archive/YearMonthPicker.swift
@@ -183,11 +183,11 @@ struct YearMonthPicker: View {
             .frame(maxWidth: .infinity)
             .frame(height: 52)
             .background(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous)
                     .fill(isSelected ? DSColor.amberDeep : DSColor.glassLo)
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous)
                     .strokeBorder(
                         isRealMonth ? DSColor.amberAccent : DSColor.glassRim,
                         lineWidth: isRealMonth ? 1.5 : 0.5

--- a/DayPage/Features/Archive/YearMonthPicker.swift
+++ b/DayPage/Features/Archive/YearMonthPicker.swift
@@ -176,7 +176,7 @@ struct YearMonthPicker: View {
 
                 // Activity dot — present only when the month holds entries.
                 Circle()
-                    .fill(isSelected ? Color.white : DSColor.amberAccent)
+                    .fill(isSelected ? Color.white : DSColor.accentOnBg)
                     .frame(width: 4, height: 4)
                     .opacity(hasEntries ? 1 : 0)
             }

--- a/DayPage/Features/Ask/AskPastView.swift
+++ b/DayPage/Features/Ask/AskPastView.swift
@@ -150,7 +150,7 @@ struct AskPastView: View {
                     Text(pinned ? "已存入今日" : "存入今日日记")
                         .font(DSType.labelSM)
                 }
-                .foregroundColor(pinned ? DSColor.successGreen : DSColor.amberAccent)
+                .foregroundColor(pinned ? DSColor.successGreen : DSColor.accentOnBg)
             }
             .buttonStyle(.plain)
             .disabled(pinned)
@@ -202,7 +202,7 @@ struct AskPastView: View {
                     HStack(spacing: 8) {
                         Image(systemName: "sparkle")
                             .font(.system(size: 12))
-                            .foregroundColor(DSColor.amberAccent)
+                            .foregroundColor(DSColor.accentOnBg)
                         Text(example)
                             .font(DSType.bodySM)
                             .foregroundColor(DSColor.inkPrimary)
@@ -279,7 +279,7 @@ struct AskPastView: View {
             Button(action: submit) {
                 Image(systemName: "arrow.up.circle.fill")
                     .font(.system(size: 28))
-                    .foregroundColor(canSend ? DSColor.amberAccent : DSColor.inkSubtle)
+                    .foregroundColor(canSend ? DSColor.accentOnBg : DSColor.inkSubtle)
             }
             .disabled(!canSend)
             .accessibilityLabel("发送")

--- a/DayPage/Features/Ask/AskPastView.swift
+++ b/DayPage/Features/Ask/AskPastView.swift
@@ -110,7 +110,7 @@ struct AskPastView: View {
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
                     .background(DSColor.surfaceContainerHigh)
-                    .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
             }
         case .assistant:
             VStack(alignment: .leading, spacing: 10) {
@@ -212,7 +212,7 @@ struct AskPastView: View {
                     .padding(.horizontal, 14)
                     .padding(.vertical, 12)
                     .background(DSColor.surfaceContainerHigh)
-                    .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                 }
                 .buttonStyle(.plain)
             }
@@ -238,7 +238,7 @@ struct AskPastView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(12)
             .background(DSColor.surfaceContainerHigh)
-            .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
     }
 
     // MARK: - Input bar
@@ -252,7 +252,7 @@ struct AskPastView: View {
                 .padding(.horizontal, 14)
                 .padding(.vertical, 10)
                 .background(DSColor.surfaceContainerHigh)
-                .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                 .onSubmit(submit)
 
             // Voice input — mirrors Today composer semantics: tap to start

--- a/DayPage/Features/Auth/AccountSheet.swift
+++ b/DayPage/Features/Auth/AccountSheet.swift
@@ -203,10 +203,10 @@ struct AccountSheet: View {
             HStack(spacing: 14) {
                 Image(systemName: "rectangle.portrait.and.arrow.right")
                     .font(.system(size: 14, weight: .medium))
-                    .foregroundColor(Color(hex: "E05A5A"))
+                    .foregroundColor(DSColor.statusError)
                 Text("退出登录")
                     .font(.custom("Inter-Regular", size: 14))
-                    .foregroundColor(Color(hex: "E05A5A"))
+                    .foregroundColor(DSColor.statusError)
                 Spacer()
             }
             .padding(.horizontal, 20)

--- a/DayPage/Features/Auth/AuthView.swift
+++ b/DayPage/Features/Auth/AuthView.swift
@@ -182,9 +182,9 @@ struct AuthView: View {
         .frame(maxWidth: .infinity)
         .frame(height: 54)
         .background(background)
-        .cornerRadius(14)
+        .cornerRadius(DSRadius.md)
         .overlay(
-            RoundedRectangle(cornerRadius: 14)
+            RoundedRectangle(cornerRadius: DSRadius.md)
                 .stroke(border, lineWidth: 1)
         )
     }

--- a/DayPage/Features/Auth/AuthView.swift
+++ b/DayPage/Features/Auth/AuthView.swift
@@ -25,7 +25,7 @@ struct AuthView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: "0A0A0A")
+            DSColor.bgWarm
                 .ignoresSafeArea()
 
             GrainOverlay()
@@ -37,11 +37,11 @@ struct AuthView: View {
                 VStack(spacing: 8) {
                     Text("DayPage")
                         .font(.custom("SpaceGrotesk-Bold", size: 32))
-                        .foregroundColor(Color(hex: "F5F0E8"))
+                        .foregroundColor(DSColor.inkPrimary)
 
                     Text(NSLocalizedString("auth.tagline", comment: "AuthView brand tagline under DayPage logo"))
                         .font(.custom("SpaceGrotesk-Regular", size: 15))
-                        .foregroundColor(Color(hex: "6B6B6B"))
+                        .foregroundColor(DSColor.inkSecondary)
                 }
                 .frame(maxWidth: .infinity)
 
@@ -50,7 +50,7 @@ struct AuthView: View {
                 if let errorText = viewModel.errorMessage {
                     Text(errorText)
                         .font(.system(size: 14))
-                        .foregroundColor(Color(hex: "E05A5A"))
+                        .foregroundColor(DSColor.statusError)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 32)
                         .padding(.bottom, 12)
@@ -66,7 +66,7 @@ struct AuthView: View {
                     } label: {
                         Text(NSLocalizedString("auth.skip", comment: "AuthView Skip-login button"))
                             .font(.custom("Inter-Regular", size: 13))
-                            .foregroundColor(Color(hex: "4A4A4A"))
+                            .foregroundColor(DSColor.inkMuted)
                     }
                     .padding(.top, 16)
                     .padding(.bottom, 32)
@@ -79,7 +79,7 @@ struct AuthView: View {
 
             if viewModel.isLoading {
                 ProgressView()
-                    .tint(.white)
+                    .tint(DSColor.inkPrimary)
             }
         }
         .task {
@@ -101,10 +101,10 @@ struct AuthView: View {
                 authButtonLoadingLabel(
                     icon: "apple.logo",
                     label: "Continue with Apple",
-                    iconColor: .white,
-                    labelColor: .white,
-                    background: Color(hex: "1A1A1A"),
-                    border: Color(hex: "2A2A2A"),
+                    iconColor: DSColor.onAmber,
+                    labelColor: DSColor.onAmber,
+                    background: DSColor.amberDeep,
+                    border: DSColor.amberRim,
                     isLoading: viewModel.isLoading
                 )
             }
@@ -119,10 +119,10 @@ struct AuthView: View {
                 authButtonLabel(
                     icon: "envelope",
                     label: "Continue with Email",
-                    iconColor: Color(hex: "A0A0A0"),
-                    labelColor: Color(hex: "A0A0A0"),
-                    background: Color(hex: "0A0A0A"),
-                    border: Color(hex: "222222")
+                    iconColor: DSColor.inkSecondary,
+                    labelColor: DSColor.inkSecondary,
+                    background: DSColor.surfaceWhite,
+                    border: DSColor.inkFaint
                 )
             }
             .buttonStyle(AuthButtonStyle())
@@ -173,8 +173,10 @@ struct AuthView: View {
             .opacity(isLoading ? 0 : 1)
 
             if isLoading {
+                // Loading spinner sits on the amber-filled CTA — use onAmber
+                // (near-white in both schemes) so it stays legible on the fill.
                 ProgressView()
-                    .tint(.white)
+                    .tint(DSColor.onAmber)
             }
         }
         .frame(maxWidth: .infinity)

--- a/DayPage/Features/Auth/EmailAuthView.swift
+++ b/DayPage/Features/Auth/EmailAuthView.swift
@@ -31,7 +31,7 @@ struct EmailAuthView: View {
 
     var body: some View {
         ZStack {
-            Color(hex: "0A0A0A").ignoresSafeArea()
+            DSColor.bgWarm.ignoresSafeArea()
             GrainOverlay()
 
             Group {
@@ -69,19 +69,19 @@ struct EmailAuthView: View {
 
                 Text("Enter your email")
                     .font(.custom("SpaceGrotesk-Bold", size: 24))
-                    .foregroundColor(Color(hex: "F5F0E8"))
+                    .foregroundColor(DSColor.inkPrimary)
 
                 Spacer().frame(height: 8)
 
                 Text("We'll send you a 6-digit code.")
                     .font(.custom("Inter-Regular", size: 14))
-                    .foregroundColor(Color(hex: "6B6B6B"))
+                    .foregroundColor(DSColor.inkSecondary)
 
                 Spacer().frame(height: 24)
 
-                TextField("", text: $viewModel.email, prompt: Text("you@domain.com").foregroundColor(Color(hex: "4A4A4A")))
+                TextField("", text: $viewModel.email, prompt: Text("you@domain.com").foregroundColor(DSColor.inkMuted))
                     .font(.custom("Inter-Regular", size: 17))
-                    .foregroundColor(Color(hex: "F5F0E8"))
+                    .foregroundColor(DSColor.inkPrimary)
                     .textContentType(.emailAddress)
                     .keyboardType(.emailAddress)
                     .autocapitalization(.none)
@@ -93,11 +93,11 @@ struct EmailAuthView: View {
                     }
                     .padding(.horizontal, 16)
                     .frame(height: 52)
-                    .background(Color(hex: "1E1E1E"))
+                    .background(DSColor.surfaceWhite)
                     .cornerRadius(12)
                     .overlay(
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(Color(hex: "2A2A2A"), lineWidth: 1)
+                            .stroke(DSColor.inkFaint, lineWidth: 1)
                     )
 
                 Spacer().frame(height: 16)
@@ -105,7 +105,7 @@ struct EmailAuthView: View {
                 if let errorMessage = viewModel.errorMessage {
                     Text(errorMessage)
                         .font(.system(size: 14))
-                        .foregroundColor(Color(hex: "E05A5A"))
+                        .foregroundColor(DSColor.statusError)
                         .padding(.bottom, 8)
                         .transition(.opacity)
                         .animation(.easeInOut(duration: 0.2), value: viewModel.errorMessage)
@@ -117,17 +117,19 @@ struct EmailAuthView: View {
                     ZStack {
                         Text("Send Code")
                             .font(.custom("SpaceGrotesk-Medium", size: 16))
-                            .foregroundColor(viewModel.isValidEmail ? Color(hex: "0A0A0A") : Color(hex: "4A4A4A"))
+                            .foregroundColor(viewModel.isValidEmail ? DSColor.onAmber : DSColor.inkMuted)
                             .opacity(viewModel.isSending ? 0 : 1)
 
                         if viewModel.isSending {
+                            // Spinner only shows while the button is enabled
+                            // (amberDeep fill), so onAmber keeps it legible.
                             ProgressView()
-                                .tint(Color(hex: "0A0A0A"))
+                                .tint(DSColor.onAmber)
                         }
                     }
                     .frame(maxWidth: .infinity)
                     .frame(height: 54)
-                    .background(viewModel.isValidEmail ? Color(hex: "F5F0E8") : Color(hex: "1A1A1A"))
+                    .background(viewModel.isValidEmail ? DSColor.amberDeep : DSColor.surfaceSunken)
                     .cornerRadius(14)
                 }
                 .buttonStyle(EmailSubmitButtonStyle())
@@ -151,7 +153,7 @@ struct EmailAuthView: View {
             dismiss()
         } label: {
             Image(systemName: "chevron.left")
-                .foregroundColor(Color(hex: "6B6B6B"))
+                .foregroundColor(DSColor.inkSecondary)
                 .font(.system(size: 18, weight: .medium))
                 .padding(.vertical, 6)
         }

--- a/DayPage/Features/Auth/EmailAuthView.swift
+++ b/DayPage/Features/Auth/EmailAuthView.swift
@@ -130,7 +130,7 @@ struct EmailAuthView: View {
                     .frame(maxWidth: .infinity)
                     .frame(height: 54)
                     .background(viewModel.isValidEmail ? DSColor.amberDeep : DSColor.surfaceSunken)
-                    .cornerRadius(14)
+                    .cornerRadius(DSRadius.md)
                 }
                 .buttonStyle(EmailSubmitButtonStyle())
                 .disabled(!viewModel.isValidEmail || viewModel.isSending)

--- a/DayPage/Features/Auth/OTPVerificationView.swift
+++ b/DayPage/Features/Auth/OTPVerificationView.swift
@@ -153,9 +153,9 @@ struct OTPVerificationView: View {
             return isActive ? DSColor.inkPrimary : DSColor.inkFaint
         }()
         return ZStack {
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: DSRadius.sm)
                 .fill(DSColor.surfaceWhite)
-            RoundedRectangle(cornerRadius: 10)
+            RoundedRectangle(cornerRadius: DSRadius.sm)
                 .stroke(strokeColor, lineWidth: isActive && !isSuccess ? 1.5 : 1)
             if let digit = digit {
                 Text(String(digit))

--- a/DayPage/Features/Auth/OTPVerificationView.swift
+++ b/DayPage/Features/Auth/OTPVerificationView.swift
@@ -26,13 +26,15 @@ struct OTPVerificationView: View {
     @FocusState private var codeFieldFocused: Bool
 
     private let codeLength = 6
-    private let successGreen = Color(hex: "6EBE71")
+    // Adaptive DS success token (was hardcoded #6EBE71, tuned for the old
+    // near-black palette and illegible on the light warm-cream background).
+    private let successGreen = DSColor.statusSuccess
 
     // MARK: Body
 
     var body: some View {
         ZStack {
-            Color(hex: "0A0A0A").ignoresSafeArea()
+            DSColor.bgWarm.ignoresSafeArea()
             GrainOverlay()
 
             VStack(alignment: .leading, spacing: 0) {
@@ -57,7 +59,7 @@ struct OTPVerificationView: View {
                 if let errorMessage = viewModel.displayedErrorMessage {
                     Text(errorMessage)
                         .font(.system(size: 14))
-                        .foregroundColor(Color(hex: "E05A5A"))
+                        .foregroundColor(DSColor.statusError)
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .padding(.bottom, 4)
@@ -75,7 +77,7 @@ struct OTPVerificationView: View {
 
             if viewModel.isVerifying {
                 ProgressView()
-                    .tint(.white)
+                    .tint(DSColor.inkPrimary)
             }
         }
         .task {
@@ -103,7 +105,7 @@ struct OTPVerificationView: View {
             onBack?()
         } label: {
             Image(systemName: "chevron.left")
-                .foregroundColor(Color(hex: "6B6B6B"))
+                .foregroundColor(DSColor.inkSecondary)
                 .font(.system(size: 18, weight: .medium))
                 .padding(.vertical, 6)
         }
@@ -113,15 +115,15 @@ struct OTPVerificationView: View {
     private var heading: some View {
         Text("Enter verification code")
             .font(.custom("SpaceGrotesk-Bold", size: 24))
-            .foregroundColor(Color(hex: "F5F0E8"))
+            .foregroundColor(DSColor.inkPrimary)
     }
 
     private var subheading: some View {
         (
             Text("We sent a 6-digit code to\n")
-                .foregroundColor(Color(hex: "6B6B6B"))
+                .foregroundColor(DSColor.inkSecondary)
             + Text(email)
-                .foregroundColor(Color(hex: "F5F0E8"))
+                .foregroundColor(DSColor.inkPrimary)
         )
         .font(.custom("Inter-Regular", size: 14))
         .lineSpacing(4)
@@ -148,20 +150,20 @@ struct OTPVerificationView: View {
         let isSuccess = index <= viewModel.successStagger
         let strokeColor: Color = {
             if isSuccess { return successGreen }
-            return isActive ? Color(hex: "F5F0E8") : Color(hex: "2A2A2A")
+            return isActive ? DSColor.inkPrimary : DSColor.inkFaint
         }()
         return ZStack {
             RoundedRectangle(cornerRadius: 10)
-                .fill(Color(hex: "1A1A1A"))
+                .fill(DSColor.surfaceWhite)
             RoundedRectangle(cornerRadius: 10)
                 .stroke(strokeColor, lineWidth: isActive && !isSuccess ? 1.5 : 1)
             if let digit = digit {
                 Text(String(digit))
                     .font(.custom("JetBrainsMono-Regular", size: 24))
-                    .foregroundColor(isSuccess ? successGreen : Color(hex: "F5F0E8"))
+                    .foregroundColor(isSuccess ? successGreen : DSColor.inkPrimary)
             } else if isActive {
                 Rectangle()
-                    .fill(Color(hex: "F5F0E8"))
+                    .fill(DSColor.inkPrimary)
                     .frame(width: 1, height: 22)
                     .opacity(0.8)
             }
@@ -180,13 +182,13 @@ struct OTPVerificationView: View {
                 Text("Paste \(viewModel.clipboardCode ?? "")")
                     .font(.custom("SpaceGrotesk-Medium", size: 13))
             }
-            .foregroundColor(Color(hex: "F5F0E8"))
+            .foregroundColor(DSColor.inkPrimary)
             .padding(.horizontal, 14)
             .padding(.vertical, 8)
             .background(
                 Capsule()
-                    .fill(Color(hex: "1A1A1A"))
-                    .overlay(Capsule().stroke(Color(hex: "2A2A2A"), lineWidth: 1))
+                    .fill(DSColor.surfaceWhite)
+                    .overlay(Capsule().stroke(DSColor.inkFaint, lineWidth: 1))
             )
         }
         .frame(maxWidth: .infinity, alignment: .center)
@@ -218,7 +220,7 @@ struct OTPVerificationView: View {
         HStack(spacing: 6) {
             Text("Didn't get it?")
                 .font(.custom("Inter-Regular", size: 13))
-                .foregroundColor(Color(hex: "6B6B6B"))
+                .foregroundColor(DSColor.inkSecondary)
             Button {
                 Task { await viewModel.triggerResend() }
             } label: {
@@ -229,7 +231,9 @@ struct OTPVerificationView: View {
                         : "Resend code"
                 )
                 .font(.custom("SpaceGrotesk-Medium", size: 13))
-                .foregroundColor(blocked ? Color(hex: "4A4A4A") : Color(hex: "F5F0E8"))
+                // Enabled resend is a tappable text link — accentOnBg (amber
+                // ink) gives it the DS link affordance in both schemes.
+                .foregroundColor(blocked ? DSColor.inkMuted : DSColor.accentOnBg)
             }
             .disabled(
                 (!viewModel.canResendImmediately && viewModel.resendCountdown > 0)

--- a/DayPage/Features/Daily/DailyPageSummarySection.swift
+++ b/DayPage/Features/Daily/DailyPageSummarySection.swift
@@ -150,7 +150,7 @@ struct DailyPageSummarySection: View {
     private func mentionCapsule(_ mention: String) -> some View {
         Text(mention)
             .font(DSFonts.inter(size: 12, weight: .medium))
-            .foregroundColor(DSColor.amberDeep)
+            .foregroundColor(DSColor.accentOnBg)
             .padding(.horizontal, 10)
             .padding(.vertical, 5)
             .background(DSColor.amberSoft)

--- a/DayPage/Features/Daily/DailyPageSummarySection.swift
+++ b/DayPage/Features/Daily/DailyPageSummarySection.swift
@@ -80,10 +80,10 @@ struct DailyPageSummarySection: View {
                 .padding(.vertical, 5)
                 .background(DSColor.surfaceSunken)
                 .overlay(
-                    RoundedRectangle(cornerRadius: DSSpacing.radiusSmall)
+                    RoundedRectangle(cornerRadius: 8)
                         .strokeBorder(DSColor.glassRimD, lineWidth: 0.5)
                 )
-                .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusSmall))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
             }
             .buttonStyle(.plain)
             .simultaneousGesture(TapGesture().onEnded { HapticFeedback.soft() })

--- a/DayPage/Features/Daily/DailyPageView.swift
+++ b/DayPage/Features/Daily/DailyPageView.swift
@@ -451,7 +451,7 @@ struct DailyPageView: View {
                         .frame(width: 28, height: 28)
                     Text(kindIcon)
                         .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
-                        .foregroundColor(DSColor.amberDeep)
+                        .foregroundColor(DSColor.accentOnBg)
                 }
 
                 // Truncated body
@@ -478,7 +478,7 @@ struct DailyPageView: View {
         VStack(alignment: .leading, spacing: 0) {
             HStack(spacing: 8) {
                 Circle()
-                    .fill(DSColor.amberAccent)
+                    .fill(DSColor.accentOnBg)
                     .frame(width: 8, height: 8)
                     .shadow(color: DSColor.amberGlow, radius: 6, x: 0, y: 0)
                 Text("COMPILED \(model.entriesCount) SIGNALS")
@@ -612,7 +612,7 @@ struct DailyPageView: View {
                 Button(action: { sendFreeform(compiledText: compiledText) }) {
                     Image(systemName: "arrow.up.circle.fill")
                         .font(.system(size: 24))
-                        .foregroundColor(canSendFreeform ? DSColor.amberAccent : DSColor.inkSubtle)
+                        .foregroundColor(canSendFreeform ? DSColor.accentOnBg : DSColor.inkSubtle)
                 }
                 .buttonStyle(.plain)
                 .disabled(!canSendFreeform)

--- a/DayPage/Features/Daily/DailyPageView.swift
+++ b/DayPage/Features/Daily/DailyPageView.swift
@@ -379,7 +379,7 @@ struct DailyPageView: View {
                     .buttonStyle(.plain)
                 }
             }
-            .liquidGlassCard(cornerRadius: 18, tone: .std)
+            .liquidGlassCard(cornerRadius: DSRadius.lg, tone: .std)
             .padding(4)
         }
     }
@@ -605,7 +605,7 @@ struct DailyPageView: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 9)
                     .background(DSColor.amberSoft.opacity(0.5))
-                    .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
 
                 InlineMicButton { transcript in freeformDraft = transcript }
 

--- a/DayPage/Features/Daily/InlineMicButton.swift
+++ b/DayPage/Features/Daily/InlineMicButton.swift
@@ -26,7 +26,7 @@ struct InlineMicButton: View {
                 ProgressView()
                     .progressViewStyle(.circular)
                     .scaleEffect(0.7)
-                    .tint(DSColor.amberAccent)
+                    .tint(DSColor.accentOnBg)
                     .frame(width: 32, height: 32)
             } else {
                 Circle()
@@ -35,7 +35,7 @@ struct InlineMicButton: View {
                     .overlay(
                         Image(systemName: isRecording ? "mic.fill" : "mic")
                             .font(.system(size: 14, weight: .medium))
-                            .foregroundColor(isRecording ? .white : DSColor.amberAccent)
+                            .foregroundColor(isRecording ? .white : DSColor.accentOnBg)
                     )
                     .scaleEffect(pulseScale)
             }

--- a/DayPage/Features/Daily/ThreadConversationView.swift
+++ b/DayPage/Features/Daily/ThreadConversationView.swift
@@ -28,7 +28,7 @@ struct ThreadConversationView: View {
             }
         }
         .background(DSColor.surfaceContainerHigh)
-        .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
         // Expand/collapse shifts content position (`.move` transition above) —
         // route through the shared `expand` token so it honors Reduce Motion.
         .dsAnimation(Motion.expand, value: vm.isExpanded)

--- a/DayPage/Features/Daily/ThreadConversationView.swift
+++ b/DayPage/Features/Daily/ThreadConversationView.swift
@@ -39,7 +39,7 @@ struct ThreadConversationView: View {
     private var questionHeader: some View {
         HStack(alignment: .top, spacing: 10) {
             RoundedRectangle(cornerRadius: 2)
-                .fill(DSColor.amberAccent)
+                .fill(DSColor.accentOnBg)
                 .frame(width: 3, height: 20)
 
             Text(vm.question ?? "自由追问")
@@ -154,7 +154,7 @@ struct ThreadConversationView: View {
             Button(action: sendFollowUp) {
                 Image(systemName: "arrow.up.circle.fill")
                     .font(.system(size: 22))
-                    .foregroundColor(canSend ? DSColor.amberAccent : DSColor.inkSubtle)
+                    .foregroundColor(canSend ? DSColor.accentOnBg : DSColor.inkSubtle)
             }
             .buttonStyle(.plain)
             .disabled(!canSend)
@@ -170,7 +170,7 @@ struct ThreadConversationView: View {
     private var aiBadge: some View {
         Text("AI")
             .font(DSFonts.jetBrainsMono(size: 9, weight: .medium))
-            .foregroundColor(DSColor.amberDeep)
+            .foregroundColor(DSColor.accentOnBg)
             .padding(.horizontal, 5)
             .padding(.vertical, 2)
             .background(DSColor.amberSoft)
@@ -205,7 +205,7 @@ private struct MessageBubble: View {
 
             Text(message.text)
                 .font(DSType.serifBody16)
-                .foregroundColor(isUser ? DSColor.amberDeep : DSColor.inkPrimary)
+                .foregroundColor(isUser ? DSColor.accentOnBg : DSColor.inkPrimary)
                 .lineSpacing(5)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 8)
@@ -239,7 +239,7 @@ private struct TypingIndicator: View {
         HStack(spacing: 3) {
             ForEach(0..<3, id: \.self) { i in
                 Circle()
-                    .fill(DSColor.amberAccent.opacity(i == phase ? 1.0 : 0.3))
+                    .fill(DSColor.accentOnBg.opacity(i == phase ? 1.0 : 0.3))
                     .frame(width: 5, height: 5)
                     .scaleEffect(i == phase ? 1.3 : 1.0)
                     .animation(.easeInOut(duration: 0.22), value: phase)

--- a/DayPage/Features/Entity/EntityPageView.swift
+++ b/DayPage/Features/Entity/EntityPageView.swift
@@ -455,13 +455,17 @@ struct EntityPageView: View {
     }
 
     private func backlinksHeader(count: Int) -> some View {
-        // "📌 被 N 个 memo 引用" — count = total linkedMemos (not the visible
+        // "被 N 个 memo 引用" — count = total linkedMemos (not the visible
         // window) so the header always reflects the full backlink fan-in.
         HStack(spacing: 16) {
-            Text("📌 被 \(count) 个 memo 引用")
-                .font(.custom("SpaceGrotesk-Bold", size: 11))
-                .foregroundColor(DSColor.outline)
-                .kerning(2)
+            HStack(spacing: 5) {
+                Image(systemName: "pin.fill")
+                    .font(.system(size: 9, weight: .semibold))
+                Text("被 \(count) 个 memo 引用")
+                    .font(.custom("SpaceGrotesk-Bold", size: 11))
+                    .kerning(2)
+            }
+            .foregroundColor(DSColor.outline)
             Rectangle()
                 .fill(DSColor.outlineVariant)
                 .frame(height: 1)

--- a/DayPage/Features/Feedback/FeedbackView.swift
+++ b/DayPage/Features/Feedback/FeedbackView.swift
@@ -416,7 +416,7 @@ struct FeedbackView: View {
                     vm.reset()
                 }
                 .font(.custom("Inter-Medium", size: 13))
-                .foregroundColor(DSColor.accentAmber)
+                .foregroundColor(DSColor.accentOnBg)
             }
             .padding(.top, 4)
         }

--- a/DayPage/Features/Feedback/FeedbackView.swift
+++ b/DayPage/Features/Feedback/FeedbackView.swift
@@ -106,10 +106,10 @@ struct FeedbackView: View {
             sectionLabel("Your Feedback")
 
             ZStack(alignment: .topLeading) {
-                RoundedRectangle(cornerRadius: 10)
+                RoundedRectangle(cornerRadius: DSRadius.sm)
                     .fill(DSColor.surfaceWhite)
                     .overlay(
-                        RoundedRectangle(cornerRadius: 10)
+                        RoundedRectangle(cornerRadius: DSRadius.sm)
                             .stroke(DSColor.borderDefault, lineWidth: 1)
                     )
 
@@ -298,10 +298,10 @@ struct FeedbackView: View {
             .padding(.vertical, 22)
             .background(DSColor.surfaceWhite)
             .overlay(
-                RoundedRectangle(cornerRadius: 14)
+                RoundedRectangle(cornerRadius: DSRadius.md)
                     .stroke(DSColor.borderDefault, lineWidth: 1)
             )
-            .cornerRadius(14)
+            .cornerRadius(DSRadius.md)
             .padding(.bottom, 120)
         }
         .frame(maxWidth: .infinity)
@@ -445,7 +445,7 @@ struct FeedbackView: View {
         }
         .padding(12)
         .background(DSColor.errorSoft)
-        .cornerRadius(10)
+        .cornerRadius(DSRadius.sm)
         .padding(.vertical, 8)
     }
 

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -1160,8 +1160,8 @@ struct GraphView: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
             // #771: zero-match toast → glass engine (.toast). Engine owns rim.
-            .dpGlass(.toast, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
-            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+            .dpGlass(.toast, in: RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
             .accessibilityLabel(msg)
     }
 

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -40,6 +40,11 @@ struct GraphView: View {
     // Auto-fit state — fires once when simulation settles; re-arms on node-set change
     @State private var didAutoFit: Bool = false
 
+    // Accessibility-layer position snapshot (model space, node.id → position).
+    // Captured when the simulation starts (initial layout) and settles/stops,
+    // so the VoiceOver element ForEach never re-lays-out per simulation frame.
+    @State private var a11yPositions: [String: CGPoint] = [:]
+
     // Zero-match haptic guard — fires warn() exactly once per zero-crossing
     @State private var lastZeroQuery: String? = nil
 
@@ -627,12 +632,37 @@ struct GraphView: View {
         }
     }
 
+    // MARK: - Hit Testing
+
+    /// Finds the nearest visible node whose screen-space hit radius contains
+    /// the tap location. Mirrors the deleted invisible tap-target circles:
+    /// screen position = model position * scale + offset + size/2, hit radius
+    /// = max(displayRadius * scale, 22) — same 44pt minimum touch target.
+    private func hitTestNode(at location: CGPoint, in size: CGSize) -> GraphNode? {
+        var best: GraphNode? = nil
+        var bestDistance = CGFloat.greatestFiniteMagnitude
+        for node in visibleNodes {
+            let x = node.position.x * scale + offset.width + size.width / 2
+            let y = node.position.y * scale + offset.height + size.height / 2
+            let r = max(node.displayRadius * scale, 22)
+            let dx = location.x - x
+            let dy = location.y - y
+            let distance = (dx * dx + dy * dy).squareRoot()
+            if distance <= r && distance < bestDistance {
+                bestDistance = distance
+                best = node
+            }
+        }
+        return best
+    }
+
     // MARK: - Graph Canvas
 
     private var graphCanvas: some View {
         GeometryReader { geo in
             let size = geo.size
-            let filteredIDs = Set(visibleNodes.map { $0.id })
+            let visible = visibleNodes
+            let filteredIDs = Set(visible.map { $0.id })
 
             ZStack {
                 Canvas { ctx, _ in
@@ -665,6 +695,28 @@ struct GraphView: View {
                         ctx.fill(Path(ellipseIn: rect), with: .color(node.color.opacity(alpha)))
                         ctx.stroke(Path(ellipseIn: rect), with: .color(node.color.opacity(0.6 * alpha)), lineWidth: 1.5 * scale)
                     }
+
+                    // Node labels (filtered only) — drawn in-Canvas so the label
+                    // layer no longer re-lays-out dozens of SwiftUI Text views on
+                    // every simulation frame (Axiom perf audit). Same font token,
+                    // color, weight, and below-node offset as the old label ForEach.
+                    // VoiceOver names come from the accessibility layer below.
+                    let query = viewModel.searchQuery
+                    for node in visible {
+                        let x = node.position.x * scale + offset.width + size.width / 2
+                        let y = node.position.y * scale + offset.height + size.height / 2
+                        let isSearchMatch = !query.isEmpty
+                            && node.name.localizedCaseInsensitiveContains(query)
+                        let label = Text(node.name)
+                            .font(.custom("JetBrainsMono-Regular", fixedSize: max(8, 10 * scale)))
+                            .fontWeight(isSearchMatch ? .bold : .regular)
+                            .foregroundColor(isSearchMatch ? DSColor.amberDeep : DSColor.inkPrimary)
+                        ctx.draw(
+                            label,
+                            at: CGPoint(x: x, y: y + node.displayRadius * scale + 10 * scale),
+                            anchor: .center
+                        )
+                    }
                 }
                 .frame(width: size.width, height: size.height)
                 .accessibilityHidden(true)
@@ -692,34 +744,26 @@ struct GraphView: View {
                     }
                 }
 
-                // Node labels (filtered only) — hidden from VoiceOver; the tap target below announces the name
-                ForEach(visibleNodes) { node in
-                    let x = node.position.x * scale + offset.width + size.width / 2
-                    let y = node.position.y * scale + offset.height + size.height / 2
-                    let isSearchMatch = !viewModel.searchQuery.isEmpty
-                        && node.name.localizedCaseInsensitiveContains(viewModel.searchQuery)
-                    Text(node.name)
-                        .font(.custom("JetBrainsMono-Regular", fixedSize: max(8, 10 * scale)))
-                        .foregroundColor(isSearchMatch ? DSColor.amberDeep : DSColor.inkPrimary)
-                        .fontWeight(isSearchMatch ? .bold : .regular)
-                        .lineLimit(1)
-                        .fixedSize()
-                        .position(x: x, y: y + node.displayRadius * scale + 10 * scale)
-                        .accessibilityHidden(true)
-                }
-
-                // Invisible tap targets for each filtered node
-                ForEach(visibleNodes) { node in
-                    let x = node.position.x * scale + offset.width + size.width / 2
-                    let y = node.position.y * scale + offset.height + size.height / 2
+                // Accessibility layer — VoiceOver-only elements for each filtered
+                // node. The visual labels are drawn inside the Canvas above and
+                // touch is handled by the SpatialTapGesture hit-test on the
+                // container, so these circles carry accessibility ONLY (hit
+                // testing disabled). Positions come from a snapshot frozen when
+                // the force simulation settles/stops — never from the live
+                // per-frame simulation positions — so this ForEach does not
+                // re-layout the SwiftUI view graph on every simulation tick.
+                // While the simulation is still running, VoiceOver targets may
+                // lag the drawn nodes by up to one settle cycle; by design.
+                ForEach(visible) { node in
+                    let pos = a11yPositions[node.id] ?? node.position
+                    let x = pos.x * scale + offset.width + size.width / 2
+                    let y = pos.y * scale + offset.height + size.height / 2
                     let r = max(node.displayRadius * scale, 22)
                     Circle()
                         .fill(Color.clear)
                         .frame(width: r * 2, height: r * 2)
-                        .contentShape(Circle())
                         .position(x: x, y: y)
-                        .onTapGesture(count: 2) { focusNode(node, in: size) }
-                        .onTapGesture { openNode(node) }
+                        .allowsHitTesting(false)
                         .accessibilityElement()
                         // R4 — VoiceOver gets entity name + recurrence count
                         // so users can scan the graph by frequency without
@@ -758,10 +802,29 @@ struct GraphView: View {
                 if isTransformed { zoomIndicator }
                 zoomControls
             }
-            .onTapGesture(count: 2) {
-                Haptics.soft()
-                fitToContent(in: size)
-            }
+            // Tap handling for the whole canvas — replaces the old per-node
+            // invisible tap-target circles. Double tap wins over single tap
+            // (.exclusively), matching the previous layered onTapGesture
+            // precedence: double-tap on a node focuses it, double-tap on empty
+            // space fits content, single tap on a node opens its entity page.
+            .gesture(
+                SpatialTapGesture(count: 2)
+                    .onEnded { value in
+                        if let node = hitTestNode(at: value.location, in: size) {
+                            focusNode(node, in: size)
+                        } else {
+                            Haptics.soft()
+                            fitToContent(in: size)
+                        }
+                    }
+                    .exclusively(
+                        before: SpatialTapGesture()
+                            .onEnded { value in
+                                guard let node = hitTestNode(at: value.location, in: size) else { return }
+                                openNode(node)
+                            }
+                    )
+            )
             .accessibilityAction(named: Text(NSLocalizedString("Reset view", comment: "VoiceOver: graph canvas reset-view action"))) {
                 Haptics.soft()
                 fitToContent(in: size)
@@ -1226,8 +1289,21 @@ struct GraphView: View {
         fitToScreen(in: simulationSize)
     }
 
+    /// Freezes current node positions for the VoiceOver accessibility layer.
+    /// Called when the simulation starts (initial layout) and when it stops
+    /// (settled, view disappeared, or app backgrounded). While the simulation
+    /// runs, accessibility targets intentionally stay at the last snapshot.
+    private func snapshotAccessibilityPositions() {
+        a11yPositions = Dictionary(
+            uniqueKeysWithValues: viewModel.nodes.map { ($0.id, $0.position) }
+        )
+    }
+
     private func startSimulation(reset: Bool = true) {
-        if reset { simulationSteps = 0 }
+        if reset {
+            simulationSteps = 0
+            snapshotAccessibilityPositions()
+        }
         // CADisplayLink ticks on the main thread @ 30fps; controller is
         // idempotent (start() is a no-op when already running), so we just
         // reinstall the closure to capture the latest state and (re)start it.
@@ -1247,6 +1323,9 @@ struct GraphView: View {
 
     private func stopSimulation() {
         displayLink.stop()
+        // Simulation halted — re-sync the accessibility layer to the final
+        // (settled) node positions.
+        snapshotAccessibilityPositions()
     }
 }
 

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -161,7 +161,7 @@ struct MemoDetailView: View {
                                 .frame(minHeight: 120)
                                 .scrollContentBackground(.hidden)
                                 .background(DSColor.glassLo)
-                                .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                                .clipShape(RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous))
 
                             HStack(spacing: 12) {
                                 Button(NSLocalizedString(
@@ -281,10 +281,10 @@ struct MemoDetailView: View {
                         .padding(.vertical, 12)
                         .background(DSColor.amberSoft)
                         .overlay(
-                            RoundedRectangle(cornerRadius: DSSpacing.radiusCard)
+                            RoundedRectangle(cornerRadius: DSRadius.md)
                                 .strokeBorder(DSColor.amberRim, lineWidth: 0.5)
                         )
-                        .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard))
+                        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md))
                     }
                     .buttonStyle(.plain)
                     .accessibilityIdentifier("memo.detail.ask.past")
@@ -379,7 +379,7 @@ private struct DetailVoiceSection: View {
                 transcript: attachment.transcript
             )
             .frame(maxWidth: .infinity)
-            .liquidGlassCard(cornerRadius: 14, tone: .lo)
+            .liquidGlassCard(cornerRadius: DSRadius.md, tone: .lo)
         }
     }
 }
@@ -416,8 +416,8 @@ private struct DetailPhotoSection: View {
                             .overlay(ProgressView().tint(DSColor.inkSubtle))
                     }
                 }
-                .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
-                .contentShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+                .contentShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                 .onTapGesture {
                     fullResImage = loadedImage
                     showFullscreen = true
@@ -441,7 +441,7 @@ private struct DetailPhotoSection: View {
                                 startPoint: .top,
                                 endPoint: .bottom
                             )
-                            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                         )
                 }
             }
@@ -511,10 +511,10 @@ private struct DetailLocationSection: View {
                     MapPreviewView(coordinate: coord)
                         .frame(maxWidth: .infinity)
                         .frame(height: 260)
-                        .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                 } else {
                     ZStack {
-                        RoundedRectangle(cornerRadius: 14, style: .continuous)
+                        RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                             .fill(DSColor.glassLo)
                             .frame(maxWidth: .infinity, minHeight: 120)
                         VStack(spacing: 6) {
@@ -567,7 +567,7 @@ private struct DetailLocationSection: View {
                 .buttonStyle(.plain)
                 .disabled(coordinate == nil)
             }
-            .liquidGlassCard(cornerRadius: 14, tone: .lo)
+            .liquidGlassCard(cornerRadius: DSRadius.md, tone: .lo)
         }
     }
 
@@ -595,7 +595,7 @@ private struct DetailFilesSection: View {
                     DetailFileRow(attachment: att)
                 }
             }
-            .liquidGlassCard(cornerRadius: 14, tone: .lo)
+            .liquidGlassCard(cornerRadius: DSRadius.md, tone: .lo)
         }
     }
 }

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -188,7 +188,7 @@ struct MemoDetailView: View {
                                     isEditingBody = false
                                 }
                                 .font(DSType.bodySM)
-                                .foregroundColor(DSColor.amberDeep)
+                                .foregroundColor(DSColor.accentOnBg)
                                 .buttonStyle(.plain)
                             }
                         }
@@ -268,14 +268,14 @@ struct MemoDetailView: View {
                         HStack(spacing: 10) {
                             Image(systemName: "sparkles")
                                 .font(.system(size: 15, weight: .semibold))
-                                .foregroundColor(DSColor.amberDeep)
+                                .foregroundColor(DSColor.accentOnBg)
                             Text("追问过去的自己")
                                 .font(DSType.bodySM)
-                                .foregroundColor(DSColor.amberDeep)
+                                .foregroundColor(DSColor.accentOnBg)
                             Spacer()
                             Image(systemName: "arrow.up.right")
                                 .font(.system(size: 12, weight: .semibold))
-                                .foregroundColor(DSColor.amberDeep.opacity(0.65))
+                                .foregroundColor(DSColor.accentOnBg.opacity(0.65))
                         }
                         .padding(.horizontal, 14)
                         .padding(.vertical, 12)
@@ -552,10 +552,10 @@ private struct DetailLocationSection: View {
                     HStack(spacing: 10) {
                         Image(systemName: "map.fill")
                             .font(.system(size: 14, weight: .semibold))
-                            .foregroundColor(DSColor.amberDeep)
+                            .foregroundColor(DSColor.accentOnBg)
                         Text(NSLocalizedString("memo.detail.location.open_maps", comment: ""))
                             .font(DSType.bodySM)
-                            .foregroundColor(DSColor.amberDeep)
+                            .foregroundColor(DSColor.accentOnBg)
                         Spacer()
                         Image(systemName: "arrow.up.right")
                             .font(.system(size: 11, weight: .semibold))
@@ -642,7 +642,7 @@ private struct DetailFileRow: View {
                     .frame(width: 32, height: 32)
                 Image(systemName: fileIcon)
                     .font(.system(size: 14, weight: .regular))
-                    .foregroundColor(DSColor.amberAccent)
+                    .foregroundColor(DSColor.accentOnBg)
             }
 
             VStack(alignment: .leading, spacing: 2) {
@@ -664,7 +664,7 @@ private struct DetailFileRow: View {
                     .font(DSFonts.jetBrainsMono(size: 10))
                     .tracking(0.6)
                     .textCase(.uppercase)
-                    .foregroundColor(DSColor.amberDeep)
+                    .foregroundColor(DSColor.accentOnBg)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
                     .background(DSColor.amberSoft)

--- a/DayPage/Features/Onboarding/OnboardingView.swift
+++ b/DayPage/Features/Onboarding/OnboardingView.swift
@@ -133,7 +133,7 @@ private struct DataFlowPage: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
                         .background(DSColor.accentAmber)
-                        .cornerRadius(DSSpacing.radiusCard)
+                        .cornerRadius(DSRadius.md)
                 }
                 .padding(.top, 8)
                 .accessibilityIdentifier("onboarding.dataflow.continue")
@@ -175,7 +175,7 @@ private struct DataFlowRow: View {
         }
         .padding(DSSpacing.cardInner)
         .background(DSColor.surfaceWhite)
-        .cornerRadius(DSSpacing.radiusCard)
+        .cornerRadius(DSRadius.md)
         .surfaceElevatedShadow()
     }
 }
@@ -219,7 +219,7 @@ private struct WelcomePage: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
                     .background(DSColor.accentSoft)
-                    .cornerRadius(DSSpacing.radiusSmall)
+                    .cornerRadius(8)
 
                 Text("onboarding.welcome.headline", bundle: .main)
                     .font(DSFonts.serif(size: 20, weight: .regular))
@@ -265,7 +265,7 @@ private struct WelcomePage: View {
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 16)
                             .background(DSColor.accentAmber)
-                            .cornerRadius(DSSpacing.radiusCard)
+                            .cornerRadius(DSRadius.md)
                     }
                     .accessibilityIdentifier("onboarding.welcome.begin")
 
@@ -320,7 +320,7 @@ private struct WelcomePage: View {
         }
         .padding(DSSpacing.cardInner)
         .background(DSColor.surfaceWhite)
-        .cornerRadius(DSSpacing.radiusCard)
+        .cornerRadius(DSRadius.md)
         .surfaceElevatedShadow()
         // Issue #15 (2026-07-03): SE 375pt × Accessibility3 audit —
         // benefit rows previously clipped their body line at AX2+ because
@@ -421,7 +421,7 @@ private struct PermissionsPage: View {
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 16)
                     .background(DSColor.accentAmber)
-                    .cornerRadius(DSSpacing.radiusCard)
+                    .cornerRadius(DSRadius.md)
             }
             .padding(.horizontal, 32)
             .padding(.bottom, 48)
@@ -462,13 +462,13 @@ private struct PermissionsPage: View {
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
                     .background(status == .unknown ? DSColor.accentAmber : DSColor.surfaceSunken)
-                    .cornerRadius(DSSpacing.radiusSmall)
+                    .cornerRadius(8)
             }
             .disabled(status != .unknown)
         }
         .padding(DSSpacing.cardInner)
         .background(DSColor.surfaceWhite)
-        .cornerRadius(DSSpacing.radiusCard)
+        .cornerRadius(DSRadius.md)
         .surfaceElevatedShadow()
     }
 
@@ -576,7 +576,7 @@ private struct ApiKeysPage: View {
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 16)
                         .background(DSColor.accentAmber)
-                        .cornerRadius(DSSpacing.radiusCard)
+                        .cornerRadius(DSRadius.md)
                 }
                 .padding(.top, 8)
 
@@ -623,7 +623,7 @@ private struct ApiKeysPage: View {
             }
             .padding(12)
             .background(DSColor.surfaceSunken)
-            .cornerRadius(DSSpacing.radiusSmall)
+            .cornerRadius(8)
         }
     }
 

--- a/DayPage/Features/Onboarding/OnboardingView.swift
+++ b/DayPage/Features/Onboarding/OnboardingView.swift
@@ -35,7 +35,7 @@ struct OnboardingView: View {
         }
         .tabViewStyle(.page(indexDisplayMode: .always))
         .background(DSColor.backgroundWarm.ignoresSafeArea())
-        .tint(DSColor.accentAmber)
+        .tint(DSColor.accentOnBg)
     }
 }
 
@@ -63,7 +63,7 @@ private struct DataFlowPage: View {
 
                 Image(systemName: "lock.shield")
                     .font(.system(size: 44, weight: .light))
-                    .foregroundColor(DSColor.accentAmber)
+                    .foregroundColor(DSColor.accentOnBg)
                     .padding(.bottom, 4)
 
                 Text("onboarding.dataflow.title", bundle: .main)
@@ -155,7 +155,7 @@ private struct DataFlowRow: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 18))
-                .foregroundColor(DSColor.accentAmber)
+                .foregroundColor(DSColor.accentOnBg)
                 .frame(width: 28)
                 .padding(.top, 2)
 
@@ -168,7 +168,7 @@ private struct DataFlowRow: View {
                     .foregroundColor(DSColor.onBackgroundMuted)
                 Text(destination)
                     .captionText()
-                    .foregroundColor(DSColor.accentAmber)
+                    .foregroundColor(DSColor.accentOnBg)
             }
 
             Spacer()
@@ -284,7 +284,7 @@ private struct WelcomePage: View {
                     } label: {
                         Text("onboarding.welcome.try_sample", bundle: .main)
                             .bodyText()
-                            .foregroundColor(DSColor.amberDeep)
+                            .foregroundColor(DSColor.accentOnBg)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 14)
                     }
@@ -301,7 +301,7 @@ private struct WelcomePage: View {
         HStack(alignment: .top, spacing: 12) {
             Image(systemName: icon)
                 .font(.system(size: 18))
-                .foregroundColor(DSColor.accentAmber)
+                .foregroundColor(DSColor.accentOnBg)
                 .frame(width: 28)
                 .padding(.top, 2)
 
@@ -445,7 +445,7 @@ private struct PermissionsPage: View {
         HStack(spacing: 16) {
             Image(systemName: icon)
                 .font(.system(size: 20))
-                .foregroundColor(DSColor.accentAmber)
+                .foregroundColor(DSColor.accentOnBg)
                 .frame(width: 32)
 
             VStack(alignment: .leading, spacing: 2) {
@@ -619,7 +619,7 @@ private struct ApiKeysPage: View {
                     }
                 }
                 .captionText()
-                .foregroundColor(DSColor.accentAmber)
+                .foregroundColor(DSColor.accentOnBg)
             }
             .padding(12)
             .background(DSColor.surfaceSunken)

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -728,8 +728,9 @@ struct SettingsView: View {
     private var iCloudNotConfiguredCard: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack(spacing: 8) {
-                Text("☁️")
-                    .font(.title2)
+                Image(systemName: "icloud")
+                    .font(.system(size: 20, weight: .medium))
+                    .foregroundColor(DSColor.accentOnBg)
                 VStack(alignment: .leading, spacing: 2) {
                     Text(NSLocalizedString("settings.icloud.enable.title", comment: ""))
                         .font(.body)
@@ -1099,7 +1100,7 @@ struct SettingsView: View {
                     if didCopyVersion {
                         Label(NSLocalizedString("settings.about.copied", comment: ""), systemImage: "checkmark")
                             .labelStyle(.titleAndIcon)
-                            .foregroundColor(DSColor.accentAmber)
+                            .foregroundColor(DSColor.accentOnBg)
                             .font(.caption)
                             .transition(.opacity)
                     } else {
@@ -1266,7 +1267,7 @@ struct SettingsView: View {
             if usageTracker.hasCrossedBudgetWarning {
                 HStack(spacing: 8) {
                     Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundColor(DSColor.amberDeep)
+                        .foregroundColor(DSColor.accentOnBg)
                     Text("已经用掉本月预算的 80% —— 可以考虑调低编译频率或提高上限。")
                         .font(DSType.labelSM)
                         .foregroundColor(DSColor.inkPrimary)

--- a/DayPage/Features/Shared/AppBanner.swift
+++ b/DayPage/Features/Shared/AppBanner.swift
@@ -172,10 +172,10 @@ struct AppBanner: View {
         .padding(DSSpacing.cardGap)
         .background(backgroundColor)
         .overlay(
-            RoundedRectangle(cornerRadius: DSSpacing.radiusCard)
+            RoundedRectangle(cornerRadius: DSRadius.md)
                 .stroke(borderColor, lineWidth: 1)
         )
-        .cornerRadius(DSSpacing.radiusCard)
+        .cornerRadius(DSRadius.md)
         .padding(.horizontal, DSSpacing.cardGap)
         .onAppear {
             switch model.kind {

--- a/DayPage/Features/Shared/ShareCard/ShareCardSystem.swift
+++ b/DayPage/Features/Shared/ShareCard/ShareCardSystem.swift
@@ -637,7 +637,7 @@ struct ShareCardSheet: View {
                     .foregroundColor(DSColor.inkPrimary)
                     .padding(.horizontal, 14)
                     .padding(.vertical, 12)
-                    .liquidGlassCard(cornerRadius: 10)
+                    .liquidGlassCard(cornerRadius: DSRadius.sm)
             }
             .buttonStyle(.plain)
             .disabled(renderedImage == nil)
@@ -653,7 +653,7 @@ struct ShareCardSheet: View {
                     .padding(.vertical, 12)
                     .background(
                         DSColor.amberDeep,
-                        in: RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        in: RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous)
                     )
             }
             .buttonStyle(.plain)

--- a/DayPage/Features/Shared/ShareCard/WeeklyShareCard.swift
+++ b/DayPage/Features/Shared/ShareCard/WeeklyShareCard.swift
@@ -34,7 +34,7 @@ struct WeeklyShareCard: View {
                     ForEach(output.keywords.prefix(4), id: \.self) { keyword in
                         Text(keyword)
                             .font(DSType.labelSM)
-                            .foregroundColor(DSColor.amberDeep)
+                            .foregroundColor(DSColor.accentOnBg)
                             .padding(.horizontal, 10)
                             .padding(.vertical, 4)
                             .background(Capsule().fill(DSColor.amberSoft))
@@ -73,7 +73,7 @@ struct WeeklyShareCard: View {
                 Spacer()
                 Text("daypage")
                     .font(.system(.footnote, design: .monospaced))
-                    .foregroundColor(DSColor.amberDeep)
+                    .foregroundColor(DSColor.accentOnBg)
             }
         }
         .padding(28)

--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -32,7 +32,7 @@ struct AISummaryCard: View {
     var body: some View {
         ZStack(alignment: .leading) {
             // Slim accent rail (left edge).
-            RoundedRectangle(cornerRadius: 999, style: .continuous)
+            RoundedRectangle(cornerRadius: DSRadius.pill, style: .continuous)
                 .fill(DSColor.accentOnBg)
                 .opacity(0.85)
                 .frame(width: 2)
@@ -55,11 +55,11 @@ struct AISummaryCard: View {
             .padding(.init(top: 18, leading: 22, bottom: 20, trailing: 20))
         }
         .background(
-            RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous)
+            RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                 .fill(DSColor.surfaceWhite)
         )
         .overlay(
-            RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous)
+            RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                 .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
         )
         .shadow(color: Color.black.opacity(0.04), radius: 1, x: 0, y: 1)

--- a/DayPage/Features/Today/AISummaryCard.swift
+++ b/DayPage/Features/Today/AISummaryCard.swift
@@ -33,7 +33,7 @@ struct AISummaryCard: View {
         ZStack(alignment: .leading) {
             // Slim accent rail (left edge).
             RoundedRectangle(cornerRadius: 999, style: .continuous)
-                .fill(DSColor.accentAmber)
+                .fill(DSColor.accentOnBg)
                 .opacity(0.85)
                 .frame(width: 2)
                 .padding(.vertical, 14)
@@ -93,12 +93,12 @@ struct AISummaryCard: View {
         HStack(spacing: 8) {
             Image(systemName: "sparkles")
                 .font(.system(size: 10, weight: .semibold))
-                .foregroundColor(DSColor.accentAmber)
+                .foregroundColor(DSColor.accentOnBg)
             Text("AI · 今日一句")
                 .font(DSType.mono9)
                 .textCase(.uppercase)
                 .tracking(1.6)
-                .foregroundColor(DSColor.accentAmber)
+                .foregroundColor(DSColor.accentOnBg)
             Spacer(minLength: 8)
             Text("TODAY")
                 .font(DSType.mono9)
@@ -164,7 +164,7 @@ struct TypewriterText: View {
             Text(shown)
             if isTyping {
                 Rectangle()
-                    .fill(DSColor.accentAmber)
+                    .fill(DSColor.accentOnBg)
                     .frame(width: 2, height: 16)
                     .opacity(caretVisible ? 1 : 0)
             }

--- a/DayPage/Features/Today/AttachmentMenuPopover.swift
+++ b/DayPage/Features/Today/AttachmentMenuPopover.swift
@@ -61,7 +61,7 @@ struct AttachmentMenuPopover: View {
             .frame(maxWidth: .infinity)
             // #771: attachment menu → glass engine (.panel). Drops the cold
             // white rim (the "old-version" look) for the warm engine hairline.
-            .dpGlass(.panel, in: RoundedRectangle(cornerRadius: 22, style: .continuous))
+            .dpGlass(.panel, in: RoundedRectangle(cornerRadius: DSRadius.xl, style: .continuous))
             .shadow(color: DSColor.accentAmber.opacity(0.08), radius: 16, x: 0, y: 8)
             .padding(.horizontal, 16)
 
@@ -86,7 +86,7 @@ struct AttachmentMenuPopover: View {
         Button(action: action) {
             VStack(spacing: 8) {
                 ZStack {
-                    RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                         .fill(DSColor.surfaceSunken)
                         .frame(width: 56, height: 56)
                     if isLoading {

--- a/DayPage/Features/Today/CompileFooterButton.swift
+++ b/DayPage/Features/Today/CompileFooterButton.swift
@@ -31,6 +31,9 @@ struct CompileFooterButton: View {
     @AppStorage(AppSettings.Keys.aiFeaturesEnabled) private var aiFeaturesEnabled: Bool = true
     /// Controls the one-shot scale pulse on first reveal (visual only).
     @State private var didAppearPulse = false
+    /// Toggles exactly once per *successful* compile run to drive the
+    /// one-shot sparkles bounce (iOS 17+, see `CompileSuccessBounce`).
+    @State private var compileSuccessBounce = false
     /// Cached hour component, refreshed every minute so the hint stays current across hour boundaries.
     @State private var currentHour: Int = Calendar.current.component(.hour, from: Date())
 
@@ -49,6 +52,15 @@ struct CompileFooterButton: View {
         .animation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.85), value: isVisible)
         .animation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.85), value: isCompiling)
         .animation(reduceMotion ? nil : .spring(response: 0.35, dampingFraction: 0.85), value: errorMessage)
+        .onChange(of: isCompiling) { compiling in
+            // Success detection: CompilationService parks `stage` at `.done`
+            // only when the pipeline finished (on failure it stays at the
+            // failing stage) and `errorMessage` stays nil. Toggle once so the
+            // sparkles glyph plays a single bounce — never on error paths.
+            if !compiling && stage == .done && errorMessage == nil {
+                compileSuccessBounce.toggle()
+            }
+        }
     }
 
     // MARK: 内容
@@ -106,6 +118,7 @@ struct CompileFooterButton: View {
                         Image(systemName: "sparkles")
                             .font(.system(size: 13, weight: .semibold))
                             .foregroundColor(DSColor.onSurface)
+                            .modifier(CompileSuccessBounce(trigger: compileSuccessBounce))
                         Text("编译今日 · \(memoCount) 条")
                             .font(.custom("Inter-Medium", size: 13))
                             .foregroundColor(DSColor.onSurface)
@@ -189,6 +202,24 @@ struct CompileFooterButton: View {
     }
 }
 
+// MARK: - CompileSuccessBounce
+
+/// One-shot symbol bounce on the sparkles glyph when a compile run finishes
+/// successfully. iOS 17+ only (`symbolEffect`); inert on iOS 16 and under
+/// Reduce Motion — same pattern as `CommitArmBounce` in SwipeableMemoCard.swift.
+private struct CompileSuccessBounce: ViewModifier {
+    let trigger: Bool
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *), !reduceMotion {
+            content.symbolEffect(.bounce, value: trigger)
+        } else {
+            content
+        }
+    }
+}
+
 // MARK: - CompilePressStyle
 
 private struct CompilePressStyle: ButtonStyle {
@@ -239,7 +270,7 @@ struct CompileProgressDock: View {
                         Capsule(style: .continuous)
                             .fill(DSColor.glassStd)
                         Capsule(style: .continuous)
-                            .fill(DSColor.accentAmber)
+                            .fill(DSColor.accentOnBg)
                             .opacity(isBreathingSegment ? (nextSegmentBreathing ? 0.55 : 0.2) : 1)
                             .animation(
                                 isBreathingSegment && !reduceMotion
@@ -292,7 +323,7 @@ struct CompileProgressDock: View {
         .onChange(of: memoCount) { newCount in
             if previousMemoCount < 3 && newCount == 3 {
                 nextSegmentBreathing = false
-                Haptics.success()
+                SignatureHaptics.compileSuccess()
                 UIAccessibility.post(notification: .announcement, argument: L10n.Empty.compileDockUnlocked)
                 thirdSegmentPulsing = true
                 Task {

--- a/DayPage/Features/Today/CompileUnlockCard.swift
+++ b/DayPage/Features/Today/CompileUnlockCard.swift
@@ -99,7 +99,7 @@ struct CompileUnlockCard: View {
         .padding(18)
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(
-            RoundedRectangle(cornerRadius: 14, style: .continuous)
+            RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                 .strokeBorder(
                     DSColor.accentBorder,
                     style: StrokeStyle(lineWidth: 1.5, dash: [6, 5])

--- a/DayPage/Features/Today/CompileUnlockCard.swift
+++ b/DayPage/Features/Today/CompileUnlockCard.swift
@@ -64,7 +64,7 @@ struct CompileUnlockCard: View {
                 Text(isOneAway ? "再记 1 条，今日成稿就解锁" : "再记 \(remaining) 条解锁今日成稿")
                     .font(DSFonts.jetBrainsMono(size: 10))
                     .tracking(1.2)
-                    .foregroundColor(DSColor.accentAmber)
+                    .foregroundColor(DSColor.accentOnBg)
                 Text("AI 将把今天的碎片连缀成一篇日页。")
                     .font(.custom("Inter-Regular", size: 13))
                     .foregroundColor(DSColor.inkMuted)
@@ -78,12 +78,12 @@ struct CompileUnlockCard: View {
                         let isFilled = index < memoCount
                         let isNext = index == nextEmptyIndex
                         Circle()
-                            .fill(isFilled ? DSColor.accentAmber : DSColor.glassStd)
+                            .fill(isFilled ? DSColor.accentOnBg : DSColor.glassStd)
                             .frame(width: 5, height: 5)
                             .scaleEffect(dotScale(index: index, isNext: isNext))
                             .overlay(
                                 Circle()
-                                    .stroke(DSColor.accentAmber, lineWidth: 1)
+                                    .stroke(DSColor.accentOnBg, lineWidth: 1)
                                     .scaleEffect(isNext && isOneAway && nextDotPulse ? 2.4 : 1.0)
                                     .opacity(isNext && isOneAway && nextDotPulse ? 0 : (isNext && isOneAway ? 0.5 : 0))
                             )

--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -353,7 +353,7 @@ struct DayOrbView: View {
                 VStack(spacing: 4) {
                     Image(systemName: "sparkles")
                         .font(.system(size: size * 0.22, weight: .light))
-                        .foregroundColor(DSColor.amberDeep)
+                        .foregroundColor(DSColor.accentOnBg)
                         .scaleEffect(invitePulse ? 1.12 : 1.0)
                         .opacity(invitePulse ? 1.0 : 0.7)
                         .animation(.easeInOut(duration: 2.2).repeatForever(autoreverses: true), value: invitePulse)
@@ -361,7 +361,7 @@ struct DayOrbView: View {
                     Text(readoutLabel)
                         .font(DSFonts.jetBrainsMono(size: 9, weight: .medium))
                         .tracking(1.4)
-                        .foregroundColor(DSColor.amberDeep)
+                        .foregroundColor(DSColor.accentOnBg)
                         .opacity(0.7)
                 }
             } else {
@@ -369,7 +369,7 @@ struct DayOrbView: View {
                     Text("\(signalCount)")
                         .font(DSFonts.spaceGrotesk(size: size * 0.36, weight: .semibold))
                         .tracking(-2)
-                        .foregroundColor(DSColor.amberDeep)
+                        .foregroundColor(DSColor.accentOnBg)
                         .modifier(OrbNumericTextTransition(value: Double(signalCount), reduceMotion: reduceMotion))
                         .animation(.snappy, value: signalCount)
                         .scaleEffect(countPop)
@@ -377,7 +377,7 @@ struct DayOrbView: View {
                     Text(readoutLabel)
                         .font(DSFonts.jetBrainsMono(size: 9, weight: .medium))
                         .tracking(1.4)
-                        .foregroundColor(DSColor.amberDeep)
+                        .foregroundColor(DSColor.accentOnBg)
                         .opacity(tierUpGlow ? 1.0 : 0.7)
                         .scaleEffect(tierUpGlow ? 1.12 : 1.0)
                         .shadow(color: DSColor.accentAmber.opacity(tierUpGlow ? 0.9 : 0), radius: tierUpGlow ? 6 : 0)

--- a/DayPage/Features/Today/InlineLensStrip.swift
+++ b/DayPage/Features/Today/InlineLensStrip.swift
@@ -78,7 +78,7 @@ struct InlineLensStrip: View {
             onSelectAsset(asset)
         } label: {
             ZStack {
-                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous)
                     .fill(DSColor.glassLo)
                     .frame(width: 56, height: 56)
 
@@ -87,7 +87,7 @@ struct InlineLensStrip: View {
                         .resizable()
                         .scaledToFill()
                         .frame(width: 56, height: 56)
-                        .clipShape(RoundedRectangle(cornerRadius: 10, style: .continuous))
+                        .clipShape(RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous))
                 } else {
                     ProgressView()
                         .frame(width: 56, height: 56)

--- a/DayPage/Features/Today/InputBarTutorialOverlay.swift
+++ b/DayPage/Features/Today/InputBarTutorialOverlay.swift
@@ -61,7 +61,7 @@ struct InputBarTutorialOverlay: View {
                     HStack(spacing: 6) {
                         ForEach(0..<steps.count, id: \.self) { i in
                             Circle()
-                                .fill(i == step ? DSColor.amberAccent : DSColor.inkFaint)
+                                .fill(i == step ? DSColor.accentOnBg : DSColor.inkFaint)
                                 .frame(width: 6, height: 6)
                                 .animation(Motion.respectReduceMotion(.easeInOut(duration: 0.2)), value: step)
                                 .contentShape(Rectangle().size(CGSize(width: 44, height: 44)).offset(x: -19, y: -19))
@@ -82,7 +82,7 @@ struct InputBarTutorialOverlay: View {
                     VStack(spacing: 20) {
                         Image(systemName: steps[step].icon)
                             .font(.system(size: 32, weight: .medium))
-                            .foregroundColor(DSColor.amberAccent)
+                            .foregroundColor(DSColor.accentOnBg)
                             .frame(height: 44)
                             .accessibilityHidden(true)
 

--- a/DayPage/Features/Today/InputBarTutorialOverlay.swift
+++ b/DayPage/Features/Today/InputBarTutorialOverlay.swift
@@ -107,7 +107,7 @@ struct InputBarTutorialOverlay: View {
                             .foregroundColor(.white)
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 14)
-                            .background(DSColor.amberAccent, in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+                            .background(DSColor.amberAccent, in: RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                     }
                     .buttonStyle(.plain)
                     .accessibilityHint(step < steps.count - 1

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -1222,15 +1222,16 @@ private struct SendAffordanceIcon: View {
     var body: some View {
         Group {
             switch affordance {
-            case .empty:
-                Image(systemName: "mic.fill")
+            case .empty, .textOnly, .locationOnly:
+                // Single-glyph affordances share ONE Image (conditional
+                // systemName) instead of separate view branches, so SwiftUI
+                // identity stays stable across mic ⇄ send ⇄ pin swaps and
+                // `contentTransition(.symbolEffect(.replace))` can morph the
+                // glyph in place on iOS 17+ (plain crossfade on iOS 16).
+                Image(systemName: simpleGlyphName)
                     .font(DSType.bodyMD)
-                    .foregroundStyle(DSColor.amberAccent.opacity(breathingOpacity))
-
-            case .textOnly:
-                Image(systemName: "arrow.up")
-                    .font(DSType.bodyMD)
-                    .foregroundStyle(.white)
+                    .foregroundStyle(simpleGlyphColor)
+                    .modifier(SymbolReplaceTransition())
 
             case .textAndPhoto:
                 // Composite: camera behind, small arrow.up overlaid top-right
@@ -1243,11 +1244,6 @@ private struct SendAffordanceIcon: View {
                         .foregroundStyle(.white)
                         .offset(x: 5, y: -5)
                 }
-
-            case .locationOnly:
-                Image(systemName: "mappin.and.ellipse")
-                    .font(DSType.bodyMD)
-                    .foregroundStyle(.white)
 
             case .multimodal:
                 // Amber ring with a small arrow.up in center
@@ -1266,6 +1262,24 @@ private struct SendAffordanceIcon: View {
         // `.animation(Motion.spring, value: affordance)` (which wraps this icon),
         // so an inner copy only made SwiftUI interpolate the same change twice.
         // Removed for a single, crisp morph. (P2 #7)
+    }
+
+    /// Glyph for the single-Image affordances (`.empty` / `.textOnly` /
+    /// `.locationOnly`). Composite affordances render their own branches;
+    /// their fallthrough here is unreachable.
+    private var simpleGlyphName: String {
+        switch affordance {
+        case .empty:        return "mic.fill"
+        case .locationOnly: return "mappin.and.ellipse"
+        default:            return "arrow.up"
+        }
+    }
+
+    private var simpleGlyphColor: Color {
+        switch affordance {
+        case .empty: return DSColor.amberAccent.opacity(breathingOpacity)
+        default:     return .white
+        }
     }
 }
 
@@ -1289,6 +1303,24 @@ private struct SendAffordanceBG: View {
             case .multimodal:
                 Circle().fill(DSColor.amberAccent)
             }
+        }
+    }
+}
+
+// MARK: - SymbolReplaceTransition
+
+/// Morphs an SF Symbol glyph swap in place (mic.fill ⇄ arrow.up ⇄ mappin)
+/// instead of crossfading. iOS 17+ only (`ContentTransition.symbolEffect`);
+/// inert on iOS 16 and under Reduce Motion — same pattern as
+/// `CommitArmBounce` in SwipeableMemoCard.swift.
+private struct SymbolReplaceTransition: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *), !reduceMotion {
+            content.contentTransition(.symbolEffect(.replace))
+        } else {
+            content
         }
     }
 }

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -115,7 +115,7 @@ struct MemoCardView: View {
                     .frame(width: 44, height: 44)
                 Image(systemName: "mappin.and.ellipse")
                     .font(.system(size: 18, weight: .regular))
-                    .foregroundColor(DSColor.amberAccent)
+                    .foregroundColor(DSColor.accentOnBg)
             }
 
             VStack(alignment: .leading, spacing: 3) {
@@ -347,7 +347,7 @@ struct MemoCardView: View {
         .font(DSFonts.jetBrainsMono(size: 9))
         .tracking(0.5)
         .textCase(.uppercase)
-        .foregroundColor(DSColor.amberAccent)
+        .foregroundColor(DSColor.accentOnBg)
     }
 
     // MARK: - Helpers
@@ -613,10 +613,10 @@ struct LocationPreviewSheet: View {
                     HStack(spacing: 10) {
                         Image(systemName: "map.fill")
                             .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(DSColor.amberDeep)
+                            .foregroundColor(DSColor.accentOnBg)
                         Text(NSLocalizedString("memo.detail.location.open_maps", comment: ""))
                             .font(DSType.titleSM)
-                            .foregroundColor(DSColor.amberDeep)
+                            .foregroundColor(DSColor.accentOnBg)
                         Spacer()
                         Image(systemName: "arrow.up.right")
                             .font(.system(size: 11, weight: .semibold))
@@ -721,7 +721,7 @@ struct VoiceMemoPlayerRow: View {
                             .frame(width: 36, height: 36)
                         Image(systemName: isPlaying ? "pause.fill" : "play.fill")
                             .font(.system(size: 13, weight: .semibold))
-                            .foregroundColor(fileError ? DSColor.inkSubtle : DSColor.amberDeep)
+                            .foregroundColor(fileError ? DSColor.inkSubtle : DSColor.accentOnBg)
                     }
                 }
                 .buttonStyle(.plain)
@@ -841,7 +841,7 @@ struct VoiceMemoPlayerRow: View {
                                  : String(format: NSLocalizedString("voice.retry.button_attempt", comment: ""), retryCount + 1, Self.maxRetries))
                                 .font(DSType.bodySM)
                         }
-                        .foregroundColor(DSColor.amberAccent)
+                        .foregroundColor(DSColor.accentOnBg)
                     }
                     .buttonStyle(.plain)
                     .padding(.horizontal, 14)
@@ -987,7 +987,7 @@ private struct WaveformView: View, Equatable {
         ZStack(alignment: .leading) {
             WaveformBars(heights: heights, color: DSColor.inkFaint)
                 .equatable()
-            WaveformBars(heights: heights, color: DSColor.amberAccent)
+            WaveformBars(heights: heights, color: DSColor.accentOnBg)
                 .equatable()
                 .mask(alignment: .leading) {
                     GeometryReader { geo in
@@ -1036,14 +1036,14 @@ struct DailyPageEntryCard: View {
                     // Amber dot + label
                     HStack(spacing: 6) {
                         Circle()
-                            .fill(DSColor.amberAccent)
+                            .fill(DSColor.accentOnBg)
                             .frame(width: 6, height: 6)
                             .shadow(color: DSColor.amberGlow, radius: 4, x: 0, y: 0)
                         Text("Today's page compiled")
                             .font(DSFonts.jetBrainsMono(size: 10))
                             .tracking(1)
                             .textCase(.uppercase)
-                            .foregroundColor(DSColor.amberAccent)
+                            .foregroundColor(DSColor.accentOnBg)
                     }
 
                     if let summary = summary, !summary.isEmpty {
@@ -1062,7 +1062,7 @@ struct DailyPageEntryCard: View {
 
                 Image(systemName: "arrow.forward")
                     .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(DSColor.amberDeep)
+                    .foregroundColor(DSColor.accentOnBg)
             }
             .padding(.horizontal, 18)
             .padding(.vertical, 18)
@@ -1073,7 +1073,7 @@ struct DailyPageEntryCard: View {
                 RoundedRectangle(cornerRadius: 2, style: .continuous)
                     .fill(
                         LinearGradient(
-                            colors: [DSColor.amberAccent, DSColor.amberAccent.opacity(0)],
+                            colors: [DSColor.accentOnBg, DSColor.accentOnBg.opacity(0)],
                             startPoint: .top, endPoint: .bottom
                         )
                     )
@@ -1110,7 +1110,7 @@ struct CompilePromptCard: View {
                     )
                     .frame(width: 44, height: 44)
                 if isCompiling {
-                    ProgressView().scaleEffect(0.7).tint(DSColor.amberDeep)
+                    ProgressView().scaleEffect(0.7).tint(DSColor.accentOnBg)
                 } else {
                     Image(systemName: "sparkles")
                         .font(.system(size: 18))
@@ -1124,7 +1124,7 @@ struct CompilePromptCard: View {
                         .font(DSFonts.spaceGrotesk(size: 13, weight: .semibold))
                         .textCase(.uppercase)
                         .tracking(1)
-                        .foregroundColor(DSColor.amberDeep)
+                        .foregroundColor(DSColor.accentOnBg)
                 } else if memoCount > 0 {
                     Text(NSLocalizedString("memocard.state.ready", comment: "Ready to compile"))
                         .font(DSFonts.spaceGrotesk(size: 13, weight: .semibold))
@@ -1198,7 +1198,7 @@ struct PhotoDownloadPlaceholder: View {
                 case .failed:
                     Image(systemName: "exclamationmark.icloud")
                         .font(.system(size: 28, weight: .regular))
-                        .foregroundColor(DSColor.amberAccent)
+                        .foregroundColor(DSColor.accentOnBg)
                     Text("Download failed — tap to retry")
                         .font(DSFonts.jetBrainsMono(size: 10))
                         .textCase(.uppercase)
@@ -1352,7 +1352,7 @@ struct AudioDownloadPlaceholder: View {
                 case .failed:
                     Image(systemName: "exclamationmark.icloud")
                         .font(.system(size: 14, weight: .semibold))
-                        .foregroundColor(DSColor.amberAccent)
+                        .foregroundColor(DSColor.accentOnBg)
                 case .current:
                     Image(systemName: "play.fill")
                         .font(.system(size: 14, weight: .semibold))
@@ -1382,7 +1382,7 @@ struct AudioDownloadPlaceholder: View {
             case .failed:
                 Text("retry")
                     .font(DSFonts.jetBrainsMono(size: 10))
-                    .foregroundColor(DSColor.amberAccent)
+                    .foregroundColor(DSColor.accentOnBg)
                     .frame(width: 36, alignment: .trailing)
             case .current:
                 Text("--:--")

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -31,6 +31,12 @@ struct MemoCardView: View {
     @State private var downloadTask: Task<Void, Never>? = nil
     @State private var showPhotoViewer: Bool = false
 
+    /// Hero zoom (iOS 18+): shared between the in-card photo thumbnail
+    /// (`matchedTransitionSource`) and the full-screen viewer
+    /// (`navigationTransition(.zoom)`). The cover is presented from this
+    /// view, so the namespace lives here. Inert on iOS 16–17.
+    @Namespace private var photoZoomNamespace
+
     /// Precise 24h time for the content-first card meta line (rendered as "15·23").
     private static let cardTimeFmt: DateFormatter = {
         let f = DateFormatter()
@@ -201,6 +207,10 @@ struct MemoCardView: View {
                     case .current:
                         PhotoThumbnailView(fileURL: photoURL, thumbnail: $thumbnail, exifText: photoExifText)
                             .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            // Hero zoom source (iOS 18+). Identity = attachment
+                            // relative path — stable per photo, so multi-photo
+                            // memos each zoom from their own thumbnail.
+                            .modifier(PhotoZoomSource(id: att.file, namespace: photoZoomNamespace))
                             .contentShape(Rectangle())
                             .onTapGesture {
                                 Haptics.tapConfirm()
@@ -214,6 +224,7 @@ struct MemoCardView: View {
                                         fileURL: VaultInitializer.vaultURL.appendingPathComponent(att.file),
                                         exifText: photoExifText
                                     )
+                                    .modifier(PhotoZoomDestination(id: att.file, namespace: photoZoomNamespace))
                                 }
                             }
                     case .downloading, .notDownloaded, .failed:
@@ -370,6 +381,44 @@ struct MemoCardView: View {
             return "\(filename) // FOCUS: \(Int(focal))mm"
         }
         return filename
+    }
+}
+
+// MARK: - Photo hero zoom (iOS 18+)
+//
+// Photos-style hero: tapping the in-card thumbnail zooms the full-screen
+// viewer out of the thumbnail frame; dismiss shrinks it back in. Mirrors the
+// CardZoomSource / CardZoomDestination pattern in TodayView.swift, but keyed
+// by the attachment's relative file path (String) so every photo has its own
+// stable transition identity. Both halves read Reduce Motion and pass content
+// through untouched when it is on — on iOS 16–17 (or with Reduce Motion) the
+// fullScreenCover keeps its default presentation.
+
+private struct PhotoZoomSource: ViewModifier {
+    let id: String
+    let namespace: Namespace.ID
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *), !reduceMotion {
+            content.matchedTransitionSource(id: id, in: namespace)
+        } else {
+            content
+        }
+    }
+}
+
+private struct PhotoZoomDestination: ViewModifier {
+    let id: String
+    let namespace: Namespace.ID
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *), !reduceMotion {
+            content.navigationTransition(.zoom(sourceID: id, in: namespace))
+        } else {
+            content
+        }
     }
 }
 

--- a/DayPage/Features/Today/OnThisDayCard.swift
+++ b/DayPage/Features/Today/OnThisDayCard.swift
@@ -80,10 +80,10 @@ struct OnThisDayCard: View {
         .padding(DSSpacing.cardInner)
         .background(DSColor.accentSoft)
         .overlay(
-            RoundedRectangle(cornerRadius: DSSpacing.radiusCard)
+            RoundedRectangle(cornerRadius: DSRadius.md)
                 .stroke(DSColor.accentBorder, lineWidth: 1)
         )
-        .cornerRadius(DSSpacing.radiusCard)
+        .cornerRadius(DSRadius.md)
     }
 
     private var dismissButton: some View {

--- a/DayPage/Features/Today/RecordingOverlayView.swift
+++ b/DayPage/Features/Today/RecordingOverlayView.swift
@@ -192,7 +192,7 @@ struct RecordingOverlayView: View {
                             .foregroundColor(mode == .cancelArmed ? DSTokens.Colors.recordingRed : DSColor.onRecording.opacity(0.75))
                             .frame(width: 72, height: 56)
                             .background(DSColor.onRecording.opacity(mode == .cancelArmed ? 0.25 : 0.12))
-                            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                         }
                         .buttonStyle(.plain)
                         .accessibilityElement(children: .combine)
@@ -212,7 +212,7 @@ struct RecordingOverlayView: View {
                             .foregroundColor(mode == .transcribeArmed ? Color(red: 0.30, green: 0.55, blue: 1.0) : DSColor.onRecording.opacity(0.90))
                             .frame(width: 72, height: 56)
                             .background(DSColor.onRecording.opacity(mode == .transcribeArmed ? 0.25 : 0.15))
-                            .clipShape(RoundedRectangle(cornerRadius: 14, style: .continuous))
+                            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                         }
                         .buttonStyle(.plain)
                         .accessibilityElement(children: .combine)

--- a/DayPage/Features/Today/RecordingSheetView.swift
+++ b/DayPage/Features/Today/RecordingSheetView.swift
@@ -172,11 +172,11 @@ struct RecordingSheetView: View {
             .frame(height: 56)
             .frame(maxWidth: .infinity)
             .background(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                     .fill(DSColor.onRecording.opacity(0.05))
             )
             .overlay(
-                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
                     .strokeBorder(DSColor.onRecording.opacity(0.08), lineWidth: 0.5)
             )
 

--- a/DayPage/Features/Today/SwipeableMemoCard.swift
+++ b/DayPage/Features/Today/SwipeableMemoCard.swift
@@ -67,7 +67,7 @@ enum SwipePhysics {
     /// surface. The drawer container clips to the same continuous shape so
     /// revealed action panels share the card's silhouette instead of
     /// poking square corners out of a rounded card.
-    static let cardCornerRadius: CGFloat = 14
+    static let cardCornerRadius: CGFloat = DSRadius.md
 
     /// Spring used for snap-open / snap-close. Delegated to the shared
     /// `Motion.panel` token (0.32s response, 0.85 damping) so drawer motion

--- a/DayPage/Features/Today/TodayCoachView.swift
+++ b/DayPage/Features/Today/TodayCoachView.swift
@@ -150,7 +150,7 @@ struct TodayCoachView: View {
                     .padding(.horizontal, 14)
                     .padding(.vertical, 10)
                     .background(DSColor.surfaceContainerHigh)
-                    .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
             }
         case .assistant:
             VStack(alignment: .leading, spacing: 10) {
@@ -304,10 +304,10 @@ struct TodayCoachView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.horizontal, 16)
                     .padding(.vertical, 13)
-                    .contentShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+                    .contentShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                 }
                 .buttonStyle(.plain)
-                .solidCard(cornerRadius: DSSpacing.radiusCard)
+                .solidCard(cornerRadius: DSRadius.md)
                 .accessibilityIdentifier("coach-seed")
             }
             Text("想查历史？打开左侧「问过去」。")
@@ -373,7 +373,7 @@ struct TodayCoachView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(12)
             .background(DSColor.surfaceContainerHigh)
-            .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard, style: .continuous))
+            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
     }
 
     // MARK: - Input bar

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -2509,69 +2509,11 @@ struct TodayView: View {
 
                 Spacer()
 
-                // R4 (#793 comp 4.png): the comp's top bar is exactly two
-                // chips — ☰ left, ⚙ right. The export-as-markdown button
-                // used to appear in the middle once the day had memos, but
-                // that made the toolbar drift between 2-chip and 3-chip
-                // layouts as the day filled in. The export action stays
-                // available via long-pressing the hero title (gesture wired
-                // below); the visible chip is removed so the toolbar
-                // rhythm is invariant.
-                if false {
-                    Button {
-                        let content = MarkdownExportService.buildExportContent(
-                            memos: viewModel.memos, date: Date(),
-                            summary: viewModel.dailyPageSummary
-                        )
-                        let dateString = MarkdownExportService.exportDateString(for: Date())
-                        do {
-                            let url = try MarkdownExportService.writeExportFile(
-                                content: content, dateString: dateString
-                            )
-                            exportFileURL = url
-                            showExportSheet = true
-                            Haptics.tapConfirm()
-                            bannerCenter.show(AppBannerModel(
-                                kind: .success,
-                                title: NSLocalizedString("export.success.title", comment: ""),
-                                autoDismiss: true
-                            ))
-                        } catch {
-                            Haptics.warn()
-                            bannerCenter.show(AppBannerModel(
-                                kind: .error,
-                                title: NSLocalizedString("export.error.title", comment: ""),
-                                autoDismiss: true
-                            ))
-                            DayPageLogger.shared.error("TodayView: export failed: \(error)")
-                        }
-                    } label: {
-                        Image(systemName: "square.and.arrow.up")
-                            .font(DSType.bodySM)
-                            .foregroundColor(DSColor.inkMuted)
-                            .frame(width: 36, height: 36)
-                            .glassSurface(in: Circle())
-                            .clipShape(Circle())
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityLabel(NSLocalizedString("export.action.title", comment: ""))
-                    .accessibilityHint(NSLocalizedString("export.action.hint", comment: ""))
-                    .accessibilityIdentifier("export-markdown-button")
-                    .onLongPressGesture(minimumDuration: 0.5) {
-                        let content = MarkdownExportService.buildExportContent(
-                            memos: viewModel.memos, date: Date(),
-                            summary: viewModel.dailyPageSummary
-                        )
-                        UIPasteboard.general.string = content
-                        Haptics.medium()
-                        Haptics.success()
-                        bannerCenter.show(AppBannerModel(
-                            kind: .info,
-                            title: NSLocalizedString("export.copied.title", comment: ""),
-                            autoDismiss: true
-                        ))
-                    }
-                }
+                // R4 (#793 comp 4.png): the top bar is exactly two chips —
+                // ☰ left, 🔍 right. No middle export chip: it made the
+                // toolbar drift between 2- and 3-chip layouts as the day
+                // filled in. Export lives in the hero title's context menu
+                // (`exportMenuItems`), keeping the toolbar rhythm invariant.
 
                 // Settings moved into the sidebar bottom section — the
                 // toolbar's trailing slot now opens global search, riding

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -903,6 +903,11 @@ struct TodayView: View {
             // 避免与已经推过的失败通知互相打架。#814 起前台重试补编的是
             // 昨天（今天只在结束后编译一次），文案随之调整。
             .onReceive(NotificationCenter.default.publisher(for: .compileSucceededForeground)) { _ in
+                // Signature "ink settling" haptic for the compile moment —
+                // fired here (same as the manual-compile path in
+                // TodayViewModel) so the texture leads before the banner's
+                // stock generator appears.
+                SignatureHaptics.compileSuccess()
                 bannerCenter.show(AppBannerModel(
                     kind: .success,
                     title: NSLocalizedString(
@@ -2590,9 +2595,12 @@ struct TodayView: View {
         .padding(.top, 8)
         .padding(.bottom, 16)
         // Collapse/expand between the big hero (empty day) and the compact
-        // toolbar title (memo day) with the shared panel spring so the first
-        // memo's arrival reads as one deliberate motion, not a layout pop.
-        .animation(reduceMotion ? nil : Motion.spring, value: hasMemos)
+        // toolbar title (memo day): both branches carry explicit transitions
+        // (big hero → .opacity + .move(.top), compact title → .opacity +
+        // .scale) and every memo mutation in TodayViewModel runs inside
+        // withAnimation, so the swap still reads as one deliberate motion
+        // WITHOUT a container-level `.animation(value: hasMemos)` that
+        // would re-animate this entire header subtree (Axiom perf rule).
         .onReceive(headerTimer) { date in
             currentTime = date
         }
@@ -2895,6 +2903,10 @@ struct TodayView: View {
                         }
                         .padding(.horizontal, 20)
                         .transition(.move(edge: .bottom).combined(with: .opacity))
+                        // 美术馆入场 (iOS 17+): subtle scroll-in settle on the
+                        // row container OUTSIDE SwipeableMemoCard, so it never
+                        // fights the card's UIKit pan / offset gesture.
+                        .modifier(ScrollEntranceModifier())
                     }
                 }
 
@@ -2980,6 +2992,15 @@ struct TodayView: View {
     /// memo 且尚未编译，就直接显示编译按钮，无论几条。
     @ViewBuilder
     private var composeSection: some View {
+        let aiKeyMissing = Secrets.resolvedDeepSeekApiKey.isEmpty
+        // Axiom perf (motion overhaul): this footer used to animate on
+        // `viewModel.memos.count`, which re-sprang the whole subtree on
+        // EVERY capture. Animate on the exact Bool that actually toggles
+        // the recovery footer's visibility instead.
+        let showsRecoveryFooter = !viewModel.isDailyPageCompiled
+            && !viewModel.memos.isEmpty
+            && (viewModel.isCompiling || viewModel.submitError != nil)
+            && !aiKeyMissing
         Group {
             // Museum-aesthetic redesign (#793): the persistent "编译今日"
             // CTA used to live here on every day with memos and added a
@@ -2998,11 +3019,7 @@ struct TodayView: View {
             // recovery cases (mid-compile or a non-key error the user must
             // see). Keeps the bottom area clean so the dock keeps its
             // floating-island read against the warm canvas.
-            let aiKeyMissing = Secrets.resolvedDeepSeekApiKey.isEmpty
-            if !viewModel.isDailyPageCompiled
-                && !viewModel.memos.isEmpty
-                && (viewModel.isCompiling || viewModel.submitError != nil)
-                && !aiKeyMissing {
+            if showsRecoveryFooter {
                 HStack {
                     Spacer()
                     CompileFooterButton(
@@ -3037,11 +3054,11 @@ struct TodayView: View {
                 .padding(.bottom, 4)
             }
         }
-        .animation(Motion.spring, value: viewModel.memos.count)
+        .animation(reduceMotion ? nil : Motion.spring, value: showsRecoveryFooter)
         .onChange(of: viewModel.memos.count) { count in
             if count >= 3 && !viewModel.isDailyPageCompiled && !didCelebrateUnlock {
                 didCelebrateUnlock = true
-                Haptics.success()
+                SignatureHaptics.compileSuccess()
                 if !reduceMotion {
                     unlockGlow = true
                     Task {
@@ -3083,7 +3100,7 @@ struct TodayView: View {
         .onChange(of: viewModel.isDailyPageCompiled) { compiled in
             if compiled && !didCelebrateCompile {
                 didCelebrateCompile = true
-                Haptics.success()
+                SignatureHaptics.compileSuccess()
                 if !reduceMotion {
                     compileRevealGlow = true
                     Task {
@@ -3992,6 +4009,31 @@ private struct ScrollOffsetPreferenceKey: PreferenceKey {
     static var defaultValue: CGFloat = 0
     static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
         value = nextValue()
+    }
+}
+
+// MARK: - Scroll entrance (iOS 17+)
+
+/// 美术馆入场: timeline memo cards settle in as they scroll into the
+/// viewport — rows just outside the visible region sit at 72% opacity /
+/// 98.5% scale and ease to identity. Deliberately subtle: the timeline is
+/// a quiet gallery wall, not a showcase. iOS 16 and Reduce Motion pass
+/// the content through unmodified. Applied to the row container that
+/// wraps SwipeableMemoCard (never inside it) so the phase scale cannot
+/// fight the card's UIKit pan + offset swipe-to-reveal.
+struct ScrollEntranceModifier: ViewModifier {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        if #available(iOS 17.0, *), !reduceMotion {
+            content.scrollTransition(.interactive(timingCurve: .easeOut), axis: .vertical) { view, phase in
+                view
+                    .opacity(phase.isIdentity ? 1 : 0.72)
+                    .scaleEffect(phase.isIdentity ? 1 : 0.985, anchor: .center)
+            }
+        } else {
+            content
+        }
     }
 }
 

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -2484,7 +2484,7 @@ struct TodayView: View {
                     nav.openSidebar()
                 } label: {
                     Image(systemName: "line.3.horizontal")
-                        .font(DSType.bodySM)
+                        .font(.system(size: 15, weight: .medium))
                         .foregroundColor(DSColor.inkMuted)
                         .frame(width: 36, height: 36)
                         .glassSurface(in: Circle())
@@ -2583,7 +2583,7 @@ struct TodayView: View {
                     nav.pendingSearchQuery = ""
                 } label: {
                     Image(systemName: "magnifyingglass")
-                        .font(DSType.bodySM)
+                        .font(.system(size: 15, weight: .medium))
                         .foregroundColor(DSColor.inkMuted)
                         .frame(width: 36, height: 36)
                         .glassSurface(in: Circle())

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -2490,7 +2490,7 @@ struct TodayView: View {
                         .glassSurface(in: Circle())
                         .clipShape(Circle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.dsIconChip)
                 .accessibilityLabel(NSLocalizedString("a11y.nav.open", comment: "Sidebar open button"))
                 .accessibilityHint(NSLocalizedString("a11y.nav.open.hint", comment: "Opens the sidebar navigation drawer"))
                 .accessibilityIdentifier("sidebar-menu-button")
@@ -2589,7 +2589,7 @@ struct TodayView: View {
                         .glassSurface(in: Circle())
                         .clipShape(Circle())
                 }
-                .buttonStyle(.plain)
+                .buttonStyle(.dsIconChip)
                 .accessibilityLabel(NSLocalizedString("today.toolbar.search", comment: "Global search button"))
                 .accessibilityHint(NSLocalizedString("today.toolbar.search.hint", comment: "Opens global search"))
                 .accessibilityIdentifier("today-search-button")

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -327,36 +327,28 @@ struct TodayView: View {
                     // Issue #814: weekly-recap preview card removed — Archive
                     // owns the This Week entry point now.
 
-                    // MARK: AI key missing banner (R3 — A2)
+                    // MARK: Status Slot — single status banner (banner collapse)
                     //
-                    // Museum-aesthetic redesign (#793): the banner used to
-                    // dominate the first screen with an amber wash + CTA.
-                    // For a calm capture surface we now surface it ONLY
-                    // when the user genuinely needs to act — i.e. the day
-                    // is empty (nothing to compile = a teaching moment),
-                    // not every launch. With memos present the same
-                    // condition shows up as a small amber dot on the
-                    // settings gear (a quieter affordance, set elsewhere).
-                    if shouldShowAIKeyBanner && viewModel.memos.isEmpty {
-                        aiKeyMissingBanner
-                            .transition(.opacity.combined(with: .move(edge: .top)))
-                    }
-
-                    // MARK: Compile Progress Banner (Issue #5, 2026-07-03)
-                    //
-                    // Shows the current stage of an in-flight compilation
-                    // (collecting → cleaning → clustering → generating →
-                    // linking). Hidden when the service is `.idle` so the
-                    // surface stays quiet 99% of the time — the banner is
-                    // a reassurance signal for the ~15-60 second window an
-                    // AI compile actually runs. Observing
-                    // BackgroundCompilationService directly (it is now an
-                    // ObservableObject) keeps it as the single source of
-                    // truth for both foreground and background triggers.
-                    if compileService.stage != .idle {
-                        compileProgressBanner
-                            .transition(.opacity.combined(with: .move(edge: .top)))
-                    }
+                    // The top region used to stack up to ~7 independent
+                    // status banners (AI key, compile progress banner,
+                    // sync queue, compile progress bar, compile failed,
+                    // sync prompt, iCloud conflict), each with its own
+                    // show-condition scattered through this VStack. Against
+                    // the calm-capture minimalism that stack read as an
+                    // alert wall, and on iPhone 12 mini it pushed the
+                    // composer below the fold. Now `activeStatusSlot` picks
+                    // the single highest-priority status surface and ONLY
+                    // that banner renders here — the banner views and their
+                    // tap/dismiss behaviors are unchanged; only the layout
+                    // conditions moved into the slot computation (see
+                    // `TodayStatusSlot` / `activeStatusSlot`). The slot sits
+                    // above every content section (focus chips / OnThisDay /
+                    // orbHero / timeline) because status rows are sticky
+                    // "system status" surfaces that must always own the
+                    // very top. Non-status content (OnThisDayCard,
+                    // LocationDraftCard, todayFocusRow, orbHero,
+                    // selectionToolbar) is NOT part of the slot.
+                    statusSlotSection
 
                     // MARK: Today Focus Chips (Issue #13, 2026-07-03)
                     //
@@ -379,22 +371,6 @@ struct TodayView: View {
                             .transition(.opacity.combined(with: .move(edge: .top)))
                     }
 
-                    // MARK: Offline Sync Queue Banner (R5)
-                    //
-                    // Museum-aesthetic redesign (#793): "1 条待同步" used to
-                    // claim a full 44pt row on the first screen — too noisy
-                    // for a normal capture flow. Now we only surface the
-                    // banner when something is actually stuck (>= 5 memos
-                    // pending OR oldest entry waited > 1h). Small queues
-                    // are invisible — the round-trip still happens in the
-                    // background and the queue indicator on the settings
-                    // gear (set elsewhere) lets the curious user dig in.
-                    if FeatureFlagStore.shared.isEnabled(.offlineQueue)
-                        && (syncQueue.pendingCount >= 5 || syncQueueWaitedTooLong) {
-                        syncQueuePendingBanner
-                            .transition(.opacity.combined(with: .move(edge: .top)))
-                    }
-
                     // MARK: On This Day Top Card (R8-CRITICAL)
                     //
                     // 顶部独立 OnThisDayCard section — 脱离 fallbackContentView
@@ -403,21 +379,23 @@ struct TodayView: View {
                     // viewModel.onThisDayEntry（由 OnThisDayIndex.candidate 或
                     // .onThisDayShouldShow 注入）就在头条位置出现。
                     //
-                    // Sits AFTER the AI key / sync queue banners (those are
-                    // sticky "system status" rows that must always own the
-                    // very top) but BEFORE every Today-content section
-                    // (orbHero / timeline / fallback). Dismiss persists for
-                    // the rest of the day via OnThisDayScheduler — same
-                    // behavior the fallback path uses, so users can't
-                    // double-dismiss.
+                    // Sits AFTER the status slot (the single sticky "system
+                    // status" row that must always own the very top) but
+                    // BEFORE every Today-content section (orbHero /
+                    // timeline / fallback). Dismiss persists for the rest
+                    // of the day via OnThisDayScheduler — same behavior the
+                    // fallback path uses, so users can't double-dismiss.
                     //
                     // R9-HIGH A2: gated by `shouldShowOnThisDayAtTop`, which
                     // the fallback path negates in the same render pass. No
                     // more lazy `.onAppear` flag flip — the two paths agree
                     // synchronously, eliminating the brief double-card race.
-                    // R9-HIGH A3: the same computed also yields to ≥ 2
-                    // sticky banners so the composer isn't pushed off the
-                    // visible viewport on small devices (iPhone 12 mini).
+                    // R9-HIGH A3 (updated for the single status slot): the
+                    // same computed yields to error/conflict slot occupants
+                    // so the composer isn't pushed off the visible viewport
+                    // on small devices (iPhone 12 mini); with at most one
+                    // banner plus this card the low-priority info slots can
+                    // coexist with it.
                     if shouldShowOnThisDayAtTop,
                        let entry = viewModel.onThisDayEntry {
                         OnThisDayCard(
@@ -431,33 +409,6 @@ struct TodayView: View {
                             }
                         )
                         .transition(.opacity.combined(with: .move(edge: .top)))
-                    }
-
-                    // MARK: Compilation Progress Bar
-                    if viewModel.isCompiling {
-                        CompilationProgressBar(stage: compilationService.stage)
-                            .transition(.opacity)
-                            .animation(Motion.fade, value: viewModel.isCompiling)
-                    }
-
-                    // MARK: Compilation Failed Banner
-                    if let failureMsg = viewModel.compilationFailedError {
-                        CompilationFailedBanner(message: failureMsg) {
-                            viewModel.compilationFailedError = nil
-                            viewModel.compile()
-                        } onDismiss: {
-                            viewModel.compilationFailedError = nil
-                        }
-                    }
-
-                    // MARK: Sync Prompt Banner
-                    if showSyncBanner {
-                        syncBanner
-                    }
-
-                    // MARK: iCloud Conflict Resolved Banner (R4-MEDIUM #38)
-                    if iCloudConflictBannerVisible {
-                        iCloudConflictBanner
                     }
 
                     // MARK: Location Draft Card
@@ -1219,38 +1170,142 @@ struct TodayView: View {
     // (which would take the user to the system Settings app where there's
     // nothing to configure).
 
-    // MARK: - R9-HIGH A2/A3 — Banner stack guards
+    // MARK: - Status Slot (banner collapse)
     //
-    // `bannerCount` counts the always-renders-at-top sections (AI key,
-    // sync queue, iCloud conflict). When too many fire at once the
-    // composer gets pushed below the fold on iPhone 12 mini, so the
-    // OnThisDay top card and WeeklyRecap preview defer to it. Read by
-    // both `shouldShowOnThisDayAtTop` and the top WeeklyRecap section
-    // guard in `body`.
-    private var bannerCount: Int {
-        var n = 0
-        // R10 (#793): AI key banner now only shows on empty days; align
-        // bannerCount so OnThisDay / WeeklyRecap cards don't yield
-        // pre-emptively to a banner that won't actually render.
-        if shouldShowAIKeyBanner && viewModel.memos.isEmpty { n += 1 }
+    // Enumerates every "system status" banner that used to render as an
+    // independent conditional row at the top of the VStack. At most ONE
+    // of these is visible at a time, chosen by strict priority (cases
+    // are declared highest → lowest). Every banner stays REACHABLE: its
+    // original show-condition still gates it inside `activeStatusSlot`;
+    // it just waits its turn instead of stacking.
+    private enum TodayStatusSlot: Equatable {
+        /// Background compile failed after all retries (DSBanner .error).
+        case compilationFailed
+        /// R4-MEDIUM #38 — iCloud conflict auto-merge acknowledgement
+        /// (DSBanner .warning). Self-dismisses after 3s (see the
+        /// `.vaultConflictResolved` onReceive), so it never starves the
+        /// slots below for long.
+        case iCloudConflict
+        /// R5 offline queue — only when something is actually stuck
+        /// (>= 5 pending OR oldest waited > 1h), per #793 museum redesign.
+        case offlineSyncQueue
+        /// In-flight AI compile. Merges the two old progress surfaces:
+        /// the rich stage banner (label + fraction bar, Issue #5) wins
+        /// when BackgroundCompilationService reports a stage; the thin
+        /// CompilationProgressBar covers foreground-only compiles where
+        /// only `viewModel.isCompiling` is set.
+        case compilationProgress
+        /// "Sync your journal across devices" sign-in prompt.
+        case syncPrompt
+        /// R3 — A2 info row: AI key missing. Museum-aesthetic (#793):
+        /// only on empty days; with memos present the same condition
+        /// shows as a small amber dot on the settings gear (set
+        /// elsewhere), so lowest priority is safe.
+        case aiKeyMissing
+
+        /// Error/conflict occupants push non-status cards (OnThisDay)
+        /// out of the top region; info/progress occupants coexist.
+        var isBlocking: Bool {
+            switch self {
+            case .compilationFailed, .iCloudConflict: return true
+            default: return false
+            }
+        }
+    }
+
+    /// Single source of truth for which status banner occupies the slot.
+    /// Each branch is the banner's ORIGINAL show-condition, moved here
+    /// verbatim from the layout; first match (highest priority) wins.
+    private var activeStatusSlot: TodayStatusSlot? {
+        if viewModel.compilationFailedError != nil { return .compilationFailed }
+        if iCloudConflictBannerVisible { return .iCloudConflict }
         if FeatureFlagStore.shared.isEnabled(.offlineQueue)
-            && (syncQueue.pendingCount >= 5 || syncQueueWaitedTooLong) { n += 1 }
-        if iCloudConflictBannerVisible { n += 1 }
-        return n
+            && (syncQueue.pendingCount >= 5 || syncQueueWaitedTooLong) {
+            return .offlineSyncQueue
+        }
+        if compileService.stage != .idle || viewModel.isCompiling { return .compilationProgress }
+        if showSyncBanner { return .syncPrompt }
+        if shouldShowAIKeyBanner && viewModel.memos.isEmpty { return .aiKeyMissing }
+        return nil
+    }
+
+    /// Renders the single active status banner. The banner views
+    /// themselves (and their tap/dismiss behaviors) are untouched — this
+    /// is purely the slot switch. `Motion.bannerSlide` on the slot value
+    /// makes an outgoing occupant slide away while the incoming one
+    /// slides in, never stacked (nil under reduce-motion, matching the
+    /// file's existing pattern).
+    @ViewBuilder
+    private var statusSlotSection: some View {
+        Group {
+            switch activeStatusSlot {
+            case .compilationFailed:
+                if let failureMsg = viewModel.compilationFailedError {
+                    CompilationFailedBanner(message: failureMsg) {
+                        viewModel.compilationFailedError = nil
+                        viewModel.compile()
+                    } onDismiss: {
+                        viewModel.compilationFailedError = nil
+                    }
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            case .iCloudConflict:
+                iCloudConflictBanner
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            case .offlineSyncQueue:
+                syncQueuePendingBanner
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            case .compilationProgress:
+                // Prefer the richer Issue #5 stage banner whenever the
+                // background service exposes a stage; fall back to the
+                // thin bar for foreground-only compiles.
+                if compileService.stage != .idle {
+                    compileProgressBanner
+                        .transition(.opacity.combined(with: .move(edge: .top)))
+                } else {
+                    CompilationProgressBar(stage: compilationService.stage)
+                        .transition(.opacity)
+                }
+            case .syncPrompt:
+                syncBanner
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            case .aiKeyMissing:
+                aiKeyMissingBanner
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+            case nil:
+                EmptyView()
+            }
+        }
+        .animation(reduceMotion ? nil : Motion.bannerSlide, value: activeStatusSlot)
+    }
+
+    // MARK: - R9-HIGH A2/A3 — Banner stack guards (post-slot)
+    //
+    // With the single status slot, `bannerCount` is now 0 or 1. Kept as
+    // a named property because the iPhone 12 mini composer-visibility
+    // rationale still applies: the slot row plus a top card is the most
+    // the region may occupy before the composer risks the fold.
+    private var bannerCount: Int {
+        activeStatusSlot == nil ? 0 : 1
     }
 
     /// R9-HIGH A2: single source of truth for whether the top-of-Today
     /// OnThisDay card renders. Used by both the `body` top section and
     /// the `onThisDayFallback(memos:)` inverse guard so the two paths
     /// agree inside the same SwiftUI render pass — no more lazy
-    /// `.onAppear` flip that briefly stacked two cards. The `bannerCount`
-    /// guard yields to the "system status" banners when ≥ 2 already
-    /// occupy the top: in that case the fallback (empty-day) path still
-    /// surfaces the card if the day has no memos to push it offscreen.
+    /// `.onAppear` flip that briefly stacked two cards.
+    ///
+    /// Slot-era guard: the card yields only when the status slot holds a
+    /// blocking (error/conflict) occupant — an urgent banner should own
+    /// the top alone, and on iPhone 12 mini banner + card + hero would
+    /// push the composer below the fold. A low-priority info occupant
+    /// (AI key, sync prompt, progress) coexists with the card; in the
+    /// yield case the fallback (empty-day) path still surfaces the card
+    /// if the day has no memos to push it offscreen.
     private var shouldShowOnThisDayAtTop: Bool {
         FeatureFlagStore.shared.isEnabled(.onThisDay)
             && viewModel.onThisDayEntry != nil
-            && bannerCount < 2
+            && !(activeStatusSlot?.isBlocking ?? false)
     }
 
     /// True when the banner should appear in this render. Combines:
@@ -1436,10 +1491,10 @@ struct TodayView: View {
         .padding(.vertical, 10)
         .background(DSColor.surfaceWhite)
         .overlay(
-            RoundedRectangle(cornerRadius: DSSpacing.radiusCard)
+            RoundedRectangle(cornerRadius: DSRadius.md)
                 .strokeBorder(DSColor.amberRim, lineWidth: 0.5)
         )
-        .clipShape(RoundedRectangle(cornerRadius: DSSpacing.radiusCard))
+        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md))
         .padding(.horizontal, DSSpacing.pageMargin)
         .padding(.bottom, DSSpacing.xs)
         .accessibilityElement(children: .combine)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -214,10 +214,6 @@ struct TodayView: View {
     @State private var orbBreathing: Bool = false
     @State private var orbTapBounce: Bool = false
 
-    /// Accumulated rotation for the settings gear — a gear should turn when
-    /// tapped. Bumped by a quarter turn on each tap so the spin feels mechanical.
-    @State private var settingsGearRotation: Double = 0
-
     /// Hint offset for the one-time swipe-left nudge on the Daily Page card.
     @State private var dailyPageHintOffset: CGFloat = 0
     @State private var memoCardHintOffset: CGFloat = 0
@@ -2577,25 +2573,26 @@ struct TodayView: View {
                     }
                 }
 
+                // Settings moved into the sidebar bottom section — the
+                // toolbar's trailing slot now opens global search, riding
+                // the same `pendingSearchQuery` rail the sidebar row and
+                // the `daypage://search?q=` URL scheme already use.
                 Button {
                     Haptics.soft()
-                    if !reduceMotion {
-                        withAnimation(Motion.spring) { settingsGearRotation += 90 }
-                    }
-                    showSettings = true
+                    nav.selectedTab = .archive
+                    nav.pendingSearchQuery = ""
                 } label: {
-                    Image(systemName: "gearshape")
+                    Image(systemName: "magnifyingglass")
                         .font(DSType.bodySM)
                         .foregroundColor(DSColor.inkMuted)
                         .frame(width: 36, height: 36)
                         .glassSurface(in: Circle())
                         .clipShape(Circle())
-                        .rotationEffect(.degrees(settingsGearRotation))
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(NSLocalizedString("a11y.settings", comment: "Settings button"))
-                .accessibilityHint(NSLocalizedString("a11y.settings.hint", comment: "Opens app settings"))
-                .accessibilityIdentifier("settings-gear-button")
+                .accessibilityLabel(NSLocalizedString("today.toolbar.search", comment: "Global search button"))
+                .accessibilityHint(NSLocalizedString("today.toolbar.search.hint", comment: "Opens global search"))
+                .accessibilityIdentifier("today-search-button")
             }
 
             // MARK: Hero title — weekday + subline, CENTERED.

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -707,7 +707,10 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
             var newMemos = memos
             newMemos[memoIdx] = updated
             let previous = memos
-            withAnimation { memos = newMemos }
+            // Re-transcription only swaps text inside an existing card —
+            // crossfade it. A bare `withAnimation` (default spring) would
+            // re-spring the whole timeline layout for a transcript update.
+            withAnimation(Motion.fade) { memos = newMemos }
             persistMemos(newMemos, capturedDate: date, previous: previous, failureMessagePrefix: NSLocalizedString("error.memo.retranscribe_failed", comment: ""))
         }
     }
@@ -1112,7 +1115,7 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
                     return
                 }
                 await OnThisDayIndex.shared.rebuildIndex()
-                HapticFeedback.success()
+                SignatureHaptics.compileSuccess()
                 BannerCenter.shared.show(AppBannerModel(
                     kind: .success,
                     title: NSLocalizedString("today.compile.success", comment: ""),

--- a/DayPage/Features/Today/UndoPillView.swift
+++ b/DayPage/Features/Today/UndoPillView.swift
@@ -147,8 +147,8 @@ struct UndoPillView: View {
     }
 
     private var ringColor: Color {
-        guard !reduceMotion else { return DSColor.accentAmber }
-        return isUrgent ? DSColor.error : DSColor.accentAmber
+        guard !reduceMotion else { return DSColor.accentOnBg }
+        return isUrgent ? DSColor.error : DSColor.accentOnBg
     }
 }
 

--- a/DayPage/Features/Today/WeeklyRecapSection.swift
+++ b/DayPage/Features/Today/WeeklyRecapSection.swift
@@ -89,7 +89,7 @@ private struct WeeklyRecapDayCard: View {
             .padding(.vertical, 14)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(DSColor.surfaceContainer)
-            .cornerRadius(DSSpacing.radiusCard)
+            .cornerRadius(DSRadius.md)
         }
         .buttonStyle(RecapCardButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(accessibilityLabel)

--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -162,7 +162,7 @@ struct WriteSheetView: View {
         }
         guard wordCount > 100 else { return DSColor.inkMuted }
         let t = CGFloat(min(wordCount - 100, 100)) / 100.0
-        return Self.lerpColor(from: DSColor.inkMuted, to: DSColor.accentAmber, t: t)
+        return Self.lerpColor(from: DSColor.inkMuted, to: DSColor.accentOnBg, t: t)
     }
 
     private static func lerpColor(from a: Color, to b: Color, t: CGFloat) -> Color {
@@ -670,7 +670,7 @@ struct WriteSheetView: View {
                         .font(.system(size: 18, weight: .regular))
                         .foregroundColor(
                             pendingLocation != nil
-                                ? DSColor.accentAmber
+                                ? DSColor.accentOnBg
                                 : DSColor.inkMuted
                         )
                 }

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -792,6 +792,8 @@
 "submit.error.retry"                         = "Retry";
 "Tap or swipe to dismiss"                    = "Tap or swipe to dismiss";
 "today.header.scroll_to_top"                 = "Scroll to top";
+"today.toolbar.search"                       = "Search";
+"today.toolbar.search.hint"                  = "Opens global search";
 "today.wordmilestone.announcement"           = "%lld words written";
 
 /* Today — timeline */

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -796,6 +796,8 @@
 "submit.error.retry"                         = "重试";
 "Tap or swipe to dismiss"                    = "点按或滑动以关闭";
 "today.header.scroll_to_top"                 = "回到顶部";
+"today.toolbar.search"                       = "搜索";
+"today.toolbar.search.hint"                  = "打开全局搜索";
 "today.wordmilestone.announcement"           = "已写满 %lld 字";
 
 /* Today — timeline (历史轨迹) */

--- a/DayPage/Services/HapticFeedback.swift
+++ b/DayPage/Services/HapticFeedback.swift
@@ -8,6 +8,7 @@ enum HapticFeedback {
 
     private static var impactGenerators: [UIImpactFeedbackGenerator.FeedbackStyle: UIImpactFeedbackGenerator] = [:]
     private static var notificationGenerator = UINotificationFeedbackGenerator()
+    private static var selectionGenerator = UISelectionFeedbackGenerator()
     private static var warmedUp = false
 
     // MARK: - Warm-up
@@ -20,6 +21,17 @@ enum HapticFeedback {
             generator(for: style).prepare()
         }
         notificationGenerator.prepare()
+        selectionGenerator.prepare()
+    }
+
+    // MARK: - Selection
+
+    /// System selection tick — for scrubbing across discrete options
+    /// (segmented controls, tab switches, calendar cells). Lighter and
+    /// semantically distinct from impact styles.
+    static func selection() {
+        selectionGenerator.selectionChanged()
+        selectionGenerator.prepare()
     }
 
     // MARK: - Impact

--- a/DayPage/Services/SignatureHaptics.swift
+++ b/DayPage/Services/SignatureHaptics.swift
@@ -1,0 +1,139 @@
+import CoreHaptics
+import UIKit
+
+/// Signature CoreHaptics moments for DayPage.
+///
+/// Unlike `HapticFeedback` (thin wrappers over the stock UIKit generators),
+/// this type authors custom `CHHapticPattern`s that give key product moments
+/// a recognizable, ownable texture. First signature: compilation success —
+/// "ink settling onto paper" (墨水落纸): a rising run of soft transient taps
+/// (the pen touching down) followed by a quiet continuous rumble that decays
+/// to nothing (the ink being absorbed by the page).
+///
+/// Design contract:
+/// - Never throws out of the public API.
+/// - On unsupported hardware or ANY engine/pattern failure, silently falls
+///   back to `HapticFeedback.success()` so the moment is never mute.
+/// - The engine is created lazily and stopped when playback finishes
+///   (`.stopEngine`), so it holds no haptic-server resources at rest.
+@MainActor
+enum SignatureHaptics {
+
+    // MARK: - State
+
+    /// Lazily-created shared engine. Nil until first use, and nilled out on
+    /// server reset so the next call rebuilds from a clean slate.
+    private static var engine: CHHapticEngine?
+
+    private static var supportsHaptics: Bool {
+        CHHapticEngine.capabilitiesForHardware().supportsHaptics
+    }
+
+    // MARK: - Public API
+
+    /// 墨水落纸 — the compilation-success signature.
+    ///
+    /// Pattern (total ≈ 0.51s):
+    /// - 4 transients rising in intensity 0.30 → 0.45 → 0.58 → 0.70,
+    ///   sharpness easing 0.45 → 0.38, spaced 70ms apart (t = 0, 0.07,
+    ///   0.14, 0.21).
+    /// - 1 continuous event at t = 0.26 for 0.25s, intensity 0.35,
+    ///   sharpness 0.20, with an intensity-control curve decaying
+    ///   1.0 → 0.0 across its duration (the "settling").
+    ///
+    /// Recognizably distinct from the stock `.success` notification
+    /// (two fixed medium transients).
+    static func compileSuccess() {
+        guard supportsHaptics else {
+            HapticFeedback.success()
+            return
+        }
+        do {
+            let engine = try sharedEngine()
+            try engine.start()
+            let player = try engine.makePlayer(with: inkSettlingPattern())
+            try player.start(atTime: CHHapticTimeImmediate)
+            // Release the Taptic Engine as soon as the pattern completes —
+            // per-call player creation is fine at this event frequency.
+            engine.notifyWhenPlayersFinished { _ in .stopEngine }
+        } catch {
+            HapticFeedback.success()
+        }
+    }
+
+    // MARK: - Engine Lifecycle
+
+    private static func sharedEngine() throws -> CHHapticEngine {
+        if let existing = engine {
+            return existing
+        }
+        let newEngine = try CHHapticEngine()
+        newEngine.playsHapticsOnly = true
+        // The haptic server can reset (audio interruption, backgrounding).
+        // Handlers run off the main actor, so hop back before touching our
+        // state; dropping the engine forces a clean rebuild on next call.
+        newEngine.resetHandler = {
+            Task { @MainActor in
+                SignatureHaptics.engine = nil
+            }
+        }
+        newEngine.stoppedHandler = { _ in
+            // Expected after `.stopEngine`; the next compileSuccess()
+            // restarts the retained engine with `start()`.
+        }
+        engine = newEngine
+        return newEngine
+    }
+
+    // MARK: - Pattern
+
+    /// Builds the "ink settling onto paper" pattern.
+    private static func inkSettlingPattern() throws -> CHHapticPattern {
+        var events: [CHHapticEvent] = []
+
+        // The pen touching down: rising taps, softening sharpness.
+        let taps: [(time: TimeInterval, intensity: Float, sharpness: Float)] = [
+            (0.00, 0.30, 0.45),
+            (0.07, 0.45, 0.42),
+            (0.14, 0.58, 0.40),
+            (0.21, 0.70, 0.38),
+        ]
+        for tap in taps {
+            events.append(CHHapticEvent(
+                eventType: .hapticTransient,
+                parameters: [
+                    CHHapticEventParameter(parameterID: .hapticIntensity, value: tap.intensity),
+                    CHHapticEventParameter(parameterID: .hapticSharpness, value: tap.sharpness),
+                ],
+                relativeTime: tap.time
+            ))
+        }
+
+        // The ink being absorbed: soft sustained rumble that decays away.
+        let settleStart: TimeInterval = 0.26
+        let settleDuration: TimeInterval = 0.25
+        events.append(CHHapticEvent(
+            eventType: .hapticContinuous,
+            parameters: [
+                CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.35),
+                CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.20),
+            ],
+            relativeTime: settleStart,
+            duration: settleDuration
+        ))
+
+        // Multiplicative intensity curve: full strength until the continuous
+        // event begins, then a linear fade to silence. The curve holds its
+        // first control-point value before it, so transients are unaffected.
+        let decay = CHHapticParameterCurve(
+            parameterID: .hapticIntensityControl,
+            controlPoints: [
+                CHHapticParameterCurve.ControlPoint(relativeTime: settleStart, value: 1.0),
+                CHHapticParameterCurve.ControlPoint(relativeTime: settleStart + settleDuration, value: 0.0),
+            ],
+            relativeTime: 0
+        )
+
+        return try CHHapticPattern(events: events, parameterCurves: [decay])
+    }
+}

--- a/design-tokens/generators/to-swift.ts
+++ b/design-tokens/generators/to-swift.ts
@@ -17,10 +17,14 @@ type Tokens = {
   spacing: Record<string, number>;
   motion: Record<string, string | number>;
   gestures: Record<string, number>;
-  // `dark` intentionally not consumed on iOS — SwiftUI adapts via Color
-  // literals against the environment's colorScheme rather than swapping
-  // CSS variables. If iOS ever needs an explicit dark-token entry, add
-  // a `DarkColors` enum here.
+  // Dark-mode variants. Colors with a `dark.colors` counterpart are emitted
+  // as adaptive UIColor dynamic providers so DSTokens.Colors no longer sinks
+  // in dark mode; colors without one stay static. `dark.elevation` is
+  // emitted alongside the light references for use-site mapping.
+  dark?: {
+    colors?: Record<string, string>;
+    elevation?: Record<string, string>;
+  };
 };
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -54,17 +58,31 @@ function buildSwift(t: Tokens): string {
   out.push(`// Source of truth: design-tokens/tokens.json`);
   out.push(``);
   out.push(`import SwiftUI`);
+  out.push(`import UIKit`);
   out.push(``);
   out.push(`enum DSTokens {`);
   out.push(`    static let version = "${t.version}"`);
   out.push(``);
 
-  // Colors
+  // Colors — tokens with a dark.colors counterpart become adaptive dynamic
+  // providers; the rest stay static (single value valid in both schemes).
+  const darkColors = t.dark?.colors ?? {};
   out.push(`    enum Colors {`);
   for (const [k, v] of Object.entries(t.colors)) {
     const [r, g, b] = hexToRGB(v);
-    out.push(`        /// ${v}`);
-    out.push(`        static let ${camel(k)} = Color(red: ${fmt(r)}, green: ${fmt(g)}, blue: ${fmt(b)})`);
+    const dark = darkColors[k];
+    if (dark) {
+      const [dr, dg, db] = hexToRGB(dark);
+      out.push(`        /// light ${v} / dark ${dark}`);
+      out.push(`        static let ${camel(k)} = Color(UIColor { traits in`);
+      out.push(`            traits.userInterfaceStyle == .dark`);
+      out.push(`                ? UIColor(red: ${fmt(dr)}, green: ${fmt(dg)}, blue: ${fmt(db)}, alpha: 1.0)`);
+      out.push(`                : UIColor(red: ${fmt(r)}, green: ${fmt(g)}, blue: ${fmt(b)}, alpha: 1.0)`);
+      out.push(`        })`);
+    } else {
+      out.push(`        /// ${v}`);
+      out.push(`        static let ${camel(k)} = Color(red: ${fmt(r)}, green: ${fmt(g)}, blue: ${fmt(b)})`);
+    }
   }
   out.push(`    }`);
   out.push(``);
@@ -110,6 +128,16 @@ function buildSwift(t: Tokens): string {
   for (const [k, v] of Object.entries(t.elevation)) {
     out.push(`        /// CSS reference: ${v}`);
     out.push(`        static let ${camel(k)} = ${JSON.stringify(v)}`);
+  }
+  const darkElevation = t.dark?.elevation ?? {};
+  if (Object.keys(darkElevation).length > 0) {
+    out.push(``);
+    out.push(`        // Dark-scheme shadow references — black-based, higher opacity`);
+    out.push(`        // (warm-ink shadows disappear on dark canvases).`);
+    for (const [k, v] of Object.entries(darkElevation)) {
+      out.push(`        /// CSS reference (dark): ${v}`);
+      out.push(`        static let ${camel(k)}Dark = ${JSON.stringify(v)}`);
+    }
   }
   out.push(`    }`);
   out.push(``);


### PR DESCRIPTION
Closes #816

> ⚠️ **Stacked PR**：base 是 `feat/compile-nightly-hash-wiki-index`（#815）。#815 合并后请 retarget 到 `main`。

## 概述

基于 axiom-swiftui + axiom-design 双 skill 的全量体验审计（审计报告见 #816），分三波全部落地，共 3 commits / ~80 文件。

## Wave 1 — P0 跟手性与触感 (`b86466d`)

- **侧边栏抽屉 1:1 跟手**：边缘滑动/scrim 实时驱动 offset，scrim 透明度按进度渐变，松手按 `predictedEndTranslation` 决定归位，settle 用 `Motion.panel` spring（打断衔接速度）
- **日详情页交互式翻页**：横向主导判定 + 边界 rubber-band(0.3) + 1/3 屏宽或 flick 提交
- **导航触感**：抽屉开合 `soft`、tab 切换 `selection` tick（新增 `UISelectionFeedbackGenerator` token）
- **Dynamic Type**：21 个 DSType 级别接入 `relativeTo:`，serif 走 UIFontMetrics 保 CJK 级联
- **Auth 调色板回归**：41 处硬编码近黑 hex → 自适应 DSColor

## Wave 2 — 签名时刻与性能 (`0123e6f`)

- **SignatureHaptics**：CoreHaptics「墨水落纸」编译签名触感（4 transient 渐强 + 衰减 continuous），5 个编译成功时刻接入，硬件不支持降级
- **Timeline 动画收敛**：容器级 `.animation(value: memos.count)` 拆解，re-transcription 改 crossfade
- **scrollTransition**（iOS17）：memo 卡滚入上浮淡入；**symbolEffect**（iOS17）：mic↔send replace 变形、编译 sparkles bounce
- **GraphView**：标签入 Canvas + SpatialTapGesture 命中检测——力导仿真期间零 SwiftUI 重排
- **暗色 token 生成**：to-swift.ts 消费 dark block，25 色 dynamic provider；DSElevation 暗色黑阴影
- **accentOnBg 扫雷**：93 处 amber 墨水迁移自适应 token；emoji→SF Symbol；hierarchical 渲染

## Wave 3 — 设计语言收敛 (`56482a4`)

- **横幅单一状态槽**：7 条条件横幅 → 优先级单槽（失败>冲突>离线>进度>同步>info）
- **照片 hero zoom**（iOS18）：缩略图→全屏 matched zoom，16/17 回退
- **半径收敛**：`radiusCard`(12) 31 处→`DSRadius.md`(14)，52 处字面量 tokenize，废弃常量删除
- **Motion.press**：press 弹簧收口，GlassErrorBanner 内联副本归 token

## 验证

- ✅ `xcodebuild build` 三波各自通过
- ✅ `DayPageTests` 全绿（TEST SUCCEEDED）
- ✅ iPhone 17 模拟器亮/暗双外观截图：单槽横幅、自适应 token、serif hero 均正确
- ⚠️ 建议真机补验：抽屉跟手手感、编译签名触感（模拟器无 Taptic Engine）、iOS 18 zoom 转场