### PR TITLE
refactor: Archive/搜索信息架构重构 — 内存索引 + IA 收敛 + 手势/token/i18n 治理

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -217,6 +217,7 @@
 		TI1000001 /* AppIntentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = TI2000001 /* AppIntentsTests.swift */; };
 		VES0000002 /* VaultExportServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VES1000002 /* VaultExportServiceTests.swift */; };
 		VTW0000001 /* VoiceTranscriptWritebackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = VTW1000001 /* VoiceTranscriptWritebackTests.swift */; };
+		SST0000001 /* SearchServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = SST1000001 /* SearchServiceTests.swift */; };
 		WR0000002 /* WeeklyRecapDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = WR1000002 /* WeeklyRecapDetailView.swift */; };
 		WR0000003 /* WeeklyCompilationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = WR1000003 /* WeeklyCompilationServiceTests.swift */; };
 		WRA0000001 /* WeeklyRecapAutoTriggerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = WRA1000001 /* WeeklyRecapAutoTriggerTests.swift */; };
@@ -464,6 +465,7 @@
 		TI2000001 /* AppIntentsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppIntentsTests.swift; sourceTree = "<group>"; };
 		VES1000002 /* VaultExportServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultExportServiceTests.swift; sourceTree = "<group>"; };
 		VTW1000001 /* VoiceTranscriptWritebackTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceTranscriptWritebackTests.swift; sourceTree = "<group>"; };
+		SST1000001 /* SearchServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SearchServiceTests.swift; sourceTree = "<group>"; };
 		WR1000002 /* WeeklyRecapDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapDetailView.swift; sourceTree = "<group>"; };
 		WR1000003 /* WeeklyCompilationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyCompilationServiceTests.swift; sourceTree = "<group>"; };
 		WRA1000001 /* WeeklyRecapAutoTriggerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeeklyRecapAutoTriggerTests.swift; sourceTree = "<group>"; };
@@ -1072,6 +1074,7 @@
 				04B9410B749C82B6E34779E4 /* MemoryChatTests.swift */,
 				MYT1000001 /* MemoYAMLTests.swift */,
 				VTW1000001 /* VoiceTranscriptWritebackTests.swift */,
+				SST1000001 /* SearchServiceTests.swift */,
 				OVS1000002 /* OrphanedVoiceScannerTests.swift */,
 				OPS1000002 /* OrphanedPhotoScannerTests.swift */,
 				INF1000002 /* InflightDraftStoreTests.swift */,
@@ -1520,6 +1523,7 @@
 				6587243C5DB109B930AB5D92 /* MemoryChatTests.swift in Sources */,
 				MYT0000001 /* MemoYAMLTests.swift in Sources */,
 				VTW0000001 /* VoiceTranscriptWritebackTests.swift in Sources */,
+				SST0000001 /* SearchServiceTests.swift in Sources */,
 				OVS0000002 /* OrphanedVoiceScannerTests.swift in Sources */,
 				OPS0000002 /* OrphanedPhotoScannerTests.swift in Sources */,
 				INF0000002 /* InflightDraftStoreTests.swift in Sources */,

--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -234,6 +234,11 @@ struct DayPageApp: App {
             // first Today load reads it instead of scanning the whole vault
             // (issue #345). Cheap no-op until the background scan completes.
             TimelineIndex.shared.warmUp()
+            // Same treatment for full-text search (#827): pre-fold the vault
+            // into SearchIndex so the first keystroke in Search never pays a
+            // disk scan. Until this build lands, SearchView falls back to the
+            // legacy scanning path.
+            SearchIndex.shared.warmUp()
         }
         // url(forUbiquityContainerIdentifier:) may return nil on first call during
         // cold launch while the iCloud daemon finishes container setup. Re-probe
