### PR TITLE
fix: 实测审计 12 项根因修复 — 数据丢失/录音死锁/主线程/跟手性

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ Conventional changelog 格式：日期倒序，每个 release 标题 + 分类列
 - 2am 编译成功本地通知 + Settings 开关
 
 ### Bug Fixes (CRITICAL)
+- 真机体验实测审计（2026-07-11，模拟器全链路 dogfood：多条文本/中文粘贴/相册双图/按住说话逐一实测）：
+  - 附件文件名秒级时间戳冲突 → 同一秒多选照片互相覆盖、第二张**永久丢失**（实测 2 张选图只落盘 1 个文件）；assetFilename 追加 4 位随机后缀
+  - 照片卡片横向溢出屏幕：PhotoThumbnailView 的 `.fill` 图片把自身超宽尺寸上报穿透 `.clipped()`（AX frame x=-229/w=557），撑爆整卡 → 图片全出血 + 正文左移出屏"被裁"；改为 Color.clear 4:5 容器 + overlay 裁剪
+  - 按住说话死锁：0.25s 长按阈值判定写在 DragGesture.onChanged 里，手指完全静止时 onChanged 不再触发 → 永远停在"再按住一下"（实测按住 10s 无法进入录音）；改为 touch-down 启动定时提交
+  - 录音启动吃掉按压时长：AVAudioSession setCategory/setActive（冷启动秒级）同步跑在 MainActor → UI 冻结 + 按 4s 只录到 <1s"再说久一点"；移到 Task.detached
+  - 多图 memo 只渲染第一张照片（查看器也只开第一张）→ ForEach 全部 photo 附件 + item-based 全屏查看器
+  - 空态 orb 点击把时段引导语（"今天最终落在哪里了？"）写进 draftText → 引导语混入 memo 正文永久落盘；改为仅聚焦（与 InputBarV4 移除"记下此刻"预填同一设计准则）
+  - EXIF 读取在卡片 body 里同步磁盘 I/O（每次重绘都读）→ 随缩略图解码移到后台
+- 侧边栏抽屉面板自身无关闭手势：1:1 跟手 drag 只挂在 scrim 上而 scrim 被 280pt 面板盖住 → 从抽屉上起手左拉纹丝不动、松手才播动画（违反"输入直接驱动位移"）；面板追加水平主导 simultaneousGesture，实测 50%→70% 全程跟手
+- 双 agent 深度审计第二轮（主线程 + 手势跟手性）：
+  - compile() 准备段（读盘+YAML parse+SHA256+读旧 daily）跑在 @MainActor，20+ memo 的日子点"编译"卡数十 ms → Step 1 整段 Task.detached
+  - WikiIndexService.rebuild() 编译尾部在主线程全量扫 wiki 目录逐文件解析 frontmatter（数百页 50–300ms）→ fire-and-forget detached + scan 函数 nonisolated 化
+  - 录音波形 40 根 bar 各自 easeOut 隐式动画去追 30fps 电平（"触发动画去追"反模式）→ 删除逐 bar 动画，高度直接映射电平
+  - Today/Archive 各挂一个 onEnded-only 左缘开抽屉手势，与 RootView 的 1:1 跟手版竞争仲裁（赢了就变成松手弹出）→ 删除，统一走 RootView
+  - MemoDetailView 两处 EXIF 在 body 里同步 CGImageSource 磁盘 I/O（每次重绘都读）→ @State + .task 后台解析
 - RawStorage replaceItemAt 静默写入失败 → 错误传播
 - LocationService 双 resume 卡死 / group.next()! 崩溃
 - VoiceService AVAudioSession 未释放 → defer 释放
@@ -27,6 +42,8 @@ Conventional changelog 格式：日期倒序，每个 release 标题 + 分类列
 - LocationService 反向地理编码 LRU 缓存（10/30min/~1km bucket）
 
 ### UX Polish
