### PR TITLE
feat: 语音输入 vNext — 整栏长按说话 + 原位录音舱 + 转录渐显与失败降级 (#821)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ Conventional changelog 格式：日期倒序，每个 release 标题 + 分类列
 ## [Unreleased] — v0.5.0 candidate
 
 ### Features
+- 语音输入 vNext（#821）：整个底部 dock 任意区域长按 0.35s 即按住说话（原先仅 50×44 mic 球）；按下瞬间 dock 微下沉（输入直驱），到阈值 heavy haptic + dock 原位 morph 成录音舱（红点脉动 + mono 计时 + 48 bar 实时波形 + 拖动指引），不再从屏幕顶/底弹出 island+sheet；上滑取消/左滑转文字过程中舱背景随手指位移 0→1 连续插值（非阈值突变）；录音期间时间线退后为暖色 scrim（聚光灯）；转录 pending 显示呼吸骨架线（非 spinner），完成后文字以墨水晕开式 blur+rise 渐显，失败降级为重试入口
+
+### Bug Fixes (#821 语音链路)
+- 语音转写永久 spinner（实测 16+ 分钟不消失）：三个根因叠加 —— ① MemoCardView 用全局 VoiceAttachmentQueue.pendingCount 决定单卡"正在转写…"（任何一条队列重试都冻结所有语音卡）→ 改为按本 attachment 的 transcription_status 判定；② press-to-talk 落卡把进行中的转录标成 `failed`（应为 `pending`）；③ 队列 3 次尝试耗尽只标记内部 failed 不回写 raw 文件 → 新增 applyStatus 回写 + 15s/60s/240s 指数退避自动重试（原先只靠切后台再回来触发）
+- Whisper key 为空时静默 return nil 白烧重试预算 → 降级到本地 SFSpeechRecognizer
+- 转录上传前 Data(contentsOf:) 在 @MainActor 同步读整个音频文件（5 分钟录音数 MB 级掉帧）→ Task.detached
 - Settings 视觉统一：themeMode / accentColor / cardDensity / attachmentPolicy 4 处原生 Picker → DSPicker amber-rim glass，与日式美术馆设计语言一致
 - 离线同步队列：网络受限时暂存 memo，恢复后自动 flush（SyncQueueService + Today banner + Settings "模拟离线" 调试）
 - 时光胶囊（On This Day）：每天打开自动显示"1 年前的今天"/"6 个月前"，点击跳归档

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		A10000007 /* Components.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000007 /* Components.swift */; };
 		A10000010 /* TodayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000010 /* TodayView.swift */; };
 		A10000804 /* TodayCoachView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000804 /* TodayCoachView.swift */; };
+		A10000821 /* DockVoiceCapsule.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000821 /* DockVoiceCapsule.swift */; };
 		A10000011 /* ArchiveView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000011 /* ArchiveView.swift */; };
 		A10000012 /* GraphView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000012 /* GraphView.swift */; };
 		A10000013 /* TodayViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000013 /* TodayViewModel.swift */; };
@@ -298,6 +299,7 @@
 		A20000007 /* Components.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Components.swift; sourceTree = "<group>"; };
 		A20000010 /* TodayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayView.swift; sourceTree = "<group>"; };
 		A20000804 /* TodayCoachView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayCoachView.swift; sourceTree = "<group>"; };
+		A20000821 /* DockVoiceCapsule.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockVoiceCapsule.swift; sourceTree = "<group>"; };
 		A20000011 /* ArchiveView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArchiveView.swift; sourceTree = "<group>"; };
 		A20000012 /* GraphView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphView.swift; sourceTree = "<group>"; };
 		A20000013 /* TodayViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TodayViewModel.swift; sourceTree = "<group>"; };
@@ -799,6 +801,7 @@
 				A20000515 /* RecordingLimits.swift */,
 				A20000513 /* WriteSheetView.swift */,
 				A20000055 /* PressToTalkButton.swift */,
+				A20000821 /* DockVoiceCapsule.swift */,
 				A20000063 /* SwipeableMemoCard.swift */,
 				A20000400 /* HorizontalPanGesture.swift */,
 				A20000084 /* WeeklyRecapSection.swift */,
@@ -1425,6 +1428,7 @@
 				A10000515 /* RecordingLimits.swift in Sources */,
 				A10000512 /* MetadataGridView.swift in Sources */,
 				A10000055 /* PressToTalkButton.swift in Sources */,