@@ -419,6 +424,7 @@ struct DayPageApp: App {
                     // actually changed (issue #345).
                     if phase == .active {
                         TimelineIndex.shared.refreshIfExternallyModified()
+                        SearchIndex.shared.refreshIfExternallyModified()
                         // Re-warm generators after backgrounding so they're ready immediately.
                         HapticFeedback.warmUp()
                         // B3: 2am 后台编译失败时，前台回流再试一次。

--- a/DayPage/DesignSystem/Interactions.swift
+++ b/DayPage/DesignSystem/Interactions.swift
@@ -1,5 +1,21 @@
 import SwiftUI
 
+// MARK: - DSGesture
+
+/// Shared horizontal-swipe tuning so every horizontal pager in the app
+/// (Archive month grid, DayDetail day paging) engages with the same feel.
+/// Values were tuned on-device for DayDetail during the premium-polish waves;
+/// #827 unifies Archive's month swipe onto them.
+enum DSGesture {
+    /// Minimum travel before a horizontal pager drag is recognized at all.
+    static let pagerMinimumDistance: CGFloat = 24
+    /// Horizontal dominance gate: |width| > |height| × ratio keeps vertical
+    /// scrolls owned by the enclosing scroll view.
+    static let horizontalDominance: CGFloat = 1.5
+    /// Fixed travel that commits a month-page change in the Archive grid.
+    static let monthSwipeCommitDistance: CGFloat = 50
+}
+
 // MARK: - PressableCardModifier
 
 /// 对任何卡片视图应用按压缩放 + 暗色叠加及触觉反馈。

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -26,22 +26,6 @@ enum MonthlySummaryFilter: String, CaseIterable {
     }
 }
 
-// MARK: - SystemStatus
-
-enum SystemStatus {
-    case synchronized
-    case pendingCompilation
-    case offline
-
-    var label: String {
-        switch self {
-        case .synchronized:       return L10n.Archive.statusSynchronized
-        case .pendingCompilation: return L10n.Archive.statusPendingCompilation
-        case .offline:            return L10n.Archive.statusOffline
-        }
-    }
-}
-
 // MARK: - DayStats
 
 /// 存档中单日统计信息。
@@ -353,25 +337,6 @@ final class ArchiveViewModel: ObservableObject {
 
     var totalEntries: Int { dayStats.values.reduce(0) { $0 + $1.memoCount } }
 
-    // MARK: System Status
-
-    /// 基于当月编译状态推算的系统状态。
-    var systemStatus: SystemStatus {
-        let days = dayStats.values
-        // Days that have raw memos but no compiled Daily Page
-        let hasPending = days.contains { $0.memoCount > 0 && !$0.isDailyPageCompiled }
-        let hasAny = days.contains { $0.memoCount > 0 || $0.isDailyPageCompiled }
-        guard hasAny else { return .synchronized }
-        return hasPending ? .pendingCompilation : .synchronized
-    }
-
-    var lastSyncTimestamp: String {
-        let compiled = dayStats.values
-            .filter { $0.isDailyPageCompiled }
-            .sorted { $0.dateString > $1.dateString }
-        guard let latest = compiled.first else { return "N/A" }
-        return latest.dateString.replacingOccurrences(of: "-", with: ".")
-    }
     var totalPhotos: Int { dayStats.values.reduce(0) { $0 + $1.photoCount } }
     var totalVoiceMinutes: Int { dayStats.values.reduce(0) { $0 + $1.voiceMinutes } }
     var totalLocations: Int { dayStats.values.reduce(0) { $0 + $1.uniqueLocations } }
@@ -583,18 +548,13 @@ struct ArchiveView: View {
                         .frame(height: 0)
 
                         VStack(spacing: 0) {
-                            // Issue #7 (2026-07-03): Vault overview strip
-                            // sits above the month navigation. Gives the
-                            // user a whole-vault sense-of-scale (total
-                            // memos + total days) without opening a
-                            // separate stats screen. Reads directly from
-                            // TimelineIndex so it always reflects on-disk
-                            // reality — no separate cache to invalidate.
-                            vaultOverviewStrip
-                                .padding(.horizontal, 20)
-                                .padding(.top, 16)
-                                .padding(.bottom, 6)
-
+                            // #827 IA convergence: the whole-vault overview
+                            // strip moved to SearchView's starter state —
+                            // in Archive it was a third stats voice
+                            // shouting over the month summary (FINDING-008
+                            // was exactly this scope collision). Calendar
+                            // mode now reads: month nav → calendar (legend
+                            // in its footer) → single month summary.
                             monthNavigationRow
                                 .padding(.horizontal, 20)
                                 .padding(.vertical, 16)
@@ -643,17 +603,21 @@ struct ArchiveView: View {
                                             }
                                     )
 
-                                legendRow
-                                    .padding(.horizontal, 12)
-                                    .padding(.top, 8)
-
-                                monthlySummary
-                                    .padding(.horizontal, 20)
-                                    .padding(.top, 32)
-
-                                systemStatusArtifact
-                                    .padding(.top, 32)
-                                    .padding(.bottom, 40)
+                                if viewModel.totalEntries == 0 {
+                                    // #827: an all-empty month used to render
+                                    // as a mute grid of gray cells with no
+                                    // explanation — the only screen in the
+                                    // app without an empty state.
+                                    emptyMonthHint
+                                        .padding(.horizontal, 20)
+                                        .padding(.top, 32)
+                                        .padding(.bottom, 40)
+                                } else {
+                                    monthlySummary
+                                        .padding(.horizontal, 20)
+                                        .padding(.top, 32)
+                                        .padding(.bottom, 40)
+                                }
                             } else {
                                 listContent
                                     .padding(.horizontal, 20)
@@ -895,44 +859,19 @@ struct ArchiveView: View {
     /// warmed by DayPageApp at launch, so this is O(1) once ready. Before
     /// warm-up we show em-dashes rather than "0" so the user can tell
     /// "index is still loading" from "vault is really empty".
-    private var vaultOverviewStrip: some View {
-        let all = TimelineIndex.shared.entries()
-        let totalMemos = all.reduce(0) { $0 + $1.memoCount }
-        let totalDays = all.count
-        let hasData = totalDays > 0 || totalMemos > 0
-        // Scope words matter: this strip is whole-vault, but it sits directly
-        // under the month title, so bare "MEMOS 16" read as July's count and
-        // contradicted the month summary's "TOTAL ENTRIES 11" (FINDING-008).
-        return HStack(alignment: .center, spacing: 20) {
-            statPillar(
-                label: "ALL-TIME MEMOS",
-                value: hasData ? "\(totalMemos)" : "—"
-            )
-            Rectangle()
-                .fill(DSColor.glassRimD)
-                .frame(width: 0.5, height: 26)
-            statPillar(
-                label: "ALL-TIME DAYS",
-                value: hasData ? "\(totalDays)" : "—"
-            )
-            Spacer()
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel("Vault 总览：\(totalMemos) 条记录，\(totalDays) 天写作")
-        .accessibilityIdentifier("archive.vault.overview")
-    }
-
-    private func statPillar(label: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(label)
-                .font(DSType.mono10)
-                .tracking(1.2)
-                .textCase(.uppercase)
+    /// #827: quiet empty state for an all-empty month — replaces the month
+    /// summary (a grid of zeros would be noise, not information).
+    private var emptyMonthHint: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "moon.zzz")
+                .font(.system(size: 22, weight: .light))
+                .foregroundColor(DSColor.inkFaint)
+            Text(NSLocalizedString("archive.month.empty", comment: "Empty month hint"))
+                .font(DSType.bodySM)
                 .foregroundColor(DSColor.inkSubtle)
-            Text(value)
-                .font(DSFonts.serif(size: 22, weight: .regular))
-                .foregroundColor(DSColor.inkPrimary)
         }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
     }
 
     private var monthNavigationRow: some View {
@@ -1061,6 +1000,13 @@ struct ArchiveView: View {
                     }
                 }
             }
+
+            // #827: the density legend lives INSIDE the calendar panel as
+            // its footer — it annotates the grid above it, so floating it
+            // outside the glass surface made it read as a separate section.
+            legendRow
+                .padding(.horizontal, 4)
+                .padding(.top, 6)
         }
         .padding(8)
         // #771: month calendar grid → glass engine (.panel). Engine owns rim.
@@ -1404,63 +1350,6 @@ struct ArchiveView: View {
         .accessibilityValue(unit != nil ? "\(value) \(unit!)" : value)
     }
 
-    // MARK: - System Status Artifact
-
-    private var systemStatusArtifact: some View {
-        VStack(spacing: 0) {
-            // Top divider line
-            Rectangle()
-                .fill(DSColor.inkFaint)
-                .frame(height: 0.5)
-
-            ZStack {
-                DSColor.amberDeep.opacity(0.92)
-                    .ignoresSafeArea(edges: [])
-
-                VStack(spacing: 16) {
-                    // Decorative geometric graphic
-                    ArtifactGeometricView()
-                        .frame(width: 80, height: 80)
-
-                    // Status label
-                    VStack(spacing: 6) {
-                        HStack(spacing: 6) {
-                            // Artifact panel background is amberDeep@0.92 — use
-                            // onAmber so the label tracks dark mode instead of
-                            // sitting on a pure-white system color.
-                            Text("SYSTEM STATUS:")
-                                .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
-                                .foregroundColor(DSColor.onAmber.opacity(0.4))
-                                .tracking(0.5)
-
-                            Text(viewModel.systemStatus.label)
-                                .font(DSFonts.jetBrainsMono(size: 11, weight: .medium))
-                                .foregroundColor(statusTextColor)
-                                .tracking(0.5)
-                        }
-
-                        Text("LAST SYNC // \(viewModel.lastSyncTimestamp)")
-                            .font(DSFonts.jetBrainsMono(size: 10, weight: .regular))
-                            .foregroundColor(DSColor.onAmber.opacity(0.3))
-                            .tracking(0.5)
-                    }
-                }
-                .padding(.vertical, 32)
-            }
-            .frame(maxWidth: .infinity)
-        }
-    }
-
-    private var statusTextColor: Color {
-        switch viewModel.systemStatus {
-        // Synchronized label sits on the amberDeep artifact panel — onAmber
-        // so the warm-cream foreground tracks dark mode.
-        case .synchronized:       return DSColor.onAmber.opacity(0.6)
-        case .pendingCompilation: return DSColor.warningAmber
-        case .offline:            return DSColor.errorRed
-        }
-    }
-
     // MARK: - List Content
 
     private var listContent: some View {
@@ -1755,91 +1644,6 @@ fileprivate enum ArchiveVaultScan {
             out.insert(base)
         }
         return out
-    }
-}
-
-// MARK: - ArtifactGeometricView
-
-/// 黑白极简装饰图案，呼应"考古档案"设计语言。
-/// 渲染带径向刻度线的同心圆 — 令人联想到罗盘或档案封印。
-private struct ArtifactGeometricView: View {
-
-    var body: some View {
-        Canvas { context, size in
-            let center = CGPoint(x: size.width / 2, y: size.height / 2)
-            let outerR = min(size.width, size.height) / 2 - 1
-            let white   = Color.white
-            let dimmed  = Color.white.opacity(0.25)
-
-            // --- Outer ring ---
-            context.stroke(
-                Path { p in p.addArc(center: center, radius: outerR, startAngle: .degrees(0), endAngle: .degrees(360), clockwise: false) },
-                with: .color(white.opacity(0.5)),
-                lineWidth: 1
-            )
-
-            // --- Middle ring ---
-            context.stroke(
-                Path { p in p.addArc(center: center, radius: outerR * 0.72, startAngle: .degrees(0), endAngle: .degrees(360), clockwise: false) },
-                with: .color(white.opacity(0.35)),
-                lineWidth: 0.75
-            )
-
-            // --- Inner ring ---
-            context.stroke(
-                Path { p in p.addArc(center: center, radius: outerR * 0.44, startAngle: .degrees(0), endAngle: .degrees(360), clockwise: false) },
-                with: .color(white.opacity(0.25)),
-                lineWidth: 0.75
-            )
-
-            // --- Center dot ---
-            let dotR: CGFloat = 3
-            context.fill(
-                Path { p in p.addArc(center: center, radius: dotR, startAngle: .degrees(0), endAngle: .degrees(360), clockwise: false) },
-                with: .color(white.opacity(0.6))
-            )
-
-            // --- Radial tick marks (24 major + 24 minor) ---
-            let totalTicks = 48
-            for i in 0..<totalTicks {
-                let angle = Double(i) * (360.0 / Double(totalTicks))
-                let rad   = angle * .pi / 180
-                let isMajor = i % 2 == 0
-                let tickOuter = outerR
-                let tickInner = isMajor ? outerR * 0.86 : outerR * 0.92
-                let color = isMajor ? white.opacity(0.55) : dimmed
-
-                let outer = CGPoint(
-                    x: center.x + tickOuter * CGFloat(cos(rad)),
-                    y: center.y + tickOuter * CGFloat(sin(rad))
-                )
-                let inner = CGPoint(
-                    x: center.x + tickInner * CGFloat(cos(rad)),
-                    y: center.y + tickInner * CGFloat(sin(rad))
-                )
-
-                context.stroke(
-                    Path { p in p.move(to: outer); p.addLine(to: inner) },
-                    with: .color(color),
-                    lineWidth: isMajor ? 1 : 0.5
-                )
-            }
-
-            // --- Cross hair lines ---
-            let crossR = outerR * 0.38
-            let crossColor = white.opacity(0.2)
-            for angleDeg in [0.0, 90.0] {
-                let rad = angleDeg * .pi / 180
-                let p1 = CGPoint(x: center.x - crossR * CGFloat(cos(rad)), y: center.y - crossR * CGFloat(sin(rad)))
-                let p2 = CGPoint(x: center.x + crossR * CGFloat(cos(rad)), y: center.y + crossR * CGFloat(sin(rad)))
-                context.stroke(
-                    Path { p in p.move(to: p1); p.addLine(to: p2) },
-                    with: .color(crossColor),
-                    lineWidth: 0.5
-                )
-            }
-        }
-        .accessibilityHidden(true)
     }
 }
 

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -421,15 +421,15 @@ final class ArchiveViewModel: ObservableObject {
     func generateMarkdownExport(filter: MonthlySummaryFilter) -> String {
         let days = filteredDays(filter: filter)
         var lines: [String] = []
-        lines.append("# \(currentMonthTitle) 月度摘要")
+        lines.append("# " + String(format: NSLocalizedString("archive.export.md.title", comment: "Markdown export H1: %@ = month title"), currentMonthTitle))
         lines.append("")
-        lines.append("- 总记录：\(totalEntries) 条")
-        lines.append("- 照片：\(totalPhotos) 张")
-        lines.append("- 语音：\(totalVoiceMinutes) 分钟")
-        lines.append("- 地点：\(totalLocations) 处")
+        lines.append(String(format: NSLocalizedString("archive.export.md.entries", comment: "Markdown export bullet: total entry count"), totalEntries))
+        lines.append(String(format: NSLocalizedString("archive.export.md.photos", comment: "Markdown export bullet: photo count"), totalPhotos))
+        lines.append(String(format: NSLocalizedString("archive.export.md.voice", comment: "Markdown export bullet: voice minutes"), totalVoiceMinutes))
+        lines.append(String(format: NSLocalizedString("archive.export.md.locations", comment: "Markdown export bullet: location count"), totalLocations))
         lines.append("")
         if filter != .all {
-            lines.append("> 筛选：\(filter.localizedLabel)")
+            lines.append(String(format: NSLocalizedString("archive.export.md.filter", comment: "Markdown export blockquote: active filter name"), filter.localizedLabel))
             lines.append("")
         }
         lines.append("---")
@@ -441,7 +441,10 @@ final class ArchiveViewModel: ObservableObject {
                 lines.append(summary)
             }
             lines.append("")
-            lines.append("- 记录：\(stats.memoCount) 条，照片：\(stats.photoCount) 张，语音：\(stats.voiceMinutes) 分钟，地点：\(stats.uniqueLocations) 处")
+            lines.append(String(
+                format: NSLocalizedString("archive.export.md.dayline", comment: "Markdown export per-day stats: memos, photos, voice minutes, locations"),
+                stats.memoCount, stats.photoCount, stats.voiceMinutes, stats.uniqueLocations
+            ))
             lines.append("")
         }
         return lines.joined(separator: "\n")
@@ -586,11 +589,12 @@ struct ArchiveView: View {
                                         )
                                     )
                                     .gesture(
-                                        DragGesture(minimumDistance: 30)
+                                        DragGesture(minimumDistance: DSGesture.pagerMinimumDistance)
                                             .onEnded { value in
                                                 let w = value.translation.width
                                                 let h = value.translation.height
-                                                guard abs(w) > abs(h) * 1.2, abs(w) > 50 else { return }
+                                                guard abs(w) > abs(h) * DSGesture.horizontalDominance,
+                                                      abs(w) > DSGesture.monthSwipeCommitDistance else { return }
                                                 if w < 0 {
                                                     monthNavDirection = .trailing
                                                     withAnimation(Motion.spring) { viewModel.goToNextMonth() }
@@ -841,8 +845,8 @@ struct ArchiveView: View {
                     .clipShape(Circle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("搜索")
-            .accessibilityHint("搜索历史记录")
+            .accessibilityLabel(NSLocalizedString("archive.a11y.search.label", comment: "A11y label: search button in archive header"))
+            .accessibilityHint(NSLocalizedString("archive.a11y.search.hint", comment: "A11y hint: search button in archive header"))
             .frame(width: 44, height: 44)
             .contentShape(Rectangle())
         }
@@ -889,8 +893,8 @@ struct ArchiveView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("上个月")
-            .accessibilityHint("切换到上一个月")
+            .accessibilityLabel(NSLocalizedString("archive.a11y.prevMonth.label", comment: "A11y label: previous month button"))
+            .accessibilityHint(NSLocalizedString("archive.a11y.prevMonth.hint", comment: "A11y hint: previous month button"))
 
             Spacer()
 
@@ -926,8 +930,8 @@ struct ArchiveView: View {
                         .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel("回到本月")
-                .accessibilityHint("跳转到当前月份")
+                .accessibilityLabel(NSLocalizedString("archive.a11y.currentMonth.label", comment: "A11y label: back-to-current-month button"))
+                .accessibilityHint(NSLocalizedString("archive.a11y.currentMonth.hint", comment: "A11y hint: back-to-current-month button"))
                 .transition(.scale.combined(with: .opacity))
             }
 
@@ -946,8 +950,8 @@ struct ArchiveView: View {
                     .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("下个月")
-            .accessibilityHint("切换到下一个月")
+            .accessibilityLabel(NSLocalizedString("archive.a11y.nextMonth.label", comment: "A11y label: next month button"))
+            .accessibilityHint(NSLocalizedString("archive.a11y.nextMonth.hint", comment: "A11y hint: next month button"))
         }
         .animation(reduceMotion ? nil : Motion.spring, value: viewModel.isViewingCurrentMonth)
     }
@@ -1103,7 +1107,7 @@ struct ArchiveView: View {
             .frame(maxWidth: .infinity)
             .accessibilityLabel(accessibilityLabel(dateStr: dateStr, state: data, stats: viewModel.dayStats[dateStr]))
             .accessibilityValue(viewModel.dayStats[dateStr]?.densityLevel.label ?? "")
-            .accessibilityHint("双击打开当天详情")
+            .accessibilityHint(NSLocalizedString("archive.a11y.day.hint", comment: "A11y hint: calendar day cell opens the day detail"))
         } else {
             RoundedRectangle(cornerRadius: DSRadius.xs, style: .continuous)
                 .fill(Color.clear)
@@ -1115,23 +1119,26 @@ struct ArchiveView: View {
     private func accessibilityLabel(dateStr: String, state: CellDataState, stats: DayStats?) -> String {
         let statePrefix: String
         switch state {
-        case .compiled: statePrefix = "已编译 Daily Page"
-        case .rawOnly:  statePrefix = "有原始记录"
-        case .none:     return "\(dateStr)，无记录"
+        case .compiled: statePrefix = NSLocalizedString("archive.a11y.day.compiled", comment: "A11y: day has a compiled daily page")
+        case .rawOnly:  statePrefix = NSLocalizedString("archive.a11y.day.rawOnly", comment: "A11y: day has raw memos only")
+        case .none:     return String(format: NSLocalizedString("archive.a11y.day.none", comment: "A11y: day with no entries; %@ = date"), dateStr)
         }
         guard let s = stats, s.memoCount > 0 else {
             return "\(dateStr)，\(statePrefix)"
         }
         let densityLabel: String
         switch s.densityLevel {
-        case .empty:  densityLabel = "空"
-        case .low:    densityLabel = "较低"
-        case .medium: densityLabel = "中等"
-        case .high:   densityLabel = "较高"
+        case .empty:  densityLabel = NSLocalizedString("archive.a11y.density.empty", comment: "A11y density level: empty")
+        case .low:    densityLabel = NSLocalizedString("archive.a11y.density.low", comment: "A11y density level: low")
+        case .medium: densityLabel = NSLocalizedString("archive.a11y.density.medium", comment: "A11y density level: medium")
+        case .high:   densityLabel = NSLocalizedString("archive.a11y.density.high", comment: "A11y density level: high")
         }
-        var parts: [String] = ["\(dateStr)，\(statePrefix)，活跃度 \(densityLabel)，\(s.memoCount) 条记录"]
-        if s.photoCount > 0 { parts.append("\(s.photoCount) 张照片") }
-        if s.uniqueLocations > 0 { parts.append("\(s.uniqueLocations) 处位置") }
+        var parts: [String] = [String(
+            format: NSLocalizedString("archive.a11y.day.summary", comment: "A11y day summary: date, compile state, density, memo count"),
+            dateStr, statePrefix, densityLabel, s.memoCount
+        )]
+        if s.photoCount > 0 { parts.append(String(format: NSLocalizedString("archive.a11y.day.photos", comment: "A11y: %d photos"), s.photoCount)) }
+        if s.uniqueLocations > 0 { parts.append(String(format: NSLocalizedString("archive.a11y.day.locations", comment: "A11y: %d locations"), s.uniqueLocations)) }
         return parts.joined(separator: "，")
     }
 
@@ -1165,7 +1172,7 @@ struct ArchiveView: View {
     private var monthlySummary: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack(spacing: 16) {
-                Text("\(viewModel.currentMonthTitle) Summary")
+                Text(String(format: NSLocalizedString("archive.summary.title", comment: "Monthly summary section title; %@ = month title"), viewModel.currentMonthTitle))
                     .font(DSType.sectionLabel)
                     .foregroundColor(DSColor.inkSubtle)
                 Rectangle()
@@ -1198,7 +1205,7 @@ struct ArchiveView: View {
             if summaryFilter != .all {
                 let filtered = viewModel.filteredDays(filter: summaryFilter)
                 if filtered.isEmpty {
-                    Text("无符合条件的日期")
+                    Text(NSLocalizedString("archive.summary.noMatch", comment: "Monthly summary: no days match the active filter"))
                         .monoLabelStyle(size: 11)
                         .foregroundColor(DSColor.onSurfaceVariant)
                         .padding(.vertical, 8)
@@ -1241,7 +1248,7 @@ struct ArchiveView: View {
             // Export / Share actions
             HStack(spacing: 10) {
                 Button(action: exportMarkdown) {
-                    Label("导出 Markdown", systemImage: "square.and.arrow.up")
+                    Label(NSLocalizedString("archive.export.markdown", comment: "Button: export monthly summary as Markdown"), systemImage: "square.and.arrow.up")
                         .monoLabelStyle(size: 11)
                         .foregroundColor(DSColor.inkPrimary)
                         .padding(.horizontal, 12)
@@ -1253,7 +1260,7 @@ struct ArchiveView: View {
                 Button {
                     Task { await shareScreenshot() }
                 } label: {
-                    Label("截图分享", systemImage: "camera")
+                    Label(NSLocalizedString("archive.export.screenshot", comment: "Button: share monthly summary as screenshot"), systemImage: "camera")
                         .monoLabelStyle(size: 11)
                         .foregroundColor(DSColor.inkPrimary)
                         .padding(.horizontal, 12)
@@ -1399,20 +1406,34 @@ struct ArchiveView: View {
     // Renders "YYYY 年 M 月" on the left and "<count> 天" on the right. Uses
     // `.ultraThinMaterial` as the background since `DSColor.bgCard` is not
     // defined in this design system.
+    /// Locale-aware "yyyy-MM" → month header ("2026年7月" / "July 2026").
+    /// Formatters are cached statically so section renders stay cheap.
+    private static let monthKeyParser: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+    private static let monthHeaderFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.setLocalizedDateFormatFromTemplate("yMMMM")
+        return f
+    }()
+
     private func monthSectionHeader(monthKey: String, dayCount: Int) -> some View {
-        // Parse "yyyy-MM" → "YYYY 年 M 月" without spinning up a DateFormatter
-        // every section render. monthKey is a fixed-width 7-char "yyyy-MM".
-        let yearPart = String(monthKey.prefix(4))
-        let monthRaw = String(monthKey.suffix(2))
-        let monthInt = Int(monthRaw) ?? 0
-        let headerTitle = "\(yearPart) 年 \(monthInt) 月"
+        let headerTitle = Self.monthKeyParser.date(from: monthKey)
+            .map { Self.monthHeaderFormatter.string(from: $0) } ?? monthKey
+        let dayCountText = String(
+            format: NSLocalizedString("archive.section.dayCount", comment: "Month section header trailing label: %d days with entries"),
+            dayCount
+        )
 
         return HStack(alignment: .firstTextBaseline) {
             Text(headerTitle)
                 .font(DSType.titleSM)
                 .foregroundColor(DSColor.inkPrimary)
             Spacer(minLength: 8)
-            Text("\(dayCount) 天")
+            Text(dayCountText)
                 .font(DSType.labelSM)
                 .foregroundColor(DSColor.inkMuted)
         }
@@ -1421,7 +1442,7 @@ struct ArchiveView: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .background(.ultraThinMaterial)
         .accessibilityElement(children: .combine)
-        .accessibilityLabel("\(headerTitle), \(dayCount) 天")
+        .accessibilityLabel("\(headerTitle), \(dayCountText)")
     }
 
     // MARK: - Month Digest Strip (list mode)

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -461,7 +461,9 @@ struct DayDetailView: View {
             }
         }
 
-        // ENTRIES — memo count
+        // ENTRIES — memo count. Tile labels ("ENTRIES"/"SPAN"/"WEATHER"/"KIND")
+        // are intentionally-untranslated archival tags (FINDING-010); values
+        // and subs carry the localized content.
         let entriesTile = MetadataGridView.Tile(
             label: "ENTRIES", value: "\(sorted.count)", sub: "MEMOS"
         )

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -20,9 +20,16 @@ struct DayDetailView: View {
 
     enum Tab: String, CaseIterable {
         // 同一控件内半英半中（"Daily Page" | "原始 Memo"）读起来像两个产品
-        // （FINDING-010）。英文 mono 保留给档案性标签，可交互控件统一中文。
-        case daily = "日记页"
-        case raw = "原始 Memo"
+        // （FINDING-010）。可交互控件在每个语言内保持整体一致 — 经 L10n 解析。
+        case daily
+        case raw
+
+        var title: String {
+            switch self {
+            case .daily: return NSLocalizedString("daydetail.tab.daily", comment: "Segment title: compiled daily page")
+            case .raw:   return NSLocalizedString("daydetail.tab.raw", comment: "Segment title: raw memos")
+            }
+        }
     }
 
     enum LoadState: Equatable {
@@ -116,7 +123,7 @@ struct DayDetailView: View {
                         .font(.system(size: 15, weight: .semibold))
                         .foregroundColor(DSColor.onSurface)
                 }
-                .accessibilityLabel("前一天")
+                .accessibilityLabel(NSLocalizedString("daydetail.a11y.prevDay", comment: "A11y label: go to previous day"))
 
                 Button(action: { go(.forward) }) {
                     Image(systemName: "chevron.right")
@@ -124,7 +131,7 @@ struct DayDetailView: View {
                         .foregroundColor(canGoForward ? DSColor.onSurface : DSColor.onSurfaceVariant.opacity(0.35))
                 }
                 .disabled(!canGoForward)
-                .accessibilityLabel("后一天")
+                .accessibilityLabel(NSLocalizedString("daydetail.a11y.nextDay", comment: "A11y label: go to next day"))
             }
         }
         .task(id: currentDate) { await load() }
@@ -163,13 +170,13 @@ struct DayDetailView: View {
     private static let boundsResistance: CGFloat = 0.3
 
     private var pageSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: 24)
+        DragGesture(minimumDistance: DSGesture.pagerMinimumDistance)
             .updating($pageDrag) { value, drag, _ in
                 // Engage only once the drag is dominantly sideways, so we never
                 // fight vertical scrolling inside the daily/raw content; after
                 // that, latch and follow the finger for the rest of the gesture.
                 if !drag.isEngaged {
-                    guard abs(value.translation.width) > abs(value.translation.height) * 1.5 else { return }
+                    guard abs(value.translation.width) > abs(value.translation.height) * DSGesture.horizontalDominance else { return }
                     drag.isEngaged = true
                 }
                 let translation = value.translation.width
@@ -180,7 +187,7 @@ struct DayDetailView: View {
             .onEnded { value in
                 // Same horizontal-dominance guard as tracking: an end that never
                 // engaged (vertical scroll) must stay a no-op.
-                guard abs(value.translation.width) > abs(value.translation.height) * 1.5 else { return }
+                guard abs(value.translation.width) > abs(value.translation.height) * DSGesture.horizontalDominance else { return }
                 let screenWidth = UIScreen.main.bounds.width
                 let translation = value.translation.width
                 // `value.velocity` is iOS 17+; the predicted overshoot is the
@@ -246,7 +253,7 @@ struct DayDetailView: View {
         VStack(spacing: 0) {
             Picker("Tab", selection: $selectedTab) {
                 ForEach(Tab.allCases, id: \.self) { tab in
-                    Text(tab.rawValue).tag(tab)
+                    Text(tab.title).tag(tab)
                 }
             }
             .pickerStyle(.segmented)
@@ -289,12 +296,12 @@ struct DayDetailView: View {
                 Image(systemName: "doc.text")
                     .font(.system(size: 40))
                     .foregroundColor(DSColor.onSurfaceVariant.opacity(0.5))
-                Text("这一天还没编译")
+                Text(NSLocalizedString("daydetail.state.notCompiled", comment: "Empty state: day has raw memos but no compiled daily page"))
                     .headlineCapsStyle()
                     .foregroundColor(DSColor.onSurfaceVariant)
                 Button(action: { selectedTab = .raw }) {
-                    Text("查看原始 Memo")
-                        .font(.custom("JetBrainsMono-Regular", fixedSize: 13))
+                    Text(NSLocalizedString("daydetail.state.viewRaw", comment: "Button: switch to the raw memo tab"))
+                        .font(DSFonts.jetBrainsMono(size: 13))
                         .foregroundColor(DSColor.primary)
                         .padding(.horizontal, 16)
                         .padding(.vertical, 8)
@@ -319,7 +326,7 @@ struct DayDetailView: View {
                 Image(systemName: "tray")
                     .font(.system(size: 40))
                     .foregroundColor(DSColor.onSurfaceVariant.opacity(0.5))
-                Text("这一天没有记录")
+                Text(NSLocalizedString("daydetail.raw.empty", comment: "Empty state: no raw memos on this day"))
                     .headlineCapsStyle()
                     .foregroundColor(DSColor.onSurfaceVariant)
                 Spacer()
@@ -346,12 +353,12 @@ struct DayDetailView: View {
             Image(systemName: "calendar.badge.exclamationmark")
                 .font(.system(size: 44))
                 .foregroundColor(DSColor.onSurfaceVariant.opacity(0.6))
-            Text("这一天还没有记录")
+            Text(NSLocalizedString("daydetail.empty.title", comment: "Empty state: nothing logged on this day at all"))
                 .headlineCapsStyle()
                 .foregroundColor(DSColor.onSurfaceVariant)
             Button(action: { dismiss() }) {
-                Text("关闭")
-                    .font(.custom("JetBrainsMono-Regular", fixedSize: 13))
+                Text(NSLocalizedString("daydetail.close", comment: "Button: dismiss the day detail view"))
+                    .font(DSFonts.jetBrainsMono(size: 13))
                     .foregroundColor(DSColor.primary)
                     .padding(.horizontal, 20)
                     .padding(.vertical, 10)
@@ -369,17 +376,17 @@ struct DayDetailView: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: 44))
                 .foregroundColor(DSColor.error)
-            Text("无法加载这一天")
+            Text(NSLocalizedString("daydetail.error.title", comment: "Error state title: the day failed to load"))
                 .headlineCapsStyle()
                 .foregroundColor(DSColor.onSurface)
             Text(message)
-                .font(.custom("JetBrainsMono-Regular", fixedSize: 11))
+                .font(DSFonts.jetBrainsMono(size: 11))
                 .foregroundColor(DSColor.onSurfaceVariant)
                 .multilineTextAlignment(.center)
                 .padding(.horizontal, 32)
             Button(action: { dismiss() }) {
-                Text("关闭")
-                    .font(.custom("JetBrainsMono-Regular", fixedSize: 13))
+                Text(NSLocalizedString("daydetail.close", comment: "Button: dismiss the day detail view"))
+                    .font(DSFonts.jetBrainsMono(size: 13))
                     .foregroundColor(DSColor.primary)
                     .padding(.horizontal, 20)
                     .padding(.vertical, 10)
@@ -474,14 +481,14 @@ struct DayDetailView: View {
         let photo = sorted.filter { $0.attachments.contains { $0.kind == "photo" } }.count
         let text = sorted.count - voice - photo
         let dominant: String = {
-            if text >= voice && text >= photo { return "文本" }
-            if voice >= photo { return "语音" }
-            return "照片"
+            if text >= voice && text >= photo { return NSLocalizedString("daydetail.kind.text", comment: "Dominant memo kind: text") }
+            if voice >= photo { return NSLocalizedString("daydetail.kind.voice", comment: "Dominant memo kind: voice") }
+            return NSLocalizedString("daydetail.kind.photo", comment: "Dominant memo kind: photo")
         }()
         var kindParts: [String] = []
-        if text > 0 { kindParts.append("\(text) 文") }
-        if voice > 0 { kindParts.append("\(voice) 声") }
-        if photo > 0 { kindParts.append("\(photo) 图") }
+        if text > 0 { kindParts.append(String(format: NSLocalizedString("daydetail.kind.part.text", comment: "Kind tile sub: %d text memos"), text)) }
+        if voice > 0 { kindParts.append(String(format: NSLocalizedString("daydetail.kind.part.voice", comment: "Kind tile sub: %d voice memos"), voice)) }
+        if photo > 0 { kindParts.append(String(format: NSLocalizedString("daydetail.kind.part.photo", comment: "Kind tile sub: %d photo memos"), photo)) }
 
         return [
             MetadataGridView.Tile(label: "WEATHER", value: weatherValue, sub: weatherSub),
@@ -501,7 +508,7 @@ struct DayDetailView: View {
         let range = NSRange(dateString.startIndex..., in: dateString)
         guard let dateRegex,
               dateRegex.firstMatch(in: dateString, options: [], range: range) != nil else {
-            return (.error("日期格式无效：\(dateString)"), false)
+            return (.error(String(format: NSLocalizedString("daydetail.error.badFormat", comment: "Error: date string is not yyyy-MM-dd; %@ = raw input"), dateString)), false)
         }
 
         // 2. 使用 DateFormatter 交叉校验（捕获 '2020-02-30' 等）。
@@ -512,7 +519,7 @@ struct DayDetailView: View {
         parser.timeZone = TimeZone.current
         parser.isLenient = false
         guard parser.date(from: dateString) != nil else {
-            return (.error("日期不存在：\(dateString)"), false)
+            return (.error(String(format: NSLocalizedString("daydetail.error.notFound", comment: "Error: date does not exist on the calendar; %@ = raw input"), dateString)), false)
         }
 
         // 3. 检查 vault 目录完整性。

--- a/DayPage/Features/Archive/RawMemoView.swift
+++ b/DayPage/Features/Archive/RawMemoView.swift
@@ -83,8 +83,8 @@ struct RawMemoView: View {
                 Image(systemName: "tray")
                     .font(.system(size: 32))
                     .foregroundColor(DSColor.onSurfaceVariant.opacity(0.5))
-                Text("该日无记录")
-                    .font(.custom("SpaceGrotesk-Bold", size: 14))
+                Text(NSLocalizedString("rawmemo.empty", comment: "Empty state: no raw memos exist for this day"))
+                    .font(DSFonts.spaceGrotesk(size: 14, weight: .bold))
                     .foregroundColor(DSColor.onSurfaceVariant)
             }
             Spacer()

--- a/DayPage/Features/Archive/RawMemoView.swift
+++ b/DayPage/Features/Archive/RawMemoView.swift
@@ -51,6 +51,8 @@ struct RawMemoView: View {
             .buttonStyle(.plain)
 
             VStack(alignment: .leading, spacing: 2) {
+                // intentionally-untranslated: archival tag (FINDING-010 —
+                // English mono caps are reserved for archival labels)
                 Text("RAW MEMOS")
                     .font(.custom("SpaceGrotesk-Bold", size: 16))
                     .foregroundColor(DSColor.onSurface)

--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -681,6 +681,51 @@ struct SearchView: View {
         }
     }
 
+    // MARK: - Vault overview (moved from ArchiveView, #827)
+
+    /// Whole-vault sense of scale: total memos + total days. Reads the
+    /// launch-warmed TimelineIndex synchronously (O(1) once built); shows
+    /// em-dashes before warm-up so "loading" is distinguishable from a
+    /// genuinely empty vault.
+    private var vaultOverviewStrip: some View {
+        let all = TimelineIndex.shared.entries()
+        let totalMemos = all.reduce(0) { $0 + $1.memoCount }
+        let totalDays = all.count
+        let hasData = totalDays > 0 || totalMemos > 0
+        return HStack(alignment: .center, spacing: 20) {
+            statPillar(
+                label: NSLocalizedString("search.overview.memos", comment: "Vault overview: all-time memo count label"),
+                value: hasData ? "\(totalMemos)" : "—"
+            )
+            Rectangle()
+                .fill(DSColor.glassRimD)
+                .frame(width: 0.5, height: 26)
+            statPillar(
+                label: NSLocalizedString("search.overview.days", comment: "Vault overview: all-time day count label"),
+                value: hasData ? "\(totalDays)" : "—"
+            )
+            Spacer()
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(String(
+            format: NSLocalizedString("search.overview.a11y", comment: "Vault overview a11y: %d memos across %d days"),
+            totalMemos, totalDays
+        ))
+    }
+
+    private func statPillar(label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(label)
+                .font(DSType.mono10)
+                .tracking(1.2)
+                .textCase(.uppercase)
+                .foregroundColor(DSColor.inkSubtle)
+            Text(value)
+                .font(DSFonts.serif(size: 22, weight: .regular))
+                .foregroundColor(DSColor.inkPrimary)
+        }
+    }
+
     // MARK: - Empty-query state (recent searches + frequent entities)
 
     private var emptyQueryState: some View {
@@ -688,6 +733,14 @@ struct SearchView: View {
             VStack(alignment: .leading, spacing: 0) {
                 let recent = vm.recentSearches
                 let entities = vm.topEntities
+
+                // #827: whole-vault scale moved here from ArchiveView — as a
+                // search-surface prologue it answers "how much is searchable",
+                // instead of shouting over Archive's month summary.
+                vaultOverviewStrip
+                    .padding(.horizontal, 20)
+                    .padding(.top, 10)
+                    .padding(.bottom, 6)
 
                 if !recent.isEmpty || !entities.isEmpty {
                     sectionHeader(title: NSLocalizedString("search.section.quickSearch", comment: "Quick search section header"), trailing: AnyView(EmptyView()))

--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -420,7 +420,7 @@ struct SearchView: View {
                     .foregroundColor(DSColor.onSurfaceVariant)
 
                 TextField(NSLocalizedString("search.placeholder", comment: "Search text field placeholder"), text: $vm.query)
-                    .font(.custom("Inter-Regular", size: 14))
+                    .font(DSFonts.inter(size: 14, relativeTo: .subheadline))
                     .foregroundColor(DSColor.onSurface)
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)
@@ -526,7 +526,7 @@ struct SearchView: View {
                 ), displayedComponents: .date)
                 .labelsHidden()
                 .datePickerStyle(.compact)
-                .font(.custom("Inter-Regular", size: 12))
+                .font(DSFonts.inter(size: 12, relativeTo: .caption))
                 .frame(maxWidth: 120)
                 .overlay(
                     filters.startDate == nil
@@ -544,7 +544,7 @@ struct SearchView: View {
                 ), displayedComponents: .date)
                 .labelsHidden()
                 .datePickerStyle(.compact)
-                .font(.custom("Inter-Regular", size: 12))
+                .font(DSFonts.inter(size: 12, relativeTo: .caption))
                 .frame(maxWidth: 120)
 
                 if filters.startDate != nil || filters.endDate != nil {
@@ -594,7 +594,7 @@ struct SearchView: View {
 
                 HStack(spacing: 6) {
                     TextField(NSLocalizedString("search.filter.location.placeholder", comment: "Filter panel location text field placeholder"), text: $filters.locationQuery)
-                        .font(.custom("Inter-Regular", size: 13))
+                        .font(DSFonts.inter(size: 13, relativeTo: .footnote))
                         .foregroundColor(DSColor.onSurface)
                         .textInputAutocapitalization(.never)
                         .disableAutocorrection(true)
@@ -880,7 +880,7 @@ struct SearchView: View {
             selectSuggestion(entity)
         }) {
             Text(entity)
-                .font(.custom("Inter-Regular", size: 13))
+                .font(DSFonts.inter(size: 13, relativeTo: .footnote))
                 .foregroundColor(DSColor.onSurface)
                 .padding(.horizontal, 10)
                 .padding(.vertical, 6)
@@ -1180,7 +1180,13 @@ struct SearchView: View {
     }
 
     private func resultRow(_ result: SearchResult) -> some View {
-        let a11yLabel = "\(formatDate(result.dateString)), \(matchLabel(for: result.matchKind)) match, \(result.isDailyPageCompiled ? "VERIFIED" : "METADATA"), \(String(result.snippet.prefix(80)))"
+        let badgeLabel = result.isDailyPageCompiled
+            ? NSLocalizedString("search.badge.compiled", comment: "Result badge: day has a compiled daily page")
+            : NSLocalizedString("search.badge.raw", comment: "Result badge: day has raw memos only")
+        let a11yLabel = String(
+            format: NSLocalizedString("search.a11y.resultRow", comment: "Result row a11y: date, match kind, compile state, snippet"),
+            formatDate(result.dateString), matchLabel(for: result.matchKind), badgeLabel, String(result.snippet.prefix(80))
+        )
         return Button(action: {
             Haptics.tapConfirm()
             vm.recordSearch(vm.query)
@@ -1194,11 +1200,11 @@ struct SearchView: View {
                 VStack(alignment: .leading, spacing: 6) {
                     HStack {
                         Text(formatDate(result.dateString))
-                            .font(.custom("SpaceGrotesk-Bold", size: 14))
+                            .font(DSFonts.spaceGrotesk(size: 14, weight: .bold, relativeTo: .footnote))
                             .foregroundColor(DSColor.onSurface)
                         Spacer()
                         StatusBadge(
-                            label: result.isDailyPageCompiled ? "VERIFIED" : "METADATA",
+                            label: badgeLabel,
                             style: result.isDailyPageCompiled ? .verified : .metadata
                         )
                     }
@@ -1238,10 +1244,10 @@ struct SearchView: View {
 
     // MARK: - Keyword highlight via AttributedString
 
-    /// Mirrors SearchService's folding so the highlighter matches exactly what the service matched.
+    /// Delegates to SearchService's canonical folding so the highlighter can
+    /// never drift from what the service actually matched (#827 dedup).
     private func foldedForSearch(_ s: String) -> String {
-        s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
-                  locale: Locale(identifier: "en_US_POSIX"))
+        SearchService.foldForSearch(s)
     }
 
     @ViewBuilder
@@ -1368,9 +1374,9 @@ struct SearchView: View {
 
     private func matchLabel(for kind: SearchResult.MatchKind) -> String {
         switch kind {
-        case .memoBody: return "MEMO"
-        case .location: return "LOCATION"
-        case .date:     return "DATE"
+        case .memoBody: return NSLocalizedString("search.matchKind.memo", comment: "Match-kind label: keyword hit in memo body")
+        case .location: return NSLocalizedString("search.matchKind.location", comment: "Match-kind label: keyword hit in location name")
+        case .date:     return NSLocalizedString("search.matchKind.date", comment: "Match-kind label: keyword hit on the date string")
         }
     }
 }
@@ -1393,11 +1399,11 @@ private struct EntityFrequencyChip: View {
             VStack(spacing: 4) {
                 HStack(spacing: 6) {
                     Text(entity.name)
-                        .font(.custom("Inter-Regular", size: 13))
+                        .font(DSFonts.inter(size: 13, relativeTo: .footnote))
                         .foregroundColor(DSColor.onSurface)
 
                     Text("\(entity.count)")
-                        .font(.custom("JetBrainsMono-Regular", size: 10))
+                        .font(DSType.mono10)
                         .foregroundColor(DSColor.onSurfaceVariant)
                         .padding(.horizontal, 4)
                         .padding(.vertical, 2)
@@ -1558,7 +1564,7 @@ private struct SwipeableRecentRow: View {
                     }
                 }) {
                     Text(query)
-                        .font(.custom("Inter-Regular", size: 14))
+                        .font(DSFonts.inter(size: 14, relativeTo: .subheadline))
                         .foregroundColor(DSColor.onSurface)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
@@ -1627,10 +1633,9 @@ extension SearchViewModel.GroupedResults: Identifiable {
 // MARK: - Testable folding helper
 
 extension SearchView {
-    /// Exposed for unit testing only — mirrors SearchService's folding options.
+    /// Exposed for unit testing only — delegates to the canonical service fold.
     static func foldedForSearchTesting(_ s: String) -> String {
-        s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
-                  locale: Locale(identifier: "en_US_POSIX"))
+        SearchService.foldForSearch(s)
     }
 }
 

--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -294,6 +294,10 @@ struct SearchView: View {
                 }
                 setupDebounce()
                 vm.loadTopEntities()
+                // Belt-and-braces (#827): the app-launch warmUp normally has
+                // the index ready long before Search opens; this covers cold
+                // deep-link entries. No-op once built.
+                SearchIndex.shared.warmUp()
                 // Pre-populate query when SearchView was opened from a deep
                 // link (e.g. `daypage://search?q=…`). Only runs on first
                 // appear; setupDebounce → Combine pipeline will execute the
@@ -354,8 +358,16 @@ struct SearchView: View {
             vm.isSearching = true
         }
         searchTask = Task {
+            // #827: prefer the pre-folded in-memory SearchIndex (a keystroke
+            // costs an in-memory scan, zero disk I/O). Falls back to the
+            // legacy full-vault disk scan only while the index's first
+            // background build is still in flight.
+            let docs = await MainActor.run { SearchIndex.shared.documentsIfBuilt() }
             let hits = await Task.detached(priority: .userInitiated) {
-                SearchService.search(keyword: trimmed, filters: capturedFilters)
+                if let docs {
+                    return SearchService.search(keyword: trimmed, filters: capturedFilters, in: docs)
+                }
+                return SearchService.search(keyword: trimmed, filters: capturedFilters)
             }.value
             guard !Task.isCancelled else {
                 await MainActor.run { vm.isSearching = false }

--- a/DayPage/Resources/L10n.swift
+++ b/DayPage/Resources/L10n.swift
@@ -112,10 +112,6 @@ enum L10n {
         static let filterHasLocation = NSLocalizedString("archive.filter.has_location", comment: "Monthly summary filter: days with a location")
         static let filterHasPhoto    = NSLocalizedString("archive.filter.has_photo", comment: "Monthly summary filter: days with a photo")
 
-        // System status banner labels rendered in the archive footer.
-        static let statusSynchronized        = NSLocalizedString("archive.status.synchronized", comment: "Archive footer status: vault is synchronized")
-        static let statusPendingCompilation  = NSLocalizedString("archive.status.pending_compilation", comment: "Archive footer status: daily compilation pending")
-        static let statusOffline             = NSLocalizedString("archive.status.offline", comment: "Archive footer status: device offline")
     }
 
     enum Banner {

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -1016,3 +1016,67 @@
 "archive.title"              = "Archive";
 "archive.today"              = "TODAY";
 "archive.heatmap.higher"     = "Higher Density";
+
+/* Archive i18n sweep — #827 */
+"archive.a11y.search.label"       = "Search";
+"archive.a11y.search.hint"        = "Search all archived entries";
+"archive.a11y.prevMonth.label"    = "Previous month";
+"archive.a11y.prevMonth.hint"     = "Switch to the previous month";
+"archive.a11y.currentMonth.label" = "Back to this month";
+"archive.a11y.currentMonth.hint"  = "Jump to the current month";
+"archive.a11y.nextMonth.label"    = "Next month";
+"archive.a11y.nextMonth.hint"     = "Switch to the next month";
+"archive.a11y.day.hint"           = "Double tap to open the day";
+"archive.a11y.day.compiled"       = "Compiled daily page";
+"archive.a11y.day.rawOnly"        = "Raw memos only";
+"archive.a11y.day.none"           = "%@, no entries";
+"archive.a11y.density.empty"      = "Empty";
+"archive.a11y.density.low"        = "Low";
+"archive.a11y.density.medium"     = "Medium";
+"archive.a11y.density.high"       = "High";
+"archive.a11y.day.summary"        = "%1$@, %2$@, activity %3$@, %4$d memos";
+"archive.a11y.day.photos"         = "%d photos";
+"archive.a11y.day.locations"      = "%d locations";
+"archive.summary.noMatch"         = "No days match this filter";
+"archive.summary.title"           = "%@ Summary";
+"archive.export.markdown"         = "Export Markdown";
+"archive.export.screenshot"       = "Share Screenshot";
+"archive.section.dayCount"        = "%d days";
+"archive.export.md.title"         = "%@ Monthly Summary";
+"archive.export.md.entries"       = "- Total entries: %d";
+"archive.export.md.photos"        = "- Photos: %d";
+"archive.export.md.voice"         = "- Voice: %d min";
+"archive.export.md.locations"     = "- Locations: %d";
+"archive.export.md.filter"        = "> Filter: %@";
+"archive.export.md.dayline"       = "- Memos: %1$d · Photos: %2$d · Voice: %3$d min · Locations: %4$d";
+
+/* Search result semantics — #827 */
+"search.badge.compiled"    = "COMPILED";
+"search.badge.raw"         = "RAW";
+"search.matchKind.memo"    = "MEMO";
+"search.matchKind.location" = "LOCATION";
+"search.matchKind.date"    = "DATE";
+"search.a11y.resultRow"    = "%1$@, %2$@ match, %3$@, %4$@";
+
+/* DayDetail toolbar — #827 */
+"daydetail.a11y.prevDay" = "Previous day";
+"daydetail.a11y.nextDay" = "Next day";
+
+/* DayDetail content — #827 */
+"daydetail.tab.daily"        = "Daily Page";
+"daydetail.tab.raw"          = "Raw Memos";
+"daydetail.state.notCompiled" = "Not compiled yet";
+"daydetail.state.viewRaw"    = "View raw memos";
+"daydetail.raw.empty"        = "No memos this day";
+"daydetail.empty.title"      = "Nothing logged this day";
+"daydetail.close"            = "Close";
+"daydetail.error.title"      = "Couldn't load this day";
+"daydetail.error.badFormat"  = "Invalid date format: %@";
+"daydetail.error.notFound"   = "No such date: %@";
+"daydetail.kind.text"        = "Text";
+"daydetail.kind.voice"       = "Voice";
+"daydetail.kind.photo"       = "Photo";
+"daydetail.kind.part.text"   = "%d text";
+"daydetail.kind.part.voice"  = "%d voice";
+"daydetail.kind.part.photo"  = "%d photo";
+"rawmemo.empty"              = "No memos this day";

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -732,9 +732,10 @@
 "archive.filter.has_photo"                   = "With photo";
 
 /* Archive — system status footer */
-"archive.status.synchronized"                = "SYNCHRONIZED";
-"archive.status.pending_compilation"         = "PENDING COMPILATION";
-"archive.status.offline"                     = "OFFLINE";
+"archive.month.empty"                        = "Nothing logged this month yet";
+"search.overview.memos"                      = "ALL-TIME MEMOS";
+"search.overview.days"                       = "ALL-TIME DAYS";
+"search.overview.a11y"                       = "Vault overview: %d memos across %d days";
 
 /* AI master toggle */
 "settings.ai.enabled"                        = "Enable AI features";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -736,9 +736,10 @@
 "archive.filter.has_photo"                   = "有照片";
 
 /* Archive — system status footer */
-"archive.status.synchronized"                = "已同步";
-"archive.status.pending_compilation"         = "待编译";
-"archive.status.offline"                     = "离线";
+"archive.month.empty"                        = "这个月还没有记录";
+"search.overview.memos"                      = "全部记录";
+"search.overview.days"                       = "记录天数";
+"search.overview.a11y"                       = "库总览：%d 条记录，跨 %d 天";
 
 /* AI 主开关 */
 "settings.ai.enabled"                        = "启用 AI 功能";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -1020,3 +1020,67 @@
 "archive.title"              = "归档";
 "archive.today"              = "今日";
 "archive.heatmap.higher"     = "密度更高";
+
+/* Archive i18n sweep — #827 */
+"archive.a11y.search.label"       = "搜索";
+"archive.a11y.search.hint"        = "搜索历史记录";
+"archive.a11y.prevMonth.label"    = "上个月";
+"archive.a11y.prevMonth.hint"     = "切换到上一个月";
+"archive.a11y.currentMonth.label" = "回到本月";
+"archive.a11y.currentMonth.hint"  = "跳转到当前月份";
+"archive.a11y.nextMonth.label"    = "下个月";
+"archive.a11y.nextMonth.hint"     = "切换到下一个月";
+"archive.a11y.day.hint"           = "双击打开当天详情";
+"archive.a11y.day.compiled"       = "已编译 Daily Page";
+"archive.a11y.day.rawOnly"        = "有原始记录";
+"archive.a11y.day.none"           = "%@，无记录";
+"archive.a11y.density.empty"      = "空";
+"archive.a11y.density.low"        = "较低";
+"archive.a11y.density.medium"     = "中等";
+"archive.a11y.density.high"       = "较高";
+"archive.a11y.day.summary"        = "%1$@，%2$@，活跃度 %3$@，%4$d 条记录";
+"archive.a11y.day.photos"         = "%d 张照片";
+"archive.a11y.day.locations"      = "%d 处位置";
+"archive.summary.noMatch"         = "无符合条件的日期";
+"archive.summary.title"           = "%@ 月度摘要";
+"archive.export.markdown"         = "导出 Markdown";
+"archive.export.screenshot"       = "截图分享";
+"archive.section.dayCount"        = "%d 天";
+"archive.export.md.title"         = "%@ 月度摘要";
+"archive.export.md.entries"       = "- 总记录：%d 条";
+"archive.export.md.photos"        = "- 照片：%d 张";
+"archive.export.md.voice"         = "- 语音：%d 分钟";
+"archive.export.md.locations"     = "- 地点：%d 处";
+"archive.export.md.filter"        = "> 筛选：%@";
+"archive.export.md.dayline"       = "- 记录：%1$d 条，照片：%2$d 张，语音：%3$d 分钟，地点：%4$d 处";
+
+/* Search result semantics — #827 */
+"search.badge.compiled"    = "已编译";
+"search.badge.raw"         = "原始";
+"search.matchKind.memo"    = "正文";
+"search.matchKind.location" = "地点";
+"search.matchKind.date"    = "日期";
+"search.a11y.resultRow"    = "%1$@，%2$@命中，%3$@，%4$@";
+
+/* DayDetail toolbar — #827 */
+"daydetail.a11y.prevDay" = "前一天";
+"daydetail.a11y.nextDay" = "后一天";
+
+/* DayDetail content — #827 */
+"daydetail.tab.daily"        = "日记页";
+"daydetail.tab.raw"          = "原始 Memo";
+"daydetail.state.notCompiled" = "这一天还没编译";
+"daydetail.state.viewRaw"    = "查看原始 Memo";
+"daydetail.raw.empty"        = "这一天没有记录";
+"daydetail.empty.title"      = "这一天还没有记录";
+"daydetail.close"            = "关闭";
+"daydetail.error.title"      = "无法加载这一天";
+"daydetail.error.badFormat"  = "日期格式无效：%@";
+"daydetail.error.notFound"   = "日期不存在：%@";
+"daydetail.kind.text"        = "文本";
+"daydetail.kind.voice"       = "语音";
+"daydetail.kind.photo"       = "照片";
+"daydetail.kind.part.text"   = "%d 文";
+"daydetail.kind.part.voice"  = "%d 声";
+"daydetail.kind.part.photo"  = "%d 图";
+"rawmemo.empty"              = "该日无记录";

--- a/DayPageKit/Sources/DayPageServices/SearchIndex.swift
+++ b/DayPageKit/Sources/DayPageServices/SearchIndex.swift
@@ -1,0 +1,280 @@
+import Foundation
+import DayPageModels
+import DayPageStorage
+
+// MARK: - SearchIndex
+
+/// In-memory full-text search index over `vault/raw/*.md`, keyed by
+/// `yyyy-MM-dd`. Companion to ``TimelineIndex`` (#827): where TimelineIndex
+/// caches per-day *metadata*, this caches per-memo *searchable text* with the
+/// expensive `folding(...)` normalization precomputed, so a keystroke's search
+/// is a pure in-memory scan instead of a full-vault disk read + YAML parse.
+///
+/// ## Why this exists
+/// `SearchService.search` re-read and re-parsed every raw day file on every
+/// (debounced) keystroke. The same measurement that motivated TimelineIndex
+/// applies: ~295 ms at 1 year of data, ~7 s at 5 years — per keystroke, on
+/// battery. The index pays that scan once, off the main thread.
+///
+/// ## Design (deliberately identical to TimelineIndex)
+/// - **Pure in-memory, rebuilt on launch.** No persistence → no snapshot/truth
+///   drift. `vault/raw/*.md` remains the source of truth.
+/// - **mtime-based external-change detection** on foreground.
+/// - **Incremental write updates** via `.rawStorageDidWrite` — re-parse just
+///   the one day that changed.
+/// - **Conflict-merge rebuild** via `.vaultConflictResolved`.
+/// - **No cold-path sync scan**: before the first build completes,
+///   `documentsIfBuilt()` returns nil and callers fall back to the legacy
+///   disk-scanning `SearchService.search` — search stays correct on a cold
+///   start, it's just not indexed yet.
+///
+/// `isDailyPageCompiled` is intentionally NOT cached here: daily compilation
+/// writes `wiki/daily/` (never `raw/`), so no notification would invalidate
+/// it. Query code stats the handful of matched days instead (≤100 by cap).
+@MainActor
+public final class SearchIndex {
+
+    public static let shared = SearchIndex()
+
+    // MARK: - Document model
+
+    /// One memo, flattened to what search needs. `folded*` fields carry the
+    /// `caseInsensitive + diacriticInsensitive + widthInsensitive` normalization
+    /// precomputed at build time. Value type so query code can snapshot the
+    /// whole index and match off the main actor.
+    public struct MemoDocument: Equatable, Sendable {
+        public let type: Memo.MemoType
+        public let body: String
+        public let foldedBody: String
+        /// Attachment transcripts, raw + folded, in attachment order.
+        public let transcripts: [TranscriptText]
+        public let locationName: String?
+        public let foldedLocationName: String?
+
+        public struct TranscriptText: Equatable, Sendable {
+            public let raw: String
+            public let folded: String
+        }
+    }
+
+    /// All searchable memos of one day, plus the day's pre-folded date string
+    /// (date matches like "2026-04" fold the same way as body text).
+    public struct DayDocument: Equatable, Sendable {
+        public let dateString: String
+        public let foldedDateString: String
+        public let memos: [MemoDocument]
+    }
+
+    // MARK: - State
+
+    /// `yyyy-MM-dd` → day document. Authoritative once built.
+    private var docsByDate: [String: DayDocument] = [:]
+
+    /// Newest-first snapshot handed to query code. Rebuilt lazily after any
+    /// mutation (dictionary order is unstable; search results must be
+    /// deterministic newest-first, same as the legacy file-name sort).
+    private var sortedSnapshot: [DayDocument]?
+
+    /// True once the first full rebuild has completed.
+    private var isBuilt = false
+
+    /// mtime of `vault/raw/` captured at the last rebuild.
+    private var rawDirMtimeSnapshot: Date?
+
+    /// Guards against overlapping rebuilds.
+    private var rebuildTask: Task<Void, Never>?
+
+    private var observerTokens: [NSObjectProtocol] = []
+
+    // MARK: - Init
+
+    private init() {
+        // Same observer shape as TimelineIndex: `.rawStorageDidWrite` posts
+        // from RawStorage's background writeQueue, so hop to the main actor
+        // via queue: .main before touching @MainActor state.
+        let writeToken = NotificationCenter.default.addObserver(
+            forName: .rawStorageDidWrite, object: nil, queue: .main
+        ) { [weak self] note in
+            let date = note.object as? Date
+            MainActor.assumeIsolated {
+                self?.handleDidWrite(date: date)
+            }
+        }
+        let conflictToken = NotificationCenter.default.addObserver(
+            forName: .vaultConflictResolved, object: nil, queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.scheduleRebuild()
+            }
+        }
+        observerTokens = [writeToken, conflictToken]
+    }
+
+    deinit {
+        observerTokens.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+
+    // MARK: - Public read API
+
+    /// Newest-first day documents, or nil while the first build is still in
+    /// flight. Callers fall back to the legacy disk scan on nil — never block
+    /// the main actor on a cold synchronous vault scan here.
+    public func documentsIfBuilt() -> [DayDocument]? {
+        guard isBuilt else { return nil }
+        if let cached = sortedSnapshot { return cached }
+        let sorted = docsByDate.values.sorted { $0.dateString > $1.dateString }
+        sortedSnapshot = sorted
+        return sorted
+    }
+
+    // MARK: - Lifecycle hooks
+
+    /// Kick the initial background build. Idempotent; call at app launch
+    /// (alongside `TimelineIndex.warmUp()`) and on search-surface appear.
+    public func warmUp() {
+        guard !isBuilt else { return }
+        scheduleRebuild()
+    }
+
+    /// Rebuild if `vault/raw/` was modified externally (iCloud sync, another
+    /// device) since the last build. One stat() when nothing changed.
+    public func refreshIfExternallyModified() {
+        let current = Self.rawDirMtime()
+        if current != rawDirMtimeSnapshot {
+            scheduleRebuild()
+        }
+    }
+
+    // MARK: - Rebuild
+
+    private func scheduleRebuild() {
+        if let existing = rebuildTask, !existing.isCancelled { return }
+
+        rebuildTask = Task { [weak self] in
+            let scanned = await Task.detached(priority: .utility) {
+                Self.scanAllDocuments()
+            }.value
+            let mtime = Self.rawDirMtime()
+            guard let self else { return }
+            self.docsByDate = scanned
+            self.sortedSnapshot = nil
+            self.rawDirMtimeSnapshot = mtime
+            self.isBuilt = true
+            self.rebuildTask = nil
+        }
+    }
+
+    // MARK: - Incremental updates
+
+    private func handleDidWrite(date: Date?) {
+        guard isBuilt else { return }
+        guard let date else {
+            scheduleRebuild()
+            return
+        }
+        let stem = Self.dateFormatter.string(from: date)
+        if let doc = Self.scanDocument(dateString: stem) {
+            docsByDate[stem] = doc
+        } else {
+            docsByDate.removeValue(forKey: stem)
+        }
+        sortedSnapshot = nil
+        rawDirMtimeSnapshot = Self.rawDirMtime()
+    }
+
+    // MARK: - Scanning (nonisolated — runs on detached tasks)
+
+    /// Full-vault scan → day documents. Same file discovery rules as the
+    /// legacy `SearchService.search` (raw/*.md, valid yyyy-MM-dd stems only).
+    nonisolated private static func scanAllDocuments() -> [String: DayDocument] {
+        let fm = FileManager.default
+        let rawDir = VaultInitializer.vaultURL.appendingPathComponent("raw")
+        guard let files = try? fm.contentsOfDirectory(
+            at: rawDir, includingPropertiesForKeys: nil, options: [.skipsHiddenFiles]
+        ) else { return [:] }
+
+        var docs: [String: DayDocument] = [:]
+        for url in files where url.pathExtension == "md" {
+            let stem = url.deletingPathExtension().lastPathComponent
+            guard isValidDateString(stem) else { continue }
+            if let doc = scanDocument(dateString: stem, fileURL: url) {
+                docs[stem] = doc
+            }
+        }
+        return docs
+    }
+
+    /// Parse one day file into a document. nil when the file is missing,
+    /// unreadable, or holds no memos (deleted-last-memo case — the entry
+    /// must disappear from the index).
+    nonisolated static func scanDocument(
+        dateString: String, fileURL: URL? = nil
+    ) -> DayDocument? {
+        let url = fileURL ?? VaultInitializer.vaultURL
+            .appendingPathComponent("raw")
+            .appendingPathComponent("\(dateString).md")
+        guard let content = try? String(contentsOf: url, encoding: .utf8) else { return nil }
+        let memos = RawStorage.parse(fileContent: content)
+        guard !memos.isEmpty else { return nil }
+
+        let memoDocs = memos.map { memo in
+            MemoDocument(
+                type: memo.type,
+                body: memo.body,
+                foldedBody: SearchService.foldForSearch(memo.body),
+                transcripts: memo.attachments.compactMap { att in
+                    guard let t = att.transcript, !t.isEmpty else { return nil }
+                    return MemoDocument.TranscriptText(
+                        raw: t, folded: SearchService.foldForSearch(t)
+                    )
+                },
+                locationName: memo.location?.name,
+                foldedLocationName: memo.location?.name.map(SearchService.foldForSearch)
+            )
+        }
+        return DayDocument(
+            dateString: dateString,
+            foldedDateString: SearchService.foldForSearch(dateString),
+            memos: memoDocs
+        )
+    }
+
+    // MARK: - Helpers
+
+    nonisolated private static func isValidDateString(_ s: String) -> Bool {
+        dateFormatter.date(from: s) != nil
+    }
+
+    nonisolated private static let dateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        return f
+    }()
+
+    private static func rawDirMtime() -> Date? {
+        let rawDir = VaultInitializer.vaultURL.appendingPathComponent("raw")
+        let attrs = try? FileManager.default.attributesOfItem(atPath: rawDir.path)
+        return attrs?[.modificationDate] as? Date
+    }
+
+    // MARK: - Test support
+
+    /// Test-only: synchronous full build so tests can assert deterministically.
+    public func rebuildSynchronouslyForTesting() {
+        docsByDate = Self.scanAllDocuments()
+        sortedSnapshot = nil
+        rawDirMtimeSnapshot = Self.rawDirMtime()
+        isBuilt = true
+    }
+
+    /// Test-only: reset to the never-built state.
+    public func resetForTesting() {
+        rebuildTask?.cancel()
+        rebuildTask = nil
+        docsByDate = [:]
+        sortedSnapshot = nil
+        rawDirMtimeSnapshot = nil
+        isBuilt = false
+    }
+}

--- a/DayPageKit/Sources/DayPageServices/SearchService.swift
+++ b/DayPageKit/Sources/DayPageServices/SearchService.swift
@@ -50,7 +50,7 @@ public enum SearchService {
     public nonisolated static func search(keyword rawKeyword: String,
                                    filters: SearchFilters = .empty) -> [SearchResult] {
         let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
-        let folded = foldedForSearch(keyword)
+        let folded = foldForSearch(keyword)
         let hasKeyword = !keyword.isEmpty
         guard hasKeyword || filters.isActive else { return [] }
 
@@ -89,7 +89,7 @@ public enum SearchService {
             let isDailyCompiled = fm.fileExists(atPath: dailyURL.path)
 
             // 日期字符串匹配（如 "2026-04" 或 "04-14"）—— 仅当有关键字且无类型过滤时
-            if hasKeyword && filters.types.isEmpty && foldedForSearch(dateString).contains(folded) {
+            if hasKeyword && filters.types.isEmpty && foldForSearch(dateString).contains(folded) {
                 results.append(SearchResult(
                     dateString: dateString,
                     snippet: dateString,
@@ -110,13 +110,13 @@ public enum SearchService {
 
                 // 位置查询过滤
                 if !filters.locationQuery.isEmpty {
-                    let foldedLoc = foldedForSearch(filters.locationQuery)
+                    let foldedLoc = foldForSearch(filters.locationQuery)
                     guard let name = memo.location?.name,
-                          foldedForSearch(name).contains(foldedLoc) else { continue }
+                          foldForSearch(name).contains(foldedLoc) else { continue }
                 }
 
                 if hasKeyword {
-                    if foldedForSearch(memo.body).contains(folded) {
+                    if foldForSearch(memo.body).contains(folded) {
                         results.append(SearchResult(
                             dateString: dateString,
                             snippet: makeSnippet(memo.body, around: folded),
@@ -137,7 +137,7 @@ public enum SearchService {
                         continue
                     }
                     if let name = memo.location?.name,
-                       foldedForSearch(name).contains(folded) {
+                       foldForSearch(name).contains(folded) {
                         results.append(SearchResult(
                             dateString: dateString,
                             snippet: name,
@@ -168,11 +168,131 @@ public enum SearchService {
         return results
     }
 
+    // MARK: - Indexed fast path (#827)
+
+    /// Index-backed variant of ``search(keyword:filters:)`` — identical match
+    /// semantics (date → body → transcript → location priority, filters-only
+    /// mode, 100-result cap, newest-first) over pre-folded in-memory
+    /// documents instead of a full-vault disk scan. Pure function over the
+    /// value-type snapshot, so callers may run it off the main actor.
+    ///
+    /// `isDailyPageCompiled` is resolved with a per-matched-day `stat()`
+    /// (≤100 by the cap) because compilation writes `wiki/daily/` and can't
+    /// invalidate the raw-file index — see `SearchIndex`'s doc comment.
+    public nonisolated static func search(
+        keyword rawKeyword: String,
+        filters: SearchFilters = .empty,
+        in docs: [SearchIndex.DayDocument]
+    ) -> [SearchResult] {
+        let keyword = rawKeyword.trimmingCharacters(in: .whitespacesAndNewlines)
+        let folded = foldForSearch(keyword)
+        let hasKeyword = !keyword.isEmpty
+        guard hasKeyword || filters.isActive else { return [] }
+
+        let fm = FileManager.default
+        let dailyDir = VaultInitializer.vaultURL.appendingPathComponent("wiki/daily")
+        // Per-day compiled flags are memoized so multiple matches inside one
+        // day cost a single stat().
+        var compiledByDate: [String: Bool] = [:]
+        func isDailyCompiled(_ dateString: String) -> Bool {
+            if let cached = compiledByDate[dateString] { return cached }
+            let exists = fm.fileExists(
+                atPath: dailyDir.appendingPathComponent("\(dateString).md").path
+            )
+            compiledByDate[dateString] = exists
+            return exists
+        }
+
+        var results: [SearchResult] = []
+
+        for day in docs {
+            // 日期范围过滤 — same start-of-day / end-of-day rules as legacy.
+            if let start = filters.startDate, let date = dateValidator.date(from: day.dateString) {
+                if date < Calendar.current.startOfDay(for: start) { continue }
+            }
+            if let end = filters.endDate, let date = dateValidator.date(from: day.dateString) {
+                let endOfDay = Calendar.current.date(
+                    byAdding: .day, value: 1, to: Calendar.current.startOfDay(for: end)
+                )!
+                if date >= endOfDay { continue }
+            }
+
+            // 日期字符串匹配 —— 仅当有关键字且无类型过滤时。
+            if hasKeyword && filters.types.isEmpty && day.foldedDateString.contains(folded) {
+                results.append(SearchResult(
+                    dateString: day.dateString,
+                    snippet: day.dateString,
+                    matchKind: SearchResult.MatchKind.date,
+                    isDailyPageCompiled: isDailyCompiled(day.dateString),
+                    memoType: Memo.MemoType?.none
+                ))
+            }
+
+            for memo in day.memos {
+                if !filters.types.isEmpty && !filters.types.contains(memo.type) { continue }
+
+                if !filters.locationQuery.isEmpty {
+                    let foldedLoc = foldForSearch(filters.locationQuery)
+                    guard let name = memo.foldedLocationName,
+                          name.contains(foldedLoc) else { continue }
+                }
+
+                if hasKeyword {
+                    if memo.foldedBody.contains(folded) {
+                        results.append(SearchResult(
+                            dateString: day.dateString,
+                            snippet: makeSnippet(memo.body, around: folded),
+                            matchKind: SearchResult.MatchKind.memoBody,
+                            isDailyPageCompiled: isDailyCompiled(day.dateString),
+                            memoType: memo.type
+                        ))
+                        continue
+                    }
+                    if let hit = memo.transcripts.first(where: { $0.folded.contains(folded) }) {
+                        results.append(SearchResult(
+                            dateString: day.dateString,
+                            snippet: makeSnippet(hit.raw, around: folded),
+                            matchKind: SearchResult.MatchKind.memoBody,
+                            isDailyPageCompiled: isDailyCompiled(day.dateString),
+                            memoType: memo.type
+                        ))
+                        continue
+                    }
+                    if let name = memo.foldedLocationName, name.contains(folded) {
+                        results.append(SearchResult(
+                            dateString: day.dateString,
+                            snippet: memo.locationName ?? "",
+                            matchKind: SearchResult.MatchKind.location,
+                            isDailyPageCompiled: isDailyCompiled(day.dateString),
+                            memoType: memo.type
+                        ))
+                        continue
+                    }
+                } else {
+                    let snippet = memo.body.isEmpty
+                        ? (memo.locationName ?? day.dateString)
+                        : String(memo.body.prefix(120))
+                    results.append(SearchResult(
+                        dateString: day.dateString,
+                        snippet: snippet,
+                        matchKind: SearchResult.MatchKind.memoBody,
+                        isDailyPageCompiled: isDailyCompiled(day.dateString),
+                        memoType: memo.type
+                    ))
+                }
+            }
+
+            if results.count >= 100 { break }
+        }
+
+        return results
+    }
+
     // MARK: - Private helpers
 
     private static func firstMatchingTranscript(in memo: Memo, keyword: String) -> String? {
         for att in memo.attachments {
-            if let t = att.transcript, foldedForSearch(t).contains(keyword) {
+            if let t = att.transcript, foldForSearch(t).contains(keyword) {
                 return t
             }
         }
@@ -184,7 +304,7 @@ public enum SearchService {
     /// 以保留显示时的重音符号。
     private static func makeSnippet(_ text: String, around foldedKeyword: String) -> String {
         let normalized = text.replacingOccurrences(of: "\n", with: " ")
-        let foldedNormalized = foldedForSearch(normalized)
+        let foldedNormalized = foldForSearch(normalized)
         guard let range = foldedNormalized.range(of: foldedKeyword) else {
             return String(normalized.prefix(120))
         }
@@ -212,7 +332,10 @@ public enum SearchService {
         return snippet
     }
 
-    private static func foldedForSearch(_ s: String) -> String {
+    /// The single folding rule shared by live queries and `SearchIndex`'s
+    /// precomputed documents — the two MUST stay identical or index hits and
+    /// legacy hits diverge. Public for the index; treat as sealed.
+    public nonisolated static func foldForSearch(_ s: String) -> String {
         s.folding(options: [.caseInsensitive, .diacriticInsensitive, .widthInsensitive],
                   locale: Locale(identifier: "en_US_POSIX"))
     }

--- a/DayPageTests/DayDetailViewStateTests.swift
+++ b/DayPageTests/DayDetailViewStateTests.swift
@@ -60,7 +60,8 @@ final class DayDetailViewStateTests: XCTestCase {
         guard case .error(let message) = state else {
             return XCTFail("Expected .error, got \(state)")
         }
-        XCTAssertTrue(message.contains("日期格式无效"), "Got message: \(message)")
+        let expected = String(format: NSLocalizedString("daydetail.error.badFormat", comment: ""), "abc")
+        XCTAssertEqual(message, expected, "Got message: \(message)")
     }
 
     func testErrorState_whenDateStringIsCalendarInvalid() {
@@ -74,7 +75,8 @@ final class DayDetailViewStateTests: XCTestCase {
         guard case .error(let message) = state else {
             return XCTFail("Expected .error, got \(state)")
         }
-        XCTAssertTrue(message.contains("日期不存在"), "Got message: \(message)")
+        let expected = String(format: NSLocalizedString("daydetail.error.notFound", comment: ""), "2020-02-30")
+        XCTAssertEqual(message, expected, "Got message: \(message)")
     }
 
     // MARK: - .rawOnly

--- a/DayPageTests/SearchServiceTests.swift
+++ b/DayPageTests/SearchServiceTests.swift
@@ -5,12 +5,18 @@ import DayPageStorage
 import DayPageServices
 @testable import DayPage
 
-@Suite("SearchService")
+// `.serialized`: every test in this file mutates the process-global
+// `VaultInitializer.testOverrideURL`. Swift Testing runs suites and cases in
+// parallel by default, so two tests pointing the vault override at different
+// temp directories race and read each other's vaults (#827 — surfaced the
+// moment this orphaned file was first wired into the target). The parity
+// suite below is NESTED so the serialization covers it too.
+@Suite("SearchService", .serialized)
 struct SearchServiceTests {
 
     // MARK: - Setup helpers
 
-    private static func makeTempVault() throws -> URL {
+    fileprivate static func makeTempVault() throws -> URL {
         let tmp = FileManager.default.temporaryDirectory
             .appendingPathComponent("SearchServiceTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
@@ -23,7 +29,7 @@ struct SearchServiceTests {
         return tmp
     }
 
-    private static func writeMemo(_ memo: Memo, dateString: String, to vaultURL: URL) throws {
+    fileprivate static func writeMemo(_ memo: Memo, dateString: String, to vaultURL: URL) throws {
         let fileURL = vaultURL.appendingPathComponent("raw/\(dateString).md")
         let existing: String
         if FileManager.default.fileExists(atPath: fileURL.path) {
@@ -38,7 +44,7 @@ struct SearchServiceTests {
         try combined.write(to: fileURL, atomically: true, encoding: .utf8)
     }
 
-    private static func makeDate(year: Int, month: Int, day: Int) -> Date {
+    fileprivate static func makeDate(year: Int, month: Int, day: Int) -> Date {
         var c = DateComponents()
         c.year = year; c.month = month; c.day = day; c.hour = 12
         return Calendar(identifier: .gregorian).date(from: c)!
@@ -278,4 +284,136 @@ struct SearchServiceTests {
         let dates = results.compactMap { $0.matchKind == .memoBody ? $0.dateString : nil }
         #expect(dates == dates.sorted(by: >), "Results must be ordered newest-first")
     }
+}
+
+// MARK: - SearchIndex parity (#827)
+
+/// The indexed fast path must return byte-identical results to the legacy
+/// disk-scanning path — the index is a cache, never a semantic fork. Every
+/// test here runs BOTH paths over the same seeded vault and diffs them.
+extension SearchServiceTests {
+@Suite("SearchIndex parity")
+@MainActor
+struct SearchIndexParityTests {
+
+    /// Comparable projection of a SearchResult (id is a fresh UUID per hit,
+    /// so equality must be field-wise).
+    private struct Hit: Equatable {
+        let dateString: String
+        let snippet: String
+        let matchKind: SearchResult.MatchKind
+        let memoType: Memo.MemoType?
+        init(_ r: SearchResult) {
+            dateString = r.dateString; snippet = r.snippet
+            matchKind = r.matchKind; memoType = r.memoType
+        }
+    }
+
+    private func seedMixedVault() throws -> URL {
+        let tmp = try SearchServiceTests.makeTempVault()
+        // Body match + diacritics
+        try SearchServiceTests.writeMemo(
+            Memo(type: .text, created: SearchServiceTests.makeDate(year: 2026, month: 4, day: 14),
+                 body: "coffee at São Paulo, long afternoon"),
+            dateString: "2026-04-14", to: tmp)
+        // Voice memo whose match lives ONLY in the transcript
+        try SearchServiceTests.writeMemo(
+            Memo(type: .voice, created: SearchServiceTests.makeDate(year: 2026, month: 3, day: 2),
+                 attachments: [Memo.Attachment(
+                    file: "raw/assets/v.m4a", kind: "audio", duration: 4,
+                    transcript: "meeting about the coffee roaster",
+                    transcriptionStatus: .done)],
+                 body: ""),
+            dateString: "2026-03-02", to: tmp)
+        // Location-only match
+        try SearchServiceTests.writeMemo(
+            Memo(type: .text, created: SearchServiceTests.makeDate(year: 2026, month: 2, day: 1),
+                 location: Memo.Location(name: "Coffee Lab Chiang Mai", lat: 18.78, lng: 98.99),
+                 body: "unrelated body text"),
+            dateString: "2026-02-01", to: tmp)
+        // Date-string match target
+        try SearchServiceTests.writeMemo(
+            Memo(type: .text, created: SearchServiceTests.makeDate(year: 2026, month: 1, day: 20),
+                 body: "plain january note"),
+            dateString: "2026-01-20", to: tmp)
+        return tmp
+    }
+
+    @Test func indexedResultsMatchLegacyAcrossMatchKinds() throws {
+        let tmp = try seedMixedVault()
+        defer {
+            VaultInitializer.testOverrideURL = nil
+            SearchIndex.shared.resetForTesting()
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        VaultInitializer.testOverrideURL = tmp
+        SearchIndex.shared.rebuildSynchronouslyForTesting()
+        let docs = try #require(SearchIndex.shared.documentsIfBuilt())
+
+        // Keywords covering: body, transcript, location, date, diacritic
+        // folding, and a zero-hit query.
+        for keyword in ["coffee", "roaster", "chiang mai", "2026-01", "sao paulo", "nothing-matches"] {
+            let legacy = SearchService.search(keyword: keyword).map(Hit.init)
+            let indexed = SearchService.search(keyword: keyword, in: docs).map(Hit.init)
+            #expect(indexed == legacy, "fast path diverged from legacy for '\(keyword)'")
+        }
+    }
+
+    @Test func indexedResultsMatchLegacyUnderFilters() throws {
+        let tmp = try seedMixedVault()
+        defer {
+            VaultInitializer.testOverrideURL = nil
+            SearchIndex.shared.resetForTesting()
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        VaultInitializer.testOverrideURL = tmp
+        SearchIndex.shared.rebuildSynchronouslyForTesting()
+        let docs = try #require(SearchIndex.shared.documentsIfBuilt())
+
+        var typeFilter = SearchFilters.empty
+        typeFilter.types = [.voice]
+        var rangeFilter = SearchFilters.empty
+        rangeFilter.startDate = SearchServiceTests.makeDate(year: 2026, month: 3, day: 1)
+        var locFilter = SearchFilters.empty
+        locFilter.locationQuery = "chiang"
+
+        for (keyword, filters) in [("coffee", typeFilter), ("coffee", rangeFilter),
+                                   ("", typeFilter), ("", locFilter)] {
+            let legacy = SearchService.search(keyword: keyword, filters: filters).map(Hit.init)
+            let indexed = SearchService.search(keyword: keyword, filters: filters, in: docs).map(Hit.init)
+            #expect(indexed == legacy, "fast path diverged for '\(keyword)' + filters")
+        }
+    }
+
+    @Test func documentsAreNilBeforeFirstBuild() throws {
+        SearchIndex.shared.resetForTesting()
+        #expect(SearchIndex.shared.documentsIfBuilt() == nil,
+                "cold index must report nil so callers fall back to the disk scan")
+    }
+
+    @Test func rebuildPicksUpNewDay() throws {
+        let tmp = try seedMixedVault()
+        defer {
+            VaultInitializer.testOverrideURL = nil
+            SearchIndex.shared.resetForTesting()
+            try? FileManager.default.removeItem(at: tmp)
+        }
+        VaultInitializer.testOverrideURL = tmp
+        SearchIndex.shared.rebuildSynchronouslyForTesting()
+        let before = SearchService.search(
+            keyword: "freshly-added", in: SearchIndex.shared.documentsIfBuilt() ?? [])
+        #expect(before.isEmpty)
+
+        try SearchServiceTests.writeMemo(
+            Memo(type: .text, created: SearchServiceTests.makeDate(year: 2026, month: 5, day: 5),
+                 body: "freshly-added memo body"),
+            dateString: "2026-05-05", to: tmp)
+        SearchIndex.shared.rebuildSynchronouslyForTesting()
+
+        let after = SearchService.search(
+            keyword: "freshly-added", in: SearchIndex.shared.documentsIfBuilt() ?? [])
+        #expect(after.count == 1)
+        #expect(after.first?.dateString == "2026-05-05")
+    }
+}
 }


### PR DESCRIPTION
Closes #827

## 概要

归档与搜索两个页面的整体重构，按三个里程碑推进：

### 1. SearchIndex 内存全文索引（974bf80）
- 新增 `DayPageKit/DayPageServices/SearchIndex.swift`：@MainActor 单例，架构与 TimelineIndex 逐行对称（启动 warmUp / `.rawStorageDidWrite` 增量 / 前台 mtime 失效 / `.vaultConflictResolved` 重建）
- 每次按键的搜索从全库扫盘变为纯内存匹配（预折叠文档）；索引未建成时回退旧磁盘扫描路径
- `SearchService.search(keyword:filters:in:)` 纯函数复刻旧语义，parity 测试逐字段验证四种 matchKind
- 顺带修复：SearchServiceTests 曾是孤儿文件（从未注册进 target，见 #830），注册 + `.serialized` 解决 `VaultInitializer.testOverrideURL` 进程级全局态的真实测试竞态

### 2. Archive 信息架构收敛（8190bc6）
- 档案页从"统计条 + status 装饰块 + 日历 + 摘要"四种声音收敛为单一叙事流：月份导航 → 日历（图例收进面板底部）→ 月度摘要 / 空月空态
- vault 全库规模感（总条数/总天数）迁到搜索页空态顶部 — 作为"可搜索范围"的前言，语义成立
- 删除 systemStatusArtifact / ArtifactGeometricView 等 -85 行装饰性代码

### 3. 手势 / token / i18n 治理（91ab816 + efc5ddf）
- `DSGesture` 共享常量：Archive 月滑 (30/1.2) 与 DayDetail 日翻页 (24/1.5) 统一为 24pt/1.5，两个水平 pager 手感一致
- 14 处裸 `.custom()` 字体收编 DSFonts，文本类补 `relativeTo` 获得 Dynamic Type
- i18n ~55 key：Archive/Search/DayDetail/RawMemo 硬编码中文与反向硬编码英文全量 L10n；刻意保留的英文档案标签（FINDING-010）已加 `intentionally-untranslated` 注释
- 语义修正：搜索结果徽章 `VERIFIED/METADATA` → `COMPILED/RAW`（zh 已编译/原始），与 raw→compile 产品词汇一致

## 验证

- ✅ xcodebuild build + 全量测试绿（176 XCTest + swift-testing parity suite）
- ✅ 模拟器 zh/en 双语言实测（38 memos / 15 days 种子数据）：日历四档密度、位置圆点、月度摘要、搜索概览 38/15、关键词高亮、徽章双语言均正确
- ✅ Evaluator 评审 47/50 APPROVE（0 BLOCKING；非阻塞建议 1 已落地，建议 2/3 记录为技术债）

## 已知非阻塞项

- `%d results` 无 stringsdict 复数（"1 RESULTS"）— mono 计数器风格下可接受，zh 无此问题
- SearchIndex 与 TimelineIndex 的观察者/失效逻辑高度重复 — 有意为之（identical design），第三个索引出现时再抽 `MTimeGatedIndex`