+- 侧边栏深度优化（2026-07-11）：热力图 16×7 网格 Canvas 化（≈800 视图节点 + 112 手势 → 单次绘制，网格数据缓存仅随 counts 变化重建，消除开抽屉/拖拽卡顿）；drawer 阴影前加 compositingGroup 让 20pt 模糊在栅格化层上合成；Recent 列表改默认收起的可展开行（@AppStorage 记忆偏好）
+- 登录链路美术馆化（2026-07-11）：AuthView serif 词标 + mono kicker + 交错入场编排（尊重 Reduce Motion）、品牌区居中/CTA 底部锚定的确定性布局；Email 输入框 amber focus 环；OTP 激活格与光标改 amber accent；三页标题统一 serif
 - 设计审计 R5（2026-07-10，评分 6.7→9.3）：图谱标签/点击/自动适配错位修复（过滤缓存只存节点 ID）、缩放控件面板不再全宽盖住画布、编译日记页双返回键与偶发空白修复（isEmbedded 拆嵌套栈）、日详情元数据卡改用当天真实数据（删除 28°/86% 假默认值）、日记正文 wikilink 显示为可读名称
 - 设置页回归暖色品牌（浅/深色），API key 未配置改单一胶囊标注，「那年今日」中文化
 - 录音页操作栏中文化（暂停/丢弃/保存）并圆角化；输入栏定位 chip 显示「解析地名中…」而非裸经纬度

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -228,8 +228,36 @@ struct RootView: View {
                 .frame(width: sidebarWidth)
                 .frame(maxHeight: .infinity)
                 .ignoresSafeArea()
+                // Flatten the drawer into one raster layer BEFORE the big
+                // blur shadow: without this, the 20pt-radius shadow is
+                // recomputed against the drawer's full view hierarchy on
+                // every frame of the slide/drag, which shows up as jank on
+                // the interactive open gesture.
+                .compositingGroup()
                 .shadow(color: Color.black.opacity(0.10), radius: 20, x: 6, y: 0)
                 .offset(x: sidebarOffset)
+                // Close-by-drag from the panel itself. The 1:1 tracking drag
+                // lived only on the scrim, but the scrim is covered by this
+                // 280pt panel — a leftward pull starting ON the drawer (the
+                // most natural close gesture) hit nothing and the drawer sat
+                // frozen until release. Same horizontal-dominance engage rule
+                // as the edge strip so the panel's vertical scroll stays free.
+                .simultaneousGesture(
+                    DragGesture(minimumDistance: 12)
+                        .onChanged { value in
+                            if sidebarDragTranslation == nil {
+                                let dx = value.translation.width
+                                let dy = value.translation.height
+                                guard dx < 0, abs(dx) > abs(dy) * 1.2 else { return }
+                            }
+                            sidebarDragTranslation = value.translation.width
+                        }
+                        .onEnded { value in
+                            settleSidebar(
+                                predictedTranslation: value.predictedEndTranslation.width
+                            )
+                        }
+                )
                 // Take the panel out of the accessibility tree when it's off-
                 // screen, otherwise VoiceOver users can still focus Settings /
                 // Recent rows that are visually at negative x coordinates.

--- a/DayPage/App/SidebarHeatmapView.swift
+++ b/DayPage/App/SidebarHeatmapView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 import DayPageModels
 import DayPageServices
 
@@ -19,6 +20,17 @@ import DayPageServices
 // Today is colored by its real memo count (amber strokeBorder marks it as today);
 // empty-today gets a dashed ghost border. Future cells render as a dashed placeholder.
 // Counts map to 4 tonal buckets via the heatmap-* color tokens.
+//
+// PERFORMANCE (2026-07): the grid is a single `Canvas` draw call. The previous
+// implementation composed 112 cell views × (fill + 3 stroke overlays + gesture
+// + onChange) ≈ 800 view nodes and rebuilt all 112 dates (~120 DateFormatter
+// calls) on EVERY body evaluation — and SidebarView re-evaluates whenever any
+// @Published on the shared nav model ticks, so opening/dragging the drawer
+// paid that cost repeatedly and stuttered. Now the grid geometry is cached in
+// a `HeatGrid` snapshot rebuilt only when `counts` actually changes, and the
+// whole board renders as one vector layer. Tap detection is plain coordinate
+// math; the tooltip and first-entry glow stay as lightweight overlays so they
+// keep their SwiftUI animations.
 
 struct SidebarHeatmapView: View {
     /// Memo count per day keyed by `YYYY-MM-DD`.
@@ -32,20 +44,19 @@ struct SidebarHeatmapView: View {
 
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
-    @State private var selectedCell: (date: Date, count: Int)? = nil
+    @State private var grid = HeatGrid()
+    @State private var selectedDay: HeatGrid.Day? = nil
     @State private var selectedColumnIndex: Int = 0
     @State private var tooltipDismissGeneration: Int = 0
     @State private var firstEntryGlow: Bool = false
 
     private let weeks = 16
     private let cellSpacing: CGFloat = 3
-
-    private static let monthFmt: DateFormatter = {
-        let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US")
-        f.dateFormat = "MMM"
-        return f
-    }()
+    private let cellHeight: CGFloat = 11
+    /// Leading column reserved for the M/T/W… weekday letters (incl. gap).
+    private let railWidth: CGFloat = 14
+    /// Month-label row (9pt text + 5pt gap) above the first cell row.
+    private let monthRowHeight: CGFloat = 14
 
     private static let monthDayFmt: DateFormatter = {
         let f = DateFormatter()
@@ -63,14 +74,13 @@ struct SidebarHeatmapView: View {
             header
                 .accessibilityElement(children: .ignore)
                 .accessibilityLabel(accessibilityText)
-            // Hide the 105-cell grid from VoiceOver entirely. The header above
-            // already exposes the full summary (`accessibilityText` — e.g. "15
-            // weeks heatmap, 3 days with entries, current streak 1"), so the
-            // per-cell labels were 100+ identical "Jun 15, 0 entries" rotor
-            // stops with no extra signal. Sighted users still tap cells for
-            // the day-detail tooltip; VoiceOver users navigate days via the
-            // Recent rows below the grid.
-            grid.accessibilityHidden(true)
+            // Hide the grid from VoiceOver entirely. The header above already
+            // exposes the full summary (`accessibilityText` — e.g. "15 weeks
+            // heatmap, 3 days with entries, current streak 1"); per-cell labels
+            // were 100+ identical "Jun 15, 0 entries" rotor stops with no extra
+            // signal. Sighted users still tap cells for the day-detail tooltip;
+            // VoiceOver users navigate days via the Recent rows below the grid.
+            gridView.accessibilityHidden(true)
             footer
                 // Footer = LESS/MORE swatches + streak pill — the swatches are a
                 // pure legend (no signal beyond the accessibilityText already
@@ -90,6 +100,31 @@ struct SidebarHeatmapView: View {
                 .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
         )
         .shadow(color: Color.black.opacity(0.04), radius: 1, x: 0, y: 1)
+        .onAppear {
+            if grid.columns.isEmpty {
+                grid = HeatGrid.build(counts: counts, weeks: weeks)
+            }
+        }
+        .onChange(of: counts) { newCounts in
+            let previousTodayCount = grid.todayCount
+            grid = HeatGrid.build(counts: newCounts, weeks: weeks)
+            // First entry of the day → brief amber glow on today's cell.
+            if grid.todayCount == 1, previousTodayCount == 0, !reduceMotion {
+                withAnimation(.easeOut(duration: 0.25)) { firstEntryGlow = true }
+                Task {
+                    try? await Task.sleep(nanoseconds: 600_000_000)
+                    withAnimation(.easeOut(duration: 0.5)) { firstEntryGlow = false }
+                }
+            }
+        }
+        // Midnight / timezone / clock changes shift the "today" anchor even
+        // when `counts` is unchanged — rebuild so the grid never shows a
+        // stale today marker.
+        .onReceive(NotificationCenter.default.publisher(
+            for: UIApplication.significantTimeChangeNotification
+        )) { _ in
+            grid = HeatGrid.build(counts: counts, weeks: weeks)
+        }
     }
 
     // MARK: - Header
@@ -113,181 +148,178 @@ struct SidebarHeatmapView: View {
         }
     }
 
-    // MARK: - Grid
+    // MARK: - Grid (single Canvas)
 
-    private var grid: some View {
-        let columns = buildColumns()
-        return HStack(alignment: .top, spacing: 8) {
-            // Weekday rail: M T W T F S S
-            VStack(spacing: cellSpacing) {
-                Spacer().frame(height: 11) // align under the month-label row
-                ForEach(Array(["M", "T", "W", "T", "F", "S", "S"].enumerated()), id: \.offset) { idx, d in
-                    Text(d)
-                        .font(.system(size: 8, design: .monospaced)) // TODO: no DSType match, kept raw (8pt heatmap grid label, smallest mono token is mono9=9pt)
-                        .tracking(1)
-                        .foregroundColor(DSColor.inkSubtle)
-                        .opacity(idx % 2 == 1 ? 0.4 : 0.9)
-                        .frame(height: 11)
-                }
-            }
-            .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 5) {
-                monthLabels(columns: columns)
-                    // MAR / APR / MAY are purely visual context for the grid —
-                    // each day cell already announces its own MMM-d in its
-                    // accessibilityLabel, so reading these labels aloud is
-                    // duplicative.
-                    .accessibilityHidden(true)
-                GeometryReader { geo in
-                    let cell = cellSize(in: geo.size.width)
-                    HStack(spacing: cellSpacing) {
-                        ForEach(columns.indices, id: \.self) { ci in
-                            VStack(spacing: cellSpacing) {
-                                ForEach(0..<7, id: \.self) { ri in
-                                    cellView(columns[ci][ri], size: cell, columnIndex: ci)
-                                }
-                            }
-                        }
-                    }
-                    .overlay(alignment: .top) {
-                        if let sel = selectedCell {
-                            let tooltipText = "\(Self.monthDayFmt.string(from: sel.date).uppercased()) · \(sel.count) 条"
-                            let xOffset = CGFloat(selectedColumnIndex) * (cell + cellSpacing) + cell / 2
-                            Text(tooltipText)
-                                .font(DSType.mono9)
-                                .tracking(0.8)
-                                .foregroundColor(DSColor.inkPrimary)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 4)
-                                .background(
-                                    Capsule(style: .continuous)
-                                        .fill(DSColor.surfaceWhite)
-                                        .overlay(
-                                            Capsule(style: .continuous)
-                                                .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
-                                        )
-                                        .shadow(color: Color.black.opacity(0.06), radius: 4, x: 0, y: 2)
-                                )
-                                .fixedSize()
-                                .position(x: xOffset, y: -14)
-                                .transition(
-                                    reduceMotion
-                                        ? .opacity
-                                        : .opacity.combined(with: .scale(scale: 0.88, anchor: .bottom))
-                                )
-                                .animation(reduceMotion ? .default : .spring(response: 0.22, dampingFraction: 0.7), value: sel.date)
-                                .allowsHitTesting(false)
-                                .zIndex(10)
-                        }
-                    }
-                    .animation(reduceMotion ? .default : .spring(response: 0.22, dampingFraction: 0.7), value: selectedCell?.date)
-                }
-                .frame(height: 7 * 11 + 6 * cellSpacing)
-            }
-        }
+    private var gridHeight: CGFloat {
+        monthRowHeight + 7 * cellHeight + 6 * cellSpacing
     }
 
-    private func cellSize(in width: CGFloat) -> CGFloat {
-        let total = width - CGFloat(weeks - 1) * cellSpacing
-        return max(8, total / CGFloat(weeks))
+    private func cellWidth(in width: CGFloat) -> CGFloat {
+        let usable = width - railWidth - CGFloat(weeks - 1) * cellSpacing
+        return max(8, usable / CGFloat(weeks))
     }
 
-    @ViewBuilder
-    private func cellView(_ cell: HeatCell, size: CGFloat, columnIndex: Int) -> some View {
-        switch cell {
-        case .future:
-            RoundedRectangle(cornerRadius: 2.5, style: .continuous)
-                .strokeBorder(DSColor.borderSubtle, style: StrokeStyle(lineWidth: 0.5, dash: [1.5, 1.5]))
-                .frame(height: 11)
-                .accessibilityHidden(true)
-        case .day(let date, let level, let isToday, let count):
-            let isTodayEmpty = isToday && level == 0
-            RoundedRectangle(cornerRadius: 2.5, style: .continuous)
-                .fill(Self.palette[level])
-                .frame(height: 11)
-                .overlay(
-                    // Dashed ghost border for an unstarted today — reads as "open, awaiting capture"
-                    RoundedRectangle(cornerRadius: 2.5, style: .continuous)
-                        .strokeBorder(
-                            isTodayEmpty ? DSColor.borderSubtle : .clear,
-                            style: StrokeStyle(lineWidth: 0.5, dash: [1.5, 1.5])
-                        )
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2.5, style: .continuous)
-                        .strokeBorder(Color.black.opacity(level == 3 ? 0.06 : 0), lineWidth: 0.5)
-                )
-                .overlay(
-                    RoundedRectangle(cornerRadius: 2.5, style: .continuous)
-                        .strokeBorder(isToday ? DSColor.accentOnBg : .clear, lineWidth: 1)
-                )
-                .shadow(
-                    color: isToday && firstEntryGlow ? DSColor.accentAmber.opacity(0.55) : .clear,
-                    radius: firstEntryGlow ? 4 : 0
-                )
-                .onChange(of: count) { newCount in
-                    if isToday && newCount == 1 && !reduceMotion {
-                        withAnimation(.easeOut(duration: 0.25)) { firstEntryGlow = true }
-                        Task {
-                            try? await Task.sleep(nanoseconds: 600_000_000)
-                            withAnimation(.easeOut(duration: 0.5)) { firstEntryGlow = false }
-                        }
+    private var gridView: some View {
+        GeometryReader { geo in
+            let cellW = cellWidth(in: geo.size.width)
+            heatCanvas
+                .overlay(alignment: .topLeading) {
+                    if firstEntryGlow, let pos = grid.todayPosition {
+                        todayGlow(position: pos, cellW: cellW)
+                    }
+                }
+                .overlay(alignment: .topLeading) {
+                    if let sel = selectedDay {
+                        tooltip(for: sel, cellW: cellW)
                     }
                 }
                 .contentShape(Rectangle())
-                .onTapGesture {
-                    if let sel = selectedCell, Calendar.current.isDate(sel.date, inSameDayAs: date) {
-                        selectedCell = nil
-                    } else {
-                        selectedCell = (date: date, count: count)
-                        selectedColumnIndex = columnIndex
-                        Haptics.soft()
-                        tooltipDismissGeneration += 1
-                        let gen = tooltipDismissGeneration
-                        Task {
-                            try? await Task.sleep(nanoseconds: 2_000_000_000)
-                            if tooltipDismissGeneration == gen {
-                                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.18)) {
-                                    selectedCell = nil
-                                }
-                            }
-                        }
+                .onTapGesture { point in
+                    handleTap(at: point, cellW: cellW)
+                }
+        }
+        .frame(height: gridHeight)
+    }
+
+    /// One vector layer for the weekday rail, month labels and all 112 cells.
+    private var heatCanvas: some View {
+        Canvas { context, size in
+            let cellW = cellWidth(in: size.width)
+
+            // Weekday rail: M T W T F S S
+            let letters = ["M", "T", "W", "T", "F", "S", "S"]
+            for (ri, letter) in letters.enumerated() {
+                let y = monthRowHeight + CGFloat(ri) * (cellHeight + cellSpacing) + cellHeight / 2
+                let text = Text(letter)
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundColor(DSColor.inkSubtle.opacity(ri % 2 == 1 ? 0.4 : 0.9))
+                context.draw(context.resolve(text), at: CGPoint(x: 5, y: y))
+            }
+
+            // Month labels along the top edge. Canvas clips to its bounds, so
+            // a label anchored at the last column (e.g. "JUL") must be clamped
+            // back inside the canvas or it renders truncated ("JU").
+            for label in grid.monthLabels {
+                let rawX = railWidth + CGFloat(label.column) * (cellW + cellSpacing)
+                let text = Text(label.text)
+                    .font(.system(size: 8, design: .monospaced))
+                    .foregroundColor(DSColor.inkSubtle)
+                let resolved = context.resolve(text)
+                let textWidth = resolved.measure(in: CGSize(width: 60, height: 12)).width
+                let x = min(rawX, size.width - textWidth)
+                context.draw(resolved, at: CGPoint(x: x, y: 4.5), anchor: .leading)
+            }
+
+            // Day cells.
+            let dashed = StrokeStyle(lineWidth: 0.5, dash: [1.5, 1.5])
+            for (ci, column) in grid.columns.enumerated() {
+                for (ri, day) in column.enumerated() {
+                    let rect = CGRect(
+                        x: railWidth + CGFloat(ci) * (cellW + cellSpacing),
+                        y: monthRowHeight + CGFloat(ri) * (cellHeight + cellSpacing),
+                        width: cellW,
+                        height: cellHeight
+                    )
+                    let path = Path(roundedRect: rect, cornerRadius: 2.5, style: .continuous)
+
+                    if day.isFuture {
+                        // Dashed placeholder for days that haven't happened yet.
+                        context.stroke(path, with: .color(DSColor.borderSubtle), style: dashed)
+                        continue
+                    }
+
+                    context.fill(path, with: .color(Self.palette[day.level]))
+
+                    if day.isToday && day.level == 0 {
+                        // Dashed ghost border for an unstarted today — reads as
+                        // "open, awaiting capture".
+                        context.stroke(path, with: .color(DSColor.borderSubtle), style: dashed)
+                    }
+                    if day.level == 3 {
+                        context.stroke(path, with: .color(.black.opacity(0.06)), lineWidth: 0.5)
+                    }
+                    if day.isToday {
+                        context.stroke(path, with: .color(DSColor.accentOnBg), lineWidth: 1)
                     }
                 }
-                // Per-cell a11y intentionally omitted: the parent `grid` is
-                // .accessibilityHidden(true), so VoiceOver gets a single
-                // summary line from the heatmap header instead of 105
-                // identical "Jun 15, 0 entries" rotor stops.
+            }
         }
     }
 
-    private func monthLabels(columns: [[HeatCell]]) -> some View {
-        // Mark a label at the first column whose top cell starts a new month.
-        var seenMonths = Set<Int>()
-        var labels: [(col: Int, text: String)] = []
-        let cal = Calendar.current
-        for (ci, col) in columns.enumerated() {
-            let firstDay = col.first(where: { if case .day = $0 { return true } else { return false } })
-            if case let .day(date, _, _, _) = firstDay {
-                let m = cal.component(.month, from: date)
-                if !seenMonths.contains(m) {
-                    seenMonths.insert(m)
-                    labels.append((ci, Self.monthFmt.string(from: date).uppercased()))
+    /// Brief amber halo over today's cell when the first memo of the day
+    /// lands. Kept as a SwiftUI overlay (not Canvas) so its fade animates.
+    private func todayGlow(position: HeatGrid.CellPosition, cellW: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: 2.5, style: .continuous)
+            .fill(Self.palette[grid.todayLevel])
+            .frame(width: cellW, height: cellHeight)
+            .shadow(color: DSColor.accentAmber.opacity(0.55), radius: 4)
+            .offset(
+                x: railWidth + CGFloat(position.column) * (cellW + cellSpacing),
+                y: monthRowHeight + CGFloat(position.row) * (cellHeight + cellSpacing)
+            )
+            .transition(.opacity)
+            .allowsHitTesting(false)
+    }
+
+    private func tooltip(for day: HeatGrid.Day, cellW: CGFloat) -> some View {
+        let tooltipText = "\(Self.monthDayFmt.string(from: day.date).uppercased()) · \(day.count) 条"
+        let xOffset = railWidth + CGFloat(selectedColumnIndex) * (cellW + cellSpacing) + cellW / 2
+        return Text(tooltipText)
+            .font(DSType.mono9)
+            .tracking(0.8)
+            .foregroundColor(DSColor.inkPrimary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(DSColor.surfaceWhite)
+                    .overlay(
+                        Capsule(style: .continuous)
+                            .strokeBorder(DSColor.borderSubtle, lineWidth: 0.5)
+                    )
+                    .shadow(color: Color.black.opacity(0.06), radius: 4, x: 0, y: 2)
+            )
+            .fixedSize()
+            .position(x: xOffset, y: 0)
+            .transition(
+                reduceMotion
+                    ? .opacity
+                    : .opacity.combined(with: .scale(scale: 0.88, anchor: .bottom))
+            )
+            .animation(
+                reduceMotion ? .default : .spring(response: 0.22, dampingFraction: 0.7),
+                value: day.date
+            )
+            .allowsHitTesting(false)
+            .zIndex(10)
+    }
+
+    /// Coordinate → cell hit test. The 3pt gutters between cells resolve to
+    /// the nearest cell (floor), which doubles as fat-finger tolerance.
+    private func handleTap(at point: CGPoint, cellW: CGFloat) {
+        let ci = Int(floor((point.x - railWidth) / (cellW + cellSpacing)))
+        let ri = Int(floor((point.y - monthRowHeight) / (cellHeight + cellSpacing)))
+        guard ci >= 0, ci < grid.columns.count, ri >= 0, ri < 7 else { return }
+        let day = grid.columns[ci][ri]
+        guard !day.isFuture else { return }
+
+        if let sel = selectedDay, Calendar.current.isDate(sel.date, inSameDayAs: day.date) {
+            selectedDay = nil
+            return
+        }
+        selectedDay = day
+        selectedColumnIndex = ci
+        Haptics.soft()
+        tooltipDismissGeneration += 1
+        let gen = tooltipDismissGeneration
+        Task {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            if tooltipDismissGeneration == gen {
+                withAnimation(reduceMotion ? nil : .easeOut(duration: 0.18)) {
+                    selectedDay = nil
                 }
             }
         }
-        return GeometryReader { geo in
-            let cell = cellSize(in: geo.size.width)
-            ForEach(labels, id: \.col) { item in
-                Text(item.text)
-                    .font(.system(size: 8, design: .monospaced)) // TODO: no DSType match, kept raw (8pt heatmap month label, smallest mono token is mono9=9pt)
-                    .tracking(1.2)
-                    .foregroundColor(DSColor.inkSubtle)
-                    .offset(x: CGFloat(item.col) * (cell + cellSpacing))
-            }
-        }
-        .frame(height: 9)
     }
 
     // MARK: - Footer
@@ -353,17 +385,48 @@ struct SidebarHeatmapView: View {
         }
         return base
     }
+}
 
-    // MARK: - Grid data
+// MARK: - HeatGrid (cached geometry snapshot)
 
-    /// A single heatmap cell.
-    private enum HeatCell {
-        case day(Date, level: Int, isToday: Bool, count: Int)
-        case future
+/// Immutable snapshot of everything the heatmap Canvas needs to draw a frame.
+/// Built once per `counts` change instead of on every body evaluation, so the
+/// ~120 Calendar/DateFormatter calls no longer run on unrelated view updates.
+private struct HeatGrid: Equatable {
+
+    struct Day: Equatable {
+        let date: Date
+        let level: Int
+        let isToday: Bool
+        let count: Int
+        let isFuture: Bool
     }
 
-    /// Build 16 columns (weeks) × 7 rows (Mon→Sun) ending with today's week.
-    private func buildColumns() -> [[HeatCell]] {
+    struct MonthLabel: Equatable {
+        let column: Int
+        let text: String
+    }
+
+    struct CellPosition: Equatable {
+        let column: Int
+        let row: Int
+    }
+
+    var columns: [[Day]] = []
+    var monthLabels: [MonthLabel] = []
+    var todayPosition: CellPosition? = nil
+    var todayCount: Int = 0
+    var todayLevel: Int = 0
+
+    private static let monthFmt: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US")
+        f.dateFormat = "MMM"
+        return f
+    }()
+
+    /// Build `weeks` columns (weeks) × 7 rows (Mon→Sun) ending with today's week.
+    static func build(counts: [String: Int], weeks: Int) -> HeatGrid {
         let cal = Calendar.current
         let today = cal.startOfDay(for: Date())
         let todayStr = DateFormatters.isoDate.string(from: today)
@@ -372,31 +435,52 @@ struct SidebarHeatmapView: View {
         // Swift Calendar weekday: 1=Sun…7=Sat. Convert to days since Monday.
         let wd = cal.component(.weekday, from: today)
         let monOffset = (wd + 5) % 7
-        guard let thisMonday = cal.date(byAdding: .day, value: -monOffset, to: today) else { return [] }
+        guard let thisMonday = cal.date(byAdding: .day, value: -monOffset, to: today) else {
+            return HeatGrid()
+        }
 
-        var columns: [[HeatCell]] = []
+        var grid = HeatGrid()
+        var seenMonths = Set<Int>()
+
         for w in stride(from: weeks - 1, through: 0, by: -1) {
             guard let weekMonday = cal.date(byAdding: .day, value: -7 * w, to: thisMonday) else { continue }
-            var col: [HeatCell] = []
+            let columnIndex = grid.columns.count
+            var col: [Day] = []
             for d in 0..<7 {
                 guard let date = cal.date(byAdding: .day, value: d, to: weekMonday) else { continue }
                 if date > today {
-                    col.append(.future)
-                } else {
-                    let key = DateFormatters.isoDate.string(from: date)
-                    let count = counts[key] ?? 0
-                    let isToday = key == todayStr
-                    let lvl = level(for: count)
-                    col.append(.day(date, level: lvl, isToday: isToday, count: count))
+                    col.append(Day(date: date, level: 0, isToday: false, count: 0, isFuture: true))
+                    continue
+                }
+                let key = DateFormatters.isoDate.string(from: date)
+                let count = counts[key] ?? 0
+                let isToday = key == todayStr
+                let lvl = level(for: count)
+                col.append(Day(date: date, level: lvl, isToday: isToday, count: count, isFuture: false))
+
+                if isToday {
+                    grid.todayPosition = CellPosition(column: columnIndex, row: d)
+                    grid.todayCount = count
+                    grid.todayLevel = lvl
+                }
+                // Month label at the first column whose top row starts a new month.
+                if d == 0 {
+                    let m = cal.component(.month, from: date)
+                    if !seenMonths.contains(m) {
+                        seenMonths.insert(m)
+                        grid.monthLabels.append(
+                            MonthLabel(column: columnIndex, text: monthFmt.string(from: date).uppercased())
+                        )
+                    }
                 }
             }
-            columns.append(col)
+            grid.columns.append(col)
         }
-        return columns
+        return grid
     }
 
     /// Map a memo count to one of 4 tonal buckets.
-    private func level(for count: Int) -> Int {
+    static func level(for count: Int) -> Int {
         switch count {
         case 0: return 0
         case 1: return 1

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -13,6 +13,10 @@ struct SidebarView: View {
     @State private var showSettings = false
     @State private var showAccountSheet = false
 
+    /// Disclosure state for the Recent jump list — collapsed by default so
+    /// the drawer opens to a single, calm screen (heatmap + stats + nav).
+    @AppStorage("sidebar.recentExpanded") private var recentExpanded = false
+
     var body: some View {
         ZStack(alignment: .topLeading) {
             // Liquid Glass drawer — dual-track (Phase 2 demo).
@@ -469,15 +473,67 @@ struct SidebarView: View {
     /// "Commit history" style list: the most recent days that actually have
     /// memos, tapping a row jumps straight to that day's detail view in
     /// Archive. Refreshed on every sidebar open via `refreshRecentDays()`.
+    ///
+    /// Collapsed by default — the heatmap above already tells the "recent
+    /// activity" story at a glance, so seven always-on list rows were
+    /// redundant weight that forced the drawer to scroll. The disclosure
+    /// state persists across launches for users who want the jump list open.
     private var recentSection: some View {
         VStack(alignment: .leading, spacing: 2) {
-            sectionLabel("Recent")
+            recentDisclosureRow
 
-            ForEach(sidebarVM.recentDays) { day in
-                recentRow(day: day)
+            if recentExpanded {
+                ForEach(sidebarVM.recentDays) { day in
+                    recentRow(day: day)
+                }
+                .transition(.opacity.combined(with: .move(edge: .top)))
             }
         }
         .padding(.horizontal, 12)
+        .clipped()  // keep collapsing rows from sliding over the section below
+    }
+
+    /// Section header doubling as the expand/collapse control: mono label +
+    /// day count + rotating chevron, styled like `sectionLabel` so the
+    /// museum-aesthetic ladder stays intact.
+    private var recentDisclosureRow: some View {
+        Button {
+            Haptics.soft()
+            withAnimation(Motion.respectReduceMotion(Motion.expand)) {
+                recentExpanded.toggle()
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Text("Recent")
+                    .font(DSType.mono9)
+                    .foregroundColor(DSColor.inkSubtle)
+                    .tracking(1.2)
+                    .textCase(.uppercase)
+                Text("\(sidebarVM.recentDays.count)")
+                    .font(DSType.mono9)
+                    .foregroundColor(DSColor.inkMuted)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 1)
+                    .background(DSColor.amberSoft, in: Capsule())
+                Spacer()
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 9, weight: .semibold))
+                    .foregroundColor(DSColor.inkSubtle)
+                    .rotationEffect(.degrees(recentExpanded ? 0 : -90))
+            }
+            .padding(.leading, 34)  // align with row text column (2 + 12 + 20)
+            .padding(.trailing, 16)
+            .padding(.vertical, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(NSLocalizedString("sidebar.recent", comment: "Recent section toggle"))
+        .accessibilityValue(recentExpanded
+            ? NSLocalizedString("a11y.expanded", comment: "Disclosure expanded state")
+            : NSLocalizedString("a11y.collapsed", comment: "Disclosure collapsed state"))
+        .accessibilityHint(NSLocalizedString("sidebar.recent.hint", comment: "Recent toggle hint"))
+        .accessibilityAddTraits(.isButton)
     }
 
     private func recentRow(day: RecentDay) -> some View {

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -694,17 +694,9 @@ struct ArchiveView: View {
                 }
             }
             .navigationBarHidden(true)
-            // US-030: left-edge swipe (within first 20pt) opens sidebar
-            .gesture(
-                DragGesture(minimumDistance: 20, coordinateSpace: .local)
-                    .onEnded { value in
-                        guard value.startLocation.x < 20,
-                              value.translation.width > 40,
-                              abs(value.translation.width) > abs(value.translation.height) * 1.2
-                        else { return }
-                        nav.openSidebar()
-                    }
-            )
+            // US-030 note: the left-edge open-sidebar swipe lives ONLY in
+            // RootView's edge strip (1:1 finger tracking) — see TodayView for
+            // why the fire-on-release duplicate was removed.
             .onAppear {
                 viewModel.loadMonth()
                 Task { await preScanVault() }

--- a/DayPage/Features/Auth/AuthView.swift
+++ b/DayPage/Features/Auth/AuthView.swift
@@ -13,6 +13,30 @@ private struct AuthButtonStyle: ButtonStyle {
     }
 }
 
+// MARK: - Entrance Choreography
+
+/// Staggered fade-up used by the auth screen's brand block / CTA stack /
+/// skip link. Falls back to a pure cross-fade (no translation) when the
+/// user has Reduce Motion enabled.
+private struct EntranceModifier: ViewModifier {
+    let isVisible: Bool
+    let reduceMotion: Bool
+    let delay: Double
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(isVisible ? 1 : 0)
+            .offset(y: isVisible || reduceMotion ? 0 : 14)
+            .animation(.easeOut(duration: 0.55).delay(delay), value: isVisible)
+    }
+}
+
+private extension View {
+    func entrance(_ isVisible: Bool, reduceMotion: Bool, delay: Double) -> some View {
+        modifier(EntranceModifier(isVisible: isVisible, reduceMotion: reduceMotion, delay: delay))
+    }
+}
+
 // MARK: - AuthView
 
 struct AuthView: View {
@@ -23,6 +47,12 @@ struct AuthView: View {
     @StateObject private var viewModel = AuthViewModel()
     @State private var showEmailAuth = false
 
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Drives the staggered entrance choreography: brand block rises first,
+    /// then the CTA stack, then the skip link. Pure opacity under Reduce Motion.
+    @State private var hasAppeared = false
+
     var body: some View {
         ZStack {
             DSColor.bgWarm
@@ -30,23 +60,36 @@ struct AuthView: View {
 
             GrainOverlay()
 
+            // Museum-aesthetic brand block: mono kicker → serif wordmark →
+            // tagline, matching the sidebar / Today header type ladder
+            // instead of the old grotesque-only lockup. Centered on the full
+            // canvas (deterministic), with the CTA stack pinned to the bottom
+            // edge — the two-Spacer sandwich this replaces distributed the
+            // slack unevenly and left the lockup stranded above the buttons.
+            VStack(spacing: 10) {
+                Text("DAYPAGE · 2026")
+                    .font(DSType.mono10)
+                    .tracking(2.4)
+                    .foregroundColor(DSColor.inkSubtle)
+                    .accessibilityHidden(true)
+
+                Text("DayPage")
+                    .font(DSFonts.serif(size: 40, weight: .semibold))
+                    .foregroundColor(DSColor.inkPrimary)
+
+                Text(NSLocalizedString("auth.tagline", comment: "AuthView brand tagline under DayPage logo"))
+                    .font(DSType.bodySM)
+                    .foregroundColor(DSColor.inkSecondary)
+                    .multilineTextAlignment(.center)
+            }
+            .entrance(hasAppeared, reduceMotion: reduceMotion, delay: 0.05)
+            .padding(.horizontal, 24)
+            // Optically centered: nudged up so the bottom CTA stack doesn't
+            // make the lockup read low on tall screens.
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+            .offset(y: -40)
+
             VStack(spacing: 0) {
-                Spacer()
-                    .frame(minHeight: 0)
-
-                VStack(spacing: 8) {
-                    Text("DayPage")
-                        .font(.custom("SpaceGrotesk-Bold", size: 32))
-                        .foregroundColor(DSColor.inkPrimary)
-
-                    Text(NSLocalizedString("auth.tagline", comment: "AuthView brand tagline under DayPage logo"))
-                        .font(.custom("SpaceGrotesk-Regular", size: 15))
-                        .foregroundColor(DSColor.inkSecondary)
-                }
-                .frame(maxWidth: .infinity)
-
-                Spacer()
-
                 if let errorText = viewModel.errorMessage {
                     Text(errorText)
                         .font(DSType.bodySM)
@@ -58,24 +101,23 @@ struct AuthView: View {
                         .animation(.easeInOut(duration: 0.2), value: viewModel.errorMessage)
                 }
 
-                VStack(spacing: 0) {
-                    buttonStack
+                buttonStack
+                    .entrance(hasAppeared, reduceMotion: reduceMotion, delay: 0.18)
 
-                    Button {
-                        onSkip?()
-                    } label: {
-                        Text(NSLocalizedString("auth.skip", comment: "AuthView Skip-login button"))
-                            .font(.custom("Inter-Regular", size: 13))
-                            .foregroundColor(DSColor.inkMuted)
-                    }
-                    .padding(.top, 16)
-                    .padding(.bottom, 32)
-                    .accessibilityLabel(NSLocalizedString("auth.skip.a11y", comment: "VoiceOver label for Skip login"))
+                Button {
+                    onSkip?()
+                } label: {
+                    Text(NSLocalizedString("auth.skip", comment: "AuthView Skip-login button"))
+                        .font(.custom("Inter-Regular", size: 13))
+                        .foregroundColor(DSColor.inkMuted)
                 }
-                .safeAreaInset(edge: .bottom) { Color.clear.frame(height: 0) }
+                .padding(.top, 16)
+                .padding(.bottom, 32)
+                .accessibilityLabel(NSLocalizedString("auth.skip.a11y", comment: "VoiceOver label for Skip login"))
+                .entrance(hasAppeared, reduceMotion: reduceMotion, delay: 0.30)
             }
             .padding(.horizontal, 24)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
 
             if viewModel.isLoading {
                 ProgressView()
@@ -85,6 +127,7 @@ struct AuthView: View {
         .task {
             viewModel.bind(authService: authService)
         }
+        .onAppear { hasAppeared = true }
         .transition(.opacity.animation(.easeOut(duration: 0.4)))
         .sheet(isPresented: $showEmailAuth) {
             EmailAuthView()

--- a/DayPage/Features/Auth/EmailAuthView.swift
+++ b/DayPage/Features/Auth/EmailAuthView.swift
@@ -68,7 +68,7 @@ struct EmailAuthView: View {
                 Spacer().frame(height: 32)
 
                 Text("Enter your email")
-                    .font(.custom("SpaceGrotesk-Bold", size: 24))
+                    .font(DSFonts.serif(size: 26, weight: .semibold))
                     .foregroundColor(DSColor.inkPrimary)
 
                 Spacer().frame(height: 8)
@@ -96,9 +96,16 @@ struct EmailAuthView: View {
                     .background(DSColor.surfaceWhite)
                     .cornerRadius(12)
                     .overlay(
+                        // Amber focus ring — the field is the only actionable
+                        // element on this stage, so it should visibly "own"
+                        // focus instead of relying on the caret alone.
                         RoundedRectangle(cornerRadius: 12)
-                            .stroke(DSColor.inkFaint, lineWidth: 1)
+                            .stroke(
+                                emailFocused ? DSColor.accentOnBg : DSColor.inkFaint,
+                                lineWidth: emailFocused ? 1.5 : 1
+                            )
                     )
+                    .animation(Motion.fade, value: emailFocused)
 
                 Spacer().frame(height: 16)
 

--- a/DayPage/Features/Auth/OTPVerificationView.swift
+++ b/DayPage/Features/Auth/OTPVerificationView.swift
@@ -114,7 +114,7 @@ struct OTPVerificationView: View {
 
     private var heading: some View {
         Text("Enter verification code")
-            .font(.custom("SpaceGrotesk-Bold", size: 24))
+            .font(DSFonts.serif(size: 26, weight: .semibold))
             .foregroundColor(DSColor.inkPrimary)
     }
 
@@ -150,7 +150,9 @@ struct OTPVerificationView: View {
         let isSuccess = index <= viewModel.successStagger
         let strokeColor: Color = {
             if isSuccess { return successGreen }
-            return isActive ? DSColor.inkPrimary : DSColor.inkFaint
+            // Active cell carries the DS amber accent — same focus language
+            // as the email field one step earlier in the flow.
+            return isActive ? DSColor.accentOnBg : DSColor.inkFaint
         }()
         return ZStack {
             RoundedRectangle(cornerRadius: DSRadius.sm)
@@ -163,7 +165,7 @@ struct OTPVerificationView: View {
                     .foregroundColor(isSuccess ? successGreen : DSColor.inkPrimary)
             } else if isActive {
                 Rectangle()
-                    .fill(DSColor.inkPrimary)
+                    .fill(DSColor.accentOnBg)
                     .frame(width: 1, height: 22)
                     .opacity(0.8)
             }

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -387,6 +387,7 @@ private struct DetailVoiceSection: View {
 
 private struct DetailPhotoSection: View {
     let attachment: Memo.Attachment
+    @State private var exifText: String?
     @Binding var fullResImage: UIImage?
     @Binding var showFullscreen: Bool
 
@@ -423,7 +424,7 @@ private struct DetailPhotoSection: View {
                 }
 
                 // EXIF overlay
-                if let exif = exifOverlayText {
+                if let exif = exifText {
                     Text(exif)
                         .font(DSFonts.jetBrainsMono(size: 10))
                         .tracking(0.5)
@@ -446,6 +447,13 @@ private struct DetailPhotoSection: View {
             }
             .task(id: photoURL) {
                 loadedImage = await loadFullResImage(from: photoURL)
+                // EXIF caption loads off-main with the image — as a computed
+                // property it re-read the file header on every body pass.
+                let url = photoURL
+                let file = attachment.file
+                exifText = await Task.detached(priority: .utility) {
+                    Self.exifOverlayText(file: file, photoURL: url)
+                }.value
             }
 
             // Tap hint
@@ -461,8 +469,8 @@ private struct DetailPhotoSection: View {
         }
     }
 
-    private var exifOverlayText: String? {
-        let filename = URL(fileURLWithPath: attachment.file).lastPathComponent.uppercased()
+    nonisolated private static func exifOverlayText(file: String, photoURL: URL) -> String? {
+        let filename = URL(fileURLWithPath: file).lastPathComponent.uppercased()
         if let source = CGImageSourceCreateWithURL(photoURL as CFURL, nil),
            let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
            let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any] {
@@ -693,6 +701,10 @@ private struct DetailFileRow: View {
 private struct DetailMetadataSection: View {
     let memo: Memo
 
+    /// Photo EXIF rows resolved off-main. Reading image properties inline in
+    /// `kindSpecificRows` was synchronous disk I/O on every body pass.
+    @State private var photoExifRows: [(label: String, value: String)] = []
+
     private var createdFull: String {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
@@ -777,6 +789,44 @@ private struct DetailMetadataSection: View {
             // Kind-specific fields
             kindSpecificRows
         }
+        .task(id: memo.id) {
+            guard let photoAtt = memo.attachments.first(where: { $0.kind == "photo" }) else { return }
+            let url = VaultInitializer.vaultURL.appendingPathComponent(photoAtt.file)
+            photoExifRows = await Task.detached(priority: .utility) {
+                Self.loadPhotoExifRows(from: url)
+            }.value
+        }
+    }
+
+    /// Metadata-only image header read (no pixel decode) — still disk I/O,
+    /// so it runs off the main actor via the .task above.
+    nonisolated private static func loadPhotoExifRows(from photoURL: URL) -> [(label: String, value: String)] {
+        guard let source = CGImageSourceCreateWithURL(photoURL as CFURL, nil),
+              let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any] else {
+            return []
+        }
+        var rows: [(label: String, value: String)] = []
+        if let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any] {
+            if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double {
+                rows.append(("Aperture", String(format: "f/%.1f", aperture)))
+            }
+            if let shutter = exif[kCGImagePropertyExifExposureTime as String] as? Double {
+                let denom = Int(1.0 / shutter)
+                rows.append(("Shutter", "1/\(denom)s"))
+            }
+            if let iso = exif[kCGImagePropertyExifISOSpeedRatings as String] as? [Int],
+               let isoVal = iso.first {
+                rows.append(("ISO", "\(isoVal)"))
+            }
+            if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double {
+                rows.append(("Focal Length", "\(Int(focal))mm"))
+            }
+        }
+        if let w = props[kCGImagePropertyPixelWidth as String] as? Int,
+           let h = props[kCGImagePropertyPixelHeight as String] as? Int {
+            rows.append(("Dimensions", "\(w) × \(h)"))
+        }
+        return rows
     }
 
     @ViewBuilder
@@ -793,33 +843,9 @@ private struct DetailMetadataSection: View {
             }
         }
 
-        // Photo: EXIF fields
-        if let photoAtt = memo.attachments.first(where: { $0.kind == "photo" }) {
-            let photoURL = VaultInitializer.vaultURL.appendingPathComponent(photoAtt.file)
-            if let source = CGImageSourceCreateWithURL(photoURL as CFURL, nil),
-               let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any] {
-                if let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any] {
-                    if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double {
-                        metaRow(label: "Aperture", value: String(format: "f/%.1f", aperture))
-                    }
-                    if let shutter = exif[kCGImagePropertyExifExposureTime as String] as? Double {
-                        let denom = Int(1.0 / shutter)
-                        metaRow(label: "Shutter", value: "1/\(denom)s")
-                    }
-                    if let iso = exif[kCGImagePropertyExifISOSpeedRatings as String] as? [Int],
-                       let isoVal = iso.first {
-                        metaRow(label: "ISO", value: "\(isoVal)")
-                    }
-                    if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double {
-                        metaRow(label: "Focal Length", value: "\(Int(focal))mm")
-                    }
-                }
-                // Pixel dimensions
-                if let w = props[kCGImagePropertyPixelWidth as String] as? Int,
-                   let h = props[kCGImagePropertyPixelHeight as String] as? Int {
-                    metaRow(label: "Dimensions", value: "\(w) × \(h)")
-                }
-            }
+        // Photo: EXIF fields — rendered from state; resolved off-main in .task.
+        ForEach(photoExifRows, id: \.label) { row in
+            metaRow(label: row.label, value: row.value)
         }
 
         // Location: coordinates

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -26,10 +26,15 @@ struct MemoCardView: View {
     var onRetranscribe: ((Memo, Memo.Attachment) -> Void)? = nil
 
     @State private var showLocationSheet: Bool = false
-    @State private var thumbnail: UIImage?
+    /// Which photo attachment the full-screen viewer is showing (nil = closed).
+    /// item-based so each photo in a multi-photo memo opens its own viewer.
+    struct PhotoViewerTarget: Identifiable {
+        let file: String
+        var id: String { file }
+    }
+    @State private var viewerPhoto: PhotoViewerTarget?
     @State private var downloadStates: [URL: AttachmentDownloadState] = [:]
     @State private var downloadTask: Task<Void, Never>? = nil
-    @State private var showPhotoViewer: Bool = false
 
     /// Hero zoom (iOS 18+): shared between the in-card photo thumbnail
     /// (`matchedTransitionSource`) and the full-screen viewer
@@ -198,49 +203,48 @@ struct MemoCardView: View {
                 }
             }
 
-            // Photo
-            if memo.type == .photo || (memo.type == .mixed && memo.attachments.contains(where: { $0.kind == "photo" })) {
-                if let att = memo.attachments.first(where: { $0.kind == "photo" }) {
-                    let photoURL = VaultInitializer.vaultURL.appendingPathComponent(att.file)
-                    let photoState = attachmentDownloadState(for: photoURL)
-                    switch photoState {
-                    case .current:
-                        PhotoThumbnailView(fileURL: photoURL, thumbnail: $thumbnail, exifText: photoExifText)
-                            .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
-                            // Hero zoom source (iOS 18+). Identity = attachment
-                            // relative path — stable per photo, so multi-photo
-                            // memos each zoom from their own thumbnail.
-                            .modifier(PhotoZoomSource(id: att.file, namespace: photoZoomNamespace))
-                            .contentShape(Rectangle())
-                            .onTapGesture {
-                                Haptics.tapConfirm()
-                                showPhotoViewer = true
+            // Photo — every photo attachment renders, not just the first.
+            // A two-photo memo used to silently drop the second image from
+            // the card (and the viewer), which read as data loss.
+            let photoAtts = memo.attachments.filter { $0.kind == "photo" }
+            ForEach(photoAtts, id: \.file) { att in
+                let photoURL = VaultInitializer.vaultURL.appendingPathComponent(att.file)
+                let photoState = attachmentDownloadState(for: photoURL)
+                switch photoState {
+                case .current:
+                    PhotoThumbnailView(fileURL: photoURL)
+                        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                        // Hero zoom source (iOS 18+). Identity = attachment
+                        // relative path — stable per photo, so multi-photo
+                        // memos each zoom from their own thumbnail.
+                        .modifier(PhotoZoomSource(id: att.file, namespace: photoZoomNamespace))
+                        .contentShape(Rectangle())
+                        .onTapGesture {
+                            Haptics.tapConfirm()
+                            viewerPhoto = PhotoViewerTarget(file: att.file)
+                        }
+                        .padding(.horizontal, 14)
+                        .padding(.top, 14)
+                case .downloading, .notDownloaded, .failed:
+                    PhotoDownloadPlaceholder(state: photoState)
+                        .padding(.top, 4)
+                        .onAppear {
+                            if photoState == .notDownloaded { startDownload(photoURL) }
+                            else if photoState == .failed { startDownload(photoURL) }
+                        }
+                        .onTapGesture {
+                            if photoState == .notDownloaded || photoState == .failed {
+                                startDownload(photoURL)
                             }
-                            .padding(.horizontal, 14)
-                            .padding(.top, 14)
-                            .fullScreenCover(isPresented: $showPhotoViewer) {
-                                if let att = memo.attachments.first(where: { $0.kind == "photo" }) {
-                                    PhotoFullScreenViewer(
-                                        fileURL: VaultInitializer.vaultURL.appendingPathComponent(att.file),
-                                        exifText: photoExifText
-                                    )
-                                    .modifier(PhotoZoomDestination(id: att.file, namespace: photoZoomNamespace))
-                                }
-                            }
-                    case .downloading, .notDownloaded, .failed:
-                        PhotoDownloadPlaceholder(state: photoState)
-                            .padding(.top, 4)
-                            .onAppear {
-                                if photoState == .notDownloaded { startDownload(photoURL) }
-                                else if photoState == .failed { startDownload(photoURL) }
-                            }
-                            .onTapGesture {
-                                if photoState == .notDownloaded || photoState == .failed {
-                                    startDownload(photoURL)
-                                }
-                            }
-                    }
+                        }
                 }
+            }
+            .fullScreenCover(item: $viewerPhoto) { target in
+                PhotoFullScreenViewer(
+                    fileURL: VaultInitializer.vaultURL.appendingPathComponent(target.file),
+                    exifText: PhotoThumbnailView.exifText(forRelativePath: target.file)
+                )
+                .modifier(PhotoZoomDestination(id: target.file, namespace: photoZoomNamespace))
             }
 
             // File attachments
@@ -349,18 +353,6 @@ struct MemoCardView: View {
         return "\(latStr) · \(lngStr)"
     }
 
-    private var photoExifText: String? {
-        guard let att = memo.attachments.first(where: { $0.kind == "photo" }) else { return nil }
-        let filename = URL(fileURLWithPath: att.file).lastPathComponent.uppercased()
-        let fileURL = VaultInitializer.vaultURL.appendingPathComponent(att.file)
-        if let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil),
-           let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
-           let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any],
-           let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double {
-            return "\(filename) // FOCUS: \(Int(focal))mm"
-        }
-        return filename
-    }
 }
 
 // MARK: - Photo hero zoom (iOS 18+)
@@ -1276,8 +1268,13 @@ private let thumbnailCache: NSCache<NSURL, UIImage> = {
 
 struct PhotoThumbnailView: View {
     let fileURL: URL
-    @Binding var thumbnail: UIImage?
-    let exifText: String?
+    /// Self-owned: each thumbnail in a multi-photo memo decodes and caches
+    /// independently (a shared parent binding made siblings overwrite each
+    /// other). EXIF caption loads with the decode, off the main actor —
+    /// reading image properties in the card's `body` was synchronous disk
+    /// I/O on every re-render.
+    @State private var thumbnail: UIImage?
+    @State private var exifText: String?
 
     var body: some View {
         Group {
@@ -1286,11 +1283,18 @@ struct PhotoThumbnailView: View {
                 // crop. Enforce the same aspect with a fill so the museum
                 // timeline keeps a consistent photo rhythm instead of letting
                 // each image dictate its own height.
-                Image(uiImage: thumb)
-                    .resizable()
-                    .aspectRatio(contentMode: .fill)
+                // The 4:5 frame must be owned by a container with the image as
+                // an overlay: a bare `.fill` image reports its oversized width
+                // up the modifier chain, so `.clipped()` had nothing to clip
+                // and landscape photos blew the card out past the screen edge.
+                Color.clear
                     .frame(maxWidth: .infinity)
                     .aspectRatio(4.0 / 5.0, contentMode: .fit)
+                    .overlay {
+                        Image(uiImage: thumb)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                    }
                     .clipped()
             } else {
                 Rectangle()
@@ -1307,10 +1311,15 @@ struct PhotoThumbnailView: View {
             let cacheKey = fileURL as NSURL
             if let cached = thumbnailCache.object(forKey: cacheKey) {
                 if thumbnail !== cached { thumbnail = cached }
-                return
+            } else {
+                thumbnail = nil
+                thumbnail = await loadThumbnailAsync(from: fileURL)
             }
-            thumbnail = nil
-            thumbnail = await loadThumbnailAsync(from: fileURL)
+            // EXIF caption rides the same off-main hop as the decode.
+            let url = fileURL
+            exifText = await Task.detached(priority: .utility) {
+                Self.exifText(for: url)
+            }.value
         }
         .overlay(alignment: .bottom) {
             if let exifText {
@@ -1348,6 +1357,24 @@ struct PhotoThumbnailView: View {
                     .accessibilityHidden(true)
             }
         }
+    }
+
+    /// "IMG_… // FOCUS: 26MM" caption. Metadata-only read (no pixel decode),
+    /// but still disk I/O — call off the main actor.
+    static func exifText(for fileURL: URL) -> String? {
+        let filename = fileURL.lastPathComponent.uppercased()
+        if let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil),
+           let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
+           let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any],
+           let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double {
+            return "\(filename) // FOCUS: \(Int(focal))mm"
+        }
+        return filename
+    }
+
+    /// Convenience for callers that hold a vault-relative path (viewer).
+    static func exifText(forRelativePath relative: String) -> String? {
+        exifText(for: VaultInitializer.vaultURL.appendingPathComponent(relative))
     }
 
     private func loadThumbnailAsync(from url: URL) async -> UIImage? {

--- a/DayPage/Features/Today/PressToTalkButton.swift
+++ b/DayPage/Features/Today/PressToTalkButton.swift
@@ -95,6 +95,12 @@ struct PressToTalkButton: View {
     @State private var pressStartTime: Date? = nil
     @State private var ringScale: CGFloat = 1.0
     @State private var ringOpacity: Double = 0.0
+    /// Fires the pre-recording → recording transition after
+    /// `longPressThreshold` even when the finger holds perfectly still.
+    /// `DragGesture.onChanged` only re-fires on movement, so gating the
+    /// threshold check inside it deadlocked a motionless press in
+    /// `.preRecording` forever ("再按住一下" with no way past it).
+    @State private var thresholdTask: Task<Void, Never>? = nil
 
     // MARK: Body
 
@@ -135,17 +141,22 @@ struct PressToTalkButton: View {
                     currentPhase = .preRecording
                     onPhaseChange(.preRecording)
                     startRingPulse()
+                    // Schedule the threshold commit on a clock, not on the next
+                    // finger movement — a still press must start recording too.
+                    thresholdTask?.cancel()
+                    thresholdTask = Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: UInt64(longPressThreshold * 1_000_000_000))
+                        guard !Task.isCancelled else { return }
+                        commitToRecordingIfNeeded()
+                    }
                 }
 
-                // Once we've held past the threshold, commit to press-to-talk mode
+                // Movement past the threshold also commits (finger moved before
+                // the timer fired) — same transition, single entry point.
                 if currentPhase == .preRecording,
                    let start = pressStartTime,
                    Date().timeIntervalSince(start) >= longPressThreshold {
-                    emitHaptic(HapticFeedback.heavy)
-                    stopRingPulse()
-                    onPressStart()
-                    currentPhase = .recording
-                    onPhaseChange(.recording)
+                    commitToRecordingIfNeeded()
                 }
 
                 guard currentPhase != .idle && currentPhase != .preRecording else { return }
@@ -170,6 +181,8 @@ struct PressToTalkButton: View {
                 defer {
                     pressStartTime = nil
                 }
+                thresholdTask?.cancel()
+                thresholdTask = nil
 
                 // Short tap — never crossed threshold, still in preRecording phase.
                 // Haptic is intentionally not emitted here: the short-tap callback
@@ -239,6 +252,17 @@ struct PressToTalkButton: View {
     }
 
     // MARK: - Helpers
+
+    /// Single entry point for the preRecording → recording transition, shared
+    /// by the timer path (still press) and the movement path (early drag).
+    private func commitToRecordingIfNeeded() {
+        guard currentPhase == .preRecording else { return }
+        emitHaptic(HapticFeedback.heavy)
+        stopRingPulse()
+        onPressStart()
+        currentPhase = .recording
+        onPhaseChange(.recording)
+    }
 
     /// Map the drag translation onto an exclusive phase. Cancel wins over
     /// transcribe when both thresholds are crossed — "cancel" is the safer

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -675,17 +675,11 @@ struct TodayView: View {
     private func applyNavigationAndOverlays(_ content: some View) -> some View {
         content
             .navigationBarHidden(true)
-            // US-030: left-edge swipe (within first 20pt) opens sidebar
-            .gesture(
-                DragGesture(minimumDistance: 20, coordinateSpace: .local)
-                    .onEnded { value in
-                        guard value.startLocation.x < 20,
-                              value.translation.width > 40,
-                              abs(value.translation.width) > abs(value.translation.height) * 1.2
-                        else { return }
-                        nav.openSidebar()
-                    }
-            )
+            // US-030 note: the left-edge open-sidebar swipe lives ONLY in
+            // RootView's edge strip (1:1 finger tracking). A fire-on-release
+            // duplicate here competed in gesture arbitration with that
+            // interactive version and could win, making the drawer pop open
+            // with a canned animation instead of following the finger.
             .navigationDestination(for: UUID.self) { memoID in
                 if let memo = viewModel.memos.first(where: { $0.id == memoID }) {
                     MemoDetailView(memo: memo, vm: viewModel)
@@ -2072,9 +2066,11 @@ struct TodayView: View {
                 .contentShape(Ellipse())
                 .onTapGesture {
                     Haptics.tapConfirm()
-                    if draftText.isEmpty {
-                        draftText = orbCapturePrompt(currentTime)
-                    }
+                    // Focus only — never write the time-of-day prompt into
+                    // draftText: it saved verbatim into the memo body ("今天
+                    // 最终落在哪里了？morning at…"). Same rationale as the
+                    // dock's removed "记下此刻" hint (InputBarV4): guidance
+                    // belongs in placeholder chrome, not in user content.
                     orbFocusToggle.toggle()
                 }
 
@@ -2103,8 +2099,8 @@ struct TodayView: View {
             .accessibilityHint(NSLocalizedString("today.orb.hint", comment: ""))
             .onLongPressGesture(minimumDuration: 0.5) {
                 Haptics.medium()
-                guard draftText.isEmpty else { return }
-                draftText = orbCapturePrompt(currentTime)
+                // Focus only — see the tap handler above for why the prompt
+                // must not be written into draftText.
                 orbFocusToggle.toggle()
             }
 
@@ -2258,17 +2254,6 @@ struct TodayView: View {
         case .afternoon: key = "empty.today.subtitle.afternoon"
         case .evening:   key = "empty.today.subtitle.evening"
         case .lateNight: key = "empty.today.subtitle.night"
-        }
-        return NSLocalizedString(key, comment: "")
-    }
-
-    private func orbCapturePrompt(_ date: Date) -> String {
-        let key: String
-        switch TimeOfDay.from(date) {
-        case .morning:   key = "today.orb.prompt.morning"
-        case .afternoon: key = "today.orb.prompt.afternoon"
-        case .evening:   key = "today.orb.prompt.evening"
-        case .lateNight: key = "today.orb.prompt.night"
         }
         return NSLocalizedString(key, comment: "")
     }

--- a/DayPage/Features/Today/VoiceRecordingView.swift
+++ b/DayPage/Features/Today/VoiceRecordingView.swift
@@ -169,8 +169,11 @@ struct VoiceRecordingView: View {
                 let level = i < bars.count ? bars[i] : 0.04
                 RoundedRectangle(cornerRadius: 1)
                     .fill(DSColor.amberArchival)
+                    // Bar height maps the live meter level directly — no
+                    // implicit animation. 40 per-bar easeOuts chasing a 30fps
+                    // metering feed made the waveform lag its own input; the
+                    // sliding history window already provides the motion.
                     .frame(width: 3, height: max(4, CGFloat(level) * 32))
-                    .animation(Motion.instant, value: level)
             }
         }
         .frame(height: 36)

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -1007,6 +1007,10 @@
 "sidebar.nav.archive"        = "Archive";
 "sidebar.nav.graph"          = "Graph";
 "sidebar.nav.feedback"       = "Feedback";
+"sidebar.recent"             = "Recent days";
+"sidebar.recent.hint"        = "Shows or hides the recent-day list";
+"a11y.expanded"              = "Expanded";
+"a11y.collapsed"             = "Collapsed";
 "heatmap.entries"            = "ENTRIES";
 "archive.title"              = "Archive";
 "archive.today"              = "TODAY";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -1011,6 +1011,10 @@
 "sidebar.nav.archive"        = "归档";
 "sidebar.nav.graph"          = "图谱";
 "sidebar.nav.feedback"       = "反馈";
+"sidebar.recent"             = "最近记录";
+"sidebar.recent.hint"        = "展开或收起最近记录列表";
+"a11y.expanded"              = "已展开";
+"a11y.collapsed"             = "已收起";
 "heatmap.entries"            = "条";
 "archive.title"              = "归档";
 "archive.today"              = "今日";

--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -243,9 +243,16 @@ final class VoiceService: NSObject, ObservableObject {
         }
 
         do {
-            let session = AVAudioSession.sharedInstance()
-            try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetooth])
-            try session.setActive(true)
+            // setCategory/setActive block for hundreds of ms (seconds on a
+            // cold audio stack). Running them on the main actor both froze
+            // the UI and delayed the actual start of capture — a 4s press
+            // could end up with <1s of audio. Hop off the main actor; the
+            // AVAudioSession API is thread-safe.
+            try await Task.detached(priority: .userInitiated) {
+                let session = AVAudioSession.sharedInstance()
+                try session.setCategory(.playAndRecord, mode: .default, options: [.defaultToSpeaker, .allowBluetooth])
+                try session.setActive(true)
+            }.value
         } catch {
             state = .failed("音频会话初始化失败：\(error.localizedDescription)")
             return

--- a/DayPageKit/Sources/DayPageServices/CompilationService.swift
+++ b/DayPageKit/Sources/DayPageServices/CompilationService.swift
@@ -81,19 +81,37 @@ public final class CompilationService: ObservableObject {
         // BG service / UI can observe the latest result without stale data.
         lastMemoUpdateFailures = 0
 
-        // Step 1: Collect memos
+        // Step 1: Collect memos.
+        // Disk reads + YAML parse + SHA256 hop off the main actor: compile()
+        // itself is @MainActor, and on a 20-memo day this prep block held the
+        // main thread for tens of ms right as the user tapped 编译.
         stage = .extracting
         compilationProgress = .extracting
-        let (memos, rawContent) = try collectMemos(for: date)
+        let dailyURL = dailyPageURL(for: dateString)
+        let (memos, rawContent, sourceHash, storedHash) =
+            try await Task.detached(priority: .userInitiated) {
+                let memos: [Memo]
+                do {
+                    memos = try RawStorage.read(for: date)
+                } catch {
+                    throw CompilationError.parseFailure("读取原始备忘录失败：\(error.localizedDescription)")
+                }
+                guard !memos.isEmpty else {
+                    throw CompilationError.emptyInput
+                }
+                let rawContent = (try? String(contentsOf: RawStorage.fileURL(for: date), encoding: .utf8)) ?? ""
+                let hash = Self.sourceHash(of: memos)
+                let stored = (try? String(contentsOf: dailyURL, encoding: .utf8))
+                    .flatMap { Self.extractSourceHash(from: $0) }
+                return (memos, rawContent, hash, stored)
+            }.value
 
         // Issue #814 cost guard: when the substantive memo content is
         // unchanged since the last compile, skip the LLM round-trip
         // entirely. Checked BEFORE the network/AI guards so an offline
         // no-op request resolves quietly instead of throwing.
-        let sourceHash = Self.sourceHash(of: memos)
         if !force,
-           let existingDaily = try? String(contentsOf: dailyPageURL(for: dateString), encoding: .utf8),
-           let storedHash = Self.extractSourceHash(from: existingDaily),
+           let storedHash,
            storedHash == sourceHash {
             appendLog(
                 timestamp: iso8601Now(),
@@ -211,24 +229,6 @@ public final class CompilationService: ObservableObject {
             }
         }
         return dailyText
-    }
-
-    // MARK: - Step 1: Collect Memos
-
-    /// Reads today's raw memos and the raw file content string.
-    /// - Returns: `(memos, rawFileContent)`
-    private func collectMemos(for date: Date) throws -> ([Memo], String) {
-        let memos: [Memo]
-        do {
-            memos = try RawStorage.read(for: date)
-        } catch {
-            throw CompilationError.parseFailure("读取原始备忘录失败：\(error.localizedDescription)")
-        }
-        guard !memos.isEmpty else {
-            throw CompilationError.emptyInput
-        }
-        let rawContent = rawFileContent(for: date)
-        return (memos, rawContent)
     }
 
     // MARK: - Step 3: Call AI

--- a/DayPageKit/Sources/DayPageServices/WikiIndexService.swift
+++ b/DayPageKit/Sources/DayPageServices/WikiIndexService.swift
@@ -26,18 +26,26 @@ public final class WikiIndexService {
     // MARK: - Rebuild
 
     /// Regenerates vault/wiki/index.md from the current wiki contents.
-    public func rebuild() {
-        let wikiURL = VaultInitializer.vaultURL.appendingPathComponent("wiki")
-        let content = Self.buildIndexMarkdown(
-            daily: Self.scanDaily(wikiURL: wikiURL),
-            weekly: Self.scanWeekly(wikiURL: wikiURL),
-            entities: Self.scanEntities(wikiURL: wikiURL),
-            updatedAt: ISO8601DateFormatter.memo.string(from: Date())
-        )
-        do {
-            try RawStorage.atomicWrite(string: content, to: wikiURL.appendingPathComponent("index.md"))
-        } catch {
-            DayPageLogger.shared.error("WikiIndexService: failed to write index.md: \(error)")
+    /// Fire-and-forget for production callers: the full-wiki directory walk
+    /// + per-file frontmatter parse used to run on the main actor at the
+    /// tail of every compile (50–300ms with a few hundred pages). The
+    /// rebuild is idempotent and atomicWrite serializes the final write, so
+    /// detaching is safe. The returned task lets tests await completion.
+    @discardableResult
+    public func rebuild() -> Task<Void, Never> {
+        Task.detached(priority: .utility) {
+            let wikiURL = VaultInitializer.vaultURL.appendingPathComponent("wiki")
+            let content = Self.buildIndexMarkdown(
+                daily: Self.scanDaily(wikiURL: wikiURL),
+                weekly: Self.scanWeekly(wikiURL: wikiURL),
+                entities: Self.scanEntities(wikiURL: wikiURL),
+                updatedAt: ISO8601DateFormatter.memo.string(from: Date())
+            )
+            do {
+                try RawStorage.atomicWrite(string: content, to: wikiURL.appendingPathComponent("index.md"))
+            } catch {
+                await DayPageLogger.shared.error("WikiIndexService: failed to write index.md: \(error)")
+            }
         }
     }
 
@@ -56,7 +64,7 @@ public final class WikiIndexService {
         }
     }
 
-    private static func scanDaily(wikiURL: URL) -> [DailyEntry] {
+    nonisolated private static func scanDaily(wikiURL: URL) -> [DailyEntry] {
         let dir = wikiURL.appendingPathComponent("daily")
         guard let files = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return [] }
         return files
@@ -77,7 +85,7 @@ public final class WikiIndexService {
             .sorted { $0.dateString > $1.dateString } // newest first
     }
 
-    private static func scanWeekly(wikiURL: URL) -> [String] {
+    nonisolated private static func scanWeekly(wikiURL: URL) -> [String] {
         let dir = wikiURL.appendingPathComponent("weekly")
         guard let files = try? FileManager.default.contentsOfDirectory(atPath: dir.path) else { return [] }
         return files
@@ -87,7 +95,7 @@ public final class WikiIndexService {
     }
 
     /// (type, slug, displayName) tuples for places / people / themes.
-    private static func scanEntities(wikiURL: URL) -> [(type: String, slug: String, name: String)] {
+    nonisolated private static func scanEntities(wikiURL: URL) -> [(type: String, slug: String, name: String)] {
         var results: [(String, String, String)] = []
         for type in ["places", "people", "themes"] {
             let dir = wikiURL.appendingPathComponent(type)
@@ -159,7 +167,7 @@ public final class WikiIndexService {
 
     /// Minimal single-level `key: value` frontmatter parse. Quoted values
     /// are unwrapped so `summary: "..."` indexes cleanly.
-    private static func frontmatterFields(of content: String) -> [String: String] {
+    nonisolated private static func frontmatterFields(of content: String) -> [String: String] {
         var fields: [String: String] = [:]
         let lines = content.components(separatedBy: "\n")
         guard lines.first?.trimmingCharacters(in: .whitespaces) == "---" else { return fields }

--- a/DayPageKit/Sources/DayPageStorage/RawStorage.swift
+++ b/DayPageKit/Sources/DayPageStorage/RawStorage.swift
@@ -50,11 +50,15 @@ public enum RawStorage {
             .appendingPathComponent("\(dateString).md")
     }
 
-    /// 生成 asset 文件名：`<prefix>_<yyyyMMdd_HHmmss>.<ext>`（本地时区）。
+    /// 生成 asset 文件名：`<prefix>_<yyyyMMdd_HHmmss>_<uniq>.<ext>`（本地时区）。
     /// 用于照片（prefix "IMG"）、语音（prefix "voice"）等带时间戳的附件。
+    /// 时间戳只有秒级精度——同一秒内保存多张照片（相册多选）会生成相同
+    /// 文件名并互相覆盖，后一张静默吞掉前一张。追加 4 位随机后缀保证
+    /// 同秒多附件各自落盘；`IMG_*.jpg` 通配消费方（OrphanedPhotoScanner）不受影响。
     public static func assetFilename(prefix: String, ext: String) -> String {
         let stamp = assetTimestampFormatter.string(from: Date())
-        return "\(prefix)_\(stamp).\(ext)"
+        let uniq = String(UUID().uuidString.prefix(4)).lowercased()
+        return "\(prefix)_\(stamp)_\(uniq).\(ext)"
     }
 
     // MARK: - Write

--- a/DayPageTests/BackgroundCompilationServiceTests.swift
+++ b/DayPageTests/BackgroundCompilationServiceTests.swift
@@ -202,9 +202,11 @@ final class BackgroundCompilationServiceTests: XCTestCase {
     /// End-to-end against the temp vault: rebuild() scans daily pages and
     /// writes wiki/index.md.
     @MainActor
-    func testWikiIndex_rebuild_writesIndexFromVault() throws {
+    func testWikiIndex_rebuild_writesIndexFromVault() async throws {
         try writeDaily(sourceHash: "abc")
-        WikiIndexService.shared.rebuild()
+        // rebuild() is fire-and-forget in production; await the returned
+        // task so the assertion runs after the detached write lands.
+        await WikiIndexService.shared.rebuild().value
         let indexURL = tempDir.appendingPathComponent("wiki/index.md")
         let content = try String(contentsOf: indexURL, encoding: .utf8)
         XCTAssertTrue(content.contains("- [[wiki/daily/\(dayString)|\(dayString)]]"))


### PR DESCRIPTION
## Summary
- **模拟器全链路实测**（多条文本、剪贴板中文、相册双图、按住说话逐一 dogfood）+ **双 agent 深度审计**（主线程阻塞 + 手势跟手性）发现的 12 项根因，全部修复并复测验证
- **数据丢失级**：同秒多选照片文件名冲突互相覆盖（实测 2 张只落盘 1 张）、多图 memo 只渲染第一张、空态引导语"今天最终落在哪里了？"混入 memo 正文永久落盘
- **交互死锁级**：按住说话静止按压永久卡在"再按住一下"（阈值判定在 onChanged 里，只有手指移动才触发）、`setActive` 同步跑主线程导致按 4s 只录到 <1s
- **主线程**：compile() 准备段（读盘+YAML+SHA256）、WikiIndexService 全量重建（50–300ms）、EXIF body 内同步磁盘 I/O 全部移后台
- **跟手性**：抽屉面板自身无关闭手势（跟手 drag 挂在被面板盖住的 scrim 上）、`.fill` 图片尺寸穿透 `.clipped()` 撑爆卡片（AX frame x=-229/w=557 实锤）、波形逐 bar 动画去追电平、两处冗余 edge-swipe 与跟手版竞争仲裁
- 另含上一工作日的侧边栏 Canvas 化收尾与登录链路美术馆化（Auth 三视图）

## Test plan
- [x] `xcodebuild test`（iPhone 17 模拟器）141 tests / 24 suites 全绿
- [x] 照片卡恢复 4:5 圆角节奏、正文不再被裁（修复前图片全出血溢出屏幕）
- [x] 静止长按 <0.25s 进入录音，波形实时跟随，`voice_*_ff90.m4a` 带唯一后缀落盘
- [x] 抽屉从面板起手左拉全程 1:1 跟手（中途截图 50%→70% 位置验证）
- [x] 双图 memo 两张照片都渲染
- [ ] 真机验证按住说话手感与波形跟随
- [ ] 大 vault（数百 wiki 页）验证编译尾部不再掉帧