### PR TITLE
feat(ux): 设计审计 R5 — 全页面截图评分修复循环（6.7→9.3），15 项 findings 全修复

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ Conventional changelog 格式：日期倒序，每个 release 标题 + 分类列
 - LocationService 反向地理编码 LRU 缓存（10/30min/~1km bucket）
 
 ### UX Polish
+- 设计审计 R5（2026-07-10，评分 6.7→9.3）：图谱标签/点击/自动适配错位修复（过滤缓存只存节点 ID）、缩放控件面板不再全宽盖住画布、编译日记页双返回键与偶发空白修复（isEmbedded 拆嵌套栈）、日详情元数据卡改用当天真实数据（删除 28°/86% 假默认值）、日记正文 wikilink 显示为可读名称
+- 设置页回归暖色品牌（浅/深色），API key 未配置改单一胶囊标注，「那年今日」中文化
+- 录音页操作栏中文化（暂停/丢弃/保存）并圆角化；输入栏定位 chip 显示「解析地名中…」而非裸经纬度
+- 归档总览统计加 ALL-TIME 范围词，与月度 TOTAL ENTRIES 口径区分；侧边栏 Recent 相对日期跟随界面语言
+- Today 横幅下移至头部行以下不再遮挡导航；CJK 草稿计数器单一化（字符数）
+- Wave 4 收尾：页面背景 token 三源合一（消除深色拼接接缝）、DSPicker 选项切换触感、侧边栏行 tapConfirm、Archive 派生集合缓存
 - Memo 滑动操作单次左滑同时露出 SHARE+DELETE + contextMenu 兜底
 - Graph 搜索 0 结果 glass toast 反馈
 - WriteSheet 自动聚焦（80ms 后 isFocused=true）

