### PR TITLE
feat(detail): Drop-to-Ask 拖拽入坞 + memo 锚定流式 AI 对话 (#837)

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -187,6 +187,8 @@
 		LS0000002 /* L10n.swift in Sources */ = {isa = PBXBuildFile; fileRef = LS1000004 /* L10n.swift */; };
 		MD0000001 /* MemoDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000001 /* MemoDetailView.swift */; };
 		MD0000002 /* MemoDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000002 /* MemoDetailViewModel.swift */; };
+		MD0000003 /* DropToAskGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000003 /* DropToAskGesture.swift */; };
+		MC0000001 /* MemoChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC1000001 /* MemoChatView.swift */; };
 		MSE0000001 /* MemoSyncE2EIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MSE1000001 /* MemoSyncE2EIntegrationTests.swift */; };
 		MST0000001 /* MemoSyncUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MST1000001 /* MemoSyncUploaderTests.swift */; };
 		MYT0000001 /* MemoYAMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MYT1000001 /* MemoYAMLTests.swift */; };
@@ -436,6 +438,8 @@
 		LS1000004 /* L10n.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = L10n.swift; sourceTree = "<group>"; };
 		MD1000001 /* MemoDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailView.swift; sourceTree = "<group>"; };
 		MD1000002 /* MemoDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailViewModel.swift; sourceTree = "<group>"; };
+		MD1000003 /* DropToAskGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropToAskGesture.swift; sourceTree = "<group>"; };
+		MC1000001 /* MemoChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoChatView.swift; sourceTree = "<group>"; };
 		MSE1000001 /* MemoSyncE2EIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSyncE2EIntegrationTests.swift; sourceTree = "<group>"; };
 		MST1000001 /* MemoSyncUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSyncUploaderTests.swift; sourceTree = "<group>"; };
 		MYT1000001 /* MemoYAMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemoYAMLTests.swift; sourceTree = "<group>"; };
@@ -534,6 +538,7 @@
 			isa = PBXGroup;
 			children = (
 				1681BDF1E5113769618DA9B0 /* AskPastView.swift */,
+				MC1000001 /* MemoChatView.swift */,
 			);
 			name = Ask;
 			path = Ask;
@@ -1049,6 +1054,7 @@
 			children = (
 				MD1000001 /* MemoDetailView.swift */,
 				MD1000002 /* MemoDetailViewModel.swift */,
+				MD1000003 /* DropToAskGesture.swift */,
 			);
 			path = MemoDetail;
 			sourceTree = "<group>";
@@ -1467,6 +1473,8 @@
 				FT0000001 /* DayOrbView.swift in Sources */,
 				MD0000001 /* MemoDetailView.swift in Sources */,
 				MD0000002 /* MemoDetailViewModel.swift in Sources */,
+				MD0000003 /* DropToAskGesture.swift in Sources */,
+				MC0000001 /* MemoChatView.swift in Sources */,
 				WS0000001 /* WelcomeScreen.swift in Sources */,
 				A10000095 /* ComposerContextProvider.swift in Sources */,
 				457A17AB7F3B4BE7C2E77026 /* StartRecordingIntent.swift in Sources */,

