### PR TITLE
fix(today): 卡片长按浮现功能菜单 + 语音 <3s 误触硬丢弃 (#826)

### DIFF
--- a/DayPage/Features/Today/HorizontalPanGesture.swift
+++ b/DayPage/Features/Today/HorizontalPanGesture.swift
@@ -97,7 +97,13 @@ struct HorizontalPanGesture: UIViewRepresentable {
 
         // Tap recognizer: fires only when the pan did not. It waits for the
         // pan to fail (requireToFail) so a swipe never also triggers a tap.
-        let tap = UITapGestureRecognizer(
+        // TimedTap (not plain UITapGestureRecognizer): a stock tap has NO
+        // duration ceiling, so a long-press whose context-menu interaction
+        // failed to begin still fired onTap at lift — long-press navigated
+        // to detail exactly like a tap (#826). TimedTap fails itself once
+        // the finger dwells past maxTapDuration, so a long hold can never
+        // fall through to navigation.
+        let tap = TimedTapGestureRecognizer(
             target: context.coordinator,
             action: #selector(Coordinator.handleTap(_:))
         )
@@ -247,6 +253,65 @@ struct HorizontalPanGesture: UIViewRepresentable {
         func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
                                shouldRequireFailureOf other: UIGestureRecognizer) -> Bool {
             false
+        }
+    }
+
+    // MARK: TimedTapGestureRecognizer
+
+    /// A tap with a duration ceiling. UITapGestureRecognizer recognizes on
+    /// lift no matter how long the finger dwelled, so any long-press that
+    /// the system context-menu interaction misses degrades into a plain tap
+    /// (#826: "long-press behaved exactly like tap"). This subclass moves
+    /// itself to .failed once the touch outlives `maxTapDuration`, before
+    /// the lift can be interpreted.
+    ///
+    /// 0.4s sits between the double-tap window and the ~0.5s context-menu
+    /// long-press threshold: every intentional tap lands well under it,
+    /// and every intentional long-press is disqualified by it. The
+    /// remaining ~0.4–0.5s band where a release does nothing is the
+    /// DELIBERATE safety margin — collapsing it (ceiling ≥ menu threshold)
+    /// would re-open the original bug whenever the menu interaction fails
+    /// to begin.
+    final class TimedTapGestureRecognizer: UITapGestureRecognizer {
+        var maxTapDuration: TimeInterval = 0.4
+        private var failTimer: Timer?
+
+        override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent) {
+            super.touchesBegan(touches, with: event)
+            scheduleFailTimer()
+        }
+
+        override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent) {
+            cancelFailTimer()
+            super.touchesEnded(touches, with: event)
+        }
+
+        override func touchesCancelled(_ touches: Set<UITouch>, with event: UIEvent) {
+            cancelFailTimer()
+            super.touchesCancelled(touches, with: event)
+        }
+
+        override func reset() {
+            cancelFailTimer()
+            super.reset()
+        }
+
+        private func scheduleFailTimer() {
+            failTimer?.invalidate()
+            let timer = Timer(timeInterval: maxTapDuration, repeats: false) { [weak self] _ in
+                guard let self, self.state == .possible else { return }
+                self.state = .failed
+            }
+            // .common, not .default: while a finger is down the main runloop
+            // sits in UITrackingRunLoopMode, where default-mode timers are
+            // deferred until lift — the ceiling would never fire mid-press.
+            RunLoop.main.add(timer, forMode: .common)
+            failTimer = timer
+        }
+
+        private func cancelFailTimer() {
+            failTimer?.invalidate()
+            failTimer = nil
         }
     }
 

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -169,18 +169,19 @@ struct InputBarV4: View {
         case micOrb    // amber orb persists across both states
     }
 
-    /// Recording floor below which a press-and-release is treated as
-    /// accidental noise. Capture v2 boundary: respect the user's time —
-    /// a sub-second silent clip carries no meaning, drop it with a hint.
-    private static let minRecordingSeconds: Int = 1
+    #if DEBUG
+    /// One-shot latch for the `-dockVoiceDemo*` launch-arg bridges (see the
+    /// onAppear in `body`). Static because the demo must run once per
+    /// PROCESS, not once per view identity.
+    @MainActor static var dockVoiceDemoDidRun = false
+    #endif
 