+				A10000821 /* DockVoiceCapsule.swift in Sources */,
 				A10000063 /* SwipeableMemoCard.swift in Sources */,
 				A10000400 /* HorizontalPanGesture.swift in Sources */,
 				A10000080 /* AppNavigationModel.swift in Sources */,

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -375,7 +375,8 @@ private struct DetailVoiceSection: View {
             VoiceMemoPlayerRow(
                 fileURL: audioURL,
                 duration: attachment.duration ?? 0,
-                transcript: attachment.transcript
+                transcript: attachment.transcript,
+                transcriptionStatus: attachment.transcriptionStatus
             )
             .frame(maxWidth: .infinity)
             .liquidGlassCard(cornerRadius: DSRadius.md, tone: .lo)

--- a/DayPage/Features/Today/DockVoiceCapsule.swift
+++ b/DayPage/Features/Today/DockVoiceCapsule.swift
@@ -1,0 +1,392 @@
+import SwiftUI
+import DayPageServices
+
+// MARK: - DockVoiceGesture
+//
+// Issue #821: whole-dock press-to-talk. The WeChat-style hold gesture used to
+// live on the 50×44 mic orb only (PressToTalkButton), which made blind
+// thumb-presses miss. This modifier lifts the same state machine onto the
+// ENTIRE dock capsule: press anywhere on the dock and hold ≥0.35s to record.
+//
+// Two invariants from the interaction audit:
+//   1. Input drives displacement directly — the press-dip (scale 0.985) and
+//      the cancel/transcribe color interpolation are written straight from
+//      `onChanged`, never wrapped in withAnimation, so they track the finger.
+//   2. The gesture host never unmounts — the dock container stays in the
+//      hierarchy across idle ↔ recording; only its CONTENT cross-fades.
+//      Swapping the host view mid-gesture would silently drop `onEnded`.
+//
+// Child buttons (+ / caret / mic / sparkle) keep their tap semantics: a tap
+// releases inside the 0.35s threshold and is ignored by this gesture (the
+// Button fires normally). Once recording commits, `isDockRecording` flips and
+// callers gate their Button actions on it so the release-after-hold can never
+// double-fire a tap action.
+
+/// Continuous drag progress reported while recording, both in 0…1.
+/// Drives the capsule's background interpolation so the finger position is
+/// visible BEFORE the threshold commits (no surprise state flips).
+struct DockDragProgress: Equatable {
+    var cancel: CGFloat = 0      // upward drag / cancelSwipeThreshold
+    var transcribe: CGFloat = 0  // leftward drag / transcribeSwipeThreshold
+}
+
+struct DockVoiceGestureModifier: ViewModifier {
+
+    // MARK: Callbacks (same contract as PressToTalkButton)
+
+    var onPressStart: () -> Void
+    var onReleaseSend: () -> Void
+    var onReleaseCancel: () -> Void
+    var onReleaseTranscribe: () -> Void
+    var onPhaseChange: (PressToTalkPhase) -> Void
+    var onDragProgress: (DockDragProgress) -> Void
+
+    // MARK: Constants
+
+    /// Hold duration separating a child-button tap from press-to-talk.
+    private let longPressThreshold: TimeInterval = 0.35
+
+    // MARK: State
+
+    @State private var currentPhase: PressToTalkPhase = .idle
+    @State private var lastTranslation: CGSize = .zero
+    @State private var pressStartTime: Date? = nil
+    @State private var thresholdTask: Task<Void, Never>? = nil
+    /// Finger-down dip. Set on press without animation intent leaking into
+    /// the gesture math; released through Motion.press so the rebound feels
+    /// physical and interruptible.
+    @State private var pressDip: Bool = false
+
+    func body(content: Content) -> some View {
+        content
+            .scaleEffect(pressDip ? 0.985 : 1.0)
+            .animation(Motion.press, value: pressDip)
+            .simultaneousGesture(dragGesture)
+    }
+
+    // MARK: - Gesture
+
+    private var dragGesture: some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onChanged { value in
+                if currentPhase == .idle {
+                    pressStartTime = Date()
+                    pressDip = true
+                    currentPhase = .preRecording
+                    onPhaseChange(.preRecording)
+                    // Clock-based commit: a perfectly still hold must record
+                    // too (DragGesture.onChanged only re-fires on movement).
+                    thresholdTask?.cancel()
+                    thresholdTask = Task { @MainActor in
+                        try? await Task.sleep(nanoseconds: UInt64(longPressThreshold * 1_000_000_000))
+                        guard !Task.isCancelled else { return }
+                        commitToRecordingIfNeeded()
+                    }
+                }
+
+                // Movement past the threshold also commits (finger moved
+                // before the timer fired) — single entry point.
+                if currentPhase == .preRecording,
+                   let start = pressStartTime,
+                   Date().timeIntervalSince(start) >= longPressThreshold {
+                    commitToRecordingIfNeeded()
+                }
+
+                guard currentPhase != .idle && currentPhase != .preRecording else { return }
+
+                lastTranslation = value.translation
+
+                // Direct-drive progress: continuous 0…1 toward each arm
+                // threshold, written every frame with NO animation so the
+                // capsule tint tracks the finger exactly.
+                let dy = max(0, -value.translation.height)
+                let dx = max(0, -value.translation.width)
+                onDragProgress(DockDragProgress(
+                    cancel: min(1, dy / InputTokens.cancelSwipeThreshold),
+                    transcribe: min(1, dx / InputTokens.transcribeSwipeThreshold)
+                ))
+
+                let newPhase = derivePhase(from: value.translation)
+                if newPhase != currentPhase {
+                    switch newPhase {
+                    case .cancelArmed:     InputTokens.cancelArmHaptic()
+                    case .transcribeArmed: InputTokens.transcribeArmHaptic()
+                    default: break
+                    }
+                    currentPhase = newPhase
+                    onPhaseChange(newPhase)
+                }
+            }
+            .onEnded { value in
+                thresholdTask?.cancel()
+                thresholdTask = nil
+                pressDip = false
+
+                // Tap released inside the threshold: this was a child-button
+                // tap (or a stray tap on the capsule). No-op here — the
+                // Button owns the interaction.
+                if currentPhase == .preRecording {
+                    currentPhase = .idle
+                    onPhaseChange(.idle)
+                    pressStartTime = nil
+                    lastTranslation = .zero
+                    onDragProgress(DockDragProgress())
+                    return
+                }
+                guard currentPhase != .idle else { return }
+
+                let translation = value.translation != .zero ? value.translation : lastTranslation
+                let endPhase = derivePhase(from: translation)
+
+                switch endPhase {
+                case .cancelArmed:
+                    InputTokens.cancelReleaseHaptic()
+                    onReleaseCancel()
+                case .transcribeArmed:
+                    InputTokens.transcribeReleaseHaptic()
+                    currentPhase = .transcribing
+                    onPhaseChange(.transcribing)
+                    onReleaseTranscribe()
+                    pressStartTime = nil
+                    lastTranslation = .zero
+                    onDragProgress(DockDragProgress())
+                    return
+                default:
+                    InputTokens.sendReleaseHaptic()
+                    onReleaseSend()
+                }
+
+                currentPhase = .idle
+                onPhaseChange(.idle)
+                pressStartTime = nil
+                lastTranslation = .zero
+                onDragProgress(DockDragProgress())
+            }
+    }
+
+    // MARK: - Helpers
+
+    private func commitToRecordingIfNeeded() {
+        guard currentPhase == .preRecording else { return }
+        HapticFeedback.heavy()
+        onPressStart()
+        currentPhase = .recording
+        onPhaseChange(.recording)
+    }
+
+    /// Cancel wins over transcribe on ambiguous diagonals (safer default).
+    private func derivePhase(from translation: CGSize) -> PressToTalkPhase {
+        let dy = -translation.height
+        let dx = -translation.width
+        let upCrossed = dy >= InputTokens.cancelSwipeThreshold
+        let leftCrossed = dx >= InputTokens.transcribeSwipeThreshold
+        if upCrossed && dy >= dx { return .cancelArmed }
+        if leftCrossed { return .transcribeArmed }
+        return .recording
+    }
+}
+
+extension View {
+    func dockVoiceGesture(
+        onPressStart: @escaping () -> Void,
+        onReleaseSend: @escaping () -> Void,
+        onReleaseCancel: @escaping () -> Void,
+        onReleaseTranscribe: @escaping () -> Void,
+        onPhaseChange: @escaping (PressToTalkPhase) -> Void,
+        onDragProgress: @escaping (DockDragProgress) -> Void
+    ) -> some View {
+        modifier(DockVoiceGestureModifier(
+            onPressStart: onPressStart,
+            onReleaseSend: onReleaseSend,
+            onReleaseCancel: onReleaseCancel,
+            onReleaseTranscribe: onReleaseTranscribe,
+            onPhaseChange: onPhaseChange,
+            onDragProgress: onDragProgress
+        ))
+    }
+}
+
+// MARK: - DockRecordingCapsuleContent
+//
+// The in-place recording chamber (#821 design B). While recording, the dock
+// capsule does NOT get replaced — it grows taller and cross-fades its content
+// into this view, so the recording surface lives exactly where the finger is
+// pressing instead of teleporting to the screen top/bottom the way the old
+// DynamicIsland + RecordingSheet pair did.
+//
+// Layout (≈112pt tall, inside the same glass capsule):
+//   ● 录音中          0:07      ← pulsing red dot · mono timer
+//   ▂▄▆▅▃▂▁▂▄▆▅▃▂▁▂▄▆▅          ← live 48-bar waveform, level-driven
+//   ↑ 上滑取消 · ← 左滑转文字     ← quiet mono guidance
+//
+// Cancel / transcribe arming tints the whole chamber CONTINUOUSLY with the
+// drag progress (0…1), so the user watches the surface warm toward red /
+// blue as the finger travels — the threshold haptic lands on an expected
+// state, never a surprise.
+
+struct DockRecordingCapsuleContent: View {
+
+    let phase: PressToTalkPhase
+    let elapsedSeconds: Int
+    let waveform: [Float]
+    let dragProgress: DockDragProgress
+
+    @State private var pulse: Bool = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// Fixed 48-bar strip; newest samples at the right edge.
+    private var bars: [Float] {
+        let count = 48
+        if waveform.count >= count { return Array(waveform.suffix(count)) }
+        return Array(repeating: Float(0), count: count - waveform.count) + waveform
+    }
+
+    private var isCancelArming: Bool { dragProgress.cancel >= dragProgress.transcribe }
+
+    /// Continuous arm tint: red for cancel, ink-blue for transcribe.
+    private var armTint: Color {
+        isCancelArming ? DSTokens.Colors.recordingRed : Color(red: 0.24, green: 0.42, blue: 0.78)
+    }
+
+    private var armProgress: CGFloat {
+        max(dragProgress.cancel, dragProgress.transcribe)
+    }
+
+    private var statusLabel: String {
+        switch phase {
+        case .cancelArmed:
+            return NSLocalizedString("dockvoice.status.cancel", value: "松手取消", comment: "Release to cancel")
+        case .transcribeArmed:
+            return NSLocalizedString("dockvoice.status.transcribe", value: "松手转文字", comment: "Release to transcribe")
+        case .transcribing:
+            return NSLocalizedString("dockvoice.status.transcribing", value: "正在转写", comment: "Transcribing")
+        default:
+            return NSLocalizedString("dockvoice.status.recording", value: "录音中", comment: "Recording")
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 10) {
+            // Header — pulsing dot + status · mono timer
+            HStack(alignment: .firstTextBaseline) {
+                HStack(spacing: 7) {
+                    Circle()
+                        .fill(DSTokens.Colors.recordingRed)
+                        .frame(width: 8, height: 8)
+                        .scaleEffect(reduceMotion ? 1 : (pulse ? 1.0 : 0.72))
+                        .opacity(reduceMotion ? 1 : (pulse ? 1.0 : 0.6))
+                        .animation(
+                            reduceMotion ? nil : .easeInOut(duration: 0.6).repeatForever(autoreverses: true),
+                            value: pulse
+                        )
+                    Text(statusLabel)
+                        .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
+                        .tracking(1.3)
+                        .textCase(.uppercase)
+                        .foregroundColor(DSTokens.Colors.accentSoft)
+                        .animation(nil, value: statusLabel)
+                }
+                Spacer()
+                Text(elapsedSeconds.mmss)
+                    .font(DSFonts.jetBrainsMono(size: 20, weight: .medium))
+                    .tracking(1.2)
+                    .monospacedDigit()
+                    .foregroundColor(DSColor.onRecording)
+            }
+
+            // Live waveform — level-driven, 80ms linear per bar (the only
+            // motion here; matches the design's `transition: height 80ms`).
+            WaveformStripView(
+                bars: bars,
+                color: DSTokens.Colors.accentSoft,
+                barWidth: 2.5,
+                gap: 2.5,
+                maxHeight: 26
+            )
+
+            // Guidance — quiet mono hints; the armed direction brightens
+            // with the live drag progress (direct-drive, no animation).
+            HStack(spacing: 12) {
+                Label {
+                    Text(NSLocalizedString("dockvoice.hint.cancel", value: "上滑取消", comment: ""))
+                } icon: {
+                    Image(systemName: "arrow.up")
+                }
+                .font(DSFonts.jetBrainsMono(size: 9))
+                .tracking(1.0)
+                .foregroundColor(DSTokens.Colors.accentSoft.opacity(
+                    phase == .cancelArmed ? 1.0 : 0.45 + 0.4 * dragProgress.cancel
+                ))
+
+                Label {
+                    Text(NSLocalizedString("dockvoice.hint.transcribe", value: "左滑转文字", comment: ""))
+                } icon: {
+                    Image(systemName: "arrow.left")
+                }
+                .font(DSFonts.jetBrainsMono(size: 9))
+                .tracking(1.0)
+                .foregroundColor(DSTokens.Colors.accentSoft.opacity(
+                    phase == .transcribeArmed ? 1.0 : 0.45 + 0.4 * dragProgress.transcribe
+                ))
+
+                Spacer()
+
+                Text(NSLocalizedString("dockvoice.hint.send", value: "松手发送", comment: ""))
+                    .font(DSFonts.jetBrainsMono(size: 9))
+                    .tracking(1.0)
+                    .foregroundColor(DSTokens.Colors.accentSoft.opacity(armProgress > 0.15 ? 0.3 : 0.75))
+            }
+            .labelStyle(CompactHintLabelStyle())
+        }
+        .padding(.horizontal, 18)
+        .padding(.vertical, 14)
+        .background(
+            // Warm dark recording surface + continuous arm tint overlay.
+            // The tint opacity is DIRECTLY the drag progress — input drives
+            // displacement; no withAnimation between finger and color.
+            RoundedRectangle(cornerRadius: 26, style: .continuous)
+                .fill(DSTokens.Colors.recordingBg.opacity(0.94))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 26, style: .continuous)
+                        .fill(armTint.opacity(0.32 * armProgress))
+                )
+        )
+        .onAppear { pulse = true }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(statusLabel)
+        .accessibilityValue(elapsedSeconds.mmss)
+    }
+}
+
+/// Icon+text hint with tightened spacing for the 9pt mono guidance row.
+private struct CompactHintLabelStyle: LabelStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(spacing: 3) {
+            configuration.icon.font(.system(size: 8, weight: .semibold))
+            configuration.title
+        }
+    }
+}
+
+// MARK: - Preview
+
+#if DEBUG
+struct DockRecordingCapsuleContent_Previews: PreviewProvider {
+    static var previews: some View {
+        ZStack {
+            DSTokens.Colors.bgWarm.ignoresSafeArea()
+            VStack {
+                Spacer()
+                DockRecordingCapsuleContent(
+                    phase: .recording,
+                    elapsedSeconds: 7,
+                    waveform: (0..<48).map { _ in Float.random(in: 0.05...1.0) },
+                    dragProgress: DockDragProgress()
+                )
+                .padding(.horizontal, 24)
+                .padding(.bottom, 24)
+            }
+        }
+    }
+}
+#endif

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -94,6 +94,10 @@ struct InputBarV4: View {
     /// Toggle this bool (flip its value) from the parent to programmatically
     /// open the composer and focus the text field.
     var requestFocusToggle: Bool = false
+    /// #821: reports when a press-to-talk session owns the dock so the parent
+    /// can dim the page behind the in-place recording capsule (spotlight
+    /// scrim). Optional — previews and secondary hosts may omit it.
+    var onRecordingActiveChange: ((Bool) -> Void)? = nil
 
     // MARK: Private State
 
@@ -109,6 +113,14 @@ struct InputBarV4: View {
     /// popover flip this flag after dismissing itself.
     @State private var showPhotosPicker: Bool = false
     @State private var pressToTalkPhase: PressToTalkPhase = .idle
+    /// Live drag progress from the whole-dock voice gesture (#821). Written
+    /// directly from the gesture's onChanged — drives the recording capsule's
+    /// cancel/transcribe tint interpolation with zero animation lag.
+    @State private var dockDragProgress = DockDragProgress()
+    /// Timestamp of the last press-to-talk session end. Dock child buttons
+    /// gate their tap actions on this so the finger-up that ends a recording
+    /// can never double-fire the button it happens to land on.
+    @State private var lastVoiceGestureEndAt: Date = .distantPast
     @State private var composerState: ComposerState = .idle
     /// True while a "录音太短" hint is visible. Prevents committing a
     /// meaningless one-frame recording while gracefully nudging the user
@@ -257,10 +269,10 @@ struct InputBarV4: View {
             // helpers are intentionally left in the file as dead code; the
             // next pass will excise them once we've verified no other
             // surface depends on the templating / send-affordance internals.
-            VStack(spacing: 8) {
-                streamDockMorph
-                dockHintLabel
-            }
+            // #821: the mono hint line that used to sit under the dock is
+            // gone — recording guidance now lives inside the in-place
+            // capsule itself, next to where the finger actually is.
+            streamDockMorph
             // Museum-aesthetic redesign (#793 R2): widen breathing room
             // so the dock reads as a floating island, not a wall-to-wall
             // toolbar. 24pt horizontal + 24pt bottom lift gives the
@@ -378,49 +390,32 @@ struct InputBarV4: View {
             transition(to: .expanding)
             isFocused = true
         }
-        // v8 recording surface — dark bottom sheet + top Dynamic-Island capsule.
-        // Presented as a full-screen overlay so the sheet anchors to the screen
-        // bottom and the island to the top, independent of the dock's position.
-        // The press-to-talk drag gesture (PressToTalkButton) still drives the
-        // state machine; the sheet's buttons mirror cancel / stop-&-transcribe.
-        .overlay { recordingSurface }
-    }
-
-    // MARK: - Recording Surface (v8 sheet + island)
-
-    @ViewBuilder
-    private var recordingSurface: some View {
-        if overlayMode != nil {
-            ZStack {
-                // Warm dim scrim — same recordingBg as the sheet for cohesion.
-                DSTokens.Colors.recordingBg.opacity(0.34)
-                    .ignoresSafeArea()
-                    .transition(.opacity)
-
-                DynamicIslandView(
-                    elapsedSeconds: voiceService.elapsedSeconds,
-                    waveform: voiceService.waveformHistory,
-                    expanded: true
-                )
-
-                RecordingSheetView(
-                    elapsedSeconds: voiceService.elapsedSeconds,
-                    waveform: voiceService.waveformHistory,
-                    transcriptPreview: "",
-                    onCancel: {
-                        handlePressToTalkReleaseCancel()
-                        pressToTalkPhase = .idle
-                    },
-                    onAccept: {
-                        handlePressToTalkReleaseTranscribe()
-                    }
-                )
-            }
-            .ignoresSafeArea()
-            // Recording panel scales+rises into place — route through the
-            // `panel` token so it honors Reduce Motion (was an inline spring).
-            .dsAnimation(Motion.panel, value: overlayMode)
+        // #821 in-place recording: the capsule morph happens inside
+        // streamDockMorph itself. The full-screen spotlight scrim is owned
+        // by the parent (TodayView) via `onRecordingActiveChange`, because a
+        // background/overlay on this bottom bar can only tint its own frame.
+        .onChange(of: pressToTalkPhase) { newPhase in
+            onRecordingActiveChange?(newPhase != .idle && newPhase != .preRecording)
         }
+        #if DEBUG
+        // Simulator-only demo bridge: `-dockVoiceDemo` walks the whole-dock
+        // press-to-talk state machine without a physical finger (synthetic
+        // HID long-presses never reach SwiftUI DragGesture). Mirrors the
+        // launch-arg bridge used by the auth screen. Real recording starts,
+        // the in-place capsule morphs in, and after 5s the send path runs —
+        // the exact sequence a hold-and-release performs.
+        .onAppear {
+            guard ProcessInfo.processInfo.arguments.contains("-dockVoiceDemo") else { return }
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 2_000_000_000)
+                handlePressToTalkStart()
+                pressToTalkPhase = .recording
+                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                handlePressToTalkReleaseSend()
+                pressToTalkPhase = .idle
+            }
+        }
+        #endif
     }
 
     // MARK: - STREAM Dock (idle state)
@@ -435,12 +430,69 @@ struct InputBarV4: View {
     // design canvas (inner highlight + soft drop shadow).
 
     // STREAM dock — full-width warm pill (design composer.jsx:82-166).
-    // Layout: [+36] [记下此刻 italic flex] [mic 50×44]
-    // Background: rgba(255,253,250,0.84) warm-white blur, 4-layer shadow stack.
+    //
+    // #821 whole-dock press-to-talk: this container is the PERMANENT gesture
+    // host. Press anywhere on it and hold ≥0.35s to record; the idle row
+    // cross-fades into the in-place recording capsule (DockRecordingCapsule-
+    // Content) while THIS view stays mounted, so the drag gesture survives
+    // the morph. Never replace this container conditionally — swapping the
+    // gesture host mid-press silently drops onEnded and strands a recording.
     private var streamDockMorph: some View {
+        ZStack {
+            if overlayMode == nil {
+                dockIdleRow
+                    .transition(.opacity)
+            } else {
+                DockRecordingCapsuleContent(
+                    phase: pressToTalkPhase,
+                    elapsedSeconds: voiceService.elapsedSeconds,
+                    waveform: voiceService.waveformHistory,
+                    dragProgress: dockDragProgress
+                )
+                .transition(.opacity.combined(with: .scale(scale: 0.97, anchor: .bottom)))
+            }
+        }
+        // Morph between the 56pt idle capsule and the ~112pt recording
+        // chamber rides the shared panel spring; the tint interpolation
+        // inside the capsule is direct-driven and never animated.
+        .dsAnimation(Motion.panel, value: overlayMode == nil)
+        .dockVoiceGesture(
+            onPressStart: handlePressToTalkStart,
+            onReleaseSend: {
+                markVoiceGestureEnd()
+                handlePressToTalkReleaseSend()
+            },
+            onReleaseCancel: {
+                markVoiceGestureEnd()
+                handlePressToTalkReleaseCancel()
+            },
+            onReleaseTranscribe: {
+                markVoiceGestureEnd()
+                handlePressToTalkReleaseTranscribe()
+            },
+            onPhaseChange: { pressToTalkPhase = $0 },
+            onDragProgress: { dockDragProgress = $0 }
+        )
+    }
+
+    /// True while a press-to-talk session owns the dock. Child-button taps
+    /// are swallowed both during the session and for a short grace window
+    /// after it ends (the finger-up that finishes a recording may land on a
+    /// button and would otherwise fire it).
+    private var isDockTapBlocked: Bool {
+        pressToTalkPhase != .idle
+            || Date().timeIntervalSince(lastVoiceGestureEndAt) < 0.35
+    }
+
+    private func markVoiceGestureEnd() {
+        lastVoiceGestureEndAt = Date()
+    }
+
+    private var dockIdleRow: some View {
         HStack(spacing: 4) {
             // LEFT — attach (+), 36×44 transparent
             Button {
+                guard !isDockTapBlocked else { return }
                 Haptics.soft()
                 showAttachmentMenu = true
             } label: {
@@ -459,6 +511,7 @@ struct InputBarV4: View {
             // affordance reduces to the caret alone. It still telegraphs
             // "tap to write" without polluting the composer with copy.
             Button {
+                guard !isDockTapBlocked else { return }
                 Haptics.soft()
                 if let openSheet = onOpenWriteSheet {
                     openSheet()
@@ -482,18 +535,24 @@ struct InputBarV4: View {
             .accessibilityLabel(NSLocalizedString("input.a11y.write_text", comment: ""))
             .accessibilityIdentifier("expand-text-composer")
 
-            // RIGHT — mic orb, 50×44, deep amber gradient
-            PressToTalkButton(
-                onPressStart: handlePressToTalkStart,
-                onReleaseSend: handlePressToTalkReleaseSend,
-                onReleaseCancel: handlePressToTalkReleaseCancel,
-                onReleaseTranscribe: handlePressToTalkReleaseTranscribe,
-                onPhaseChange: { pressToTalkPhase = $0 },
-                onTapShortRelease: handleMicTap,
-                size: 44,
-                idleBackgroundColor: DSColor.amberDeep,
-                idleIconColor: .white
-            )
+            // RIGHT — mic orb, 50×44, deep amber gradient.
+            // #821: press-to-talk moved up to the whole-dock gesture; the
+            // orb itself is now a plain tap target (Flomo-style recording
+            // sheet) and the visual anchor that telegraphs "voice lives
+            // here". Long-pressing it records like anywhere else on the dock.
+            Button {
+                guard !isDockTapBlocked else { return }
+                handleMicTap()
+            } label: {
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 19.8, weight: .regular))
+                    .foregroundColor(.white)
+                    .frame(width: 44, height: 44)
+                    .background(DSColor.amberDeep)
+                    .clipShape(Circle())
+                    .contentShape(Circle())
+            }
+            .buttonStyle(.plain)
             .frame(width: 50, height: 44)
             // Amber glow that makes the send/mic button read as "lit". Kept as a
             // deliberate colored halo (not a neutral DSElevation), but sourced
@@ -503,6 +562,7 @@ struct InputBarV4: View {
             .shadow(color: DSColor.accentOnBg.opacity(0.18), radius: 1, x: 0, y: 1)
             .accessibilityLabel(NSLocalizedString("input.a11y.mic", comment: ""))
             .accessibilityHint(NSLocalizedString("input.a11y.mic_hint_full", comment: ""))
+            .accessibilityIdentifier("dock-mic-button")
 
             // FAR-RIGHT — AI chat sparkle. The amber sparkle is the dock's
             // entry into AskPastView (D1 「和过去对话」). We only render the
@@ -512,6 +572,7 @@ struct InputBarV4: View {
             // primary recording action; the sparkle is the calm AI side-door.
             if onAskAI != nil {
                 Button {
+                    guard !isDockTapBlocked else { return }
                     Haptics.tapConfirm()
                     onAskAI?()
                 } label: {
@@ -539,33 +600,6 @@ struct InputBarV4: View {
         // its lift on the charcoal canvas instead of vanishing like the old
         // hardcoded warm-ink (#3C280F) shadow did.
         .elevation(.floating)
-    }
-
-    // Hint label below the dock — JetBrains Mono uppercase, like the design.
-    // Museum-aesthetic redesign (#793): the idle hint ("轻点书写 · 长按录音")
-    // is now hidden so the dock reads as a single quiet capsule on rest. The
-    // hint still appears during a press-to-talk session so the gesture stays
-    // legible (pre/recording/cancel/transcribe stages). Idle collapses to a
-    // 0-height spacer to keep the dock's vertical rhythm stable when a
-    // recording session ends.
-    private var dockHintLabel: some View {
-        let raw: String
-        switch pressToTalkPhase {
-        case .idle:            raw = ""
-        case .preRecording:    raw = NSLocalizedString("input.hint.pre_recording", comment: "")
-        case .recording:       raw = NSLocalizedString("input.hint.recording", comment: "")
-        case .cancelArmed:     raw = NSLocalizedString("input.hint.cancel_armed", comment: "")
-        case .transcribeArmed: raw = NSLocalizedString("input.hint.transcribe_armed", comment: "")
-        case .transcribing:    raw = NSLocalizedString("input.hint.transcribing", comment: "")
-        }
-        return Text(raw)
-            .font(DSType.mono9)
-            .tracking(1.4)
-            .textCase(.uppercase)
-            .foregroundStyle(DSColor.inkSubtle)
-            .frame(height: raw.isEmpty ? 0 : 12)
-            .opacity(raw.isEmpty ? 0 : 1)
-            .animation(.easeInOut(duration: 0.18), value: pressToTalkPhase)
     }
 
     // MARK: - Word/Char Count Footer

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -184,6 +184,7 @@ struct MemoCardView: View {
                             fileURL: audioURL,
                             duration: att.duration ?? 0,
                             transcript: att.transcript,
+                            transcriptionStatus: att.transcriptionStatus,
                             onRetranscribe: { onRetranscribe?(memo, att) }
                         )
                         .padding(.top, 4)
@@ -733,6 +734,12 @@ struct VoiceMemoPlayerRow: View {
     let fileURL: URL
     let duration: TimeInterval
     let transcript: String?
+    /// #821: per-attachment transcription state from the vault frontmatter
+    /// (`transcription_status: pending|done|failed`). The transcribing /
+    /// failed branches below key off THIS, not the global queue count — a
+    /// stuck retry loop elsewhere in the queue must never freeze this card
+    /// in a spinner (the exact failure observed in the 2026-07-11 audit).
+    var transcriptionStatus: Memo.TranscriptionStatus? = nil
     // US-016: called when user taps retry on a failed transcript
     var onRetranscribe: (() -> Void)? = nil
 
@@ -844,16 +851,22 @@ struct VoiceMemoPlayerRow: View {
                 }
                 .padding(.horizontal, 14)
                 .padding(.bottom, 4)
+                // #821 ink-bloom reveal: the finished transcript settles in
+                // like ink spreading on paper — blur 6→0 + rise 4pt + fade.
+                // Replaces the hard pop when the shimmer skeleton swapped to
+                // text. Honors Reduce Motion via the transition's insertion
+                // being driven by Motion.rise below.
+                .transition(TranscriptBloom.transition)
             } else if transcript == nil {
-                if VoiceAttachmentQueue.shared.pendingCount > 0 || isRetranscribing {
-                    HStack(spacing: 6) {
-                        ProgressView().scaleEffect(0.7).tint(DSColor.inkSubtle)
-                        Text(NSLocalizedString("voice.retry.transcribing", comment: ""))
-                            .font(DSType.bodySM)
-                            .foregroundColor(DSColor.inkSubtle)
-                    }
-                    .padding(.horizontal, 14)
-                    .padding(.bottom, 6)
+                if transcriptionStatus == .pending || isRetranscribing {
+                    // #821: breathing skeleton lines, not a spinner — this is
+                    // "becoming text", not "loading". Keyed to THIS
+                    // attachment's status so a stuck queue can never freeze
+                    // the card (was: global pendingCount > 0).
+                    TranscriptShimmerPlaceholder()
+                        .padding(.horizontal, 14)
+                        .padding(.bottom, 6)
+                        .accessibilityLabel(NSLocalizedString("voice.retry.transcribing", comment: ""))
                 } else if retryCount >= Self.maxRetries {
                     // US-016: permanent failure after max retries
                     HStack(spacing: 6) {
@@ -895,6 +908,11 @@ struct VoiceMemoPlayerRow: View {
         .onAppear {
             retryCount = UserDefaults.standard.integer(forKey: retryKey)
         }
+        // Drives the shimmer→transcript bloom (and shimmer→retry downgrade)
+        // through one calm curve; without this the .transition above never
+        // animates because the state change itself would be un-animated.
+        .animation(Motion.rise, value: transcript)
+        .animation(Motion.fade, value: transcriptionStatus)
         .onChange(of: transcript) { newValue in
             // When transcription succeeds, also clear the persisted retry counter
             // so future failures start over from attempt #1. Previously this
@@ -1406,6 +1424,64 @@ struct PhotoThumbnailView: View {
 }
 
 // MARK: - AudioDownloadPlaceholder
+
+// MARK: - Transcript Shimmer & Bloom (#821)
+
+/// Two breathing skeleton lines shown while an audio attachment is being
+/// transcribed. Deliberately NOT a spinner: the memo is already safe on
+/// disk, so the affordance reads as "text is forming", with the calm of the
+/// museum surface. Static under Reduce Motion.
+struct TranscriptShimmerPlaceholder: View {
+    @State private var bright = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 7) {
+            skeletonLine(widthFraction: 0.92)
+            skeletonLine(widthFraction: 0.58)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .onAppear {
+            guard !reduceMotion else { return }
+            withAnimation(.easeInOut(duration: 1.1).repeatForever(autoreverses: true)) {
+                bright = true
+            }
+        }
+        .accessibilityElement(children: .ignore)
+    }
+
+    private func skeletonLine(widthFraction: CGFloat) -> some View {
+        GeometryReader { geo in
+            Capsule(style: .continuous)
+                .fill(DSColor.inkFaint.opacity(bright ? 0.55 : 0.28))
+                .frame(width: geo.size.width * widthFraction)
+        }
+        .frame(height: 9)
+    }
+}
+
+/// Ink-bloom transition for a freshly arrived transcript: blur 6→0, rise
+/// 4pt, fade in — the text settles like ink spreading into paper.
+enum TranscriptBloom {
+    static var transition: AnyTransition {
+        .modifier(
+            active: BloomModifier(blur: 6, opacity: 0, offsetY: 4),
+            identity: BloomModifier(blur: 0, opacity: 1, offsetY: 0)
+        )
+    }
+
+    struct BloomModifier: ViewModifier {
+        let blur: CGFloat
+        let opacity: Double
+        let offsetY: CGFloat
+        func body(content: Content) -> some View {
+            content
+                .blur(radius: blur)
+                .opacity(opacity)
+                .offset(y: offsetY)
+        }
+    }
+}
 
 struct AudioDownloadPlaceholder: View {
     let state: AttachmentDownloadState

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -181,6 +181,9 @@ struct TodayView: View {
     /// affordance (composer.jsx:183). Routes saves through `submitCombinedMemo`
     /// (the same path the inline composer uses) via `draftText`.
     @State private var showWriteSheet: Bool = false
+    /// #821: true while a whole-dock press-to-talk session is recording.
+    /// Drives the timeline spotlight scrim behind the in-place capsule.
+    @State private var isDockVoiceActive: Bool = false
 
     /// Issue #804: Today sparkle 现在打开 `TodayCoachView`（陪写引导）。
     /// AskPastView（RAG 「问过去」）保留在侧边栏 + Siri intent —— 两条路径
@@ -450,6 +453,19 @@ struct TodayView: View {
 
                     // MARK: Timeline (US-021: extracted subview)
                     timelineSection
+                        // #821 spotlight scrim: while a press-to-talk session
+                        // owns the dock, the timeline recedes behind a warm
+                        // dim so the in-place recording capsule is the single
+                        // lit object on the page. Never intercepts touches —
+                        // the recording finger is still down on the dock.
+                        .overlay {
+                            if isDockVoiceActive {
+                                DSTokens.Colors.recordingBg.opacity(0.22)
+                                    .allowsHitTesting(false)
+                                    .transition(.opacity)
+                            }
+                        }
+                        .animation(Motion.fade, value: isDockVoiceActive)
 
                     // MARK: Compose (US-021: extracted subview)
                     composeSection
@@ -2329,7 +2345,10 @@ struct TodayView: View {
             onAddPhotoAsset: nil,
             batchPhotoProgress: viewModel.batchPhotoProgress,
             batchPhotoTotal: viewModel.batchPhotoTotal,
-            requestFocusToggle: orbFocusToggle
+            requestFocusToggle: orbFocusToggle,
+            onRecordingActiveChange: { active in
+                isDockVoiceActive = active
+            }
         )
     }
 

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -43,7 +43,12 @@ enum PendingAttachment: Identifiable {
             let exifSummary = exifParts.isEmpty ? nil : exifParts.joined(separator: " ")
             return Memo.Attachment(file: r.filePath, kind: "photo", duration: nil, transcript: exifSummary)
         case .voice(let r):
-            let txStatus: Memo.TranscriptionStatus? = r.transcript != nil ? .done : .failed
+            // #821: a voice result without a transcript is PENDING, not
+            // failed — stopAndSaveAudio() enqueues the transcription into
+            // VoiceAttachmentQueue at save time, and the queue writes back
+            // .done / .failed when it resolves. Marking it .failed here made
+            // the on-disk state lie about an in-flight transcription.
+            let txStatus: Memo.TranscriptionStatus? = r.transcript != nil ? .done : .pending
             return Memo.Attachment(file: r.filePath, kind: "audio", duration: r.duration, transcript: r.transcript, transcriptionStatus: txStatus)
         case .file(let r):
             return Memo.Attachment(file: r.filePath, kind: "file", duration: nil, transcript: r.fileName)

--- a/DayPage/Services/VoiceAttachmentQueue.swift
+++ b/DayPage/Services/VoiceAttachmentQueue.swift
@@ -85,6 +85,7 @@ final class VoiceAttachmentQueue: ObservableObject {
                 guard FileManager.default.fileExists(atPath: audioURL.path) else {
                     entries[i].failed = true
                     entries[i].lastError = "audio file not found"
+                    Self.applyStatus(.failed, audioPath: entry.audioPath, memoDate: entry.memoDate)
                     changedThisPass = true
                     continue
                 }
@@ -100,6 +101,11 @@ final class VoiceAttachmentQueue: ObservableObject {
                     entries[i].lastError = "transcription returned nil"
                     if entries[i].attempts >= maxAttempts {
                         entries[i].failed = true
+                        // #821: exhausting retries must also write .failed
+                        // into the day file — the card UI keys off the
+                        // attachment's transcription_status, and leaving it
+                        // `pending` froze the shimmer placeholder forever.
+                        Self.applyStatus(.failed, audioPath: entry.audioPath, memoDate: entry.memoDate)
                     }
                     changedThisPass = true
                 }
@@ -114,7 +120,36 @@ final class VoiceAttachmentQueue: ObservableObject {
             // success path; if the whole pass produced no transcripts and the
             // remaining entries are all failed or attempts-exhausted, stop.
             let remaining = entries.filter { !$0.failed }
-            if remaining.isEmpty || !consumedOne { return }
+            if remaining.isEmpty { return }
+            if !consumedOne {
+                // #821: entries remain but this pass made no progress
+                // (transient network / recognizer hiccup). Previously the
+                // queue went silent until the next app activation; now it
+                // self-schedules an exponential-backoff retry so a pending
+                // card never waits on the user backgrounding the app.
+                scheduleBackoffRetry(minAttempts: remaining.map(\.attempts).min() ?? 1)
+                return
+            }
+        }
+    }
+
+    /// Pending Task for the next backoff-driven processQueue run.
+    private var backoffTask: Task<Void, Never>?
+
+    /// Retry pending entries after 15s · 60s · 240s (by attempt count).
+    private func scheduleBackoffRetry(minAttempts: Int) {
+        guard backoffTask == nil else { return }
+        let delay: UInt64
+        switch minAttempts {
+        case ..<2:  delay = 15_000_000_000
+        case 2:     delay = 60_000_000_000
+        default:    delay = 240_000_000_000
+        }
+        backoffTask = Task { @MainActor [weak self] in
+            try? await Task.sleep(nanoseconds: delay)
+            guard !Task.isCancelled else { return }
+            self?.backoffTask = nil
+            await self?.processQueue()
         }
     }
 
@@ -226,6 +261,46 @@ final class VoiceAttachmentQueue: ObservableObject {
             return false
         }
         return true
+    }
+
+    /// #821: write a bare transcription status onto the matching attachment
+    /// (no transcript text). Used when retries are exhausted so the card UI
+    /// can downgrade from the shimmer placeholder to the retry affordance.
+    /// Same serialization guarantees as `applyTranscript` (RawStorage.mutate
+    /// runs inside the shared writeQueue).
+    @discardableResult
+    nonisolated static func applyStatus(
+        _ status: Memo.TranscriptionStatus,
+        audioPath: String,
+        memoDate: String
+    ) -> Bool {
+        guard let date = parseMemoDate(memoDate) else { return false }
+
+        var matched = false
+        do {
+            try RawStorage.mutate(for: date) { memos in
+                let updated = memos.map { memo -> Memo in
+                    var copy = memo
+                    copy.attachments = memo.attachments.map { att -> Memo.Attachment in
+                        guard att.file == audioPath, att.kind == "audio" else { return att }
+                        matched = true
+                        var a = att
+                        a.transcriptionStatus = status
+                        return a
+                    }
+                    return copy
+                }
+                return matched ? updated : nil
+            }
+        } catch {
+            SentryReporter.breadcrumb(
+                category: "voice-queue",
+                level: .error,
+                message: "applyStatus: mutate failed: \(error)"
+            )
+            return false
+        }
+        return matched
     }
 
     nonisolated private static func parseMemoDate(_ s: String) -> Date? {

--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -467,6 +467,12 @@ final class VoiceService: NSObject, ObservableObject {
         if !NetworkMonitor.shared.isOnline {
             return await transcribeAudioOffline(at: url)
         }
+        // #821: no Whisper key configured — fall back to on-device
+        // recognition instead of silently returning nil and burning the
+        // queue's retry budget on calls that can never succeed.
+        if Secrets.resolvedOpenAIWhisperApiKey.isEmpty {
+            return await transcribeAudioOffline(at: url)
+        }
         return await transcribeAudioWhisper(at: url)
     }
 
@@ -548,10 +554,13 @@ final class VoiceService: NSObject, ObservableObject {
         } onTimeout: {
             // Timeout fired: cancel the recognition task and resume the continuation
             // directly so `withCheckedContinuation` doesn't hang forever.
+            // Defense-in-depth: skip the resume when the recognition callback
+            // already resumed (didResume) — a second resume traps.
             box.lock.lock()
-            let task = box.task
-            let cont = box.continuation
+            let alreadyResumed = box.didResume
             box.didResume = true
+            let task = box.task
+            let cont = alreadyResumed ? nil : box.continuation
             box.lock.unlock()
             task?.cancel()
             cont?.resume(returning: nil)
@@ -563,7 +572,10 @@ final class VoiceService: NSObject, ObservableObject {
         guard !apiKey.isEmpty else { return nil }
 
         let audioData: Data
-        do { audioData = try Data(contentsOf: url) }
+        // #821 main-thread hygiene: this class is @MainActor, and a 5-minute
+        // take is several MB — reading it synchronously here froze a frame.
+        // Hop to a detached task for the disk read.
+        do { audioData = try await Task.detached(priority: .userInitiated) { try Data(contentsOf: url) }.value }
         catch {
             DayPageLogger.shared.error("transcribeAudio: read file: \(error)")
             SentryReporter.breadcrumb(
@@ -728,6 +740,13 @@ extension VoiceService {
             group.addTask {
                 let ns = UInt64(max(0, seconds) * 1_000_000_000)
                 try? await Task.sleep(nanoseconds: ns)
+                // The winning operation branch triggers group.cancelAll(),
+                // which wakes this sleep early with a CancellationError that
+                // `try?` swallows. Running onTimeout() in that case fired the
+                // timeout cleanup after a SUCCESSFUL completion — for the
+                // offline transcriber that meant resuming its continuation a
+                // second time (EXC_BREAKPOINT, observed 2026-07-11 20:30/33).
+                guard !Task.isCancelled else { return nil }
                 onTimeout()
                 return nil
             }


### PR DESCRIPTION
Closes #821

## 背景

模拟器全链路实测（2026-07-11）语音输入发现：长按入口只有 50×44 mic 球、录音 UI 从屏幕顶/底弹出与手指割裂、转写失败后卡片"正在转写…"**永久 spinner（实测 16+ 分钟）**、且转录完成路径存在必崩的 double-resume（实测 2 次 SIGTRAP 复现，crash log 定位）。

## 改动

### A. 整栏长按 = 语音（DockVoiceCapsule.swift 新增）
- dock 任意区域按住 0.35s 进入按住说话；按下瞬间 dock scale 0.985 下沉（onChanged 直写，无动画延迟）
- 到阈值 heavy haptic + dock **原位 morph 成录音舱**：红点脉动 + mono 计时 + 48 bar 实时波形 + 「↑上滑取消 · ←左滑转文字 · 松手发送」指引
- 上滑/左滑过程舱背景色随手指位移 **0→1 连续插值**（非阈值突变），阈值 haptic 落在预期状态
- 手势宿主容器全程不卸载（内容交叉淡出）——条件互换宿主会静默丢 onEnded
- 子按钮 tap 语义不变；录音期间及松手后 0.35s 内 gate 子按钮防误触
- 录音期间时间线退后暖色 scrim（美术馆聚光灯）

### B. 转录状态机修复（永久 spinner 三重根因）
1. `MemoCardView` 改为按**本 attachment** 的 `transcription_status` 判定（原为全局 `VoiceAttachmentQueue.pendingCount`——任何一条队列重试冻结所有语音卡）
2. `TodayViewModel` press-to-talk 落卡状态 `failed` → `pending`（转录确实已入队）
3. `VoiceAttachmentQueue` attempts 耗尽新增 `applyStatus` 回写 raw 文件 + 15s/60s/240s 指数退避自动重试
- pending = 呼吸骨架线（非 spinner）；done = 文字 blur+rise 墨水晕开渐显；failed = 重试入口

### C. 崩溃修复（EXC_BREAKPOINT double-resume）
- `withTimeout`: sleep 被 `cancelAll()` 提前唤醒后 `try?` 吞掉 CancellationError 仍无条件执行 `onTimeout()` → 识别成功后二次 resume continuation 必崩；补 `Task.isCancelled` guard + `transcribeAudioOffline` onTimeout 侧 `didResume` 双保险
- Whisper key 缺失降级本地 SFSpeechRecognizer（原先静默 nil 白烧重试预算）
- 转录上传前 `Data(contentsOf:)` 移出 @MainActor

## 验证
- `xcodebuild build` ✓；`xcodebuild test` 全绿 ✓
- 模拟器 `-dockVoiceDemo` launch-arg 桥全链路可视化验证：录音舱 morph + scrim + 波形计时 → 松手落卡 + shimmer → 队列 3 次耗尽 → raw 文件 `transcription_status: failed` 正确回写
- 崩溃修复后同路径连跑 2 轮无 SIGTRAP
- 长按手势本体与 PressToTalkButton 状态机同构（上一轮真机验证过）；idb 合成 HID 无法触发 SwiftUI DragGesture 长按，**真机手感请在设备上复验**

## 截图
录音舱（原位 morph + scrim + 实时波形）、shimmer 骨架卡见 issue #821 评论。