--- a/DayPage/App/SidebarHeatmapView.swift
+++ b/DayPage/App/SidebarHeatmapView.swift
@@ -123,7 +123,7 @@ struct SidebarHeatmapView: View {
                 Spacer().frame(height: 11) // align under the month-label row
                 ForEach(Array(["M", "T", "W", "T", "F", "S", "S"].enumerated()), id: \.offset) { idx, d in
                     Text(d)
-                        .font(.system(size: 8, design: .monospaced))
+                        .font(.system(size: 8, design: .monospaced)) // TODO: no DSType match, kept raw (8pt heatmap grid label, smallest mono token is mono9=9pt)
                         .tracking(1)
                         .foregroundColor(DSColor.inkSubtle)
                         .opacity(idx % 2 == 1 ? 0.4 : 0.9)
@@ -281,7 +281,7 @@ struct SidebarHeatmapView: View {
             let cell = cellSize(in: geo.size.width)
             ForEach(labels, id: \.col) { item in
                 Text(item.text)
-                    .font(.system(size: 8, design: .monospaced))
+                    .font(.system(size: 8, design: .monospaced)) // TODO: no DSType match, kept raw (8pt heatmap month label, smallest mono token is mono9=9pt)
                     .tracking(1.2)
                     .foregroundColor(DSColor.inkSubtle)
                     .offset(x: CGFloat(item.col) * (cell + cellSpacing))

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -151,6 +151,7 @@ struct SidebarView: View {
     /// 46pt amber-gradient avatar + serif name + mono membership + chevron.
     private var profileRow: some View {
         Button {
+            Haptics.tapConfirm()
             showAccountSheet = true
         } label: {
             HStack(spacing: 14) {
@@ -543,6 +544,7 @@ struct SidebarView: View {
         VStack(alignment: .leading, spacing: 2) {
             // Settings
             Button {
+                Haptics.tapConfirm()
                 showSettings = true
             } label: {
                 HStack(spacing: 12) {
@@ -581,6 +583,7 @@ struct SidebarView: View {
         let initial = sidebarVM.accountInitial
 
         return Button {
+            Haptics.tapConfirm()
             showAccountSheet = true
         } label: {
             HStack(spacing: 12) {

--- a/DayPage/DesignSystem/Colors.swift
+++ b/DayPage/DesignSystem/Colors.swift
@@ -50,7 +50,13 @@ enum DSColor {
     // migrates.
 
     /// Page background — warm cream in light, deep charcoal-brown in dark.
-    static let bgWarm        = Color(light: Color(hex: "FAF8F6"), dark: Color(hex: "1A1410"))
+    /// Points at the generated token (`DSTokens.Colors.bgWarm`, from
+    /// design-tokens/tokens.json) so this is the SINGLE source of truth for the
+    /// page background. Previously this hand-wrote `dark #1A1410` while the
+    /// generated source said `#1A1814` and the v3 `backgroundWarm` said
+    /// `#1A1612` — three different charcoals for "the page background" left a
+    /// visible seam where surfaces met. All three now resolve here.
+    static let bgWarm        = DSTokens.Colors.bgWarm
     /// Standard glass fill — adaptive opacity glass layer.
     static let glassStd      = Color(light: Color(red: 1, green: 252/255, blue: 250/255, opacity: 0.62),
                                      dark: Color(red: 30/255, green: 22/255, blue: 14/255, opacity: 0.62))
@@ -151,12 +157,16 @@ enum DSColor {
 
     // MARK: - V3 Warm-White Tokens
 
-    /// 页面 / 屏幕背景 — 暖色调米白 / 深暖棕
-    static let backgroundWarm = Color(light: Color(hex: "FAF8F6"), dark: Color(hex: "1A1612"))
-    /// 纯白表面（卡片、弹出面板）
-    static let surfaceWhite = Color(light: Color(hex: "FFFFFF"), dark: Color(hex: "242018"))
-    /// 下凹表面 — 微暖灰色 / 深凹表面
-    static let surfaceSunken = Color(light: Color(hex: "F3F0EB"), dark: Color(hex: "131210"))
+    /// 页面 / 屏幕背景 — 暖色调米白 / 深暖棕。
+    /// v3 别名，现指向单一真源 `bgWarm`（→ `DSTokens.Colors.bgWarm`）。
+    /// 曾经手写 `dark #1A1612`，与 v4/生成源不一致造成拼接接缝，已收敛。
+    static let backgroundWarm = bgWarm
+    /// 纯白表面（卡片、弹出面板）。指向生成真源，深色统一为 `#1F1C18`
+    ///（此前手写 `#242018`，与 tokens.json 生成值漂移）。
+    static let surfaceWhite = DSTokens.Colors.surfaceWhite
+    /// 下凹表面 — 微暖灰色 / 深凹表面。指向生成真源，深色统一为 `#252118`
+    ///（此前手写 `#131210`，比生成值更沉，造成同类下凹面深浅不一）。
+    static let surfaceSunken = DSTokens.Colors.surfaceSunken
 
     /// 暖色背景主文本
     static let onBackgroundPrimary = Color(light: Color(hex: "2B2822"), dark: Color(hex: "EDE6DC"))

--- a/DayPage/DesignSystem/DSPicker.swift
+++ b/DayPage/DesignSystem/DSPicker.swift
@@ -78,6 +78,12 @@ struct DSPicker<Value: Hashable, Label: View>: View {
             if isExpanded {
                 ForEach(options, id: \.value) { option in
                     Button {
+                        // Selection tick — the system scrubbing feel for moving
+                        // between discrete options. Centralized here so every
+                        // DSPicker across the app (Settings appearance / density
+                        // / attachment policy …) gets consistent haptic feedback
+                        // without each call site wiring it.
+                        if option.value != selection { Haptics.selection() }
                         selection = option.value
                         withAnimation(.spring(response: 0.3, dampingFraction: 0.9)) {
                             isExpanded = false

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -110,7 +110,36 @@ final class ArchiveViewModel: ObservableObject {
 
     @Published var currentYear: Int
     @Published var currentMonth: Int
-    @Published var dayStats: [String: DayStats] = [:]  // keyed by "yyyy-MM-dd"
+    @Published var dayStats: [String: DayStats] = [:] {  // keyed by "yyyy-MM-dd"
+        // Rebuild the derived list-mode collections once per dayStats change,
+        // instead of recomputing filter+sort+regroup on every SwiftUI body pass.
+        // `sortedDays`/`groupedByMonth` were computed vars read inside the
+        // LazyVStack AND re-read on every scroll frame (scroll-offset preference)
+        // AND re-run on every unrelated @Published mutation (e.g. isLoading) —
+        // the source of the acknowledged "1-2s first-scroll freeze".
+        didSet { rebuildDerivedDays() }
+    }
+
+    /// Cached, list-mode day collections derived from `dayStats`. Recomputed
+    /// only in `rebuildDerivedDays()` (via `dayStats.didSet`).
+    @Published private(set) var sortedDays: [DayStats] = []
+    @Published private(set) var groupedByMonth: [(monthKey: String, days: [DayStats])] = []
+
+    private func rebuildDerivedDays() {
+        let sorted = dayStats.values
+            .filter { $0.memoCount > 0 || $0.isDailyPageCompiled }
+            .sorted { $0.dateString > $1.dateString }
+        sortedDays = sorted
+
+        var groups: [String: [DayStats]] = [:]
+        for stats in sorted {
+            let monthKey = String(stats.dateString.prefix(7))
+            groups[monthKey, default: []].append(stats)
+        }
+        groupedByMonth = groups
+            .map { (monthKey: $0.key, days: $0.value) }
+            .sorted { $0.monthKey > $1.monthKey }
+    }
     @Published var isLoading: Bool = false
 
     // Task handle used to cancel a stale loadMonth request when the user
@@ -400,34 +429,14 @@ final class ArchiveViewModel: ObservableObject {
         Calendar.current.component(.day, from: Date())
     }
 
-    // MARK: Sorted Days for List Mode
-
-    var sortedDays: [DayStats] {
-        dayStats.values
-            .filter { $0.memoCount > 0 || $0.isDailyPageCompiled }
-            .sorted { $0.dateString > $1.dateString }
-    }
-
-    // MARK: Grouped By Month (list-mode sectioning, Issue #13 perf)
+    // MARK: Sorted Days / Grouped By Month
     //
-    // Buckets `sortedDays` by their "yyyy-MM" prefix so the LazyVStack can
-    // render proper Sections with month headers. SwiftUI's LazyVStack is
-    // smarter about offscreen-row layout when it sees an explicit Section
-    // boundary, which is what unsticks the 1-2s first-scroll freeze on
-    // months with many populated days.
-    //
-    // The underlying scan is O(n) and `n` is at most ~31 within the loaded
-    // month, so this is cheap to recompute on every dayStats change.
-    var groupedByMonth: [(monthKey: String, days: [DayStats])] {
-        var groups: [String: [DayStats]] = [:]
-        for stats in sortedDays {
-            let monthKey = String(stats.dateString.prefix(7))
-            groups[monthKey, default: []].append(stats)
-        }
-        return groups
-            .map { (monthKey: $0.key, days: $0.value) }
-            .sorted { $0.monthKey > $1.monthKey }
-    }
+    // These are now cached stored properties (see `sortedDays` /
+    // `groupedByMonth` @Published declarations above, rebuilt in
+    // `rebuildDerivedDays()` via `dayStats.didSet`). They were computed vars —
+    // filter+sort, then bucket-by-"yyyy-MM"+sort — read inside the LazyVStack
+    // and re-evaluated on every scroll frame and every unrelated @Published
+    // change, which is what caused the 1-2s first-scroll freeze (Issue #13).
 
     // MARK: Monthly Filter
 
@@ -501,8 +510,15 @@ struct ArchiveView: View {
     @EnvironmentObject private var nav: AppNavigationModel
     @StateObject private var viewModel = ArchiveViewModel()
     @State private var mode: ArchiveMode = .calendar
-    @State private var selectedDateString: String? = nil
-    @State private var showDayDetail: Bool = false
+    /// The historical day pushed onto Archive's NavigationStack as a
+    /// DayDetailView. Replaces the former `selectedDateString` + `showDayDetail`
+    /// bool that drove a `fullScreenCover`; pushing gives the day a system back
+    /// button + interactive edge-swipe-to-pop and a zoom hero (iOS 18+) out of
+    /// the tapped calendar cell / list row.
+    @State private var selectedDay: DayNavTarget? = nil
+    /// Shared zoom namespace so the tapped calendar cell / list row is the
+    /// `matchedTransitionSource` for the pushed DayDetailView.
+    @Namespace private var dayZoomNamespace
     @State private var showSearch: Bool = false
     /// Pre-filled query passed into SearchView when opened via deep link
     /// (`daypage://search?q=…` from `AskTodayIntent`). Cleared after consume
@@ -703,18 +719,32 @@ struct ArchiveView: View {
             .onChange(of: nav.pendingSearchQuery) { _ in
                 consumePendingSearchQuery()
             }
-            .fullScreenCover(isPresented: $showDayDetail) {
-                if let dateStr = selectedDateString {
-                    DayDetailView(dateString: dateStr)
+            // isPresented-based (iOS 16+) rather than item: (iOS 17+) so the
+            // push compiles against the 17.0 deployment target without an
+            // availability gate. The bound day is read inside the builder.
+            .navigationDestination(
+                isPresented: Binding(
+                    get: { selectedDay != nil },
+                    set: { if !$0 { selectedDay = nil } }
+                )
+            ) {
+                if let target = selectedDay {
+                    DayDetailView(dateString: target.dateString)
+                        .modifier(ArchiveDayZoomDestination(
+                            id: target.dateString, namespace: dayZoomNamespace
+                        ))
                 }
             }
             .sheet(isPresented: $showSearch) {
                 SearchView(
                     onSelect: { dateStr in
-                        selectedDateString = dateStr
+                        // Close the search sheet, then push the day once it has
+                        // dismissed. A push while the sheet is still animating
+                        // out gets swallowed, so defer by one runloop hop — much
+                        // shorter than the old 0.25s cover-vs-sheet workaround.
                         showSearch = false
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
-                            showDayDetail = true
+                        DispatchQueue.main.async {
+                            selectedDay = DayNavTarget(dateString: dateStr)
                         }
                     },
                     initialQuery: searchInitialQuery
@@ -754,8 +784,7 @@ struct ArchiveView: View {
     /// `.empty` / `.error` / `.rawOnly` / `.compiled` 等状态 — 参见 US-002。
     private func handleDateTap(dateStr: String) {
         Haptics.soft()
-        selectedDateString = dateStr
-        showDayDetail = true
+        selectedDay = DayNavTarget(dateString: dateStr)
     }
 
     /// Consume any pending deep-link from the sidebar's Recent row. Cleared
@@ -764,12 +793,10 @@ struct ArchiveView: View {
     private func consumePendingArchiveDate() {
         guard let dateStr = nav.pendingArchiveDate else { return }
         nav.pendingArchiveDate = nil
-        selectedDateString = dateStr
-        // Defer the cover so SwiftUI commits the tab switch first; presenting
-        // a fullScreenCover during the same runloop as the tab change can
-        // race and skip the animation on some iOS 16 builds.
+        // Defer the push so SwiftUI commits the tab switch first; pushing during
+        // the same runloop as the tab change can race and skip the animation.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            showDayDetail = true
+            selectedDay = DayNavTarget(dateString: dateStr)
         }
     }
 
@@ -992,10 +1019,15 @@ struct ArchiveView: View {
     }
 
     private func toggleButton(_ label: String, isSelected: Bool, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
+        Button {
+            // Selection tick only when actually switching mode — tapping the
+            // already-selected segment shouldn't fire feedback.
+            if !isSelected { Haptics.selection() }
+            action()
+        } label: {
             Text(label)
                 .monoLabelStyle(size: 10)
-                .foregroundColor(isSelected ? .white : DSColor.inkSubtle)
+                .foregroundColor(isSelected ? DSColor.onAmber : DSColor.inkSubtle)
                 .padding(.horizontal, 12)
                 .padding(.vertical, 6)
                 .background(isSelected ? DSColor.amberDeep : Color.clear, in: Capsule())
@@ -1126,6 +1158,7 @@ struct ArchiveView: View {
                 .aspectRatio(1, contentMode: .fit)
             }
             .buttonStyle(CalendarCellButtonStyle())
+            .modifier(ArchiveDayZoomSource(id: dateStr, namespace: dayZoomNamespace))
             .frame(maxWidth: .infinity)
             .accessibilityLabel(accessibilityLabel(dateStr: dateStr, state: data, stats: viewModel.dayStats[dateStr]))
             .accessibilityValue(viewModel.dayStats[dateStr]?.densityLevel.label ?? "")
@@ -1256,6 +1289,7 @@ struct ArchiveView: View {
                                 .liquidGlassCard(cornerRadius: DSRadius.sm)
                             }
                             .buttonStyle(.plain)
+                            .modifier(ArchiveDayZoomSource(id: stats.dateString, namespace: dayZoomNamespace))
                             .accessibilityLabel(RelativeDate.label(for: stats.dateString, style: .caps))
                             .accessibilityHint("Opens this day's entry")
                         }
@@ -1676,6 +1710,7 @@ struct ArchiveView: View {
             .pressableCard()
         }
         .buttonStyle(.plain)
+        .modifier(ArchiveDayZoomSource(id: stats.dateString, namespace: dayZoomNamespace))
     }
 
     private func metaIcon(_ systemName: String, count: Int, unit: String? = nil) -> some View {
@@ -1831,5 +1866,40 @@ private struct CalendarCellButtonStyle: ButtonStyle {
             .scaleEffect(configuration.isPressed ? 0.93 : 1.0)
             .opacity(configuration.isPressed ? 0.82 : 1.0)
             .dsAnimation(Motion.spring, value: configuration.isPressed)
+    }
+}
+
+// MARK: - Archive Day Zoom Transition
+//
+// Mirror of Today's CardZoomSource/CardZoomDestination: the tapped calendar
+// cell / list row is the source, the pushed DayDetailView is the destination,
+// keyed by the day's date string. iOS 18+ only, and skipped under Reduce
+// Motion — everywhere else the push falls back to the default slide.
+
+struct ArchiveDayZoomSource: ViewModifier {
+    let id: String
+    let namespace: Namespace.ID
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *), !reduceMotion {
+            content.matchedTransitionSource(id: id, in: namespace)
+        } else {
+            content
+        }
+    }
+}
+
+struct ArchiveDayZoomDestination: ViewModifier {
+    let id: String
+    let namespace: Namespace.ID
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *), !reduceMotion {
+            content.navigationTransition(.zoom(sourceID: id, in: namespace))
+        } else {
+            content
+        }
     }
 }

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -908,16 +908,19 @@ struct ArchiveView: View {
         let totalMemos = all.reduce(0) { $0 + $1.memoCount }
         let totalDays = all.count
         let hasData = totalDays > 0 || totalMemos > 0
+        // Scope words matter: this strip is whole-vault, but it sits directly
+        // under the month title, so bare "MEMOS 16" read as July's count and
+        // contradicted the month summary's "TOTAL ENTRIES 11" (FINDING-008).
         return HStack(alignment: .center, spacing: 20) {
             statPillar(
-                label: "MEMOS",
+                label: "ALL-TIME MEMOS",
                 value: hasData ? "\(totalMemos)" : "—"
             )
             Rectangle()
                 .fill(DSColor.glassRimD)
                 .frame(width: 0.5, height: 26)
             statPillar(
-                label: "DAYS WRITTEN",
+                label: "ALL-TIME DAYS",
                 value: hasData ? "\(totalDays)" : "—"
             )
             Spacer()

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -19,7 +19,9 @@ struct DayDetailView: View {
     @EnvironmentObject private var nav: AppNavigationModel
 
     enum Tab: String, CaseIterable {
-        case daily = "Daily Page"
+        // 同一控件内半英半中（"Daily Page" | "原始 Memo"）读起来像两个产品
+        // （FINDING-010）。英文 mono 保留给档案性标签，可交互控件统一中文。
+        case daily = "日记页"
         case raw = "原始 Memo"
     }
 

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -46,6 +46,8 @@ struct DayDetailView: View {
     @State private var state: LoadState = .loading
     @State private var hasRawFile: Bool = false
     @State private var selectedTab: Tab = .daily
+    /// 当天真实元数据瓦片（天气/条数/跨度/类型），无 raw 数据时为 nil 并隐藏。
+    @State private var metaTiles: [MetadataGridView.Tile]? = nil
 
     /// Finger-tracked horizontal offset for interactive paging. `@GestureState`
     /// auto-resets when the gesture ends or is cancelled; the reset transaction
@@ -271,11 +273,13 @@ struct DayDetailView: View {
             // v8 detail.jsx:258-271 — 4-column metadata tile row pinned above
             // the compiled daily page (WEATHER / HUMIDITY / LIGHT / KIND).
             VStack(spacing: 0) {
-                MetadataGridView()
-                    .padding(.horizontal, 22)
-                    .padding(.top, 16)
-                    .padding(.bottom, 6)
-                DailyPageView(dateString: currentDate)
+                if let tiles = metaTiles {
+                    MetadataGridView(tiles: tiles)
+                        .padding(.horizontal, 22)
+                        .padding(.top, 16)
+                        .padding(.bottom, 6)
+                }
+                DailyPageView(dateString: currentDate, isEmbedded: true)
             }
         case .rawOnly:
             VStack(spacing: 20) {
@@ -415,6 +419,74 @@ struct DayDetailView: View {
         case .empty, .error, .loading:
             state = resolved.0
         }
+
+        // FINDING-004: the metadata strip previously rendered MetadataGridView's
+        // design-reference defaults (28° / 86 PERCENT / …) — fabricated numbers
+        // presented as this day's facts. Derive the tiles from the day's raw
+        // memos instead; fields with no source data show "—".
+        if resolved.1, let date = DateFormatters.isoDate.date(from: target) {
+            let memos = await Task.detached(priority: .userInitiated) {
+                (try? RawStorage.read(for: date)) ?? []
+            }.value
+            metaTiles = Self.buildMetaTiles(from: memos)
+        } else {
+            metaTiles = nil
+        }
+    }
+
+    /// 从当天 raw memos 推导 4 块元数据（天气 / 条数 / 时间跨度 / 类型）。
+    /// 纯函数，便于测试。
+    static func buildMetaTiles(from memos: [Memo]) -> [MetadataGridView.Tile]? {
+        guard !memos.isEmpty else { return nil }
+        let sorted = memos.sorted { $0.created < $1.created }
+
+        // WEATHER — first memo that captured one, e.g. "小雨 24°C"
+        var weatherValue = "—", weatherSub: String? = nil
+        if let w = sorted.compactMap(\.weather).first {
+            let parts = w.split(separator: " ")
+            if let temp = parts.first(where: { $0.contains("°") }) {
+                weatherValue = String(temp)
+                weatherSub = parts.first(where: { !$0.contains("°") }).map(String.init)
+            } else {
+                weatherValue = w
+            }
+        }
+
+        // ENTRIES — memo count
+        let entriesTile = MetadataGridView.Tile(
+            label: "ENTRIES", value: "\(sorted.count)", sub: "MEMOS"
+        )
+
+        // SPAN — first→last capture time
+        let fmt = DateFormatters.timeHHmm
+        let first = fmt.string(from: sorted.first!.created)
+        let last = fmt.string(from: sorted.last!.created)
+        let spanTile = MetadataGridView.Tile(
+            label: "SPAN",
+            value: sorted.count > 1 ? "\(first)" : first,
+            sub: sorted.count > 1 ? "→ \(last)" : nil
+        )
+
+        // KIND — dominant memo type
+        let voice = sorted.filter { $0.type == .voice }.count
+        let photo = sorted.filter { $0.attachments.contains { $0.kind == "photo" } }.count
+        let text = sorted.count - voice - photo
+        let dominant: String = {
+            if text >= voice && text >= photo { return "文本" }
+            if voice >= photo { return "语音" }
+            return "照片"
+        }()
+        var kindParts: [String] = []
+        if text > 0 { kindParts.append("\(text) 文") }
+        if voice > 0 { kindParts.append("\(voice) 声") }
+        if photo > 0 { kindParts.append("\(photo) 图") }
+
+        return [
+            MetadataGridView.Tile(label: "WEATHER", value: weatherValue, sub: weatherSub),
+            entriesTile,
+            spanTile,
+            MetadataGridView.Tile(label: "KIND", value: dominant, sub: kindParts.joined(separator: " · "))
+        ]
     }
 
     /// 纯解析器 — 不含 SwiftUI，不含异步。返回 `(state, hasRawFile)`。

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -68,63 +68,59 @@ struct DayDetailView: View {
     private static let dateRegex = try? NSRegularExpression(pattern: #"^\d{4}-\d{2}-\d{2}$"#)
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                DSColor.background.ignoresSafeArea()
+        // No inner NavigationStack — DayDetailView is now pushed onto the host's
+        // stack (Today / Archive both root a NavigationStack), so it inherits
+        // the system back button AND the interactive edge-swipe-to-pop that a
+        // self-contained modal `fullScreenCover` could never offer. The leading
+        // "返回" chevron is gone because the system back button replaces it; the
+        // ›/‹ day-stepper toolbar stays on the trailing side.
+        ZStack {
+            DSColor.background.ignoresSafeArea()
 
-                Group {
-                    switch state {
-                    case .loading:
-                        loadingView
-                    case .compiled, .rawOnly:
-                        loadedContent
-                    case .empty:
-                        emptyStateView
-                    case .error(let message):
-                        errorStateView(message: message)
-                    }
+            Group {
+                switch state {
+                case .loading:
+                    loadingView
+                case .compiled, .rawOnly:
+                    loadedContent
+                case .empty:
+                    emptyStateView
+                case .error(let message):
+                    errorStateView(message: message)
                 }
-                // Re-key on the displayed day so SwiftUI treats each day as a
-                // distinct subtree and runs the directional slide transition.
-                .id(currentDate)
-                .transition(dayTransition)
-                // Finger-tracked paging: 1:1 while paging is possible in the
-                // drag direction, rubber-banded at the bounds (see gesture).
-                .offset(x: pageDrag.offset)
             }
-            // Interactive horizontal paging between days: the page follows the
-            // finger once the drag is dominantly sideways, rubber-bands at the
-            // bounds, and commits on distance or flick. `simultaneousGesture`
-            // + the dominance gate keep vertical scrolls inside the daily/raw
-            // content untouched.
-            .simultaneousGesture(pageSwipeGesture)
-            .navigationTitle(formattedTitle)
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "chevron.left")
-                            .font(.system(size: 16, weight: .semibold))
-                            .foregroundColor(DSColor.onSurface)
-                    }
-                    .accessibilityLabel("返回")
+            // Re-key on the displayed day so SwiftUI treats each day as a
+            // distinct subtree and runs the directional slide transition.
+            .id(currentDate)
+            .transition(dayTransition)
+            // Finger-tracked paging: 1:1 while paging is possible in the
+            // drag direction, rubber-banded at the bounds (see gesture).
+            .offset(x: pageDrag.offset)
+        }
+        // Interactive horizontal paging between days: the page follows the
+        // finger once the drag is dominantly sideways, rubber-bands at the
+        // bounds, and commits on distance or flick. `simultaneousGesture`
+        // + the dominance gate keep vertical scrolls inside the daily/raw
+        // content untouched.
+        .simultaneousGesture(pageSwipeGesture)
+        .navigationTitle(formattedTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                Button(action: { go(.backward) }) {
+                    Image(systemName: "chevron.left")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(DSColor.onSurface)
                 }
-                ToolbarItemGroup(placement: .navigationBarTrailing) {
-                    Button(action: { go(.backward) }) {
-                        Image(systemName: "chevron.left")
-                            .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(DSColor.onSurface)
-                    }
-                    .accessibilityLabel("前一天")
+                .accessibilityLabel("前一天")
 
-                    Button(action: { go(.forward) }) {
-                        Image(systemName: "chevron.right")
-                            .font(.system(size: 15, weight: .semibold))
-                            .foregroundColor(canGoForward ? DSColor.onSurface : DSColor.onSurfaceVariant.opacity(0.35))
-                    }
-                    .disabled(!canGoForward)
-                    .accessibilityLabel("后一天")
+                Button(action: { go(.forward) }) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundColor(canGoForward ? DSColor.onSurface : DSColor.onSurfaceVariant.opacity(0.35))
                 }
+                .disabled(!canGoForward)
+                .accessibilityLabel("后一天")
             }
         }
         .task(id: currentDate) { await load() }
@@ -250,6 +246,7 @@ struct DayDetailView: View {
                 }
             }
             .pickerStyle(.segmented)
+            .onChange(of: selectedTab) { _ in Haptics.selection() }
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
             .background(DSColor.surfaceContainerLow)

--- a/DayPage/Features/Archive/MetadataGridView.swift
+++ b/DayPage/Features/Archive/MetadataGridView.swift
@@ -30,17 +30,11 @@ struct MetadataGridView: View {
         }
     }
 
+    // No default tiles: the old design-reference fallback (28° / 86 PERCENT /
+    // 下午 15:30) rendered fabricated numbers as if they were the day's real
+    // metadata whenever a caller forgot to pass data (FINDING-004). Callers
+    // must now supply real tiles — or hide the strip.
     let tiles: [Tile]
-
-    /// Default 4-tile layout matching detail.jsx:267-270.
-    init(tiles: [Tile]? = nil) {
-        self.tiles = tiles ?? [
-            Tile(label: "WEATHER", value: "28°", sub: "多云"),
-            Tile(label: "HUMIDITY", value: "86", sub: "PERCENT"),
-            Tile(label: "LIGHT", value: "下午", sub: "15:30"),
-            Tile(label: "KIND", value: "文本", sub: "—")
-        ]
-    }
 
     var body: some View {
         HStack(spacing: 0) {
@@ -105,8 +99,13 @@ struct MetadataGridView_Previews: PreviewProvider {
     static var previews: some View {
         ZStack {
             DSColor.bgWarm.ignoresSafeArea()
-            MetadataGridView()
-                .padding(.horizontal, 22)
+            MetadataGridView(tiles: [
+                MetadataGridView.Tile(label: "WEATHER", value: "24°", sub: "小雨"),
+                MetadataGridView.Tile(label: "ENTRIES", value: "6", sub: "MEMOS"),
+                MetadataGridView.Tile(label: "SPAN", value: "08:12", sub: "→ 21:40"),
+                MetadataGridView.Tile(label: "KIND", value: "文本", sub: "5 文 · 1 声")
+            ])
+            .padding(.horizontal, 22)
         }
     }
 }

--- a/DayPage/Features/Auth/AccountSheet.swift
+++ b/DayPage/Features/Auth/AccountSheet.swift
@@ -116,7 +116,7 @@ struct AccountSheet: View {
 
             Image(systemName: "checkmark.circle.fill")
                 .font(.system(size: 16))
-                .foregroundColor(.green)
+                .foregroundColor(DSColor.statusSuccess)
         }
         .padding(.horizontal, 20)
         .padding(.vertical, 8)

--- a/DayPage/Features/Auth/AuthView.swift
+++ b/DayPage/Features/Auth/AuthView.swift
@@ -49,7 +49,7 @@ struct AuthView: View {
 
                 if let errorText = viewModel.errorMessage {
                     Text(errorText)
-                        .font(.system(size: 14))
+                        .font(DSType.bodySM)
                         .foregroundColor(DSColor.statusError)
                         .multilineTextAlignment(.center)
                         .padding(.horizontal, 32)

--- a/DayPage/Features/Auth/EmailAuthView.swift
+++ b/DayPage/Features/Auth/EmailAuthView.swift
@@ -104,7 +104,7 @@ struct EmailAuthView: View {
 
                 if let errorMessage = viewModel.errorMessage {
                     Text(errorMessage)
-                        .font(.system(size: 14))
+                        .font(DSType.bodySM)
                         .foregroundColor(DSColor.statusError)
                         .padding(.bottom, 8)
                         .transition(.opacity)

--- a/DayPage/Features/Auth/OTPVerificationView.swift
+++ b/DayPage/Features/Auth/OTPVerificationView.swift
@@ -58,7 +58,7 @@ struct OTPVerificationView: View {
 
                 if let errorMessage = viewModel.displayedErrorMessage {
                     Text(errorMessage)
-                        .font(.system(size: 14))
+                        .font(DSType.bodySM)
                         .foregroundColor(DSColor.statusError)
                         .multilineTextAlignment(.leading)
                         .frame(maxWidth: .infinity, alignment: .leading)

--- a/DayPage/Features/Daily/DailyPageParser.swift
+++ b/DayPage/Features/Daily/DailyPageParser.swift
@@ -49,6 +49,9 @@ enum DailyPageParser {
             }
         }
 
+        // 摘要同样可能携带 wikilink（编译器把实体名写进一句话总结）。
+        summary = normalizeWikilinks(in: summary)
+
         // 回退：如果 frontmatter 中没有封面，从当日 raw memo 中推导。
         let resolvedCover = cover ?? firstPhotoAttachmentPath(for: dateString)
 
@@ -149,7 +152,35 @@ enum DailyPageParser {
             range: range,
             withTemplate: ""
         ).trimmingCharacters(in: .whitespacesAndNewlines)
-        return (cleaned, ordered)
+        return (normalizeWikilinks(in: cleaned), ordered)
+    }
+
+    // Cached — pattern is invariant, and sections re-parse on every page load.
+    private static let wikilinkDisplayRegex = try? NSRegularExpression(
+        pattern: #"\[\[([^\]|]+)(?:\|([^\]]+))?\]\]"#
+    )
+
+    /// 将叙事正文中的 wikilink 展示为人类可读名称（FINDING-005）。
+    /// `[[wiki/people/a-ling|阿玲]]` → `阿玲`；`[[joma-coffee]]` → `joma coffee`。
+    /// 编译器输出与手写页都可能带任一形式；在做成可点 chip 之前，至少不能把
+    /// 原始链接语法裸露给读者。
+    static func normalizeWikilinks(in text: String) -> String {
+        guard text.contains("[["), let regex = wikilinkDisplayRegex else { return text }
+        let ns = NSMutableString(string: text)
+        let matches = regex.matches(in: text, range: NSRange(location: 0, length: ns.length))
+        // Replace back-to-front so earlier ranges stay valid.
+        for m in matches.reversed() {
+            let display: String
+            if m.range(at: 2).location != NSNotFound {
+                display = ns.substring(with: m.range(at: 2))
+            } else {
+                let target = ns.substring(with: m.range(at: 1))
+                let slug = target.split(separator: "/").last.map(String.init) ?? target
+                display = slug.replacingOccurrences(of: "-", with: " ")
+            }
+            ns.replaceCharacters(in: m.range(at: 0), with: display)
+        }
+        return ns as String
     }
 
     private static func firstPhotoAttachmentPath(for dateString: String) -> String? {

--- a/DayPage/Features/Daily/DailyPageView.swift
+++ b/DayPage/Features/Daily/DailyPageView.swift
@@ -12,6 +12,9 @@ struct DailyPageView: View {
 
     let dateString: String
     var onReturnToToday: ((String) -> Void)? = nil  // 点击跟进问题时调用，传入预填充文本
+    /// true = 由外层导航栈 push 呈现（DayDetailView 内嵌）；false = 独立模态
+    /// （Today fullScreenCover / EntityPage sheet）需要自带 NavigationStack。
+    var isEmbedded: Bool = false
 
     @Environment(\.dismiss) private var dismiss
     @StateObject private var memoVM = DailyPageMemoVM()
@@ -41,8 +44,21 @@ struct DailyPageView: View {
     @State private var freeformDraft: String = ""
     @State private var freeformVM: ThreadConversationViewModel? = nil
 
+    /// Hosts the page in its own NavigationStack ONLY when presented modally.
+    /// When pushed inside an existing stack (DayDetailView), nesting a second
+    /// NavigationStack produced a duplicate back affordance (system chevron +
+    /// arrow.left) and an intermittently blank first render (FINDING-003).
+    @ViewBuilder
+    private func navContainer<C: View>(@ViewBuilder content: () -> C) -> some View {
+        if isEmbedded {
+            content()
+        } else {
+            NavigationStack(root: content)
+        }
+    }
+
     var body: some View {
-        NavigationStack {
+        navContainer {
             ZStack {
                 DSColor.background.ignoresSafeArea()
 
@@ -99,17 +115,21 @@ struct DailyPageView: View {
             }
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    Button(action: { dismiss() }) {
-                        Image(systemName: "arrow.left")
-                            .font(.system(size: 16, weight: .medium))
+                // Embedded (pushed) mode inherits the host stack's back button
+                // and title — adding our own here doubled both (FINDING-003).
+                if !isEmbedded {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        Button(action: { dismiss() }) {
+                            Image(systemName: "arrow.left")
+                                .font(.system(size: 16, weight: .medium))
+                                .foregroundColor(DSColor.onSurface)
+                        }
+                    }
+                    ToolbarItem(placement: .principal) {
+                        Text(dailyPageMonthDay(dateString))
+                            .headlineMDStyle()
                             .foregroundColor(DSColor.onSurface)
                     }
-                }
-                ToolbarItem(placement: .principal) {
-                    Text(dailyPageMonthDay(dateString))
-                        .headlineMDStyle()
-                        .foregroundColor(DSColor.onSurface)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
                     if isRecompiling {

--- a/DayPage/Features/Daily/DailyPageView.swift
+++ b/DayPage/Features/Daily/DailyPageView.swift
@@ -664,7 +664,7 @@ struct DailyPageView: View {
                 VStack(alignment: .leading, spacing: 8) {
                     Text(errMsg)
                         .font(DSType.bodySM)
-                        .foregroundColor(.red)
+                        .foregroundColor(DSColor.statusError)
                         .fixedSize(horizontal: false, vertical: true)
                     Button(action: { Task { await recompile() } }) {
                         Text("RETRY →")

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -940,10 +940,12 @@ struct GraphView: View {
             .accessibilityLabel(NSLocalizedString("graph.a11y.fit", comment: "Graph fit-to-screen button"))
             .accessibilityAddTraits(.isButton)
 
+            // Fixed-width hairline: an unconstrained Rectangle is greedy and
+            // stretches the whole VStack (and its glass card) to full screen
+            // width, burying the graph under a giant panel (FINDING-002).
             Rectangle()
                 .fill(DSColor.glassRim)
-                .frame(height: 0.5)
-                .padding(.horizontal, 10)
+                .frame(width: 24, height: 0.5)
 
             Button {
                 zoom(by: 1.3)
@@ -961,8 +963,7 @@ struct GraphView: View {
 
             Rectangle()
                 .fill(DSColor.glassRim)
-                .frame(height: 0.5)
-                .padding(.horizontal, 10)
+                .frame(width: 24, height: 0.5)
 
             Button {
                 zoom(by: 1 / 1.3)

--- a/DayPage/Features/Graph/GraphViewModel.swift
+++ b/DayPage/Features/Graph/GraphViewModel.swift
@@ -55,11 +55,16 @@ final class GraphViewModel: ObservableObject {
     // searchQuery: debounced output observed by filtering + canvas redraw.
     // 200ms debounce keeps O(n) filter + full canvas redraw off the keystroke path on big graphs.
     @Published var searchInput: String = "" { didSet { scheduleSearchDebounce() } }
-    @Published var searchQuery: String = "" { didSet { _filteredNodes = nil } }
-    @Published var filterStartDate: Date? = nil { didSet { _filteredNodes = nil } }
-    @Published var filterEndDate: Date? = nil { didSet { _filteredNodes = nil } }
+    @Published var searchQuery: String = "" { didSet { _filteredIDs = nil } }
+    @Published var filterStartDate: Date? = nil { didSet { _filteredIDs = nil } }
+    @Published var filterEndDate: Date? = nil { didSet { _filteredIDs = nil } }
 
-    private var _filteredNodes: [GraphNode]? = nil
+    // Membership cache ONLY (node IDs), never node copies. The force simulation
+    // mutates `nodes[i].position` every frame; caching full GraphNode structs
+    // froze positions at filter time, so labels / hit-testing / fit-to-content
+    // all worked against a stale layout while the canvas drew the live one
+    // (FINDING-001: labels detached from their nodes).
+    private var _filteredIDs: Set<String>? = nil
     private var searchDebounceTask: Task<Void, Never>? = nil
 
     private func scheduleSearchDebounce() {
@@ -80,12 +85,20 @@ final class GraphViewModel: ObservableObject {
         }
     }
 
-    /// Nodes after applying search and date filters. Result is cached and
-    /// invalidated only when nodes, searchQuery, or date filters change.
+    /// Nodes after applying search and date filters. Membership (which IDs
+    /// match) is cached; the returned elements are always taken from the live
+    /// `nodes` array so positions reflect the current simulation frame.
     var filteredNodes: [GraphNode] {
-        if let cached = _filteredNodes { return cached }
-        let result = computeFilteredNodes()
-        _filteredNodes = result
+        let ids = filteredIDs
+        // Fast path: nothing filtered out — return the live array as-is.
+        if ids.count == nodes.count { return nodes }
+        return nodes.filter { ids.contains($0.id) }
+    }
+
+    private var filteredIDs: Set<String> {
+        if let cached = _filteredIDs { return cached }
+        let result = Set(computeFilteredNodes().map { $0.id })
+        _filteredIDs = result
         return result
     }
 
@@ -128,7 +141,7 @@ final class GraphViewModel: ObservableObject {
             let result = Self.buildGraph()
             await MainActor.run { [weak self] in
                 self?.nodes = result.nodes
-                self?._filteredNodes = nil
+                self?._filteredIDs = nil
                 self?.edges = result.edges
                 self?.hasCompiledDailies = result.hasCompiledDailies
                 self?.isLoading = false

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -203,7 +203,7 @@ struct SettingsView: View {
                         editingKeyValue = ""
                     }
                     .buttonStyle(.bordered)
-                    .tint(.red)
+                    .tint(DSColor.statusError)
                     .accessibilityLabel(NSLocalizedString("settings.apikey.clear.label", comment: ""))
                     .accessibilityIdentifier("api-key-clear-button")
                 }
@@ -538,7 +538,10 @@ struct SettingsView: View {
             // "Use legacy voice recording" per the PRD's legacy-fallback copy.
             Toggle(isOn: Binding(
                 get: { !usePressToTalk },
-                set: { usePressToTalk = !$0 }
+                set: {
+                    Haptics.selection()
+                    usePressToTalk = !$0
+                }
             )) {
                 Label(NSLocalizedString("settings.appearance.legacy_voice", comment: ""), systemImage: "mic.circle")
             }
@@ -548,6 +551,7 @@ struct SettingsView: View {
                 Label("On This Day", systemImage: "calendar.badge.clock")
             }
             .accessibilityIdentifier("onthisday-enabled-toggle")
+            .onChange(of: onThisDayEnabled) { _ in Haptics.selection() }
             .onChange(of: onThisDayEnabled) { val in
                 OnThisDayScheduler.shared.isEnabled = val
             }
@@ -630,6 +634,7 @@ struct SettingsView: View {
             }
             if appSettings.preferredTimeZone.identifier != TimeZone.current.identifier {
                 Button(role: .destructive) {
+                    Haptics.warn()
                     appSettings.resetToDeviceTimeZone()
                     BackgroundCompilationService.shared.scheduleIfNeeded()
                 } label: {
@@ -705,12 +710,12 @@ struct SettingsView: View {
         case .error(let message):
             HStack(spacing: 10) {
                 Image(systemName: "exclamationmark.triangle.fill")
-                    .foregroundColor(.red)
+                    .foregroundColor(DSColor.statusError)
                 VStack(alignment: .leading, spacing: 2) {
-                    Text(NSLocalizedString("settings.icloud.error", comment: "")).font(.body).fontWeight(.medium).foregroundColor(.red)
+                    Text(NSLocalizedString("settings.icloud.error", comment: "")).font(.body).fontWeight(.medium).foregroundColor(DSColor.statusError)
                     Text(message)
                         .font(.caption)
-                        .foregroundColor(.red)
+                        .foregroundColor(DSColor.statusError)
                         .lineLimit(2)
                 }
             }
@@ -780,6 +785,7 @@ struct SettingsView: View {
     }
 
     private func rollbackToLocal() {
+        Haptics.warn()
         appSettings.vaultLocation = .local
         VaultInitializer.shared = LocalVaultLocator()
         bannerCenter.show(AppBannerModel(
@@ -816,6 +822,7 @@ struct SettingsView: View {
     }
 
     private func cleanupLocalBackup() {
+        Haptics.warn()
         do {
             try VaultMigrationService.shared.deleteLocalBackup()
             bannerCenter.show(AppBannerModel(
@@ -884,7 +891,7 @@ struct SettingsView: View {
                           systemImage: webSyncSaved ? "checkmark.circle.fill" : "arrow.up.circle")
                     Spacer()
                     if SyncSettings.isConfigured {
-                        Text("已配置").font(DSType.labelSM).foregroundColor(.green)
+                        Text("已配置").font(DSType.labelSM).foregroundColor(DSColor.statusSuccess)
                     }
                 }
             }
@@ -897,7 +904,7 @@ struct SettingsView: View {
                     Spacer()
                     Text("\(syncQueue.pendingCount) 条")
                         .font(DSType.labelSM)
-                        .foregroundColor(.orange)
+                        .foregroundColor(DSColor.statusWarning)
                 }
             } else if SyncSettings.isConfigured {
                 HStack {
@@ -992,6 +999,7 @@ struct SettingsView: View {
                     titleVisibility: .visible
                 ) {
                     Button(NSLocalizedString("settings.data.clear_sample.confirm.action", comment: ""), role: .destructive) {
+                        Haptics.warn()
                         SampleDataSeeder.clearSampleData()
                         bannerCenter.show(AppBannerModel(
                             kind: .success,
@@ -1020,6 +1028,7 @@ struct SettingsView: View {
                 titleVisibility: .visible
             ) {
                 Button(NSLocalizedString("settings.data.purge_all.confirm.action", comment: ""), role: .destructive) {
+                    Haptics.warn()  // irreversible on-device wipe — the strongest cue
                     purgeAllLocalData()
                 }
                 Button(NSLocalizedString("settings.common.cancel", comment: ""), role: .cancel) {}
@@ -1049,7 +1058,10 @@ struct SettingsView: View {
                     flag.title,
                     isOn: Binding(
                         get: { flagStore.isEnabled(flag) },
-                        set: { flagStore.set(flag, enabled: $0) }
+                        set: {
+                            Haptics.selection()
+                            flagStore.set(flag, enabled: $0)
+                        }
                     )
                 )
                 .accessibilityIdentifier("experiments-flag-\(flag.rawValue)")
@@ -1208,6 +1220,7 @@ struct SettingsView: View {
                 }
             }
             Button(role: .destructive) {
+                Haptics.warn()
                 AnalyticsService.shared.reset()
             } label: {
                 Label("清空调试事件", systemImage: "trash")

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -126,21 +126,32 @@ struct SettingsView: View {
     var body: some View {
         NavigationStack {
             List {
-                accountSection
-                apiKeysSection
-                aiEngineSection
-                aiUsageSection
-                notificationsSection
-                permissionsSection
-                appearanceSection
-                timeZoneSection
-                iCloudSyncSection
-                webSyncSection
-                dataSection
-                experimentsSection
-                analyticsDebugSection
-                aboutSection
+                // listRowBackground on the Group re-themes every row: the
+                // system insetGrouped white/gray reads as a stock iOS page,
+                // a jarring break from the warm-cream brand everywhere else
+                // (FINDING-006). surfaceWhite adapts (#FFF light / warm
+                // charcoal dark) so both modes stay on-palette.
+                Group {
+                    accountSection
+                    apiKeysSection
+                    aiEngineSection
+                    aiUsageSection
+                    notificationsSection
+                    permissionsSection
+                    appearanceSection
+                    timeZoneSection
+                    iCloudSyncSection
+                    webSyncSection
+                    dataSection
+                    experimentsSection
+                    analyticsDebugSection
+                    aboutSection
+                }
+                .listRowBackground(DSColor.surfaceWhite)
             }
+            .scrollContentBackground(.hidden)
+            .background(DSColor.bgWarm.ignoresSafeArea())
+            .tint(DSColor.primary)
             .appErrorAlert($appError)
             .accessibilityIdentifier("settings-list")
             .navigationTitle(NSLocalizedString("settings.nav.title", comment: ""))
@@ -333,11 +344,11 @@ struct SettingsView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(name)
                         .font(.body)
-                    if key.isEmpty {
-                        Text(badgeLabel)
-                            .font(.caption)
-                            .foregroundColor(badgeColor)
-                    } else {
+                    // Unconfigured state is announced once, by the trailing
+                    // capsule — repeating the same red "未配置" as a subtitle
+                    // double-encoded one fact and read as two problems
+                    // (FINDING-011).
+                    if !key.isEmpty {
                         // B1: default render is fully masked + last 2 chars so the
                         // value is recognizable without leaking the secret. The
                         // user can opt in to reveal via the eye button below.
@@ -548,7 +559,7 @@ struct SettingsView: View {
 
             // On This Day configuration
             Toggle(isOn: $onThisDayEnabled) {
-                Label("On This Day", systemImage: "calendar.badge.clock")
+                Label(NSLocalizedString("settings.appearance.onthisday.title", comment: "On This Day toggle"), systemImage: "calendar.badge.clock")
             }
             .accessibilityIdentifier("onthisday-enabled-toggle")
             .onChange(of: onThisDayEnabled) { _ in Haptics.selection() }

--- a/DayPage/Features/Shared/AppBanner.swift
+++ b/DayPage/Features/Shared/AppBanner.swift
@@ -130,23 +130,27 @@ struct AppBanner: View {
             leadingIcon
             VStack(alignment: .leading, spacing: 4) {
                 Text(model.title)
-                    .font(.system(size: 14, weight: .semibold))
+                    .font(DSType.bodySM)
+                    .fontWeight(.semibold)
                     .foregroundColor(foregroundColor)
                 if let subtitle = model.subtitle {
                     Text(subtitle)
-                        .font(.system(size: 13))
+                        .font(DSType.caption)
+                        .fontWeight(.regular)
                         .foregroundColor(foregroundColor.opacity(0.8))
                 }
                 if model.primaryAction != nil || model.secondaryAction != nil {
                     HStack(spacing: 16) {
                         if let action = model.primaryAction {
                             Button(action.label, action: action.handler)
-                                .font(.system(size: 13, weight: .semibold))
+                                .font(DSType.caption)
+                                .fontWeight(.semibold)
                                 .foregroundColor(accentColor)
                         }
                         if let action = model.secondaryAction {
                             Button(action.label, action: action.handler)
-                                .font(.system(size: 13))
+                                .font(DSType.caption)
+                                .fontWeight(.regular)
                                 .foregroundColor(foregroundColor.opacity(0.7))
                         }
                     }

--- a/DayPage/Features/Shared/AppBanner.swift
+++ b/DayPage/Features/Shared/AppBanner.swift
@@ -254,6 +254,10 @@ struct AppBanner: View {
 
 struct BannerOverlayModifier: ViewModifier {
     @ObservedObject private var bannerCenter = BannerCenter.shared
+    /// Distance from the safe-area top. Screens with a floating header row
+    /// (Today) pass a larger inset so the banner lands BELOW the row instead
+    /// of covering the menu / search buttons while visible (FINDING-014).
+    var topInset: CGFloat = 8
 
     func body(content: Content) -> some View {
         // ZStack keeps the banner floating above content without shifting layout.
@@ -261,7 +265,7 @@ struct BannerOverlayModifier: ViewModifier {
             content
             if let banner = bannerCenter.currentBanner {
                 AppBanner(model: banner)
-                    .padding(.top, 8)
+                    .padding(.top, topInset)
                     // Asymmetric: slide-down + fade-in on entry; pure fade-up
                     // on exit so dismissal feels gentle rather than yanked.
                     .transition(.asymmetric(
@@ -276,7 +280,7 @@ struct BannerOverlayModifier: ViewModifier {
 }
 
 extension View {
-    func bannerOverlay() -> some View {
-        modifier(BannerOverlayModifier())
+    func bannerOverlay(topInset: CGFloat = 8) -> some View {
+        modifier(BannerOverlayModifier(topInset: topInset))
     }
 }

--- a/DayPage/Features/Shared/RelativeDate.swift
+++ b/DayPage/Features/Shared/RelativeDate.swift
@@ -20,8 +20,16 @@ enum RelativeDate {
             return Self.fullDateFormatter.string(from: date).uppercased()
 
         case .natural:
-            if cal.isDateInToday(date) { return "Today" }
-            if cal.isDateInYesterday(date) { return "Yesterday" }
+            // Natural style feeds content rows (sidebar Recent list) — it must
+            // follow the UI locale. Hardcoded "Today" next to the 「今日」 nav
+            // item read as two different products (FINDING-012). `.caps` stays
+            // English by design: it's the archival mono-label register.
+            if cal.isDateInToday(date) {
+                return NSLocalizedString("relative.date.today", value: "今天", comment: "Relative date — today")
+            }
+            if cal.isDateInYesterday(date) {
+                return NSLocalizedString("relative.date.yesterday", value: "昨天", comment: "Relative date — yesterday")
+            }
             let daysDiff = cal.dateComponents([.day], from: cal.startOfDay(for: date), to: cal.startOfDay(for: now)).day ?? 0
             if daysDiff < 7 { return Self.weekdayFormatter.string(from: date) }
             return Self.shortMonthDayFormatter.string(from: date)

--- a/DayPage/Features/Today/DayOrbView.swift
+++ b/DayPage/Features/Today/DayOrbView.swift
@@ -129,22 +129,28 @@ struct DayOrbView: View {
             previous = new
             previousTier = newTier
         }
-        // Drop shadow: two-layer stack matching the glass card recipe
-        .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 4, x: 0, y: 2)
-        .shadow(color: Color(hex: "2D1E0A").opacity(0.14), radius: 28, x: 0, y: 12)
+        // Drop shadow → DSElevation.floating (two-layer, dark-mode adaptive).
+        // The Day Orb is the hero element; floating keeps it clearly lifted on
+        // the charcoal canvas instead of sinking like hardcoded warm-ink did.
+        .elevation(.floating)
         .accessibilityElement(children: .ignore)
         .accessibilityAddTraits(.isButton)
         .accessibilityLabel(accessibilityLabelText)
         .accessibilityHint("Activates to start writing today's note")
         .accessibilityAction { onTap?() }
         .onAppear {
+            // Gate the ambient breathe on Reduce Motion — a forever-repeating
+            // scale animation is exactly the kind of continuous movement that
+            // setting exists to suppress (and it needlessly drives the main
+            // thread while the orb is on screen).
+            guard !reduceMotion else { return }
             withAnimation(
                 .easeInOut(duration: 4).repeatForever(autoreverses: true)
             ) {
                 // Amplitude ×0.7 relative to the original ±0.05 range → ±0.035
                 breatheScale = 1.035
             }
-            guard signalCount == 0, !reduceMotion else { return }
+            guard signalCount == 0 else { return }
             withAnimation(.easeInOut(duration: 2.2).repeatForever(autoreverses: true)) {
                 invitePulse = true
             }

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -287,7 +287,7 @@ struct InputBarV4: View {
                 // #771: transient toast → glass engine (.toast role).
                 .dpGlass(.toast, in: Capsule())
                 .clipShape(Capsule())
-                .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 8, x: 0, y: 2)
+                .elevation(.glass)
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                 .accessibilityLabel(NSLocalizedString("input.a11y.too_short", comment: ""))
@@ -305,7 +305,7 @@ struct InputBarV4: View {
                 // #771: transient toast → glass engine (.toast role).
                 .dpGlass(.toast, in: Capsule())
                 .clipShape(Capsule())
-                .shadow(color: Color(hex: "2D1E0A").opacity(0.08), radius: 8, x: 0, y: 2)
+                .elevation(.glass)
                 .padding(.top, -34)
                 .transition(.opacity.combined(with: .move(edge: .bottom)))
                 .accessibilityLabel(NSLocalizedString("input.a11y.mic_hint", comment: ""))
@@ -495,8 +495,12 @@ struct InputBarV4: View {
                 idleIconColor: .white
             )
             .frame(width: 50, height: 44)
-            .shadow(color: Color(hex: "5D3000").opacity(0.45), radius: 10, x: 0, y: 4)
-            .shadow(color: Color(hex: "5D3000").opacity(0.18), radius: 1, x: 0, y: 1)
+            // Amber glow that makes the send/mic button read as "lit". Kept as a
+            // deliberate colored halo (not a neutral DSElevation), but sourced
+            // from the dark-adaptive `accentOnBg` so it doesn't sink into the
+            // charcoal canvas in dark mode the way hardcoded #5D3000 did.
+            .shadow(color: DSColor.accentOnBg.opacity(0.45), radius: 10, x: 0, y: 4)
+            .shadow(color: DSColor.accentOnBg.opacity(0.18), radius: 1, x: 0, y: 1)
             .accessibilityLabel(NSLocalizedString("input.a11y.mic", comment: ""))
             .accessibilityHint(NSLocalizedString("input.a11y.mic_hint_full", comment: ""))
 
@@ -529,8 +533,12 @@ struct InputBarV4: View {
         // iOS 26 → native .glassEffect (refraction + specular + interactive),
         // iOS 16–25 → warm faux-glass fallback. See docs/liquid-glass-vNext.md.
         .dpGlass(.control, in: Capsule())
-        .shadow(color: Color(hex: "3C280F").opacity(0.22), radius: 16, x: 0, y: 9)
-        .shadow(color: Color(hex: "3C280F").opacity(0.08), radius: 3, x: 0, y: 1)
+        // The dock is the app's highest-frequency surface — it must read as
+        // clearly lifted. DSElevation.floating carries a two-layer drop that
+        // switches to black-at-higher-opacity in dark mode, so the dock keeps
+        // its lift on the charcoal canvas instead of vanishing like the old
+        // hardcoded warm-ink (#3C280F) shadow did.
+        .elevation(.floating)
     }
 
     // Hint label below the dock — JetBrains Mono uppercase, like the design.
@@ -769,8 +777,10 @@ struct InputBarV4: View {
         .padding(.horizontal, 16)
         .padding(.top, 10)
         .padding(.bottom, 14)
-        .shadow(color: Color(hex: "2D1E0A").opacity(0.10), radius: 24, x: 0, y: 8)
-        .shadow(color: Color(hex: "2D1E0A").opacity(0.06), radius: 4, x: 0, y: 1)
+        // Expanded composer card lift → DSElevation.glass (two-layer, dark-mode
+        // adaptive), replacing the hardcoded warm-ink shadow that disappeared
+        // against the dark canvas.
+        .elevation(.glass)
     }
 
     // MARK: - Inline Action Row
@@ -980,6 +990,11 @@ struct InputBarV4: View {
             isFocused = false
             return
         }
+        // Fire the commit haptic on THIS frame (causality) — the memo's
+        // async append later fires `.successNotification()` on completion, but
+        // waiting for the disk write to feed back reads as "half a beat late".
+        // Mirrors WriteSheetView.handleSave(), which already commits on tap.
+        Haptics.commit()
         onSubmit()
         isFocused = false
         transition(to: .collapsing)

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -571,18 +571,25 @@ struct InputBarV4: View {
     // MARK: - Word/Char Count Footer
 
     private var countFooter: some View {
+        // Same single-counter rule as WriteSheetView (FINDING-013): CJK
+        // segmentation makes words ≈ characters, so showing both repeats one
+        // number. Characters for CJK-dominant drafts, words for latin.
         let wordsLabel = wordCount == 1
             ? NSLocalizedString("writesheet.count.words.one", comment: "1 word")
             : String(format: NSLocalizedString("writesheet.count.words.other", comment: "%d words"), wordCount)
+        let isCJKDominant = charCount > 0 && wordCount * 10 >= charCount * 8
+        let countLabel = isCJKDominant
+            ? "\(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))"
+            : wordsLabel
         return HStack {
             Spacer()
-            Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+            Text(countLabel)
                 .font(DSType.mono10)
                 .tracking(1.0)
                 .textCase(.uppercase)
                 .monospacedDigit()
                 .foregroundColor(DSColor.inkSubtle)
-                .accessibilityLabel("\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+                .accessibilityLabel(countLabel)
                 .accessibilityIdentifier("composer-word-count")
         }
         .padding(.horizontal, 20)
@@ -1144,10 +1151,13 @@ struct InputBarV4: View {
 
     private func locationLabel(_ loc: Memo.Location) -> String {
         if let name = loc.name, !name.isEmpty { return name }
-        if let lat = loc.lat, let lng = loc.lng {
-            return String(format: "%.4f, %.4f", lat, lng)
+        // Reverse geocoding hasn't resolved yet — "37.7858, -122.4064" reads
+        // as debug output, not a place (FINDING-007). Say what's happening
+        // instead; the coordinates still ride along in the memo metadata.
+        if loc.lat != nil, loc.lng != nil {
+            return NSLocalizedString("composer.location.resolving", value: "已定位 · 解析地名中…", comment: "Location chip while reverse geocoding")
         }
-        return "Unknown location"
+        return NSLocalizedString("composer.location.unknown", value: "未知位置", comment: "Location chip fallback")
     }
 
 }

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -419,13 +419,24 @@ struct PhotoFullScreenViewer: View {
     @State private var offset: CGSize = .zero
     @State private var lastOffset: CGSize = .zero
 
+    /// Live downward drag while at fit-scale, driving the interactive
+    /// swipe-to-dismiss: the photo follows the finger and the black backdrop
+    /// fades proportionally, so releasing past the threshold reads as the photo
+    /// falling away (Apple Photos rubber-band dismiss) rather than a hard cut.
+    @State private var dismissDragY: CGFloat = 0
+
     private let minScale: CGFloat = 1.0
     private let maxScale: CGFloat = 4.0
     private let snapBackThreshold: CGFloat = 1.05
 
     var body: some View {
         ZStack {
-            Color.black.ignoresSafeArea()
+            // Backdrop fades as the photo is dragged down toward dismissal, so
+            // the underlying content shows through — the photo reads as lifting
+            // off the page rather than a modal snapping shut.
+            Color.black
+                .opacity(Double(max(0, 1 - abs(dismissDragY) / 320)))
+                .ignoresSafeArea()
 
             if isLoading {
                 ProgressView()
@@ -435,7 +446,7 @@ struct PhotoFullScreenViewer: View {
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .scaleEffect(scale)
-                    .offset(offset)
+                    .offset(x: offset.width, y: offset.height + dismissDragY)
                     .gesture(
                         SimultaneousGesture(
                             MagnificationGesture()
@@ -460,20 +471,31 @@ struct PhotoFullScreenViewer: View {
                             DragGesture()
                                 .onChanged { value in
                                     if scale > 1.0 {
+                                        // Zoomed in — pan around the photo.
                                         offset = CGSize(
                                             width: lastOffset.width + value.translation.width,
                                             height: lastOffset.height + value.translation.height
                                         )
+                                    } else if value.translation.height > 0 {
+                                        // At fit-scale, a downward drag is a
+                                        // dismissal-in-progress: track the finger
+                                        // 1:1 so the photo falls with it.
+                                        dismissDragY = value.translation.height
                                     }
                                 }
                                 .onEnded { value in
                                     if scale <= 1.0 {
-                                        let threshold: CGFloat = 100
-                                        if value.translation.height > threshold {
+                                        let threshold: CGFloat = 120
+                                        if value.translation.height > threshold
+                                            || value.predictedEndTranslation.height > 260 {
+                                            Haptics.light()
                                             dismiss()
                                         } else {
+                                            // Below threshold — rubber-band the
+                                            // photo and backdrop back to rest.
                                             withAnimation(reduceMotion ? nil : .spring(response: 0.3, dampingFraction: 0.75)) {
                                                 offset = .zero
+                                                dismissDragY = 0
                                             }
                                             lastOffset = .zero
                                         }
@@ -662,10 +684,10 @@ struct LocationPreviewSheet: View {
                         HStack(spacing: 10) {
                             Image(systemName: "trash")
                                 .font(.system(size: 15, weight: .semibold))
-                                .foregroundColor(.red)
+                                .foregroundColor(DSColor.statusError)
                             Text("Delete")
                                 .font(DSType.titleSM)
-                                .foregroundColor(.red)
+                                .foregroundColor(DSColor.statusError)
                             Spacer()
                         }
                         .padding(.horizontal, 20)

--- a/DayPage/Features/Today/SpotlightStripView.swift
+++ b/DayPage/Features/Today/SpotlightStripView.swift
@@ -93,6 +93,8 @@ private struct SpotlightChip: View {
             Image(systemName: "mappin")
         case .timeRitual(let emoji, _):
             Text(emoji)
+                // TODO: no DSType match, kept raw — emoji glyph sized to sit in the
+                // icon slot next to sibling Image(systemName:); this is icon sizing, not a text ramp.
                 .font(.system(size: 12))
         case .lastMemoTail:
             Image(systemName: "text.quote")

--- a/DayPage/Features/Today/TimelineSectionView.swift
+++ b/DayPage/Features/Today/TimelineSectionView.swift
@@ -26,6 +26,10 @@ import DayPageServices
 struct TimelineSectionView: View {
 
     let section: TimelineSection
+    /// Shared zoom namespace from the Today root, so each row can act as the
+    /// `matchedTransitionSource` for the DayDetailView it pushes (iOS 18+ zoom
+    /// hero). Optional — previews / callers that don't wire it get a plain push.
+    var zoomNamespace: Namespace.ID? = nil
     /// Parent-driven actions invoked by each row. All are optional so the
     /// section view stays usable in previews and from call sites that haven't
     /// wired the new gesture vocabulary yet.
@@ -53,6 +57,7 @@ struct TimelineSectionView: View {
                     entry: day,
                     isFirst: index == 0,
                     isLast: index == section.days.count - 1,
+                    zoomNamespace: zoomNamespace,
                     onOpenDate: onOpenDate,
                     onShareDate: onShareDate,
                     onDeleteDate: onDeleteDate
@@ -125,6 +130,9 @@ struct TimelineDayRow: View {
     let isFirst: Bool
     let isLast: Bool
 
+    /// Shared zoom namespace from Today root — makes this row the
+    /// `matchedTransitionSource` for the DayDetailView it pushes (iOS 18+).
+    var zoomNamespace: Namespace.ID? = nil
     /// Parent-driven actions. All optional — when nil the corresponding
     /// gesture / menu item is hidden, so the row keeps working in previews.
     var onOpenDate: ((String) -> Void)? = nil
@@ -154,15 +162,30 @@ struct TimelineDayRow: View {
     fileprivate enum SwipeSide { case leading, trailing }
 
     var body: some View {
-        gestureSurface
-            .clipped()
-            .accessibilityElement(children: .combine)
-            .accessibilityLabel(accessibilityLabel)
-            .accessibilityHint(NSLocalizedString("today.timeline.openDailyPage", value: "Open Daily Page", comment: ""))
-            .accessibilityAction(named: shareActionTitle) { onShareDate?(entry) }
-            .accessibilityAction(named: pinActionTitle) { _ = pinService.togglePin(entry.dateString) }
-            .contextMenu { menuButtons } preview: { previewCard }
-            .alert(deleteAlertTitle, isPresented: $showDeleteConfirm, actions: deleteAlertActions, message: deleteAlertMessage)
+        rowZoomSource(
+            gestureSurface
+                .clipped()
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(accessibilityLabel)
+                .accessibilityHint(NSLocalizedString("today.timeline.openDailyPage", value: "Open Daily Page", comment: ""))
+                .accessibilityAction(named: shareActionTitle) { onShareDate?(entry) }
+                .accessibilityAction(named: pinActionTitle) { _ = pinService.togglePin(entry.dateString) }
+                .contextMenu { menuButtons } preview: { previewCard }
+                .alert(deleteAlertTitle, isPresented: $showDeleteConfirm, actions: deleteAlertActions, message: deleteAlertMessage)
+        )
+    }
+
+    /// Tags the row as the zoom transition source keyed by its date, so the
+    /// pushed DayDetailView (which carries a matching `CardZoomDestination`)
+    /// grows out of this row on iOS 18+. No-op on iOS 17 / Reduce Motion / when
+    /// no namespace was wired — the push just uses the default slide.
+    @ViewBuilder
+    private func rowZoomSource(_ content: some View) -> some View {
+        if #available(iOS 18.0, *), let ns = zoomNamespace, !reduceMotion {
+            content.matchedTransitionSource(id: entry.dateString, in: ns)
+        } else {
+            content
+        }
     }
 
     // MARK: Body sub-views (kept small so SwiftUI's type-checker stays fast)
@@ -578,30 +601,34 @@ struct TimelineDayRow: View {
     }
 
     // MARK: Formatters
+    //
+    // These read from process-level cached formatters instead of allocating a
+    // fresh `DateFormatter` per computed-var read. The Today history timeline
+    // reads `weekdayLabel`/`monthDayLabel` per visible row, re-evaluated on
+    // every scroll frame (the main scroll fires a ScrollOffsetPreferenceKey) —
+    // a `DateFormatter()` alloc there is one of Foundation's most expensive
+    // per-frame costs and showed up as visible scroll hitching.
+
+    /// Localized "M月d日" — user-locale, so it can't live in the POSIX-only
+    /// shared `DateFormatters` cache. Cached statically here instead.
+    private static let localizedMonthDay: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "M月d日"
+        f.locale = Locale.current
+        return f
+    }()
 
     private var weekdayLabel: String {
-        let f = DateFormatter()
-        f.dateFormat = "EEE"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone.current
-        return f.string(from: entry.date).uppercased()
+        DateFormatters.weekdayShort.string(from: entry.date).uppercased()
     }
 
     /// Display date for the nameplate — mirrors web's `item.date` (e.g. 05.30).
     private var monthDayLabel: String {
-        let f = DateFormatter()
-        f.dateFormat = "MM.dd"
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.timeZone = TimeZone.current
-        return f.string(from: entry.date)
+        DateFormatters.monthDayDotted.string(from: entry.date)
     }
 
     private var longDateLabel: String {
-        let f = DateFormatter()
-        f.dateFormat = "M月d日"
-        f.locale = Locale.current
-        f.timeZone = TimeZone.current
-        return f.string(from: entry.date)
+        Self.localizedMonthDay.string(from: entry.date)
     }
 
     private var memoCountTag: String {

--- a/DayPage/Features/Today/TodayCoachView.swift
+++ b/DayPage/Features/Today/TodayCoachView.swift
@@ -409,8 +409,9 @@ struct TodayCoachView: View {
             .accessibilityIdentifier("coach-send")
         }
         .dpGlass(.control, in: Capsule())
-        .shadow(color: Color(hex: "3C280F").opacity(0.16), radius: 14, x: 0, y: 7)
-        .shadow(color: Color(hex: "3C280F").opacity(0.07), radius: 2, x: 0, y: 1)
+        // Coach input capsule lift → DSElevation.glass (dark-mode adaptive),
+        // replacing the hardcoded warm-ink shadow that sank in dark mode.
+        .elevation(.glass)
         .padding(.horizontal, 16)
         .padding(.top, 8)
         .padding(.bottom, 12)

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -95,13 +95,13 @@ struct TodayView: View {
     /// Whether to show the Daily Page sheet.
     @State private var showDailyPage: Bool = false
 
-    /// Date string for the fallback yesterday daily page sheet.
-    @State private var fallbackDailyPageDateString: String? = nil
-
-    /// Date string for opening a historical day from the timeline via tap or
-    /// long-press → "Open Daily Page". Drives a dedicated `.fullScreenCover`
-    /// so it doesn't collide with the today/fallback covers.
-    @State private var timelineNavDateString: String? = nil
+    /// The historical day to push onto the NavigationStack as a `DayDetailView`.
+    /// All three former entry points — On This Day card, zero-memo fallback
+    /// "yesterday" page, and timeline tap/long-press — now set this single
+    /// item (previously three separate `String?` bindings driving three
+    /// `fullScreenCover`s). Pushing instead of covering gives the day a system
+    /// back button + interactive edge-swipe-to-pop and a zoom transition.
+    @State private var historicalDay: DayNavTarget? = nil
 
     /// Plain-text payload for the system share sheet when the user shares a
     /// timeline day. Identifiable wrapper because `.sheet(item:)` needs an id.
@@ -109,9 +109,6 @@ struct TodayView: View {
 
     /// Whether to show the Settings sheet.
     @State private var showSettings: Bool = false
-
-    /// Date string for On This Day navigation.
-    @State private var onThisDayDateString: String? = nil
 
     // R9-HIGH A2: `onThisDayShownAtTop` @State removed. The top vs fallback
     // OnThisDay card decision is now driven by the `shouldShowOnThisDayAtTop`
@@ -923,6 +920,11 @@ struct TodayView: View {
                         viewModel.load()
                     }
                 )
+                // Focused writing helper — medium detent + grab handle, so it
+                // sits as a light panel over Today instead of a full-screen
+                // modal, matching the self-drawn WriteSheet / recording sheets.
+                .presentationDetents([.medium, .large])
+                .presentationDragIndicator(.visible)
             }
             // US-019: Markdown export share sheet
             .sheet(isPresented: $showExportSheet) {
@@ -955,32 +957,29 @@ struct TodayView: View {
                 )
                 .ignoresSafeArea()
             }
-            // On This Day navigation to DayDetailView
-            .fullScreenCover(item: Binding(
-                get: { onThisDayDateString.map { OnThisDayNavTarget(dateString: $0) } },
-                set: { onThisDayDateString = $0?.dateString }
-            )) { target in
-                DayDetailView(dateString: target.dateString)
-            }
-            // Fallback "yesterday daily page" cover — opened from the zero-memo
-            // fallback view when yesterday already has a compiled page.
-            // Issue #814: historical days now route to DayDetailView (the
-            // 4-state Archive surface with Daily/raw tabs + day swiping) so
-            // the app has ONE way to look at a past day instead of two.
-            .fullScreenCover(item: Binding(
-                get: { fallbackDailyPageDateString.map { OnThisDayNavTarget(dateString: $0) } },
-                set: { fallbackDailyPageDateString = $0?.dateString }
-            )) { target in
-                DayDetailView(dateString: target.dateString)
-            }
-            // Timeline tap / contextMenu → open that historical day.
-            // Kept separate from showDailyPage / fallbackDailyPageDateString so the
-            // three navigation entry points don't collide on a single binding.
-            .fullScreenCover(item: Binding(
-                get: { timelineNavDateString.map { OnThisDayNavTarget(dateString: $0) } },
-                set: { timelineNavDateString = $0?.dateString }
-            )) { target in
-                DayDetailView(dateString: target.dateString)
+            // Historical-day navigation → DayDetailView, PUSHED onto this
+            // NavigationStack (not a fullScreenCover). Issue #814 already routed
+            // every "look at a past day" entry — On This Day card, zero-memo
+            // fallback, timeline tap — through DayDetailView; this unifies their
+            // *presentation* too: one `navigationDestination(item:)` instead of
+            // three covers. Push gives the day a system back button + interactive
+            // edge-swipe-to-pop, and (iOS 18+) a zoom transition out of the
+            // tapped source via `.matchedTransitionSource` at each call site.
+            // isPresented-based (iOS 16+) rather than item: (iOS 17+) so the
+            // push compiles against the 17.0 deployment target without an
+            // availability gate. The bound day is read inside the builder.
+            .navigationDestination(
+                isPresented: Binding(
+                    get: { historicalDay != nil },
+                    set: { if !$0 { historicalDay = nil } }
+                )
+            ) {
+                if let target = historicalDay {
+                    DayDetailView(dateString: target.dateString)
+                        .modifier(CardZoomDestination(
+                            id: target.dateString, namespace: detailZoomNamespace
+                        ))
+                }
             }
             // Timeline share sheet — plain text payload, no poster pipeline.
             .sheet(item: $timelineShareText) { payload in
@@ -1577,7 +1576,7 @@ struct TodayView: View {
                             comment: "Today banner sub-label: queue stuck > 24h"
                         ))
                             .font(DSFonts.inter(size: 11, weight: .semibold))
-                            .foregroundColor(.red)
+                            .foregroundColor(DSColor.statusError)
                             .lineLimit(1)
                     } else if syncQueueWaitedTooLong {
                         Text(String(
@@ -1589,7 +1588,7 @@ struct TodayView: View {
                             syncQueueWaitedHours
                         ))
                             .font(DSFonts.inter(size: 11, weight: .semibold))
-                            .foregroundColor(.red)
+                            .foregroundColor(DSColor.statusError)
                             .lineLimit(1)
                     }
                 }
@@ -1761,7 +1760,7 @@ struct TodayView: View {
             onThisDayFallback(memos: memos)
         case .weekRecap(let entries):
             WeeklyRecapSection(entries: entries) { dateString in
-                onThisDayDateString = dateString
+                historicalDay = DayNavTarget(dateString: dateString)
             }
         case .pureEmpty:
             // R3 (#793 comp 4.png): orbHero now carries the full empty-state
@@ -1808,9 +1807,10 @@ struct TodayView: View {
             DailyPageEntryCard(
                 summary: page.summary.isEmpty ? nil : page.summary,
                 onTap: {
-                    fallbackDailyPageDateString = page.dateString
+                    historicalDay = DayNavTarget(dateString: page.dateString)
                 }
             )
+            .modifier(CardZoomSource(id: page.dateString, namespace: detailZoomNamespace))
             .padding(.horizontal, 20)
         }
     }
@@ -1832,7 +1832,10 @@ struct TodayView: View {
             ForEach(viewModel.timelineSections) { section in
                 TimelineSectionView(
                     section: section,
-                    onOpenDate: { dateString in timelineNavDateString = dateString },
+                    zoomNamespace: detailZoomNamespace,
+                    onOpenDate: { dateString in
+                        historicalDay = DayNavTarget(dateString: dateString)
+                    },
                     onShareDate: { entry in shareTimelineDay(entry) },
                     onDeleteDate: { entry in deleteTimelineDay(entry) }
                 )
@@ -1890,17 +1893,17 @@ struct TodayView: View {
         }
     }
 
-    /// R6 — tap callback for the OnThisDayCard. Drives the in-Today
-    /// `fullScreenCover` (existing `onThisDayDateString` binding) AND posts
+    /// R6 — tap callback for the OnThisDayCard. Pushes the historical day onto
+    /// the Today NavigationStack (via the `historicalDay` item) AND posts
     /// `.openArchiveAt` so a deep-link consumer (Archive tab, navigation
     /// model) can pivot to the historical day. The Notification post is
     /// harmless when there's no listener — Archive may not be mounted yet
-    /// on a cold tap, in which case the fullScreenCover path handles UX.
+    /// on a cold tap, in which case the in-Today push path handles UX.
     private func handleOnThisDayTap(_ entry: OnThisDayEntry) {
         let dateStr = Self.dateString(from: entry.originalDate)
-        // Keep the in-Today fullScreenCover path so the existing UX (open the
-        // historical DayDetail without switching tabs) still works.
-        onThisDayDateString = dateStr
+        // Keep the in-Today push path so the existing UX (open the historical
+        // DayDetail without switching tabs) still works.
+        historicalDay = DayNavTarget(dateString: dateStr)
         // Forward to .openArchiveAt for consumers that want to pivot to
         // Archive instead — R5 backlinks + EntityPageView already use this
         // bus, so OnThisDay rides the same channel.
@@ -3402,9 +3405,14 @@ struct TodayView: View {
     // card (ArchiveView.weeklyRecapEntryCard) is the single This Week surface.
 }
 
-// MARK: - OnThisDayNavTarget
+// MARK: - DayNavTarget
 
-private struct OnThisDayNavTarget: Identifiable {
+/// Identifiable wrapper around a `yyyy-MM-dd` date string that drives a
+/// `navigationDestination(item:)` push to `DayDetailView`. Shared by Today
+/// (On This Day / fallback / timeline entries) and Archive (calendar / list /
+/// search) so both surfaces push the historical day the same way, keyed by the
+/// date. `id == dateString` also makes it the stable zoom-transition identity.
+struct DayNavTarget: Identifiable, Hashable {
     let dateString: String
     var id: String { dateString }
 }
@@ -3964,8 +3972,11 @@ private struct NumericTextContentTransition: ViewModifier {
 // push — no behavioral change below the availability floor.
 
 /// Marks a timeline card as the zoom source for `memo.id`.
-struct CardZoomSource: ViewModifier {
-    let id: UUID
+// `ID` is generic over `Hashable` so this works for both the memo cards
+// (keyed by `UUID`) and the historical-day entries (keyed by the `yyyy-MM-dd`
+// date string). `matchedTransitionSource(id:)` accepts any Hashable identity.
+struct CardZoomSource<ID: Hashable>: ViewModifier {
+    let id: ID
     let namespace: Namespace.ID
 
     func body(content: Content) -> some View {
@@ -3978,8 +3989,8 @@ struct CardZoomSource: ViewModifier {
 }
 
 /// Applies the zoom navigation transition to the pushed detail page.
-struct CardZoomDestination: ViewModifier {
-    let id: UUID
+struct CardZoomDestination<ID: Hashable>: ViewModifier {
+    let id: ID
     let namespace: Namespace.ID
 
     func body(content: Content) -> some View {

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -993,7 +993,9 @@ struct TodayView: View {
     @ViewBuilder
     private func applyAuxiliarySheets(_ content: some View) -> some View {
         content
-            .bannerOverlay()
+            // 60pt clears Today's floating header row (menu / date / search)
+            // so a live banner never blocks navigation (FINDING-014).
+            .bannerOverlay(topInset: 60)
             // US-010: First-run input bar tutorial
             .overlay {
                 if showTutorial {

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -85,14 +85,25 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
     // MARK: Published State
 
     /// Today's memos in reverse-chronological order (newest first).
-    @Published var memos: [Memo] = []
+    /// `didSet` refreshes the cached `todayWordCount` so the O(total-characters)
+    /// CJK scan runs once per memo-list mutation instead of once per read.
+    /// `todayWordCount` used to be a computed var read from TodayView's body via
+    /// `.onChange`; because the main scroll re-evaluates the body every frame
+    /// (ScrollOffsetPreferenceKey), that full scan ran on every scroll frame AND
+    /// every keystroke — worst exactly when a heavy-writing user is most active.
+    @Published var memos: [Memo] = [] {
+        didSet { recomputeWordCount() }
+    }
 
     /// Number of signals (memos) captured today — drives the Day Orb readout.
     var signalCount: Int { memos.count }
 
-    /// Total word count across all of today's memo bodies.
-    var todayWordCount: Int {
-        memos.reduce(0) { $0 + TodayViewModel.wordCount(in: $1.body) }
+    /// Total word count across all of today's memo bodies. Cached; recomputed
+    /// only when `memos` changes (see `memos.didSet` / `recomputeWordCount`).
+    @Published private(set) var todayWordCount: Int = 0
+
+    private func recomputeWordCount() {
+        todayWordCount = memos.reduce(0) { $0 + TodayViewModel.wordCount(in: $1.body) }
     }
 
     /// CJK-aware word counter: each CJK ideograph = 1 word; runs of non-CJK

--- a/DayPage/Features/Today/VoiceRecordingView.swift
+++ b/DayPage/Features/Today/VoiceRecordingView.swift
@@ -250,7 +250,9 @@ struct VoiceRecordingView: View {
                     HStack(spacing: 8) {
                         Image(systemName: voiceService.state == .recording ? "pause.fill" : "play.fill")
                             .font(.system(size: 14, weight: .semibold))
-                        Text(voiceService.state == .recording ? "PAUSE" : "RESUME")
+                        Text(voiceService.state == .recording
+                            ? NSLocalizedString("voice.recording.pause", value: "暂停", comment: "Voice recording — pause button")
+                            : NSLocalizedString("voice.recording.resume", value: "继续", comment: "Voice recording — resume button"))
                             .monoLabelStyle(size: 12)
                     }
                     .foregroundColor(DSColor.onSurface)
@@ -268,9 +270,11 @@ struct VoiceRecordingView: View {
             .padding(.horizontal, 0)
         }
 
-        // DISCARD | SAVE full-width bottom buttons
-        HStack(spacing: 0) {
-            // DISCARD (white bg, black text)
+        // 丢弃 | 保存 — inset rounded action bar. The old full-bleed square
+        // blocks (hard 90° brown slab, English "SAVE"/"PAUSE" in an otherwise
+        // Chinese flow) clashed with the app's continuous-radius card language
+        // (FINDING-009).
+        HStack(spacing: 12) {
             Button(action: {
                 voiceService.cancelRecording()
                 onCancel()
@@ -279,22 +283,16 @@ struct VoiceRecordingView: View {
                     .monoLabelStyle(size: 14)
                     .foregroundColor(isProcessing ? DSColor.onSurfaceVariant : DSColor.onSurface)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 56)
-                    .background(DSColor.surface)
+                    .frame(height: 52)
+                    .background(DSColor.surfaceContainerHigh)
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
             }
             .disabled(isProcessing)
             .buttonStyle(.plain)
-            .cornerRadius(0)
             .accessibilityLabel(NSLocalizedString("voice.recording.a11y.discard", value: "丢弃录音", comment: "Voice recording — discard button a11y label"))
             .accessibilityHint(NSLocalizedString("voice.recording.a11y.discard.hint", value: "永久删除此次录音内容", comment: "Voice recording — discard hint"))
 
-            // Separator
-            Rectangle()
-                .fill(DSColor.outlineVariant)
-                .frame(width: 1, height: 56)
-
-            // SAVE (black bg, white text)
-            // Send path: audio saves instantly, transcription runs in the
+            // 保存 — send path: audio saves instantly, transcription runs in the
             // background via VoiceAttachmentQueue and patches the memo later.
             Button(action: {
                 guard canSave else { return }
@@ -304,24 +302,22 @@ struct VoiceRecordingView: View {
                     onCancel()
                 }
             }) {
-                Text("SAVE")
+                Text(NSLocalizedString("voice.recording.save", value: "保存", comment: "Save recording"))
                     .monoLabelStyle(size: 14)
                     .foregroundColor(canSave ? DSColor.onPrimary : DSColor.onSurfaceVariant)
                     .frame(maxWidth: .infinity)
-                    .frame(height: 56)
+                    .frame(height: 52)
                     .background(canSave ? DSColor.primary : DSColor.surfaceContainerLow)
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
             }
             .disabled(!canSave)
             .buttonStyle(.plain)
-            .cornerRadius(0)
             .accessibilityLabel(NSLocalizedString("voice.recording.a11y.save", value: "保存录音", comment: "Voice recording — save button a11y label"))
             .accessibilityHint(NSLocalizedString("voice.recording.a11y.save.hint", value: "停止录音并发送给 AI 转写", comment: "Voice recording — save hint"))
         }
-        .overlay(alignment: .top) {
-            Rectangle()
-                .fill(DSColor.outlineVariant)
-                .frame(height: 1)
-        }
+        .padding(.horizontal, 20)
+        .padding(.top, 12)
+        .padding(.bottom, 8)
     }
 
     // MARK: - Helpers

--- a/DayPage/Features/Today/VoiceRecordingView.swift
+++ b/DayPage/Features/Today/VoiceRecordingView.swift
@@ -141,6 +141,8 @@ struct VoiceRecordingView: View {
             }
 
             Text(formattedTime(voiceService.elapsedSeconds))
+                // TODO: no DSType match, kept raw — 56pt hero timer far exceeds the
+                // mono ramp (mono9…mono11); no semantic token for a display-size mono readout.
                 .font(.system(size: 56, weight: .bold, design: .monospaced))
                 .foregroundColor(timerColor)
                 .monospacedDigit()

--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -458,17 +458,24 @@ struct WriteSheetView: View {
 
             Spacer()
 
-            // Word + char counter — mono10/inkSubtle, milestones every 100 words.
+            // Single counter — for CJK drafts the segmenter counts ~1 word per
+            // character, so "10 个词 · 10 字符" said the same number twice
+            // (FINDING-013). Show characters for CJK-dominant text, words for
+            // latin text; milestones every 100 words either way.
             let wordsLabel = wordCount == 1
                 ? NSLocalizedString("writesheet.count.words.one", comment: "1 word")
                 : String(format: NSLocalizedString("writesheet.count.words.other", comment: "%d words"), wordCount)
+            let isCJKDominant = charCount > 0 && wordCount * 10 >= charCount * 8
+            let countLabel = isCJKDominant
+                ? "\(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))"
+                : wordsLabel
             let readLabel = String(format: NSLocalizedString("writesheet.count.read", comment: "~%d min read"), readingMinutes)
             HStack(spacing: 0) {
                 // Counter text updates instantly per keystroke — no per-character
                 // numericText/spring (those stacked 0.35s animations under the
                 // typing cadence and starved the main thread). monospacedDigit
                 // keeps the digits from reflowing as they change.
-                Text("\(wordsLabel) · \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+                Text(countLabel)
                 if showReadingTime {
                     Text(" · \(readLabel)")
                         .transition(.opacity)
@@ -484,9 +491,7 @@ struct WriteSheetView: View {
             // Only the reading-time chip's appear/disappear gets a soft tick.
             .animation(reduceMotion ? nil : Motion.countTick, value: showReadingTime)
             .padding(.trailing, 10)
-            .accessibilityLabel(showReadingTime
-                ? "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars")), \(readLabel)"
-                : "\(wordsLabel), \(charCount) \(NSLocalizedString("writesheet.count.chars", comment: "chars"))")
+            .accessibilityLabel(showReadingTime ? "\(countLabel), \(readLabel)" : countLabel)
             .onChange(of: wordCount) { newCount in
                 let milestone = newCount / 100
                 if milestone > lastMilestone {

--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -85,7 +85,13 @@ struct WriteSheetView: View {
     /// long drafts. All downstream readers keep using `wordCount`/`charCount`.
     @State private var cachedWordCount: Int = 0
     @State private var cachedCharCount: Int = 0
-    @GestureState private var dragOffset: CGFloat = 0
+    /// Sheet drag offset. `resetTransaction` springs the offset back to rest
+    /// when the gesture ends below the dismiss threshold — `@GestureState`
+    /// auto-resets to 0 on release, and without a transaction that reset snaps
+    /// instantly (the old empty `withAnimation(Motion.spring){}` couldn't
+    /// animate the framework's own reset). Near-instant under Reduce Motion.
+    @GestureState(resetTransaction: Transaction(animation: Motion.respectReduceMotion(Motion.spring)))
+    private var dragOffset: CGFloat = 0
     @State private var committedClose: Bool = false
     @State private var saveReadyPulse: Bool = false
     @State private var confirmingDiscard: Bool = false
@@ -359,11 +365,11 @@ struct WriteSheetView: View {
                     || value.predictedEndTranslation.height > 260
                 if shouldDismiss {
                     attemptClose()
-                } else if !reduceMotion {
-                    withAnimation(Motion.spring) { }
-                } else {
-                    withAnimation(.easeOut(duration: 0.2)) { }
                 }
+                // Below the threshold we do nothing here: `dragOffset` is a
+                // @GestureState, so it auto-resets to 0 on release and springs
+                // back via its `resetTransaction`. (The old empty
+                // `withAnimation` blocks couldn't animate that reset anyway.)
             }
     }
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -995,6 +995,8 @@
 "voice.recording.title"      = "Voice memo";
 "voice.recording.discard"    = "Discard";
 "voice.recording.save"       = "Save";
+"relative.date.today"        = "Today";
+"relative.date.yesterday"    = "Yesterday";
 "voice.recording.pause"      = "Pause";
 "voice.recording.resume"     = "Resume";
 "memo.not_found"             = "Memo no longer exists";

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -637,6 +637,7 @@
 "settings.appearance.fontsize"               = "Body font size";
 "settings.appearance.density"                = "Card density";
 "settings.appearance.legacy_voice"           = "Use legacy voice recording";
+"settings.appearance.onthisday.title"        = "On This Day";
 "settings.appearance.onthisday.refresh_time" = "Refresh time";
 "settings.appearance.onthisday.midnight"     = "Midnight 00:00";
 "settings.appearance.onthisday.dawn"         = "Dawn 06:00";
@@ -993,6 +994,9 @@
 "weekly.recap.compiled"      = "Daily page compiled.";
 "voice.recording.title"      = "Voice memo";
 "voice.recording.discard"    = "Discard";
+"voice.recording.save"       = "Save";
+"voice.recording.pause"      = "Pause";
+"voice.recording.resume"     = "Resume";
 "memo.not_found"             = "Memo no longer exists";
 "sidebar.settings"           = "Settings";
 "sidebar.ask_past"           = "Ask the past";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -999,6 +999,8 @@
 "voice.recording.title"      = "语音备忘";
 "voice.recording.discard"    = "丢弃";
 "voice.recording.save"       = "保存";
+"relative.date.today"        = "今天";
+"relative.date.yesterday"    = "昨天";
 "voice.recording.pause"      = "暂停";
 "voice.recording.resume"     = "继续";
 "memo.not_found"             = "该 memo 已不存在";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -641,6 +641,7 @@
 "settings.appearance.fontsize"               = "正文字号";
 "settings.appearance.density"                = "卡片密度";
 "settings.appearance.legacy_voice"           = "使用旧版语音录制";
+"settings.appearance.onthisday.title"        = "那年今日";
 "settings.appearance.onthisday.refresh_time" = "刷新时间";
 "settings.appearance.onthisday.midnight"     = "午夜 00:00";
 "settings.appearance.onthisday.dawn"         = "清晨 06:00";
@@ -997,6 +998,9 @@
 "weekly.recap.compiled"      = "今日页已生成。";
 "voice.recording.title"      = "语音备忘";
 "voice.recording.discard"    = "丢弃";
+"voice.recording.save"       = "保存";
+"voice.recording.pause"      = "暂停";
+"voice.recording.resume"     = "继续";
 "memo.not_found"             = "该 memo 已不存在";
 "sidebar.settings"           = "设置";
 "sidebar.ask_past"           = "和过去对话";

--- a/DayPageKit/Sources/DayPageServices/DateFormatters.swift
+++ b/DayPageKit/Sources/DayPageServices/DateFormatters.swift
@@ -39,6 +39,11 @@ public enum DateFormatters {
     /// "Jun 19" — short month-day for relative time fallbacks.
     public static let monthDay: DateFormatter = posix("MMM d")
 
+    /// "05.30" — dotted month-day for the timeline row nameplate (mirrors web's
+    /// `item.date`). Cached here so the Today history timeline stops allocating
+    /// a fresh DateFormatter per visible row per scroll frame.
+    public static let monthDayDotted: DateFormatter = posix("MM.dd")
+
     /// "2026-06" — year-month key for monthly archive grouping.
     public static let yearMonth: DateFormatter = posix("yyyy-MM")
 


### PR DESCRIPTION
## Summary

对 App 全部主要页面（Today/Sidebar/Archive/DayDetail/DailyPage/Graph/Settings/Composer/Voice）做了一轮「截图 → 评分 → 修复 → 复验」的设计审计闭环。整体设计分 **6.7 → 9.3**（10 分制），15 项 findings 全部修复，每项独立提交。

**功能级修复（原评分 2-3 分的页面）**
- **图谱页**（F-001/002）：`filteredNodes` 缓存了力导仿真前的位置快照，导致标签漂离节点、点击命中失效、回中失效——改为只缓存匹配 ID 集合，元素始终取实时数组；缩放控件的无约束分隔线把玻璃卡撑成全屏面板盖住画布——改定宽 24pt
- **编译日记页**（F-003/004/005）：内嵌 NavigationStack 造成双返回键与首次进入偶发整页空白——新增 `isEmbedded` 拆栈；元数据卡渲染写死的假数据（任何一天都是 28°/86%）——改由当天 raw memos 推导 WEATHER/ENTRIES/SPAN/KIND，删除假默认 init；正文 wikilink 原文裸露——解析时归一化为可读名称

**品牌与诚实性**
- Settings 整页从系统冷灰回归暖米色品牌（浅/深色，F-006）；未配置状态单一胶囊标注（F-011）
- 输入栏定位 chip 不再显示裸经纬度，反解析完成前显示「已定位 · 解析地名中…」（F-007）
- 归档「MEMOS 16（全期）」与「TOTAL ENTRIES 11（月度）」口径打架——加 ALL-TIME 范围词（F-008）

**语言与一致性**（约定：档案性 mono 标签保留英文，可交互控件跟随界面语言）
- 录音页 PAUSE/SAVE → 暂停/保存 + 操作栏圆角化（F-009）；日详情分段控件「日记页 | 原始 Memo」（F-010）；侧边栏 Recent「今天」（F-012）；「那年今日」设置项（F-015）
- Today 横幅下移至头部行以下不再遮挡导航（F-014）；CJK 草稿计数器单一化（F-013）

**Wave 4 收尾**（3b5ea9d）：页面背景 token 三源合一消除深色拼接接缝、DSPicker 选项切换触感、侧边栏行 tapConfirm、Archive 派生集合缓存。

## Test Coverage

- 全量测试：**176/176 通过**（合并 origin/main 后的状态，含 DailyPageParserEvidenceTests 验证 wikilink 归一化不影响证据标记剥离）
- 改动均为视图层/展示逻辑；新增逻辑 `normalizeWikilinks` / `buildMetaTiles` 为 internal 纯函数，可后续补单测

## Pre-Landing Review

15 项 findings 即本 PR 的修复对象，全部在模拟器（iPhone 17 / iOS 26.1）截图复验：图谱聚合与控件、日详情真实元数据与单返回键、设置浅/深色品牌、录音中文圆角操作栏、归档 ALL-TIME 标签、侧边栏「今天」。合并 main 后逐项 grep 确认 15 处修复完好。

审计报告与前后对比截图：`~/.gstack/projects/getyak-daypage/designs/design-audit-20260710/`

## Deferred（polish 级，未阻塞）

图谱密集簇标签轻微重叠、自动 fit 垂直略偏下、Composer 表头材质透字、Settings 分组标题系统样式、侧边栏 streak 双重展示。

## Test plan
- [x] xcodebuild test 全量 176/176 通过（合并态复跑）
- [x] 各页面模拟器截图前后对比复验（浅色 + 深色）
- [x] 合并 origin/main 后 15 处修复 grep 逐项确认

🤖 Generated with [Claude Code](https://claude.com/claude-code)