-    /// True when the active recording is below the meaning threshold AND
-    /// the captured waveform is silent. Both gates so a brief but audible
-    /// "嗯" / "对" / "好" still goes through.
+    /// True when the active recording is below the send floor
+    /// (`RecordingLimits.minSendableSeconds`, #826) — the release is treated
+    /// as an accidental touch: discarded with the too-short toast, never
+    /// sent or transcribed.
     private var isRecordingTooShort: Bool {
-        let belowFloor = voiceService.elapsedSeconds < Self.minRecordingSeconds
-        let isSilent = voiceService.waveformHistory.allSatisfy { $0 < 0.05 }
-        return belowFloor && isSilent
+        RecordingLimits.isBelowSendFloor(voiceService.elapsedSeconds)
     }
 
     // MARK: - State machine
@@ -405,12 +406,26 @@ struct InputBarV4: View {
         // the in-place capsule morphs in, and after 5s the send path runs —
         // the exact sequence a hold-and-release performs.
         .onAppear {
-            guard ProcessInfo.processInfo.arguments.contains("-dockVoiceDemo") else { return }
+            // `-dockVoiceDemo` holds 5s (≥ the 3s floor → memo lands);
+            // `-dockVoiceDemoShort` holds 1.5s (< floor → recording is
+            // discarded with the too-short toast, #826). Both walk the real
+            // release-send handler, so the floor decision under test is the
+            // shipping one, not a test double.
+            let args = ProcessInfo.processInfo.arguments
+            let holdNanos: UInt64
+            if args.contains("-dockVoiceDemo") { holdNanos = 5_000_000_000 }
+            else if args.contains("-dockVoiceDemoShort") { holdNanos = 1_500_000_000 }
+            else { return }
+            // onAppear re-fires every time navigation returns to Today;
+            // without this latch the demo started a SECOND unattended
+            // recording minutes into the session (observed live, #826).
+            guard !Self.dockVoiceDemoDidRun else { return }
+            Self.dockVoiceDemoDidRun = true
             Task { @MainActor in
                 try? await Task.sleep(nanoseconds: 2_000_000_000)
                 handlePressToTalkStart()
                 pressToTalkPhase = .recording
-                try? await Task.sleep(nanoseconds: 5_000_000_000)
+                try? await Task.sleep(nanoseconds: holdNanos)
                 handlePressToTalkReleaseSend()
                 pressToTalkPhase = .idle
             }

--- a/DayPage/Features/Today/RecordingLimits.swift
+++ b/DayPage/Features/Today/RecordingLimits.swift
@@ -16,6 +16,17 @@ enum RecordingLimits {
     /// transcription limit).
     static let redThreshold = 540  // 9:00
 
+    /// Send floor (#826): a press-to-talk release under this many seconds is
+    /// treated as an accidental touch and discarded — never sent, never
+    /// transcribed. Duration alone decides; ambient noise used to defeat the
+    /// old "sub-second AND silent" gate, shipping stray 1–2s holds as memos.
+    static let minSendableSeconds = 3
+
+    /// True when a recording of `elapsedSeconds` is below the send floor.
+    static func isBelowSendFloor(_ elapsedSeconds: Int) -> Bool {
+        elapsedSeconds < minSendableSeconds
+    }
+
     /// The warning stage a given elapsed time falls into. Each view maps these
     /// stages onto its own tint tokens.
     enum Stage {

--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -572,6 +572,15 @@ struct WriteSheetView: View {
     }
 
     private func handleMicReleaseSend() {
+        // Same send floor as the dock (#826): a sub-3s hold is an accidental
+        // touch — discard it instead of shipping a meaningless clip. The two
+        // press-to-talk surfaces must stay behaviorally identical or users
+        // get a memo from one mic and silence from the other.
+        if RecordingLimits.isBelowSendFloor(voiceService.elapsedSeconds) {
+            Haptics.warningNotification()
+            voiceService.cancelRecording()
+            return
+        }
         // Send path: audio is saved instantly, transcription runs in the
         // background via VoiceAttachmentQueue and patches the memo later.
         if let result = voiceService.stopAndSaveAudio() {
@@ -580,6 +589,17 @@ struct WriteSheetView: View {
     }
 
     private func handleMicReleaseTranscribe() {
+        // Same floor as the send path — a sub-3s clip would burn a Whisper
+        // call and return nothing useful (#826).
+        if RecordingLimits.isBelowSendFloor(voiceService.elapsedSeconds) {
+            Haptics.warningNotification()
+            voiceService.cancelRecording()
+            // The transcribe branch in PressToTalkButton.onEnded early-returns
+            // past the unconditional `.idle` reset — without this the button
+            // stays mounted in `.transcribing` until the next gesture.
+            pressToTalkPhase = .idle
+            return
+        }
         Task {
             if let result = await voiceService.stopAndTranscribe(),
                let transcript = result.transcript,

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -31,7 +31,7 @@
 "input.hint.transcribing"    = "Transcribing…";
 
 /* InputBarV4 — capsule toasts */
-"input.toast.too_short"      = "Hold a little longer · at least 1 second";
+"input.toast.too_short"      = "Too short · hold at least 3 seconds";
 "input.toast.mic_hint"       = "Tap to open recorder · Hold to send voice";
 
 /* v8 RecordingSheet / DynamicIsland */

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -31,7 +31,7 @@
 "input.hint.transcribing"    = "正在转文字…";
 
 /* InputBarV4 — capsule toasts */
-"input.toast.too_short"      = "再说久一点 · 至少 1 秒";
+"input.toast.too_short"      = "说话时间太短 · 至少 3 秒";
 "input.toast.mic_hint"       = "单击打开录音页 · 长按发送语音";
 
 /* v8 RecordingSheet / DynamicIsland */

--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -232,15 +232,46 @@ final class VoiceService: NSObject, ObservableObject {
 
     // MARK: - Start
 
+    /// Set when `cancelRecording()` arrives while `startRecording()` is
+    /// still awaiting the permission check or the detached audio-session
+    /// bring-up (hundreds of ms; seconds on a cold stack). At that moment
+    /// `recorder`/`currentFileURL` are still nil, so cancel's cleanup has
+    /// nothing to stop — and without this flag the recorder created moments
+    /// later would run unattended until process death, leaking a growing
+    /// orphan .m4a and pinning the mic indicator (#826). `startRecording`
+    /// consumes the flag after each await and aborts itself.
+    private var cancelRequestedDuringStart = false
+
+    /// True (and consumed) when a cancel arrived mid-start. MainActor
+    /// serialization guarantees no cancel can interleave between this
+    /// check and the synchronous recorder creation that follows it.
+    private func consumeStartCancellation(deactivateSession: Bool) -> Bool {
+        guard cancelRequestedDuringStart else { return false }
+        cancelRequestedDuringStart = false
+        state = .idle
+        if deactivateSession {
+            // The session HAS been activated by the time this call site
+            // runs; the cancel path's own setActive(false) fired too early
+            // to undo it. Same detached hop as activation — deactivation
+            // also blocks.
+            Task.detached(priority: .userInitiated) {
+                try? AVAudioSession.sharedInstance().setActive(false, options: .notifyOthersOnDeactivation)
+            }
+        }
+        return true
+    }
+
     /// 请求权限、设置音频会话并开始录制。
     /// 成功时将 `state` 设为 `.recording`，失败时设为 `.failed`。
     func startRecording() async {
+        cancelRequestedDuringStart = false
         state = .requesting
         let granted = await requestMicrophonePermission()
         guard granted else {
             state = .failed("麦克风权限被拒绝，请在「设置 -> 隐私 -> 麦克风」中授权")
             return
         }
+        if consumeStartCancellation(deactivateSession: false) { return }
 
         do {
             // setCategory/setActive block for hundreds of ms (seconds on a
@@ -257,6 +288,7 @@ final class VoiceService: NSObject, ObservableObject {
             state = .failed("音频会话初始化失败：\(error.localizedDescription)")
             return
         }
+        if consumeStartCancellation(deactivateSession: true) { return }
 
         let fileURL = makeAudioFileURL()
         currentFileURL = fileURL
@@ -419,6 +451,12 @@ final class VoiceService: NSObject, ObservableObject {
     /// recovery UI), but the breadcrumb tells us when this path is
     /// firing so we can debug if orphans pile up.
     func cancelRecording() {
+        // A quick press-and-release can land here while startRecording()
+        // is still awaiting the audio-session bring-up — recorder and
+        // currentFileURL are nil and the cleanup below is a no-op. Flag
+        // the in-flight start so it aborts on arrival instead of spinning
+        // up a recorder nobody will ever stop (#826).
+        if state == .requesting { cancelRequestedDuringStart = true }
         stopTimer()
         stopMeteringTimer()
         recorder?.stop()

--- a/DayPageTests/VoiceTranscriptWritebackTests.swift
+++ b/DayPageTests/VoiceTranscriptWritebackTests.swift
@@ -237,3 +237,35 @@ final class VoiceTranscriptWritebackTests: XCTestCase {
         XCTAssertEqual(m.attachments.first?.transcript, "preserved")
     }
 }
+
+// MARK: - RecordingSendFloorTests (#826)
+
+/// Contract tests for the press-to-talk send floor: releases under
+/// `RecordingLimits.minSendableSeconds` are accidental touches and must be
+/// discarded (no memo, no transcription), regardless of audio content.
+final class RecordingSendFloorTests: XCTestCase {
+
+    /// The floor is a product decision (3s, issue #826) — a silent change
+    /// here should fail loudly, not slip through a refactor.
+    func testFloorIsThreeSeconds() {
+        XCTAssertEqual(RecordingLimits.minSendableSeconds, 3)
+    }
+
+    func testReleasesUnderFloorAreDiscarded() {
+        XCTAssertTrue(RecordingLimits.isBelowSendFloor(0))
+        XCTAssertTrue(RecordingLimits.isBelowSendFloor(1))
+        XCTAssertTrue(RecordingLimits.isBelowSendFloor(2))
+    }
+
+    func testReleasesAtOrOverFloorAreSent() {
+        XCTAssertFalse(RecordingLimits.isBelowSendFloor(3))
+        XCTAssertFalse(RecordingLimits.isBelowSendFloor(4))
+        XCTAssertFalse(RecordingLimits.isBelowSendFloor(600))
+    }
+
+    /// Duration alone decides — the floor must sit below the 5:00 amber
+    /// warning band so the two thresholds can never invert.
+    func testFloorSitsBelowWarningBands() {
+        XCTAssertLessThan(RecordingLimits.minSendableSeconds, RecordingLimits.amberThreshold)
+    }
+}


### PR DESCRIPTION
## Summary

修复 #826 的两组交互缺陷，并顺手修复实测中暴露的一个数据泄漏级既有 bug：

1. **卡片长按 = 点击（回归）**：长按 0.35–0.5s 灰区内松手时，`HorizontalPanGesture` 的 UITapGestureRecognizer（无时长上限）把长按抬手当 tap → 直接进详情，用户感知为"长按和点击一样"。系统 contextMenu 链路本身完好（1.1s 长按实测弹出合并菜单）。
2. **语音 <3s 误触发送**：整栏长按 0.35s 即进录音、松手即发送；原丢弃门槛为"<1s 且波形全静音"双条件，1–2s 误触带环境音照样落成 memo。
3. **（实测新发现）快按快放泄漏无人值守录音**：`cancelRecording()` 在 `startRecording()` 异步启动（权限 await + detached 音频会话激活，冷栈可达秒级）完成前到达时无物可停；之后创建的 recorder 无人再停，录音持续到进程死亡（实测抓到 2 个 1.7MB、持续录制 3 分钟的孤儿 .m4a）。3s 门槛让丢弃路径高频化，此修复是其前置条件。

## What changed

- `HorizontalPanGesture.swift`：新增 `TimedTapGestureRecognizer`（0.4s 上限，超时自转 `.failed`；Timer 挂 `.common` mode——触摸期间 runloop 处于 tracking mode，default-mode 定时器不触发）。0.4–0.5s 的"两不沾"死区是有意的安全边界，注释已显式声明。
- `RecordingLimits.swift`：`minSendableSeconds = 3` + `isBelowSendFloor(_:)` 单一事实来源。
- `InputBarV4.swift`：dock 松手 send/transcribe 均接入 3s 门槛（时长单条件，删除静音门槛）；DEBUG demo 桥新增 `-dockVoiceDemoShort`（1.5s 丢弃路径）+ onAppear 重触发一次性守卫。
- `WriteSheetView.swift`：composer 内按住说话接入同一门槛（Evaluator round-1 指出的同源缺口），两个语音入口行为一致。
- `VoiceService.swift`：`cancelRequestedDuringStart` 标志——cancel 在 start 进行中（`state == .requesting`）到达时置位，`startRecording` 在每个 await 后消费并自我中止（已激活会话则 detached 反激活）。MainActor 序列化保证检查与 recorder 创建之间无插入窗口。
- `Localizable.strings`（zh-Hans/en）：toast 文案改为"说话时间太短 · 至少 3 秒"。
- `VoiceTranscriptWritebackTests.swift`：新增 `RecordingSendFloorTests`（4 用例，含"门槛=3s 是产品决策，静默改动必须炸测试"守卫）。

## Why this approach

- 保留系统 contextMenu 而非自绘浮层：模糊背景 + 卡片悬浮预览本就是"优雅浮现"的原生形态，且该卡片已叠加滚动/横滑/tap/长按四种手势，自绘意味着重进手势仲裁泥潭（历史翻车 4 次）。
- TimedTap 的 0.4s 上限选在双击窗口与 ~0.5s 系统长按阈值之间：意图点击远低于它，意图长按被它排除；把上限提到 ≥ 菜单阈值会在菜单交互失败时重新打开原 bug。
- 3s 门槛做成时长单条件（用户拍板方案 a，微信语义）：环境音会击穿静音检测；真实短语音被丢弃是已声明并接受的 tradeoff。

## Quality gates

- Build: `xcodebuild -scheme DayPage build` **BUILD SUCCEEDED**
- Tests: 141 既有测试全绿（2 个 KeychainHelper 失败查明为 simctl defaults 注入的测试环境污染，清理后通过，与本 diff 无关）+ 新增 4/4 绿
- Generator-Evaluator 双 agent 循环：round-1 41/50（无 blocking）→ 3 条建议全部处理 → round-2 **48/50 APPROVE**（剩余 2 分为 non-blocking theoretical）
- 模拟器实测（iPhone 17 Pro / iOS 26.1）：
  - 1.1s 长按 → 合并菜单弹出（置顶/分享卡片/分享引用/复制/多选/删除 + 卡片预览）
  - 0.7s 落空按压 → 不再误导航（修复前必进详情）
  - 单击 → 详情；横滑 → 抽屉，均无回归
  - 1.5s 录音松手 → 无 memo 落盘、无孤儿资产、录音机确认终止
  - 5s 录音 → 正常发送 + 真实 Whisper 转写全链路（录音→保存→队列→转写→写回→卡片渐显）一次通过

## Test plan

- [x] 长按卡片 ≥0.5s 弹出功能菜单，不进详情
- [x] 单击卡片进详情
- [x] 横滑抽屉（分享/删除/置顶/更多）无回归
- [x] dock 按住 <3s 松手：丢弃 + toast，无 memo、无孤儿音频
- [x] dock 按住 ≥3s 松手：正常发送 + 后台转写
- [x] WriteSheet 内按住说话同样受 3s 门槛保护
- [x] 上滑取消 / 左滑转文字路径不受影响
- [x] 全量单元测试绿

Closes #826
