### PR TITLE
fix(today): Today 首屏视觉审计整改 — 编译卡透色 bug + 设计语言收敛

### DIFF
--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -332,6 +332,9 @@ struct MemoCardView: View {
 
                 Spacer(minLength: 4)
             }
+            // Meta whispers, prose speaks — sink the whole timestamp row a
+            // touch below inkSubtle so the memo body owns the card.
+            .opacity(0.85)
             .padding(.horizontal, 14)
             .padding(.top, 10)
             .padding(.bottom, 14)
@@ -1088,60 +1091,63 @@ struct DailyPageEntryCard: View {
     let summary: String?
     var onTap: (() -> Void)?
 
+    private var hasSummary: Bool {
+        guard let summary else { return false }
+        return !summary.isEmpty
+    }
+
     var body: some View {
         Button(action: { onTap?() }) {
-            HStack(alignment: .center, spacing: 16) {
-                VStack(alignment: .leading, spacing: 6) {
-                    // Amber dot + label
-                    HStack(spacing: 6) {
-                        Circle()
-                            .fill(DSColor.accentOnBg)
-                            .frame(width: 6, height: 6)
-                            .shadow(color: DSColor.amberGlow, radius: 4, x: 0, y: 0)
-                        Text("Today's page compiled")
-                            .font(DSFonts.jetBrainsMono(size: 10))
-                            .tracking(1)
-                            .textCase(.uppercase)
-                            .foregroundColor(DSColor.accentOnBg)
-                    }
-
-                    if let summary = summary, !summary.isEmpty {
-                        Text(summary)
-                            .font(DSType.serifBody18)
-                            .foregroundColor(DSColor.inkPrimary)
-                            .lineLimit(2)
-                            .lineSpacing(2)
-                    } else {
-                        Text(NSLocalizedString("memocard.digest.ready", comment: "Daily digest fallback"))
-                            .font(DSType.serifBody18)
-                            .foregroundColor(DSColor.inkPrimary)
-                    }
+            // Content-first: the compiled page speaks through its own serif
+            // opening line. No trailing arrow (the whole card is the tap
+            // target) and no "digest is ready" meta copy — without a summary
+            // the card collapses to the quiet ribbon line.
+            VStack(alignment: .leading, spacing: 6) {
+                // Amber dot + label
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(DSColor.accentOnBg)
+                        .frame(width: 6, height: 6)
+                        .shadow(color: DSColor.amberGlow, radius: 4, x: 0, y: 0)
+                    Text("Today's page compiled")
+                        .font(DSFonts.jetBrainsMono(size: 10))
+                        .tracking(1)
+                        .textCase(.uppercase)
+                        .foregroundColor(DSColor.accentOnBg)
                 }
-                .frame(maxWidth: .infinity, alignment: .leading)
 
-                Image(systemName: "arrow.forward")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundColor(DSColor.accentOnBg)
+                if let summary, hasSummary {
+                    Text(summary)
+                        .font(DSType.serifBody18)
+                        .foregroundColor(DSColor.inkPrimary)
+                        .lineLimit(2)
+                        .lineSpacing(2)
+                }
             }
+            .frame(maxWidth: .infinity, alignment: .leading)
             .padding(.horizontal, 18)
-            .padding(.vertical, 18)
+            .padding(.vertical, hasSummary ? 18 : 14)
             .frame(maxWidth: .infinity)
             .liquidGlassCard(cornerRadius: 18, tone: .hi)
             .overlay(alignment: .leading) {
-                // Left amber accent strip
-                RoundedRectangle(cornerRadius: 2, style: .continuous)
-                    .fill(
-                        LinearGradient(
-                            colors: [DSColor.accentOnBg, DSColor.accentOnBg.opacity(0)],
-                            startPoint: .top, endPoint: .bottom
+                // Left amber accent strip — only alongside serif prose. On
+                // the compact ribbon-only form (~44pt tall) the 14pt vertical
+                // insets squeeze it to a stub that reads as a glitch.
+                if hasSummary {
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .fill(
+                            LinearGradient(
+                                colors: [DSColor.accentOnBg, DSColor.accentOnBg.opacity(0)],
+                                startPoint: .top, endPoint: .bottom
+                            )
                         )
-                    )
-                    // Unify accent-rail width across cards. Design app.jsx:420
-                    // renders the rail at 2px; AISummaryCard already uses 2.
-                    .frame(width: 2)
-                    .padding(.vertical, 14)
-                    .padding(.leading, 0)
-                    .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        // Unify accent-rail width across cards. Design app.jsx:420
+                        // renders the rail at 2px; AISummaryCard already uses 2.
+                        .frame(width: 2)
+                        .padding(.vertical, 14)
+                        .padding(.leading, 0)
+                        .clipShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+                }
             }
         }
         .buttonStyle(.plain)

--- a/DayPage/Features/Today/TimelineSectionView.swift
+++ b/DayPage/Features/Today/TimelineSectionView.swift
@@ -102,10 +102,12 @@ struct TimelineSectionView: View {
         }
     }
 
-    /// Right mono caption — "BY DAY · N条". app.jsx:598-601, 614.
+    /// Right mono caption — "BY DAY · N". app.jsx:598-601, 614.
+    /// Pure mono-English, matching the untranslated MEMOS/WORDS row labels
+    /// (FINDING-010 convention) — no mixed-script "N 条" tail.
     private var headerSub: String {
         let n = section.days.count
-        return "BY DAY · \(n) 条"
+        return "BY DAY · \(n)"
     }
 }
 
@@ -339,11 +341,18 @@ struct TimelineDayRow: View {
             }
             if let lede = displayLede {
                 TimelineSpine.RowLede(text: lede)
-                    .padding(.top, 10)        // app.jsx:656 margin:'10px 0 0'
+                    // app.jsx:656 margin:'10px 0 0' — only under a title;
+                    // an uncompiled row's excerpt starts flush at the top.
+                    .padding(.top, displayTitle == nil ? 0 : 10)
                     .lineLimit(3)
             }
-            TimelineSpine.RowMeta(tags: metaTags, right: { wordsRight })
-                .padding(.top, 14)            // app.jsx:705 marginTop:14
+            TimelineSpine.RowMeta(tags: metaTags, right: {
+                // Word count only for compiled prose. Uncompiled days used
+                // to fall back to memoCount here, printing "3 MEMOS … 3
+                // WORDS" — fabricated data that always mirrored the left tag.
+                if hasSummary { wordsRight }
+            })
+            .padding(.top, 14)                // app.jsx:705 marginTop:14
         }
         .padding(.leading, 6)                 // app.jsx:645 paddingLeft:6
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -570,23 +579,29 @@ struct TimelineDayRow: View {
 
     // MARK: Derived content
 
-    /// Compiled summary acts as the serif title (the day's "成稿" headline).
-    /// Falls back to the formatted date when the day hasn't compiled yet so
-    /// the row still reads as a museum plate rather than an empty card.
-    private var displayTitle: String? {
-        if let summary = entry.summary, !summary.isEmpty {
-            // First sentence / line as the title; keeps the serif headline tight.
-            let firstLine = summary
-                .split(whereSeparator: { $0 == "\n" || $0 == "。" })
-                .first.map(String.init) ?? summary
-            return firstLine
-        }
-        return longDateLabel
+    private var hasSummary: Bool {
+        guard let summary = entry.summary else { return false }
+        return !summary.isEmpty
     }
 
-    /// Lede only when a compiled summary spills past its title line.
-    private var displayLede: String? {
+    /// Compiled summary acts as the serif title (the day's "成稿" headline).
+    /// Uncompiled days get NO serif title — the nameplate already states the
+    /// date, and repeating it at 20pt serif was pure duplication. The serif
+    /// voice is reserved for compiled prose; drafts speak through the lede.
+    private var displayTitle: String? {
         guard let summary = entry.summary, !summary.isEmpty else { return nil }
+        // First sentence / line as the title; keeps the serif headline tight.
+        return summary
+            .split(whereSeparator: { $0 == "\n" || $0 == "。" })
+            .first.map(String.init) ?? summary
+    }
+
+    /// Lede: the compiled summary's spill-over — or, for uncompiled days,
+    /// the first memo's opening line so the row smells of real content.
+    private var displayLede: String? {
+        guard let summary = entry.summary, !summary.isEmpty else {
+            return entry.excerpt
+        }
         guard let title = displayTitle, summary.count > title.count + 1 else { return nil }
         let remainder = summary.dropFirst(title.count)
             .drop(while: { $0 == "\n" || $0 == "。" || $0 == " " })
@@ -609,14 +624,6 @@ struct TimelineDayRow: View {
     // a `DateFormatter()` alloc there is one of Foundation's most expensive
     // per-frame costs and showed up as visible scroll hitching.
 
-    /// Localized "M月d日" — user-locale, so it can't live in the POSIX-only
-    /// shared `DateFormatters` cache. Cached statically here instead.
-    private static let localizedMonthDay: DateFormatter = {
-        let f = DateFormatter()
-        f.dateFormat = "M月d日"
-        f.locale = Locale.current
-        return f
-    }()
 
     private var weekdayLabel: String {
         DateFormatters.weekdayShort.string(from: entry.date).uppercased()
@@ -625,10 +632,6 @@ struct TimelineDayRow: View {
     /// Display date for the nameplate — mirrors web's `item.date` (e.g. 05.30).
     private var monthDayLabel: String {
         DateFormatters.monthDayDotted.string(from: entry.date)
-    }
-
-    private var longDateLabel: String {
-        Self.localizedMonthDay.string(from: entry.date)
     }
 
     private var memoCountTag: String {
@@ -640,9 +643,10 @@ struct TimelineDayRow: View {
     }
 
     /// CJK-aware word count using the canonical counter from TodayViewModel.
-    /// Falls back to memo count when no compiled summary is available.
+    /// Only meaningful for compiled days — callers must gate on `hasSummary`
+    /// (never fabricate a count from memoCount; see the RowMeta note).
     private var approxWordCount: Int {
-        guard let summary = entry.summary, !summary.isEmpty else { return entry.memoCount }
+        guard let summary = entry.summary, !summary.isEmpty else { return 0 }
         return TodayViewModel.wordCount(in: summary)
     }
 
@@ -668,7 +672,9 @@ struct TimelineDayRow: View {
     }
 
     private var accessibilityLabel: String {
-        let summaryText = entry.summary.flatMap { $0.isEmpty ? nil : $0 } ?? memoCountTag
+        let summaryText = entry.summary.flatMap { $0.isEmpty ? nil : $0 }
+            ?? entry.excerpt
+            ?? memoCountTag
         return "\(entry.dateString), \(summaryText)"
     }
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -120,6 +120,12 @@ struct TodayView: View {
 
     /// Whether the daily page card is swiped open to reveal the recompile action.
     @State private var dailyPageRevealed: Bool = false
+    /// Whether the recompile action chip behind the Daily Page card is
+    /// mounted visibly. The card surface is 85%-translucent glass, so the
+    /// amber chip must stay at opacity 0 while the card is at rest —
+    /// otherwise it bleeds through the blur as an orange smear and its
+    /// square corners peek past the card's rounded ones.
+    @State private var dailyPageActionVisible: Bool = false
 
     /// Session-only flag: true once the "restored unsent draft" banner has been shown this session.
     @State private var draftRestoredBannerShown: Bool = false
@@ -1130,28 +1136,62 @@ struct TodayView: View {
         }
     }
 
+    /// Museum-language sign-in prompt: one quiet mono line instead of the
+    /// old two-line DSBanner card. Backup is plumbing — it may whisper from
+    /// the status slot, but it must never outrank the day's own content
+    /// (same voice as `modeBadge`: dot + mono uppercase + glass capsule).
     private var syncBanner: some View {
-        DSBanner(
-            kind: .info,
-            title: "Sync your journal across devices",
-            subtitle: "Sign in to back up your notes",
-            primaryAction: (label: "Sync", action: { showAuthSheet = true }),
-            onDismiss: {
-                withAnimation { showSyncBanner = false }
-                UserDefaults.standard.set(Date(), forKey: AppSettings.Keys.lastSyncBannerDate)
+        HStack(spacing: 8) {
+            Circle()
+                .fill(DSColor.accentOnBg.opacity(0.55))
+                .frame(width: 5, height: 5)
+            Text(NSLocalizedString("today.sync.prompt", value: "SYNC ACROSS DEVICES", comment: "One-line sign-in prompt on Today"))
+                .font(DSType.mono10)
+                .tracking(1.2)
+                .foregroundColor(DSColor.inkSubtle)
+                .lineLimit(1)
+            Spacer(minLength: 12)
+            Button {
+                showAuthSheet = true
+            } label: {
+                Text(NSLocalizedString("today.sync.action", value: "SIGN IN", comment: "Sign-in action on the sync prompt"))
+                    .font(DSType.mono10)
+                    .tracking(1.2)
+                    .foregroundColor(DSColor.accentOnBg)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
             }
-        )
+            .buttonStyle(.plain)
+            Button {
+                dismissSyncBanner()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(DSColor.inkMuted)
+                    .frame(width: 36, height: 44)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(L10n.Banner.closeA11y)
+        }
+        .padding(.leading, 14)
+        .background(Capsule().fill(DSColor.glassLo))
+        .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
         .padding(.horizontal, DSSpacing.pageMargin)
         .padding(.bottom, DSSpacing.xs)
         .gesture(
             DragGesture(minimumDistance: 20)
                 .onEnded { value in
                     if value.translation.height < -10 {
-                        withAnimation { showSyncBanner = false }
-                        UserDefaults.standard.set(Date(), forKey: AppSettings.Keys.lastSyncBannerDate)
+                        dismissSyncBanner()
                     }
                 }
         )
+    }
+
+    private func dismissSyncBanner() {
+        withAnimation { showSyncBanner = false }
+        UserDefaults.standard.set(Date(), forKey: AppSettings.Keys.lastSyncBannerDate)
     }
 
     // MARK: - AI key missing banner (R3 — A2)
@@ -1838,8 +1878,10 @@ struct TodayView: View {
         if !viewModel.memos.isEmpty && viewModel.loadState == .ready && !viewModel.timelineSections.isEmpty {
             // Quiet breathing room replaces the redundant "EARLIER" rule —
             // the timeline's own SectionHeader (本周/上周) already separates bands.
+            // 12 here + the SectionHeader's own 20 top padding lands the
+            // page's section rhythm on a single 32pt beat.
             Color.clear
-                .frame(height: 20)
+                .frame(height: 12)
                 .accessibilityLabel(Text(NSLocalizedString("today.section.earlier", comment: "")))
             ForEach(viewModel.timelineSections) { section in
                 TimelineSectionView(
@@ -1945,18 +1987,27 @@ struct TodayView: View {
                     withAnimation(Motion.spring) {
                         dailyPageRevealed = false
                     }
+                    hideDailyPageActionSoon()
                     viewModel.compile()
                 } label: {
                     Text(NSLocalizedString("today.action.recompile", comment: ""))
                         .font(DSType.caption)
                         .foregroundColor(.white)
-                        .frame(width: 80)
+                        .frame(width: 72)
                         .frame(maxHeight: .infinity)
-                        .background(DSColor.accentAmber)
+                        .background(
+                            RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                .fill(DSColor.accentAmber)
+                        )
                 }
                 .buttonStyle(.plain)
                 .accessibilityLabel(NSLocalizedString("a11y.recompile", comment: "Recompile daily page"))
             }
+            // Invisible until a swipe (or the one-time hint) actually starts:
+            // the glass card above is translucent, so a permanently-mounted
+            // amber panel bleeds through at rest (#audit — orange smear +
+            // exposed square corners on the compiled card).
+            .opacity(dailyPageActionVisible ? 1 : 0)
 
             DailyPageEntryCard(
                 summary: viewModel.dailyPageSummary,
@@ -1966,6 +2017,7 @@ struct TodayView: View {
                         withAnimation(Motion.spring) {
                             dailyPageRevealed = false
                         }
+                        hideDailyPageActionSoon()
                     } else {
                         Haptics.tapConfirm()
                         showDailyPage = true
@@ -1979,6 +2031,7 @@ struct TodayView: View {
                 withAnimation(Motion.spring) {
                     dailyPageRevealed = false
                 }
+                hideDailyPageActionSoon()
             }
             .offset(x: (dailyPageRevealed ? -80 : 0) + dailyPageDrag + dailyPageHintOffset)
             .onAppear {
@@ -1987,10 +2040,12 @@ struct TodayView: View {
                 UserDefaults.standard.set(true, forKey: AppSettings.Keys.dailyPageSwipeHintShown)
                 Task { @MainActor in
                     try? await Task.sleep(for: .seconds(0.6))
+                    dailyPageActionVisible = true
                     withAnimation(Motion.spring) { dailyPageHintOffset = -24 }
                     Haptics.soft()
                     try? await Task.sleep(for: .seconds(0.45))
                     withAnimation(Motion.spring) { dailyPageHintOffset = 0 }
+                    hideDailyPageActionSoon()
                 }
             }
             .highPriorityGesture(
@@ -2004,8 +2059,14 @@ struct TodayView: View {
                         withAnimation(Motion.spring) {
                             dailyPageRevealed = value.translation.width < -44
                         }
+                        if !dailyPageRevealed {
+                            hideDailyPageActionSoon()
+                        }
                     }
             )
+            .onChange(of: dailyPageDrag) { drag in
+                if drag < 0 { dailyPageActionVisible = true }
+            }
         }
         .accessibilityElement(children: .combine)
         .accessibilityLabel(NSLocalizedString("a11y.daily_page", comment: "Daily page card"))
@@ -2014,7 +2075,21 @@ struct TodayView: View {
         .accessibilityAction { showDailyPage = true }
         .accessibilityAction(named: Text(NSLocalizedString("today.action.recompile", comment: ""))) {
             dailyPageRevealed = false
+            hideDailyPageActionSoon()
             viewModel.compile()
+        }
+    }
+
+    /// Fades the recompile chip out shortly after the card snaps shut —
+    /// the delay lets the spring cover the chip's footprint first so the
+    /// dismissal never flashes a cream hole where amber used to be.
+    private func hideDailyPageActionSoon() {
+        Task { @MainActor in
+            try? await Task.sleep(for: .seconds(0.35))
+            guard !dailyPageRevealed, dailyPageDrag == 0 else { return }
+            withAnimation(.easeOut(duration: 0.2)) {
+                dailyPageActionVisible = false
+            }
         }
     }
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -746,6 +746,10 @@
 "today.badge.ai_off"                         = "AI off · local only";
 "today.badge.offline"                        = "Offline · local only";
 
+/* Today — one-line sync/sign-in prompt */
+"today.sync.prompt"                          = "SYNC ACROSS DEVICES";
+"today.sync.action"                          = "SIGN IN";
+
 /* Graph — search a11y */
 "graph.search.clear.a11y"                    = "Clear search";
 
@@ -984,7 +988,6 @@
 "tutorial.dismiss.hint"      = "Dismisses the tutorial";
 
 /* Round-3 — MemoCard state copy (was hardcoded English) */
-"memocard.digest.ready"      = "Your daily digest is ready.";
 "memocard.state.ready"       = "Ready to compile";
 "memocard.state.captured"    = "%d signals captured today";
 "memocard.state.empty"       = "Start capturing";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -750,6 +750,10 @@
 "today.badge.ai_off"                         = "AI 已关闭 · 仅本地";
 "today.badge.offline"                        = "离线 · 仅本地";
 
+/* Today — 单行同步/登录提示 */
+"today.sync.prompt"                          = "多设备同步与备份";
+"today.sync.action"                          = "登录";
+
 /* 图谱 — 搜索辅助 */
 "graph.search.clear.a11y"                    = "清除搜索";
 
@@ -988,7 +992,6 @@
 "tutorial.dismiss.hint"      = "关闭新手引导";
 
 /* Round-3 — MemoCard 状态文案（之前硬编码英文） */
-"memocard.digest.ready"      = "今日摘要已生成。";
 "memocard.state.ready"       = "可以编译了";
 "memocard.state.captured"    = "今日已捕获 %d 条信号";
 "memocard.state.empty"       = "开始记录";

--- a/DayPageKit/Sources/DayPageServices/TimelineService.swift
+++ b/DayPageKit/Sources/DayPageServices/TimelineService.swift
@@ -24,12 +24,19 @@ public struct TimelineDayEntry: Identifiable, Equatable {
     /// nil/empty when the day has not been AI-compiled yet.
     public let summary: String?
 
+    /// First non-empty line of the day's earliest memo. Gives an
+    /// uncompiled day a content scent in the timeline row instead of a
+    /// serif date that would duplicate the nameplate. nil when the day's
+    /// memos carry no text (e.g. photo-only captures).
+    public let excerpt: String?
+
     public var id: String { dateString }
 
     public static func == (lhs: TimelineDayEntry, rhs: TimelineDayEntry) -> Bool {
         lhs.dateString == rhs.dateString &&
         lhs.memoCount == rhs.memoCount &&
-        lhs.summary == rhs.summary
+        lhs.summary == rhs.summary &&
+        lhs.excerpt == rhs.excerpt
     }
 }
 
@@ -136,7 +143,8 @@ public enum TimelineService {
                 dateString: stem,
                 date: date,
                 memoCount: memos.count,
-                summary: summary(forDateString: stem, dailyDir: dailyDir)
+                summary: summary(forDateString: stem, dailyDir: dailyDir),
+                excerpt: excerpt(from: memos)
             ))
         }
 
@@ -162,8 +170,22 @@ public enum TimelineService {
             dateString: stem,
             date: date,
             memoCount: memos.count,
-            summary: summary(forDateString: stem, dailyDir: dailyDir)
+            summary: summary(forDateString: stem, dailyDir: dailyDir),
+            excerpt: excerpt(from: memos)
         )
+    }
+
+    /// First non-empty line of the day's earliest memo, capped so the index
+    /// stays lightweight. Used by the timeline row as the lede for days that
+    /// have no compiled summary yet.
+    nonisolated private static func excerpt(from memos: [Memo]) -> String? {
+        guard let earliest = memos.min(by: { $0.created < $1.created }) else { return nil }
+        let line = earliest.body
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { !$0.isEmpty }
+        guard let line, !line.isEmpty else { return nil }
+        return String(line.prefix(120))
     }
 
     /// Reads the compiled daily-page `summary:` for a day, if compiled.


### PR DESCRIPTION
## 背景

对 Today 首屏做了一轮乔布斯视角的视觉审计（总分 56/100），发现一个硬渲染缺陷和四处设计语言问题。本 PR 按审计优先级逐项整改。

## 硬缺陷：编译卡透色 bug

`swipeableDailyPageCard` 把"重新编译"按钮（80pt 实心 amber、直角）常驻垫在 `liquidGlassCard(tone: .hi)`（85% 透明 + 材质模糊）卡片背后：

- 橙色透过玻璃渗出为一团光斑
- 直角按钮在圆角卡四角裸露成深色残块

**修复**：按钮仅在滑动 / 一次性 hint 期间可见（`dailyPageActionVisible` 状态门控），关闭后延迟 0.35s 淡出避免弹回闪洞；按钮圆角化为 Mail 式 action chip（72pt / r14）。

## 设计整改

| 区域 | Before | After |
|---|---|---|
| 编译卡 | 箭头 + "Your daily digest is ready." 元文案 | 内容优先：衬线首句自己说话；无 summary 收拢为单行 ribbon，rail 只随正文出现 |
| Sync 横幅 | DSBanner 双行卡 + 系统 icon + 重复副标题 | mono10 单行胶囊（● SYNC ACROSS DEVICES · SIGN IN · ×），与 modeBadge 同声部 |
| 时间线 | 未编译日伪造 "3 WORDS"（恒等于 memoCount）；衬线日期与铭牌重复；"BY DAY · 5 条" 混排 | 只留 3 MEMOS；未编译日用首条 memo 摘录做 lede（`TimelineDayEntry.excerpt` 新字段）；"BY DAY · 5" 纯 mono |
| 节奏 | 历史区前导 20+20=40pt | 12+20=32pt 拍点；memo 卡时间戳行沉至 0.85 |

## 验证

- [x] `xcodebuild -scheme DayPage build` 通过
- [x] `TimelineIndexTests` 全绿
- [x] iPhone 17 Pro (iOS 26.1) 模拟器截图逐项核对：透色消失、四角干净、单行 Sync、时间线真实摘录、无假字数

截图（修复后）：编译卡 ribbon 干净无渗色，Last week 行显示真实内容摘录。