--- a/DayPage/Features/Ask/MemoChatView.swift
+++ b/DayPage/Features/Ask/MemoChatView.swift
@@ -1,0 +1,525 @@
+import SwiftUI
+import DayPageModels
+import DayPageServices
+
+// MARK: - MemoChatView
+
+/// Memo 锚定的 AI 对话 sheet（issue #837）。
+///
+/// 与 `AskPastView` 的边界：
+/// - **AskPastView**：通用「问过去」——侧边栏 / Siri intent 入口，无锚点。
+/// - **MemoChatView**：一条具体记录被「拽进对话框」——记录以「记忆芯片」
+///   形式挂在输入框上，全程作为一等上下文注入，可摘除退化为通用对话。
+///
+/// Agent loop 可视化：`MemoryChatService.AgentPhase` 驱动一行状态文案
+/// （重读 → 沿实体翻找 → 找到 N 条 → 逐字作答），流式回答实时渲染。
+struct MemoChatView: View {
+
+    let memo: Memo
+    /// slug → 实体显示名（由 MemoDetailView 已解析的 wiki `name:`），
+    /// 喂给 `.retrieving` 阶段文案与建议问题。
+    let entityDisplayNames: [String: String]
+    let onClose: () -> Void
+
+    @StateObject private var chat = MemoryChatService()
+    @State private var draft: String = ""
+    @State private var didAttach = false
+    @State private var pinnedTurnIDs: Set<UUID> = []
+    @State private var caretVisible = true
+    @FocusState private var inputFocused: Bool
+
+    private var memoDateString: String {
+        DateFormatters.isoDate.string(from: memo.created)
+    }
+
+    private var clues: [String] {
+        memo.entityMentions.compactMap { entityDisplayNames[$0] }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            conversation
+            Divider().background(DSColor.borderSubtle)
+            if chat.attachedMemo != nil {
+                memoryChip
+                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+            }
+            inputBar
+        }
+        .background(DSColor.bgWarm.ignoresSafeArea())
+        .animation(Motion.spring, value: chat.attachedMemo == nil)
+        .task {
+            guard !didAttach else { return }
+            didAttach = true
+            chat.attach(memo: memo, clues: clues)
+            inputFocused = true
+        }
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(alignment: .center, spacing: 10) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 15, weight: .semibold))
+                .foregroundColor(DSColor.accentOnBg)
+            VStack(alignment: .leading, spacing: 2) {
+                Text("ASK · \(memoDateString)")
+                    .font(DSType.mono10)
+                    .tracking(1.2)
+                    .foregroundColor(DSColor.inkMuted)
+                Text(NSLocalizedString(
+                    "memo.chat.title",
+                    value: "Ask this memory",
+                    comment: "Memo chat — sheet title"
+                ))
+                .font(DSType.serifBody20)
+                .foregroundColor(DSColor.inkPrimary)
+            }
+            Spacer()
+            Button {
+                Haptics.soft()
+                onClose()
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundColor(DSColor.inkMuted)
+                    .frame(width: 30, height: 30)
+                    .background(DSColor.surfaceContainerHigh)
+                    .clipShape(Circle())
+            }
+            .accessibilityLabel(NSLocalizedString(
+                "memo.chat.a11y.close",
+                value: "关闭对话",
+                comment: "Memo chat — close button VoiceOver label"
+            ))
+        }
+        .padding(.horizontal, 20)
+        .padding(.top, 18)
+        .padding(.bottom, 14)
+    }
+
+    // MARK: - Conversation
+
+    private var conversation: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 16) {
+                    if chat.turns.isEmpty && !chat.isResponding {
+                        suggestions
+                    }
+                    ForEach(chat.turns) { turn in
+                        turnRow(turn).id(turn.id)
+                    }
+                    if chat.isResponding {
+                        agentStatusRow.id("agent-status")
+                    }
+                    if let err = chat.errorMessage {
+                        errorRow(err)
+                    }
+                }
+                .padding(.horizontal, 20)
+                .padding(.vertical, 8)
+            }
+            .onChange(of: chat.turns.count) { _ in
+                withAnimation { proxy.scrollTo(chat.turns.last?.id, anchor: .bottom) }
+            }
+            .onChange(of: chat.streamingText) { _ in
+                proxy.scrollTo("agent-status", anchor: .bottom)
+            }
+            .onChange(of: chat.isResponding) { responding in
+                if responding {
+                    withAnimation { proxy.scrollTo("agent-status", anchor: .bottom) }
+                }
+            }
+        }
+    }
+
+    // MARK: - Agent loop status / streaming
+
+    /// Agent 检索循环的可视区：非流式阶段渲染一行状态，流式阶段渲染
+    /// 增量回答 + 琥珀光标。
+    @ViewBuilder
+    private var agentStatusRow: some View {
+        switch chat.phase {
+        case .streaming:
+            streamingBubble
+        default:
+            HStack(spacing: 8) {
+                ProgressView().controlSize(.small)
+                Text(statusText(for: chat.phase))
+                    .font(DSType.bodySM)
+                    .foregroundColor(DSColor.inkSecondary)
+                    .animation(.easeInOut(duration: 0.2), value: chat.phase)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .transition(.opacity)
+        }
+    }
+
+    private func statusText(for phase: MemoryChatService.AgentPhase) -> String {
+        switch phase {
+        case .reading:
+            return NSLocalizedString(
+                "memo.chat.status.reading",
+                value: "Rereading this memory…",
+                comment: "Memo chat — agent phase: rereading the anchored memo"
+            )
+        case .retrieving(let names) where !names.isEmpty:
+            return String(
+                format: NSLocalizedString(
+                    "memo.chat.status.retrieving.along",
+                    value: "Tracing “%@” through your records…",
+                    comment: "Memo chat — agent phase: tracing entities; %@ is entity names"
+                ),
+                names.prefix(2).joined(separator: NSLocalizedString(
+                    "memo.chat.status.retrieving.sep",
+                    value: "”, “",
+                    comment: "Memo chat — separator between entity names inside the retrieving status quotes"
+                ))
+            )
+        case .retrieving:
+            return NSLocalizedString(
+                "memo.chat.status.retrieving",
+                value: "Searching related records…",
+                comment: "Memo chat — agent phase: keyword retrieval"
+            )
+        case .thinking(let found) where found > 0:
+            return String(
+                format: NSLocalizedString(
+                    "memo.chat.status.found",
+                    value: "Found %d related records, thinking…",
+                    comment: "Memo chat — agent phase: retrieval done; %d is record count"
+                ),
+                found
+            )
+        default:
+            return NSLocalizedString(
+                "memo.chat.status.thinking",
+                value: "Thinking…",
+                comment: "Memo chat — agent phase: waiting for the model"
+            )
+        }
+    }
+
+    /// 流式回答气泡：serif 正文 + 尾随琥珀光标（呼吸闪烁）。
+    private var streamingBubble: some View {
+        (Text(chat.streamingText)
+            .font(DSType.serifBody16)
+            .foregroundColor(DSColor.inkPrimary)
+        + Text("▍")
+            .font(DSType.serifBody16)
+            .foregroundColor(DSColor.amberAccent.opacity(caretVisible ? 0.8 : 0.15)))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .onAppear {
+                withAnimation(.easeInOut(duration: 0.6).repeatForever(autoreverses: true)) {
+                    caretVisible.toggle()
+                }
+            }
+    }
+
+    // MARK: - Turn rows
+
+    @ViewBuilder
+    private func turnRow(_ turn: ChatTurn) -> some View {
+        switch turn.role {
+        case .user:
+            HStack {
+                Spacer(minLength: 40)
+                Text(turn.text)
+                    .font(DSType.serifBody16)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 10)
+                    .background(DSColor.surfaceContainerHigh)
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+            }
+        case .assistant:
+            VStack(alignment: .leading, spacing: 10) {
+                Text(turn.text)
+                    .font(DSType.serifBody16)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                if let context = turn.context, !context.memoHits.isEmpty {
+                    sourceRow(context)
+                }
+                assistantActions(for: turn)
+            }
+        }
+    }
+
+    /// 来源「依据」区：命中的日期渲染为可点 chip → 跳到那一天。
+    /// SOURCES 是 chrome，保持英文 mono（FINDING-010 惯例）。
+    private func sourceRow(_ context: RetrievedContext) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("SOURCES")
+                .font(DSType.mono10)
+                .tracking(1.2)
+                .foregroundColor(DSColor.inkMuted)
+            let dates = Array(Array(Set(context.memoHits.map { $0.dateString })).sorted(by: >).prefix(4))
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(Array(stride(from: 0, to: dates.count, by: 2)), id: \.self) { i in
+                    HStack(spacing: 6) {
+                        ForEach(dates[i..<min(i + 2, dates.count)], id: \.self) { date in
+                            sourceChip(date)
+                        }
+                    }
+                }
+            }
+        }
+        .padding(.top, 2)
+    }
+
+    private func sourceChip(_ dateString: String) -> some View {
+        Button {
+            openArchive(at: dateString)
+        } label: {
+            HStack(spacing: 4) {
+                Text(dateString)
+                    .font(DSType.mono10)
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: 8, weight: .semibold))
+            }
+            .foregroundColor(DSColor.accentOnBg)
+            .padding(.horizontal, 9)
+            .padding(.vertical, 5)
+            .background(DSColor.amberSoft)
+            .overlay(Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
+            .clipShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(String(
+            format: NSLocalizedString(
+                "memo.chat.a11y.source",
+                value: "查看 %@ 的记录",
+                comment: "Memo chat — source chip VoiceOver label; %@ is a date"
+            ),
+            dateString
+        ))
+    }
+
+    @ViewBuilder
+    private func assistantActions(for turn: ChatTurn) -> some View {
+        let pinned = pinnedTurnIDs.contains(turn.id)
+        Button {
+            Haptics.tapConfirm()
+            if chat.pinTurnToDiary(turn) {
+                pinnedTurnIDs.insert(turn.id)
+            }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: pinned ? "checkmark.circle.fill" : "text.badge.plus")
+                    .font(.system(size: 13, weight: .semibold))
+                Text(pinned
+                     ? NSLocalizedString("memo.chat.pin.done", value: "Saved to today", comment: "Memo chat — pin action done state")
+                     : NSLocalizedString("memo.chat.pin", value: "Save to today", comment: "Memo chat — pin answer into today's diary"))
+                    .font(DSType.labelSM)
+            }
+            .foregroundColor(pinned ? DSColor.successGreen : DSColor.accentOnBg)
+        }
+        .buttonStyle(.plain)
+        .disabled(pinned)
+        .padding(.top, 2)
+    }
+
+    // MARK: - Suggestions (empty state)
+
+    /// 实体感知的建议问题：围绕这条记录能问出「时间跨度」价值的问法。
+    private var suggestedQuestions: [String] {
+        var out: [String] = [
+            NSLocalizedString(
+                "memo.chat.suggest.why",
+                value: "Why did I think this at the time?",
+                comment: "Memo chat — suggested question 1"
+            )
+        ]
+        if let firstClue = clues.first {
+            out.append(String(
+                format: NSLocalizedString(
+                    "memo.chat.suggest.entity",
+                    value: "What else have I said about “%@”?",
+                    comment: "Memo chat — suggested question 2; %@ is an entity name"
+                ),
+                firstClue
+            ))
+        }
+        out.append(NSLocalizedString(
+            "memo.chat.suggest.changed",
+            value: "Has this thought changed since?",
+            comment: "Memo chat — suggested question 3"
+        ))
+        return out
+    }
+
+    private var suggestions: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            ForEach(suggestedQuestions, id: \.self) { q in
+                Button {
+                    Haptics.soft()
+                    Task { await chat.ask(q) }
+                } label: {
+                    HStack(spacing: 8) {
+                        Image(systemName: "sparkle")
+                            .font(.system(size: 11))
+                            .foregroundColor(DSColor.accentOnBg)
+                        Text(q)
+                            .font(DSType.bodySM)
+                            .foregroundColor(DSColor.inkPrimary)
+                            .multilineTextAlignment(.leading)
+                        Spacer(minLength: 0)
+                    }
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+                    .background(DSColor.surfaceContainerHigh)
+                    .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(.top, 8)
+    }
+
+    // MARK: - Error
+
+    private func errorRow(_ message: String) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(message)
+                .font(DSType.bodySM)
+                .foregroundColor(DSColor.inkSecondary)
+            Button {
+                Haptics.soft()
+                Task { await chat.retryLast() }
+            } label: {
+                Text(NSLocalizedString(
+                    "memo.chat.retry",
+                    value: "Retry",
+                    comment: "Memo chat — retry failed answer"
+                ))
+                .font(DSType.labelSM)
+                .foregroundColor(DSColor.accentOnBg)
+            }
+            .buttonStyle(.plain)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(12)
+        .background(DSColor.surfaceContainerHigh)
+        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+    }
+
+    // MARK: - Memory chip
+
+    /// 「记忆芯片」——被拽进对话框的那条记录。左侧琥珀细杆呼应详情页
+    /// 眉批的设计语言；× 摘除后对话退化为通用问过去。
+    private var memoryChip: some View {
+        HStack(alignment: .top, spacing: 10) {
+            RoundedRectangle(cornerRadius: 1)
+                .fill(DSColor.amberRim)
+                .frame(width: 2)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(memoDateString.uppercased())
+                    .font(DSType.mono9)
+                    .tracking(1.0)
+                    .foregroundColor(DSColor.inkMuted)
+                Text(memo.body.replacingOccurrences(of: "\n", with: " "))
+                    .font(DSFonts.serif(size: 13, weight: .regular, relativeTo: .footnote))
+                    .foregroundColor(DSColor.inkSecondary)
+                    .lineLimit(2)
+            }
+            Spacer(minLength: 8)
+            Button {
+                Haptics.soft()
+                withAnimation(Motion.spring) { chat.detachMemo() }
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(DSColor.inkMuted)
+                    .frame(width: 22, height: 22)
+                    .background(DSColor.surfaceContainerHigh)
+                    .clipShape(Circle())
+            }
+            .accessibilityLabel(NSLocalizedString(
+                "memo.chat.a11y.detach",
+                value: "摘除这条记忆",
+                comment: "Memo chat — detach memory chip VoiceOver label"
+            ))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .fixedSize(horizontal: false, vertical: true)
+        .background(DSColor.amberSoft)
+        .overlay(
+            RoundedRectangle(cornerRadius: DSRadius.md)
+                .strokeBorder(DSColor.amberRim, lineWidth: 0.5)
+        )
+        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md))
+        .padding(.horizontal, 16)
+        .padding(.top, 10)
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - Input bar
+
+    private var inputBar: some View {
+        HStack(spacing: 10) {
+            TextField(
+                NSLocalizedString(
+                    "memo.chat.input.placeholder",
+                    value: "Ask about this memory…",
+                    comment: "Memo chat — input placeholder"
+                ),
+                text: $draft,
+                axis: .vertical
+            )
+            .font(DSType.bodySM)
+            .focused($inputFocused)
+            .lineLimit(1...4)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background(DSColor.surfaceContainerHigh)
+            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+            .onSubmit(submit)
+
+            Button(action: submit) {
+                Image(systemName: "arrow.up.circle.fill")
+                    .font(.system(size: 28))
+                    .foregroundColor(canSend ? DSColor.accentOnBg : DSColor.inkSubtle)
+            }
+            .disabled(!canSend)
+            .accessibilityLabel(NSLocalizedString(
+                "memo.chat.a11y.send",
+                value: "发送",
+                comment: "Memo chat — send button VoiceOver label"
+            ))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 12)
+    }
+
+    private var canSend: Bool {
+        !draft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !chat.isResponding
+    }
+
+    private func submit() {
+        let question = draft.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !question.isEmpty, !chat.isResponding else { return }
+        draft = ""
+        Task { await chat.ask(question) }
+    }
+
+    // MARK: - Navigation out
+
+    /// 来源 chip → 跳到那一天。与 MemoDetailView.openEcho 同款
+    /// dismiss-then-post 模式：先收 sheet（与详情页一起让位），再发通知。
+    private func openArchive(at dateString: String) {
+        Haptics.soft()
+        onClose()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) {
+            NotificationCenter.default.post(
+                name: .openArchiveAt,
+                object: nil,
+                userInfo: ["date": dateString]
+            )
+        }
+    }
+}

