### PR TITLE
fix(watch): 补齐 watch target manual 签名修复 TestFlight 归档失败

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -1680,7 +1680,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = 6RG2F8YY59;
@@ -1695,6 +1696,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app.watchkitapp";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -1937,7 +1939,8 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 6RG2F8YY59;
 				ENABLE_PREVIEWS = YES;
@@ -1951,6 +1954,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.daypage.app.watchkitapp;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.daypage.app.watchkitapp";
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## 问题

PR #840 合并后，main 触发的 TestFlight 构建在 **归档（build_app）** 阶段失败：

```
error: No profiles for 'com.daypage.app.watchkitapp' were found
```

## 根因

`match` 步骤本身成功了（日志 summary 里 3 个 match 各 3 秒都过），profile 已拉取并安装进 keychain。但 **watch target 在 pbxproj 里用的是 `CODE_SIGN_STYLE = Automatic` 且缺 `PROVISIONING_PROFILE_SPECIFIER`** —— manual match 流程下，xcodebuild 归档时不知道该给 watch 用哪个 profile。

对比同为 embedded target 的 DayPageWidget（CI 里能正常签名），它有完整的 manual signing 设置，而 watch 一件都没有。

## 修复

照 widget 的成功模式，给 watch 的 Debug/Release 两个 config 补齐：

| 设置 | 值 |
|---|---|
| `CODE_SIGN_STYLE` | Automatic → **Manual** |
| `CODE_SIGN_IDENTITY` | **"Apple Distribution"**（watchOS 分发证书） |
| `PROVISIONING_PROFILE_SPECIFIER` | **"match AppStore com.daypage.app.watchkitapp"** |

profile 名取自失败 run 里 `MATCH_PROVISIONING_PROFILE_MAPPING` 的真实值，确保与 CI 动态生成的映射一致。`DEVELOPMENT_TEAM = 6RG2F8YY59` 原已存在，保持不变。

## 验证
- ✅ `plutil -lint project.pbxproj` — OK
- ✅ `xcodebuild -scheme DayPageWatch` (watchOS Simulator) — BUILD SUCCEEDED
- 归档签名需 CI 真实 profile，合并后由 TestFlight 流水线验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)