--- a/DayPage/Features/MemoDetail/DropToAskGesture.swift
+++ b/DayPage/Features/MemoDetail/DropToAskGesture.swift
@@ -1,0 +1,356 @@
+import SwiftUI
+import UIKit
+
+// MARK: - Drop-to-Ask（issue #837）
+//
+// 小红书式「拖回变卡片 → 投入对话坞」交互：
+//
+//  1. 横向起手（复用 HorizontalPanGesture.isHorizontalDominant 的速度方向锁，
+//     纵向滚动零损）后，整页跟手凝缩成圆角卡片；
+//  2. 底部升起「对话坞」；卡片拖入坞判定区时坞点亮 + soft haptic；
+//  3. 释放：入坞 → onAsk（呈现 memo 锚定对话）；坞外且右移超过屏宽 40%
+//     → onCommitBack（等效返回，保留慢拖返回语义）；否则 spring 弹回。
+//
+// 手势宿主：不能用覆盖全页的 UIViewRepresentable overlay —— 那会吞掉
+// SwiftUI 按钮点击（HorizontalPanGesture 的 onTap 回路就是为此存在的，
+// 但详情页可点元素太多，逐个回路不现实）。这里改为把 recognizer 挂到
+// **祖先容器 view** 上：recognizer 对后代 touch 全收，而 SwiftUI 自身的
+// 点击/滚动在方向锁失败（纵向/静止）时完全不受影响。
+
+// MARK: - DropPanAttacher
+
+/// 零尺寸标记 view：挂载后向上爬 superview 链找到页面级容器，把
+/// UIPanGestureRecognizer 装上去。翻译值（2D）与状态经闭包回给 SwiftUI。
+private struct DropPanAttacher: UIViewRepresentable {
+
+    let isEnabled: Bool
+    let onBegan: () -> Void
+    /// (translation, fingerLocation) —— translation 驱动凝缩进度与
+    /// commit-back 判定；location 驱动卡片位置（XHS 手感：卡心贴手指）。
+    let onChanged: (CGPoint, CGPoint) -> Void
+    let onEnded: (CGPoint, CGPoint) -> Void   // translation, fingerLocation
+    let onCancelled: () -> Void
+
+    func makeCoordinator() -> Coordinator { Coordinator(parent: self) }
+
+    func makeUIView(context: Context) -> UIView {
+        let marker = AttachMarkerView()
+        marker.isUserInteractionEnabled = false
+        marker.backgroundColor = .clear
+        // makeUIView 时 superview/window 尚未建立，一次性的 async 也可能
+        // 抢跑（首次验证时 pan 从未挂上、拖拽被 ScrollView 整个吃掉）。
+        // didMoveToWindow 是唯一可靠的挂载时机。
+        let coordinator = context.coordinator
+        marker.onWindow = { [weak marker] in
+            guard let marker else { return }
+            DispatchQueue.main.async {
+                coordinator.attachIfNeeded(from: marker)
+            }
+        }
+        return marker
+    }
+
+    /// 进窗即回调的标记 view——挂载时机的唯一可靠信号源。
+    final class AttachMarkerView: UIView {
+        var onWindow: (() -> Void)?
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            if window != nil { onWindow?() }
+        }
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.parent = self
+        context.coordinator.recognizer?.isEnabled = isEnabled
+        DispatchQueue.main.async {
+            context.coordinator.attachIfNeeded(from: uiView)
+        }
+    }
+
+    static func dismantleUIView(_ uiView: UIView, coordinator: Coordinator) {
+        coordinator.detach()
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var parent: DropPanAttacher
+        weak var recognizer: UIPanGestureRecognizer?
+        private weak var host: UIView?
+
+        init(parent: DropPanAttacher) { self.parent = parent }
+
+        /// 从标记 view 向上找「页面级」容器（宽度接近屏宽的首个祖先），
+        /// 把 pan 装上去。幂等——已挂载则跳过。
+        func attachIfNeeded(from marker: UIView) {
+            guard recognizer == nil, marker.window != nil else { return }
+            let screenWidth = marker.window?.bounds.width ?? UIScreen.main.bounds.width
+            var candidate: UIView? = marker.superview
+            var pageHost: UIView?
+            var topmost: UIView?
+            while let view = candidate {
+                if pageHost == nil, view.bounds.width >= screenWidth * 0.9 {
+                    pageHost = view
+                    break
+                }
+                topmost = view
+                candidate = view.superview
+            }
+            // 兜底：找不到页面级宽度的祖先时挂最顶层，宁可范围偏大
+            // 也不要静默失效（方向锁保证误伤为零）。
+            guard let target = pageHost ?? topmost else { return }
+
+            let pan = UIPanGestureRecognizer(target: self, action: #selector(handlePan(_:)))
+            pan.delegate = self
+            pan.maximumNumberOfTouches = 1
+            // 确认横向后即拥有 touch；SwiftUI 按压随之取消，避免拖完误触。
+            pan.cancelsTouchesInView = true
+            pan.isEnabled = parent.isEnabled
+            target.addGestureRecognizer(pan)
+            recognizer = pan
+            host = target
+        }
+
+        func detach() {
+            if let pan = recognizer, let host { host.removeGestureRecognizer(pan) }
+            recognizer = nil
+            host = nil
+        }
+
+        // 与 HorizontalPanGesture 同款方向锁：UIKit 只在 pan 自身滞回点
+        // 问一次 shouldBegin，速度在那一刻已经成形——一次速度比较即可。
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let pan = gestureRecognizer as? UIPanGestureRecognizer,
+                  let view = pan.view else { return true }
+            let v = pan.velocity(in: view)
+            return HorizontalPanGesture.isHorizontalDominant(vx: v.x, vy: v.y)
+        }
+
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                               shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
+            true
+        }
+
+        // 让 ScrollView 的滚动 pan 等待我们的方向判定（一次查询，纵向即
+        // 秒败放行）——没有这条，滚动 pan 先动手就永远轮不到我们。
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                               shouldBeRequiredToFailBy other: UIGestureRecognizer) -> Bool {
+            guard gestureRecognizer is UIPanGestureRecognizer else { return false }
+            return other is UIPanGestureRecognizer && other !== gestureRecognizer
+        }
+
+        @objc func handlePan(_ pan: UIPanGestureRecognizer) {
+            guard let view = pan.view else { return }
+            let t = pan.translation(in: view)
+            let loc = pan.location(in: view)
+            switch pan.state {
+            case .began:
+                parent.onBegan()
+                parent.onChanged(t, loc)
+            case .changed:
+                parent.onChanged(t, loc)
+            case .ended:
+                parent.onEnded(t, loc)
+            case .cancelled, .failed:
+                parent.onCancelled()
+            default:
+                break
+            }
+        }
+    }
+}
+
+// MARK: - DropToAskModifier
+
+/// 应用到详情页 ScrollView：驱动「凝缩成卡 + 对话坞」的全部视觉与判定。
+struct DropToAskModifier: ViewModifier {
+
+    let isEnabled: Bool
+    /// 卡片投入对话坞。
+    let onAsk: () -> Void
+    /// 坞外右移超过 commit 阈值——等效返回。
+    let onCommitBack: () -> Void
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    /// 累计位移——驱动凝缩进度与 commit-back 判定。
+    @State private var translation: CGPoint = .zero
+    /// 卡片视觉位移（卡心贴手指的偏移量）——XHS 手感的核心。
+    @State private var cardOffset: CGSize = .zero
+    @State private var isDragging = false
+    @State private var isOverDock = false
+
+    // MARK: Tuning
+
+    /// 距离→进度的归一化半径：拖过这个距离即完全凝缩。
+    private static let condenseRadius: CGFloat = 220
+    /// 完全凝缩时的缩放。
+    private static let minScale: CGFloat = 0.62
+    /// 坞判定区高度（自底部算起）。
+    private static let dockZoneHeight: CGFloat = 170
+    /// 等效返回的右移距离占屏宽比例。
+    private static let backCommitFraction: CGFloat = 0.4
+
+    private var progress: CGFloat {
+        let d = hypot(translation.x, translation.y)
+        return min(1, d / Self.condenseRadius)
+    }
+
+    func body(content: Content) -> some View {
+        GeometryReader { geo in
+            ZStack {
+                content
+                    // 仅拖拽时铺不透明纸面：静止时必须让 AmbientBackground
+                    // 渐变透上来（常驻 bgWarm 会把它盖成死平色）。
+                    .background(isDragging ? DSColor.bgWarm : Color.clear)
+                    .clipShape(RoundedRectangle(
+                        cornerRadius: reduceMotion ? 0 : 28 * progress,
+                        style: .continuous
+                    ))
+                    .shadow(
+                        color: Color.black.opacity(reduceMotion ? 0 : 0.22 * progress),
+                        radius: 24, x: 0, y: 10
+                    )
+                    .scaleEffect(reduceMotion ? 1 : 1 - (1 - Self.minScale) * progress)
+                    .offset(reduceMotion ? .zero : cardOffset)
+                    .opacity(reduceMotion && isDragging ? max(0.5, 1 - 0.5 * progress) : 1)
+
+                // 对话坞：拖拽开始后自底部升起。
+                if isDragging {
+                    VStack {
+                        Spacer()
+                        AskDockView(isHighlighted: isOverDock)
+                            .padding(.bottom, 28)
+                    }
+                    .transition(.move(edge: .bottom).combined(with: .opacity))
+                    .allowsHitTesting(false)
+                }
+            }
+            .background(
+                DropPanAttacher(
+                    isEnabled: isEnabled,
+                    onBegan: {
+                        Haptics.soft()
+                        withAnimation(Motion.spring) { isDragging = true }
+                    },
+                    onChanged: { t, loc in
+                        translation = t
+                        // 卡心向手指位置收敛（按凝缩进度插值）：起手时页面
+                        // 还大，只轻微跟随；凝缩完成后卡心稳贴手指——
+                        // 1:1 translation 会把卡片甩出屏幕（首轮实测）。
+                        let p = min(1, hypot(t.x, t.y) / Self.condenseRadius)
+                        cardOffset = CGSize(
+                            width: (loc.x - geo.size.width / 2) * p,
+                            height: (loc.y - geo.size.height / 2) * p
+                        )
+                        updateDockHover(fingerY: loc.y, in: geo.size)
+                    },
+                    onEnded: { t, _ in
+                        resolveRelease(translation: t, in: geo.size)
+                    },
+                    onCancelled: { snapBack() }
+                )
+                .frame(width: 0, height: 0)
+            )
+        }
+    }
+
+    // MARK: Hit-testing & release
+
+    /// 手指落进底部判定区即视为悬于坞上（卡心贴手指，两者等价，
+    /// 但手指判定对用户更直觉）。
+    private func updateDockHover(fingerY: CGFloat, in size: CGSize) {
+        let hovering = fingerY > size.height - Self.dockZoneHeight
+        if hovering != isOverDock {
+            withAnimation(Motion.spring) { isOverDock = hovering }
+            if hovering { Haptics.soft() }
+        }
+    }
+
+    private func resolveRelease(translation t: CGPoint, in size: CGSize) {
+        if isOverDock {
+            Haptics.rigid(intensity: 0.8)
+            // 卡片吸入坞位，随即交给 sheet 呈现。
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.85)) {
+                cardOffset = CGSize(width: 0, height: size.height / 2 - Self.dockZoneHeight / 2)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.18) {
+                onAsk()
+                snapBack(delay: 0.35)
+            }
+        } else if t.x > size.width * Self.backCommitFraction {
+            Haptics.tapConfirm()
+            onCommitBack()
+            snapBack(delay: 0.3)
+        } else {
+            snapBack()
+        }
+    }
+
+    /// 复位。`delay` 用于 onAsk/onCommitBack 后等 sheet/pop 呈现完再复位，
+    /// 避免复位动画在转场底下闪一帧。
+    private func snapBack(delay: TimeInterval = 0) {
+        let work = {
+            withAnimation(Motion.spring) {
+                translation = .zero
+                cardOffset = .zero
+                isDragging = false
+                isOverDock = false
+            }
+        }
+        if delay > 0 {
+            DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+        } else {
+            work()
+        }
+    }
+}
+
+extension View {
+    /// 详情页「拖拽入坞唤起 AI 对话」手势（issue #837）。
+    func dropToAsk(
+        isEnabled: Bool = true,
+        onAsk: @escaping () -> Void,
+        onCommitBack: @escaping () -> Void
+    ) -> some View {
+        modifier(DropToAskModifier(
+            isEnabled: isEnabled,
+            onAsk: onAsk,
+            onCommitBack: onCommitBack
+        ))
+    }
+}
+
+// MARK: - AskDockView
+
+/// 底部「对话坞」：玻璃胶囊，卡片悬停时琥珀点亮。
+private struct AskDockView: View {
+    let isHighlighted: Bool
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Image(systemName: "sparkles")
+                .font(.system(size: 16, weight: .semibold))
+                .foregroundColor(isHighlighted ? DSColor.amberAccent : DSColor.accentOnBg)
+            Text(NSLocalizedString(
+                "memo.detail.drop_dock",
+                value: "Drop here to ask",
+                comment: "Detail view — drop-to-ask dock label"
+            ))
+            .font(DSType.bodySM)
+            .foregroundColor(DSColor.inkPrimary)
+        }
+        .padding(.horizontal, 22)
+        .padding(.vertical, 14)
+        .background(isHighlighted ? AnyView(DSColor.amberSoft) : AnyView(Color.clear))
+        .liquidGlassCard(cornerRadius: 28)
+        .overlay(
+            RoundedRectangle(cornerRadius: 28, style: .continuous)
+                .strokeBorder(
+                    DSColor.amberRim.opacity(isHighlighted ? 1 : 0.4),
+                    lineWidth: isHighlighted ? 1 : 0.5
+                )
+        )
+        .scaleEffect(isHighlighted ? 1.06 : 1.0)
+        .animation(Motion.spring, value: isHighlighted)
+        .accessibilityHidden(true) // 手势不可达路径；无障碍走 CTA。
+    }
+}

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -37,6 +37,9 @@ struct MemoDetailView: View {
     // Entity Ink — tapped entity opens its wiki page (issue #835)
     @State private var selectedEntityType: String = "themes"
     @State private var selectedEntitySlug: String?
+
+    // Drop-to-Ask — memo 锚定 AI 对话（issue #837）：拖拽入坞或 CTA 触发。
+    @State private var showMemoChat: Bool = false
     /// slug → wiki display name; resolved async so CJK prose (which never
     /// contains the latin slug) can still be inked by its display name.
     @State private var entityDisplayNames: [String: String] = [:]
@@ -312,18 +315,12 @@ struct MemoDetailView: View {
                     // a rule here boxed the CTA between two full-width lines.
                     Button {
                         Haptics.tapConfirm()
-                        let question = String(
-                            format: NSLocalizedString(
-                                "memo.detail.ask_past.question",
-                                value: "About this memo (%@) — why did I think this at the time?",
-                                comment: "Detail view — seeded question sent to Ask Past chat; %@ is the memo body prefix"
-                            ),
-                            String(memo.body.prefix(60))
-                        )
-                        if let encoded = question.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed),
-                           let url = URL(string: "daypage://ask?q=\(encoded)") {
-                            UIApplication.shared.open(url)
-                        }
+                        // Issue #837: 直接呈现 memo 锚定对话（不再走
+                        // daypage://ask URL round-trip）——memo 全文 + 实体
+                        // 作为一等上下文进入 Agent 检索循环。此 CTA 与
+                        // Drop-to-Ask 拖拽手势通向同一个 sheet：拖拽是
+                        // 彩蛋，CTA 是明路（也是无障碍路径）。
+                        showMemoChat = true
                     } label: {
                         HStack(spacing: 10) {
                             Image(systemName: "sparkles")
@@ -368,6 +365,14 @@ struct MemoDetailView: View {
                 .padding(.horizontal, 24)
                 .padding(.bottom, 32)
             }
+            // Issue #837: 小红书式拖拽——横向起手把整页凝缩成卡片，
+            // 投入底部对话坞 → memo 锚定 AI 对话；坞外右移超阈值 → 返回。
+            // 只包 ScrollView：AmbientBackground 留在原位当拖拽的舞台底。
+            .dropToAsk(
+                isEnabled: !isEditingBody,
+                onAsk: { showMemoChat = true },
+                onCommitBack: { dismiss() }
+            )
         }
         .navigationBarHidden(true)
         .onAppear {
@@ -402,6 +407,18 @@ struct MemoDetailView: View {
                     sourceDateString: DateFormatters.isoDate.string(from: memo.created)
                 )
             }
+        }
+        // Issue #837: memo 锚定 AI 对话——Drop-to-Ask 拖拽与 ask-past CTA
+        // 汇入同一个 sheet。entityDisplayNames 复用实体墨迹的异步解析结果，
+        // 喂给对话的 retrieving 阶段文案与建议问题。
+        .sheet(isPresented: $showMemoChat) {
+            MemoChatView(
+                memo: memo,
+                entityDisplayNames: entityDisplayNames,
+                onClose: { showMemoChat = false }
+            )
+            .presentationDetents([.fraction(0.85), .large])
+            .presentationDragIndicator(.visible)
         }
         .sheet(isPresented: $showShareSheet) {
             // Reuse the app-wide ShareSheet wrapper (Settings/ObsidianExport

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -1102,3 +1102,24 @@
 "daydetail.kind.part.voice"  = "%d voice";
 "daydetail.kind.part.photo"  = "%d photo";
 "rawmemo.empty"              = "No memos this day";
+
+/* MARK: - Drop-to-Ask + memo-anchored chat (issue #837) */
+"memo.detail.drop_dock"              = "Drop here to ask";
+"memo.chat.title"                    = "Ask this memory";
+"memo.chat.a11y.close"               = "Close chat";
+"memo.chat.status.reading"           = "Rereading this memory…";
+"memo.chat.status.retrieving"        = "Searching related records…";
+"memo.chat.status.retrieving.along"  = "Tracing “%@” through your records…";
+"memo.chat.status.retrieving.sep"    = "”, “";
+"memo.chat.status.found"             = "Found %d related records, thinking…";
+"memo.chat.status.thinking"          = "Thinking…";
+"memo.chat.input.placeholder"        = "Ask about this memory…";
+"memo.chat.pin"                      = "Save to today";
+"memo.chat.pin.done"                 = "Saved to today";
+"memo.chat.retry"                    = "Retry";
+"memo.chat.suggest.why"              = "Why did I think this at the time?";
+"memo.chat.suggest.entity"           = "What else have I said about “%@”?";
+"memo.chat.suggest.changed"          = "Has this thought changed since?";
+"memo.chat.a11y.detach"              = "Detach memory";
+"memo.chat.a11y.source"              = "Open records of %@";
+"memo.chat.a11y.send"                = "Send";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -1107,3 +1107,24 @@
 "daydetail.kind.part.voice"  = "%d 声";
 "daydetail.kind.part.photo"  = "%d 图";
 "rawmemo.empty"              = "该日无记录";
+
+/* MARK: - Drop-to-Ask + memo 锚定对话 (issue #837) */
+"memo.detail.drop_dock"              = "拖到这里，问 AI";
+"memo.chat.title"                    = "与这条记忆对话";
+"memo.chat.a11y.close"               = "关闭对话";
+"memo.chat.status.reading"           = "正在重读这条记忆…";
+"memo.chat.status.retrieving"        = "翻找相关记录…";
+"memo.chat.status.retrieving.along"  = "沿「%@」翻找相关记录…";
+"memo.chat.status.retrieving.sep"    = "」「";
+"memo.chat.status.found"             = "找到 %d 条相关记录，正在思考…";
+"memo.chat.status.thinking"          = "正在思考…";
+"memo.chat.input.placeholder"        = "问问这条记忆…";
+"memo.chat.pin"                      = "存入今日日记";
+"memo.chat.pin.done"                 = "已存入今日";
+"memo.chat.retry"                    = "重试";
+"memo.chat.suggest.why"              = "当时的我为什么这么想？";
+"memo.chat.suggest.entity"           = "关于「%@」我还说过什么？";
+"memo.chat.suggest.changed"          = "这个想法后来有变化吗？";
+"memo.chat.a11y.detach"              = "摘除这条记忆";
+"memo.chat.a11y.source"              = "查看 %@ 的记录";
+"memo.chat.a11y.send"                = "发送";

--- a/DayPageKit/Sources/DayPageServices/GraphRetriever.swift
+++ b/DayPageKit/Sources/DayPageServices/GraphRetriever.swift
@@ -110,16 +110,26 @@ public enum GraphRetriever {
     /// 为 `query` 组装图谱增强检索上下文。
     /// - Parameters:
     ///   - query: 用户的自然语言查询或关键词。
+    ///   - seedEntitySlugs: 额外的实体种子（issue #837 memo 锚定对话）——
+    ///     调用方已知的强相关实体（如当前 memo 的 `entityMentions`），
+    ///     无论关键词是否命中都直接参与图谱扩展。空查询 + 非空种子时
+    ///     退化为纯实体扩展（memo 锚定对话的首轮就是这种形态）。
     ///   - maxMemoHits: 保留的种子 memo 命中上限（按日期降序，最新优先）。
     ///   - maxEntityHits: 扩展的邻居实体上限（按出现次数降序，最相关优先）。
     public nonisolated static func retrieve(
         query rawQuery: String,
+        seedEntitySlugs: [String] = [],
         maxMemoHits: Int = 8,
         maxEntityHits: Int = 6
     ) -> RetrievedContext {
         let query = rawQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let seeds = seedEntitySlugs.filter { !$0.isEmpty }
         guard !query.isEmpty else {
-            return RetrievedContext(query: query, memoHits: [], entityHits: [])
+            guard !seeds.isEmpty else {
+                return RetrievedContext(query: query, memoHits: [], entityHits: [])
+            }
+            let entityHits = expandEntities(slugs: Set(seeds), limit: maxEntityHits)
+            return RetrievedContext(query: query, memoHits: [], entityHits: entityHits)
         }
 
         // Step 1: 种子命中——复用现有关键词检索。
@@ -161,8 +171,10 @@ public enum GraphRetriever {
         }
 
         // Step 3: 图谱扩展——沿 entityMentions 读邻居实体页。
-        // 同时把 query 本身当作可能的实体 slug 直接命中（用户可能在问某地/某人）。
+        // 同时把 query 本身当作可能的实体 slug 直接命中（用户可能在问某地/某人），
+        // 以及调用方注入的实体种子（memo 锚定对话）。
         entitySlugs.formUnion(slugCandidates(from: query))
+        entitySlugs.formUnion(seeds)
         let entityHits = expandEntities(slugs: entitySlugs, limit: maxEntityHits)
 
         return RetrievedContext(query: query, memoHits: memoHits, entityHits: entityHits)

--- a/DayPageKit/Sources/DayPageServices/LLMClient.swift
+++ b/DayPageKit/Sources/DayPageServices/LLMClient.swift
@@ -246,6 +246,118 @@ public struct LLMClient {
         }
     }
 
+    // MARK: - Streaming completion (SSE)
+
+    /// One parsed server-sent-event line from an OpenAI-compatible
+    /// `stream: true` response.
+    public enum SSEEvent: Equatable {
+        case delta(String)
+        case done
+        case ignore
+    }
+
+    /// Parse a single SSE line into an event. Pure function — the whole
+    /// streaming loop's correctness hinges on this, so it is exposed for
+    /// unit tests while the network loop stays thin.
+    public static func parseSSELine(_ line: String) -> SSEEvent {
+        guard line.hasPrefix("data: ") else { return .ignore }
+        let payload = String(line.dropFirst(6))
+        if payload == "[DONE]" { return .done }
+        guard let data = payload.data(using: .utf8),
+              let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let choices = json["choices"] as? [[String: Any]],
+              let delta = choices.first?["delta"] as? [String: Any],
+              let chunk = delta["content"] as? String,
+              !chunk.isEmpty else { return .ignore }
+        return .delta(chunk)
+    }
+
+    /// 流式聊天补全：逐 token 回调 `onDelta`，结束后返回完整文本（已 trim）。
+    ///
+    /// 与 `complete` 的边界：流式无法安全地中途重试（用户已看到前半段），
+    /// 因此单次尝试、失败即抛——重试语义交给 UI 层的「重试」按钮。
+    /// SSE 走 `URLSession.bytes` 而非 `HTTPTransport`（该协议刻意只覆盖
+    /// `data(for:)`；见 HTTPTransport.swift 的注释——流式另开路径而非拓宽协议）。
+    /// `onDelta` 标注 `@MainActor` 并被 `await` 调用——保证 token 以到达顺序
+    /// 落到主线程状态上，避免 `Task { @MainActor }` 逐段投递的乱序风险。
+    public func stream(
+        messages: [LLMMessage],
+        onDelta: @escaping @MainActor @Sendable (String) -> Void
+    ) async throws -> String {
+        let online = await MainActor.run { NetworkMonitor.shared.isOnline }
+        guard online else { throw LLMError.offline }
+        guard !config.apiKey.isEmpty else { throw LLMError.missingApiKey }
+        guard let url = URL(string: "\(config.baseURL)/chat/completions") else {
+            throw LLMError.invalidURL
+        }
+
+        let body: [String: Any] = [
+            "model": config.model,
+            "messages": messages.map { ["role": $0.role.rawValue, "content": $0.content] },
+            "max_tokens": config.maxTokens,
+            "temperature": config.temperature,
+            "stream": true
+        ]
+        let request = try HTTPClientHelper.bearerJSON(
+            url: url,
+            apiKey: config.apiKey,
+            timeout: config.timeout,
+            body: body
+        )
+
+        let span = SentryReporter.startTransaction(name: spanName, operation: "http.client")
+        defer { span?.finish() }
+
+        let (asyncBytes, response): (URLSession.AsyncBytes, URLResponse)
+        do {
+            (asyncBytes, response) = try await URLSession.shared.bytes(for: request)
+        } catch let urlError as URLError {
+            switch urlError.code {
+            case .timedOut: throw LLMError.networkTimeout
+            case .notConnectedToInternet, .networkConnectionLost: throw LLMError.offline
+            default: throw LLMError.unknown(urlError)
+            }
+        }
+
+        if let http = response as? HTTPURLResponse, http.statusCode != 200 {
+            span?.setTag(String(http.statusCode), key: "http.status_code")
+            // Drain a bounded slice of the error body for the message.
+            var errBody = ""
+            for try await line in asyncBytes.lines {
+                errBody += line
+                if errBody.count > 500 { break }
+            }
+            DayPageLogger.log(level: "ERROR", message: "[LLMClient/\(spanName)] stream status=\(http.statusCode) body=\(errBody.prefix(500))")
+            if http.statusCode == 429 { throw LLMError.rateLimited }
+            throw LLMError.apiError(statusCode: http.statusCode, body: errBody)
+        }
+
+        var full = ""
+        for try await line in asyncBytes.lines {
+            switch Self.parseSSELine(line) {
+            case .delta(let chunk):
+                full += chunk
+                await onDelta(chunk)
+            case .done:
+                break
+            case .ignore:
+                continue
+            }
+        }
+
+        let trimmed = full.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { throw LLMError.emptyResponse }
+
+        // Same usage accounting as `complete` — spanName buckets per purpose.
+        let promptChars = messages.reduce(0) { $0 + $1.content.count }
+        let approxTokens = max(1, (promptChars + trimmed.count) / 4)
+        let purpose = spanName
+        Task { @MainActor in
+            LLMUsageTracker.shared.recordTokens(approxTokens, purpose: purpose)
+        }
+        return trimmed
+    }
+
     // MARK: - Response parsing
 
     /// 从 OpenAI 兼容响应中提取 `choices[0].message.content`。

--- a/DayPageKit/Sources/DayPageServices/MemoryChatService.swift
+++ b/DayPageKit/Sources/DayPageServices/MemoryChatService.swift
@@ -51,29 +51,61 @@ public struct ChatTurn: Identifiable, Equatable, Codable {
 @MainActor
 public final class MemoryChatService: ObservableObject {
 
+    // MARK: AgentPhase
+
+    /// Agent 检索循环的可视阶段（issue #837）。UI 把每个阶段渲染成一行
+    /// 状态文案，让「翻找 → 思考 → 逐字作答」的过程被用户感知——
+    /// 这是把图谱检索的价值显性化的延伸（研究文档 §5 风险 4）。
+    public enum AgentPhase: Equatable {
+        case idle
+        /// 正在重读附着的那条记录（memo 锚定对话首拍）。
+        case reading
+        /// 沿这些线索（实体显示名）翻找相关记录。
+        case retrieving([String])
+        /// 检索完成，找到 N 条相关记录，正在组织回答。
+        case thinking(found: Int)
+        /// LLM token 流式输出中（增量文本见 `streamingText`）。
+        case streaming
+    }
+
     // MARK: Published state
 
     @Published public var turns: [ChatTurn] = []
     @Published public var isResponding = false
     @Published public var errorMessage: String?
+    /// Agent 循环当前阶段；仅在 `isResponding` 期间离开 `.idle`。
+    @Published public private(set) var phase: AgentPhase = .idle
+    /// 流式回答的增量缓冲；回答完成后清空并整体落入 assistant turn。
+    @Published public private(set) var streamingText: String = ""
+    /// memo 锚定对话（issue #837）：附着的那条记录会作为一等上下文
+    /// 注入每一轮 prompt，其 entityMentions 作为图谱检索种子。
+    @Published public private(set) var attachedMemo: Memo?
+    /// 附着 memo 的实体显示名（由调用方解析 wiki `name:` 后传入），
+    /// 用于 `.retrieving` 阶段的文案——slug 直出对 CJK 用户不可读。
+    public private(set) var attachedClues: [String] = []
 
     // MARK: Dependencies
 
     /// 注入式 LLM 调用闭包，便于测试替身。默认走云端 DeepSeek。
     private let send: ([LLMMessage]) async throws -> String
-    /// 注入式检索闭包，默认走图谱增强检索。
+    /// 注入式流式 LLM 闭包（messages, onDelta）→ 完整回答。为 nil 时
+    /// `ask` 走非流式 `send`（测试注入 `send:` 即保持旧行为与节奏）。
+    private let streamSend: (([LLMMessage], @escaping @MainActor @Sendable (String) -> Void) async throws -> String)?
+    /// 注入式检索闭包 `(query, seedEntitySlugs)`，默认走图谱增强检索。
     /// `@Sendable` 标注让它可以安全地跨 actor 边界传给 detached task —— 真实
     /// 默认值 `GraphRetriever.retrieve` 是 `nonisolated static`，本身无主线程
     /// 依赖；测试桩通常是值语义闭包，也可跨线程调度。
-    private let retrieve: @Sendable (String) -> RetrievedContext
+    private let retrieve: @Sendable (String, [String]) -> RetrievedContext
 
     public init(
         send: (([LLMMessage]) async throws -> String)? = nil,
-        retrieve: @escaping @Sendable (String) -> RetrievedContext = { GraphRetriever.retrieve(query: $0) }
+        streamSend: (([LLMMessage], @escaping @MainActor @Sendable (String) -> Void) async throws -> String)? = nil,
+        retrieve: @escaping @Sendable (String, [String]) -> RetrievedContext = { GraphRetriever.retrieve(query: $0, seedEntitySlugs: $1) }
     ) {
         self.retrieve = retrieve
         if let send {
             self.send = send
+            self.streamSend = streamSend
         } else {
             self.send = { messages in
                 let client = LLMClient(
@@ -82,7 +114,36 @@ public final class MemoryChatService: ObservableObject {
                 )
                 return try await client.complete(messages: messages)
             }
+            // 生产默认：优先流式。spanName 与非流式分桶，便于用量对比。
+            self.streamSend = streamSend ?? { messages, onDelta in
+                let client = LLMClient(
+                    config: .deepSeek(maxTokens: 1500, temperature: 0.5),
+                    spanName: "askpast.stream"
+                )
+                return try await client.stream(messages: messages, onDelta: onDelta)
+            }
         }
+    }
+
+    // MARK: - Attached memo (issue #837)
+
+    /// 把一条 memo 附着为对话锚点。`clues` 是其实体的显示名（UI 已解析），
+    /// 缺省时回退为去连字符的 slug。
+    public func attach(memo: Memo, clues: [String] = []) {
+        attachedMemo = memo
+        if clues.isEmpty {
+            attachedClues = memo.entityMentions.map {
+                $0.replacingOccurrences(of: "-", with: " ")
+            }
+        } else {
+            attachedClues = clues
+        }
+    }
+
+    /// 摘除锚点——对话退化为通用「问过去」。已生成的回合保留。
+    public func detachMemo() {
+        attachedMemo = nil
+        attachedClues = []
     }
 
     // MARK: - System prompt
@@ -112,34 +173,81 @@ public final class MemoryChatService: ObservableObject {
     // MARK: - Ask
 
     /// 处理一条用户提问：检索 → 组装 prompt → 调 LLM → 追加 assistant 回合。
+    ///
+    /// Agent loop（issue #837）：每一步驱动 `phase`，让 UI 把「重读 → 翻找 →
+    /// 思考 → 逐字作答」的过程可视化。节奏拍（短 sleep）只在流式路径生效——
+    /// 注入 `send:` 的测试路径保持原有零延迟行为。
     public func ask(_ rawQuestion: String) async {
+        await run(rawQuestion, appendUserTurn: true)
+    }
+
+    /// 重试最近一条 user 提问——不重复追加 user 气泡（流式失败后的
+    /// 「重试」按钮语义：同一个问题，再答一次）。
+    public func retryLast() async {
+        guard let lastUser = turns.last(where: { $0.role == .user }) else { return }
+        await run(lastUser.text, appendUserTurn: false)
+    }
+
+    private func run(_ rawQuestion: String, appendUserTurn: Bool) async {
         let question = rawQuestion.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !question.isEmpty, !isResponding else { return }
 
         errorMessage = nil
-        let userTurn = ChatTurn(role: .user, text: question)
-        turns.append(userTurn)
-        Self.appendTurn(userTurn)
+        if appendUserTurn {
+            let userTurn = ChatTurn(role: .user, text: question)
+            turns.append(userTurn)
+            Self.appendTurn(userTurn)
+        }
         isResponding = true
-        defer { isResponding = false }
+        defer {
+            isResponding = false
+            phase = .idle
+            streamingText = ""
+        }
 
-        // Step 1: 图谱增强检索——磁盘 I/O 走 detached task 避免阻塞主线程。
-        // GraphRetriever.retrieve 是 nonisolated 静态函数，捕获 question 不可
-        // 变副本进入后台，再回到主 actor 装配 messages。
+        let paced = streamSend != nil
+
+        // Phase 0: 重读锚定记录（仅 memo 锚定对话；本地即时，仅是节奏拍）。
+        if attachedMemo != nil {
+            phase = .reading
+            if paced { try? await Task.sleep(nanoseconds: 400_000_000) }
+        }
+
+        // Phase 1 / Step 1: 图谱增强检索——磁盘 I/O 走 detached task 避免阻塞
+        // 主线程。GraphRetriever.retrieve 是 nonisolated 静态函数，捕获不可变
+        // 副本进入后台，再回到主 actor 装配 messages。
+        phase = .retrieving(attachedClues)
         let retrieveClosure = self.retrieve
+        let seedSlugs = attachedMemo?.entityMentions ?? []
         let context = await Task.detached(priority: .userInitiated) { @Sendable in
-            retrieveClosure(question)
+            retrieveClosure(question, seedSlugs)
         }.value
 
         // Allow caller (e.g. sheet dismissal) to cancel mid-flight.
         if Task.isCancelled { return }
 
-        // Step 2: 组装 messages（system + 检索上下文 + 近几轮历史 + 当前问题）。
+        // Phase 2: 「找到 N 条」短拍——检索通常快到不可见，这一拍把
+        // 结果数量讲给用户听，然后才进入等待 LLM 的阶段。
+        phase = .thinking(found: context.memoHits.count)
+        if paced { try? await Task.sleep(nanoseconds: 450_000_000) }
+
+        // Step 2: 组装 messages（system + 锚定 memo + 检索上下文 + 历史 + 问题）。
         let messages = buildMessages(question: question, context: context)
 
-        // Step 3: 调 LLM。
+        // Step 3: 调 LLM——优先流式（token 逐段落入 streamingText），
+        // 无流式闭包时回退一次性 complete。
         do {
-            let answer = try await send(messages)
+            let answer: String
+            if let streamSend {
+                phase = .streaming
+                streamingText = ""
+                answer = try await streamSend(messages) { [weak self] chunk in
+                    self?.streamingText += chunk
+                }
+            } else {
+                answer = try await send(messages)
+            }
+            if Task.isCancelled { return }
             let assistantTurn = ChatTurn(role: .assistant, text: answer, context: context)
             turns.append(assistantTurn)
             Self.appendTurn(assistantTurn)
@@ -237,10 +345,22 @@ public final class MemoryChatService: ObservableObject {
 
     // MARK: - Message assembly
 
+    /// memo 锚定对话的追加 system 规则（issue #837）。
+    public static let anchoredMemoRule = """
+    补充情境：用户此刻正打开自己过去的一条具体记录，并针对它追问。
+    - 优先围绕这条记录回答；它的全文在「用户正在追问的这条记录」块中。
+    - 当检索上下文里出现其他日期的相关记录时，指出它们与这条记录之间的
+      联系或变化（想法的延续、反转、重现），并带上日期。
+    - 不要复述这条记录本身——用户正看着它；直接给出观察与回答。
+    """
+
     /// 构造发给 LLM 的 messages。
     /// 历史只带最近若干轮，避免上下文无限膨胀（token 成本控制，研究文档 §5）。
     public func buildMessages(question: String, context: RetrievedContext, historyLimit: Int = 4) -> [LLMMessage] {
         var messages: [LLMMessage] = [.system(Self.systemPrompt)]
+        if attachedMemo != nil {
+            messages.append(.system(Self.anchoredMemoRule))
+        }
 
         // 最近 historyLimit 轮历史（不含当前这条尚未入队的 user 问题）。
         let priorTurns = turns.dropLast().suffix(historyLimit)
@@ -251,15 +371,28 @@ public final class MemoryChatService: ObservableObject {
             }
         }
 
-        // 当前问题 + 检索上下文一起作为 user 消息，让模型看到依据。
-        let userContent = """
+        // 当前问题 + 锚定记录 + 检索上下文一起作为 user 消息，让模型看到依据。
+        var blocks: [String] = []
+        if let memo = attachedMemo {
+            let f = DateFormatter()
+            f.locale = Locale(identifier: "en_US_POSIX")
+            f.timeZone = TimeZone.current
+            f.dateFormat = "yyyy-MM-dd HH:mm"
+            let moodPart = memo.mood.map { "（情绪：\($0)）" } ?? ""
+            blocks.append("""
+            ## 用户正在追问的这条记录（\(f.string(from: memo.created))\(moodPart)）
+            \(memo.body)
+            """)
+        }
+        blocks.append("""
         ## 检索到的上下文
         \(context.toPromptContext())
-
+        """)
+        blocks.append("""
         ## 我的问题
         \(question)
-        """
-        messages.append(.user(userContent))
+        """)
+        messages.append(.user(blocks.joined(separator: "\n\n")))
         return messages
     }
 }

--- a/DayPageKit/Tests/DayPageServicesTests/MemoryChatEmptyContextTests.swift
+++ b/DayPageKit/Tests/DayPageServicesTests/MemoryChatEmptyContextTests.swift
@@ -19,7 +19,7 @@ final class MemoryChatEmptyContextTests: XCTestCase {
 
     @MainActor
     func test_buildMessages_empty_context_still_includes_promptContext_header() async {
-        let svc = MemoryChatService(send: { _ in "unused" }, retrieve: { _ in
+        let svc = MemoryChatService(send: { _ in "unused" }, retrieve: { _, _ in
             RetrievedContext(query: "", memoHits: [], entityHits: [])
         })
         let empty = RetrievedContext(query: "", memoHits: [], entityHits: [])
@@ -34,7 +34,7 @@ final class MemoryChatEmptyContextTests: XCTestCase {
 
     @MainActor
     func test_pinTurnToDiary_rejects_empty_and_user_role() {
-        let svc = MemoryChatService(send: { _ in "" }, retrieve: { _ in
+        let svc = MemoryChatService(send: { _ in "" }, retrieve: { _, _ in
             RetrievedContext(query: "", memoHits: [], entityHits: [])
         })
         let empty = ChatTurn(role: .assistant, text: "")

--- a/DayPageTests/MemoryChatTests.swift
+++ b/DayPageTests/MemoryChatTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import DayPageServices
+import DayPageModels
 @testable import DayPage
 
 // MARK: - LLMClient parsing
@@ -138,7 +139,7 @@ struct MemoryChatServiceTests {
     @Test func askAppendsUserThenAssistantTurns() async {
         let service = MemoryChatService(
             send: { _ in "这是回答" },
-            retrieve: { Self.fixedContext($0) }
+            retrieve: { q, _ in Self.fixedContext(q) }
         )
         await service.ask("我做了什么？")
         #expect(service.turns.count == 2)
@@ -154,7 +155,7 @@ struct MemoryChatServiceTests {
     @Test func askSurfacesErrorWithoutAssistantTurn() async {
         let service = MemoryChatService(
             send: { _ in throw LLMError.rateLimited },
-            retrieve: { Self.fixedContext($0) }
+            retrieve: { q, _ in Self.fixedContext(q) }
         )
         await service.ask("会失败")
         // 只有 user 回合；assistant 回合不入队，错误走 errorMessage。
@@ -164,13 +165,13 @@ struct MemoryChatServiceTests {
     }
 
     @Test func emptyQuestionIsIgnored() async {
-        let service = MemoryChatService(send: { _ in "x" }, retrieve: { Self.fixedContext($0) })
+        let service = MemoryChatService(send: { _ in "x" }, retrieve: { q, _ in Self.fixedContext(q) })
         await service.ask("   ")
         #expect(service.turns.isEmpty)
     }
 
     @Test func buildMessagesIncludesSystemAndRetrievedContext() {
-        let service = MemoryChatService(send: { _ in "" }, retrieve: { Self.fixedContext($0) })
+        let service = MemoryChatService(send: { _ in "" }, retrieve: { q, _ in Self.fixedContext(q) })
         let ctx = Self.fixedContext("问题")
         let messages = service.buildMessages(question: "我去过哪里？", context: ctx)
         #expect(messages.first?.role == .system)
@@ -180,10 +181,165 @@ struct MemoryChatServiceTests {
     }
 
     @Test func resetClearsConversation() async {
-        let service = MemoryChatService(send: { _ in "答" }, retrieve: { Self.fixedContext($0) })
+        let service = MemoryChatService(send: { _ in "答" }, retrieve: { q, _ in Self.fixedContext(q) })
         await service.ask("Q")
         service.reset()
         #expect(service.turns.isEmpty)
         #expect(service.errorMessage == nil)
+    }
+}
+
+// MARK: - LLMClient SSE line parsing (issue #837)
+
+@Suite("LLMClient.parseSSELine")
+struct LLMClientSSETests {
+
+    @Test func parsesDeltaChunk() {
+        let line = #"data: {"choices":[{"delta":{"content":"你好"}}]}"#
+        #expect(LLMClient.parseSSELine(line) == .delta("你好"))
+    }
+
+    @Test func recognizesDoneSentinel() {
+        #expect(LLMClient.parseSSELine("data: [DONE]") == .done)
+    }
+
+    @Test func ignoresNonDataLinesAndEmptyDeltas() {
+        #expect(LLMClient.parseSSELine("") == .ignore)
+        #expect(LLMClient.parseSSELine(": keep-alive") == .ignore)
+        #expect(LLMClient.parseSSELine("event: message") == .ignore)
+        // role-only first chunk（无 content）与空 content 都应忽略。
+        #expect(LLMClient.parseSSELine(#"data: {"choices":[{"delta":{"role":"assistant"}}]}"#) == .ignore)
+        #expect(LLMClient.parseSSELine(#"data: {"choices":[{"delta":{"content":""}}]}"#) == .ignore)
+        #expect(LLMClient.parseSSELine("data: not-json") == .ignore)
+    }
+}
+
+// MARK: - Memo-anchored chat (issue #837)
+
+@Suite("MemoryChatService memo anchoring")
+@MainActor
+struct MemoAnchoredChatTests {
+
+    nonisolated static func fixedContext(_ q: String) -> RetrievedContext {
+        RetrievedContext(
+            query: q,
+            memoHits: [.init(dateString: "2026-06-22", snippet: "旧的信息架构太吵了", mood: nil, entityMentions: ["xinxi-jiagou"])],
+            entityHits: []
+        )
+    }
+
+    private func makeMemo() -> Memo {
+        Memo(
+            type: .text,
+            created: ISO8601DateFormatter.memo.date(from: "2026-07-12T02:00:00.000Z")!,
+            mood: "平静",
+            entityMentions: ["xinxi-jiagou", "daypage-dev"],
+            body: "凌晨改完档案页的信息架构，出奇地安静。"
+        )
+    }
+
+    @Test func buildMessagesIncludesAnchoredMemoBlockAndRule() {
+        let service = MemoryChatService(send: { _ in "" }, retrieve: { q, _ in Self.fixedContext(q) })
+        service.attach(memo: makeMemo(), clues: ["信息架构"])
+        let messages = service.buildMessages(question: "当时我为什么这么想？", context: Self.fixedContext("x"))
+
+        // system prompt + 锚定规则两条 system 消息。
+        let systems = messages.filter { $0.role == .system }
+        #expect(systems.count == 2)
+        #expect(systems[1].content.contains("针对它追问"))
+
+        let user = messages.last
+        #expect(user?.content.contains("用户正在追问的这条记录") == true)
+        #expect(user?.content.contains("凌晨改完档案页的信息架构") == true)
+        #expect(user?.content.contains("情绪：平静") == true)
+        #expect(user?.content.contains("当时我为什么这么想？") == true)
+    }
+
+    @Test func detachRemovesMemoBlock() {
+        let service = MemoryChatService(send: { _ in "" }, retrieve: { q, _ in Self.fixedContext(q) })
+        service.attach(memo: makeMemo())
+        service.detachMemo()
+        let messages = service.buildMessages(question: "Q", context: Self.fixedContext("x"))
+        #expect(messages.filter { $0.role == .system }.count == 1)
+        #expect(messages.last?.content.contains("用户正在追问的这条记录") == false)
+    }
+
+    @Test func askSeedsRetrievalWithAttachedMemoEntities() async {
+        // Capture the seed slugs the service hands to the retriever.
+        let captured = CapturedSeeds()
+        let service = MemoryChatService(
+            send: { _ in "答" },
+            retrieve: { q, seeds in
+                captured.record(seeds)
+                return Self.fixedContext(q)
+            }
+        )
+        service.attach(memo: makeMemo(), clues: ["信息架构"])
+        await service.ask("关于信息架构我说过什么？")
+        #expect(captured.value == ["xinxi-jiagou", "daypage-dev"])
+        #expect(service.turns.count == 2)
+        // 回合结束后 agent 状态应复位。
+        #expect(service.phase == .idle)
+        #expect(service.streamingText.isEmpty)
+    }
+
+    @Test func attachFallsBackToDehyphenatedSlugsAsClues() {
+        let service = MemoryChatService(send: { _ in "" }, retrieve: { q, _ in Self.fixedContext(q) })
+        service.attach(memo: makeMemo())
+        #expect(service.attachedClues == ["xinxi jiagou", "daypage dev"])
+    }
+
+    @Test func streamSendPathAccumulatesStreamingTextInOrder() async {
+        let service = MemoryChatService(
+            send: { _ in "unused" },
+            streamSend: { _, onDelta in
+                let chunks = ["你在", " 2026-06-22 ", "提到过它。"]
+                for c in chunks { await onDelta(c) }
+                return chunks.joined()
+            },
+            retrieve: { q, _ in Self.fixedContext(q) }
+        )
+        await service.ask("它是什么时候开始的？")
+        #expect(service.turns.count == 2)
+        #expect(service.turns[1].text == "你在 2026-06-22 提到过它。")
+        // 完成后增量缓冲清空、状态复位。
+        #expect(service.streamingText.isEmpty)
+        #expect(service.phase == .idle)
+    }
+
+    @Test func retryLastDoesNotDuplicateUserTurn() async {
+        let flaky = FlipFlop()
+        let service = MemoryChatService(
+            send: { _ in
+                if flaky.flip() { throw LLMError.networkTimeout }
+                return "第二次成功"
+            },
+            retrieve: { q, _ in Self.fixedContext(q) }
+        )
+        await service.ask("会先失败的问题")
+        #expect(service.turns.count == 1)
+        #expect(service.errorMessage != nil)
+
+        await service.retryLast()
+        #expect(service.turns.count == 2)      // user + assistant，无重复 user
+        #expect(service.turns[0].role == .user)
+        #expect(service.turns[1].text == "第二次成功")
+        #expect(service.errorMessage == nil)
+    }
+}
+
+/// 跨 @Sendable 闭包捕获检索种子的小盒子（class 引用语义；测试里检索
+/// 闭包只被调用一次，无并发写）。
+private final class CapturedSeeds: @unchecked Sendable {
+    private(set) var value: [String] = []
+    func record(_ seeds: [String]) { value = seeds }
+}
+
+/// 第一次调用返回 true（触发失败），之后 false。
+private final class FlipFlop: @unchecked Sendable {
+    private var first = true
+    func flip() -> Bool {
+        defer { first = false }
+        return first
     }
 }


### PR DESCRIPTION
Closes #837 · Stacked on #836（base: `feature/memo-detail-memory-layer`）

## 这是什么

小红书式「拖回变卡片 → 投入对话坞」：在 memo 详情页横向起手拖拽，整页凝缩成卡片跟随手指；底部升起「对话坞」，投入即打开 **memo 锚定的 AI 对话**——这条笔记以「记忆芯片」挂在输入框上，全程作为一等上下文进入 Agent 检索循环。

## 交互（DropToAskGesture.swift）

- pan 挂**祖先容器**（`didMoveToWindow` 可靠挂载）+ 复用 `HorizontalPanGesture` 速度方向锁 → 纵向滚动、页内点击零损
- 卡心按凝缩进度向手指收敛（`location` 驱动，非 translation 1:1）
- 入坞琥珀点亮 + haptic；释放入坞 → sheet；坞外右移 >40% 屏宽 → 等效返回（保留慢拖返回语义）；否则弹回
- Reduce Motion 降级；无障碍走 CTA 明路（原「追问过去的自己」改为直开同一 sheet，不再 URL round-trip）

## 对话（MemoChatView.swift）

- 记忆芯片可 × 摘除（退化为通用问过去）· 实体感知建议问题（wiki 显示名）
- serif 流式回答 + 琥珀呼吸光标 · SOURCES 日期 chip → 跳回那一天 · 存入今日日记 · 失败 Retry

## Agent Loop（DayPageKit）

- `AgentPhase`：reading → retrieving(沿「实体」翻找) → thinking(找到 N 条) → streaming，全程可视化
- `GraphRetriever.retrieve(seedEntitySlugs:)`：锚定 memo 的 entityMentions 直接图谱扩展
- `LLMClient.stream`：DeepSeek SSE（`parseSSELine` 纯函数可测；onDelta `@MainActor` await 保序；流式不重试，重试归 UI `retryLast()`——不重复 user 气泡）

## 验证

- 单测 **23/23**（SSE/锚定 prompt/种子捕获/流式顺序/retry）+ Kit 包测试 3/3
- iPhone 17 Pro 实拍（亮+暗）：凝缩跟手、坞点亮、入坞开 sheet（`hover=1 → release overDock=1` 日志确证）、commit-back 返回、记忆芯片/建议问题/错误态+Retry
- 备注：模拟器无 LLM key，流式真回答请真机体验；坞判定阈值（`dockZoneHeight=170`）可按真机手感再调