### PR TITLE
feat(watch): 手表捕获重设计 — 三页导航 + 可配置 + 双手势 + 历史

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -161,6 +161,7 @@
 		DS0000014 /* DSBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000014 /* DSBanner.swift */; };
 		DS0000015 /* DSPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = DS1000015 /* DSPicker.swift */; };
 		E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11E0748715A251EE4A0168A /* WatchReceiveService.swift */; };
+		T10000074 /* WatchTranscriptSender.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000074 /* WatchTranscriptSender.swift */; };
 		E4AC46FA495D4BD178789A14 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0881AB423FF6F12FCDE27C5B /* Assets.xcassets */; };
 		E5077A7D97855770914BFB8D /* MarkdownExportService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC8043A3D3371852ACB3D6F3 /* MarkdownExportService.swift */; };
 		E536EEB8C13B2BA42DF4980F /* SidebarHeatmapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C551D36362FF97C44EB4D5DE /* SidebarHeatmapView.swift */; };
@@ -430,6 +431,7 @@
 		ES1000002 /* GlassErrorBanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GlassErrorBanner.swift; sourceTree = "<group>"; };
 		ES1000004 /* GraphSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphSkeleton.swift; sourceTree = "<group>"; };
 		F11E0748715A251EE4A0168A /* WatchReceiveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchReceiveService.swift; sourceTree = "<group>"; };
+		T20000074 /* WatchTranscriptSender.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTranscriptSender.swift; sourceTree = "<group>"; };
 		F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTransferService.swift; sourceTree = "<group>"; };
 		T20000070 /* WatchSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSettingsStore.swift; sourceTree = "<group>"; };
 		T20000071 /* WatchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHistoryStore.swift; sourceTree = "<group>"; };
@@ -770,6 +772,7 @@
 			isa = PBXGroup;
 			children = (
 				F11E0748715A251EE4A0168A /* WatchReceiveService.swift */,
+				T20000074 /* WatchTranscriptSender.swift */,
 				A20000018 /* PhotoService.swift */,
 				A20000019 /* VoiceService.swift */,
 				A20000023 /* BackgroundCompilationService.swift */,
@@ -1417,6 +1420,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				E20A68158C940060066B2B73 /* WatchReceiveService.swift in Sources */,
+				T10000074 /* WatchTranscriptSender.swift in Sources */,
 				A10000001 /* DayPageApp.swift in Sources */,
 				A10000002 /* RootView.swift in Sources */,
 				A10000004 /* GeneratedSecrets.swift in Sources */,

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		T10000003 /* VaultMigrationServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000003 /* VaultMigrationServiceTests.swift */; };
 		T10000004 /* VaultLocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000004 /* VaultLocatorTests.swift */; };
 		T10000005 /* RawStorageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000005 /* RawStorageTests.swift */; };
+		T10000062 /* WatchReceiveServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000062 /* WatchReceiveServiceTests.swift */; };
 		T10000006 /* ComposerContextProviderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000006 /* ComposerContextProviderTests.swift */; };
 		T10000050 /* TimelineIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000050 /* TimelineIndexTests.swift */; };
 		T10000060 /* OnThisDayHeaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000060 /* OnThisDayHeaderTests.swift */; };
@@ -471,6 +472,7 @@
 		T20000003 /* VaultMigrationServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultMigrationServiceTests.swift; sourceTree = "<group>"; };
 		T20000004 /* VaultLocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultLocatorTests.swift; sourceTree = "<group>"; };
 		T20000005 /* RawStorageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RawStorageTests.swift; sourceTree = "<group>"; };
+		T20000062 /* WatchReceiveServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchReceiveServiceTests.swift; sourceTree = "<group>"; };
 		T20000006 /* ComposerContextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerContextProviderTests.swift; sourceTree = "<group>"; };
 		T20000050 /* TimelineIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineIndexTests.swift; sourceTree = "<group>"; };
 		T20000060 /* OnThisDayHeaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayHeaderTests.swift; sourceTree = "<group>"; };
@@ -1082,6 +1084,7 @@
 				T20000003 /* VaultMigrationServiceTests.swift */,
 				T20000004 /* VaultLocatorTests.swift */,
 				T20000005 /* RawStorageTests.swift */,
+				T20000062 /* WatchReceiveServiceTests.swift */,
 				T20000050 /* TimelineIndexTests.swift */,
 				T20000060 /* OnThisDayHeaderTests.swift */,
 				T20000061 /* OnThisDayIntegrationTests.swift */,
@@ -1543,6 +1546,7 @@
 				T10000003 /* VaultMigrationServiceTests.swift in Sources */,
 				T10000004 /* VaultLocatorTests.swift in Sources */,
 				T10000005 /* RawStorageTests.swift in Sources */,
+				T10000062 /* WatchReceiveServiceTests.swift in Sources */,
 				T10000050 /* TimelineIndexTests.swift in Sources */,
 				T10000060 /* OnThisDayHeaderTests.swift in Sources */,
 				T10000061 /* OnThisDayIntegrationTests.swift in Sources */,

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -22,6 +22,10 @@
 		31D89981FFB0794C1682BEC9 /* DayPageStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 1849755B85C13ED4D81002E9 /* DayPageStorage */; };
 		326A14114B34412568007B4A /* DayPageWidgetBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */; };
 		347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */; };
+		T10000070 /* WatchSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000070 /* WatchSettingsStore.swift */; };
+		T10000071 /* WatchHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000071 /* WatchHistoryStore.swift */; };
+		T10000072 /* WatchSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000072 /* WatchSettingsView.swift */; };
+		T10000073 /* WatchHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = T20000073 /* WatchHistoryView.swift */; };
 		3C0AE791CCB255E33198C9F9 /* UndoPillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12641793A8F375B34321E87A /* UndoPillView.swift */; };
 		457A17AB7F3B4BE7C2E77026 /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */; };
 		485EFA11789212D87CB1B74B /* StartRecordingIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2EF24DE1810B0DA979103772 /* StartRecordingIntent.swift */; };
@@ -427,6 +431,10 @@
 		ES1000004 /* GraphSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GraphSkeleton.swift; sourceTree = "<group>"; };
 		F11E0748715A251EE4A0168A /* WatchReceiveService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchReceiveService.swift; sourceTree = "<group>"; };
 		F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchTransferService.swift; sourceTree = "<group>"; };
+		T20000070 /* WatchSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSettingsStore.swift; sourceTree = "<group>"; };
+		T20000071 /* WatchHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHistoryStore.swift; sourceTree = "<group>"; };
+		T20000072 /* WatchSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchSettingsView.swift; sourceTree = "<group>"; };
+		T20000073 /* WatchHistoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchHistoryView.swift; sourceTree = "<group>"; };
 		F5BB61FECBCF7AB756E7A6CE /* WatchApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WatchApp.swift; sourceTree = "<group>"; };
 		FB1000002 /* FeedbackViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackViewModel.swift; sourceTree = "<group>"; };
 		FB1000003 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
@@ -573,6 +581,8 @@
 			isa = PBXGroup;
 			children = (
 				B93ED807E07C2171E9F4234B /* RecordingView.swift */,
+				T20000072 /* WatchSettingsView.swift */,
+				T20000073 /* WatchHistoryView.swift */,
 			);
 			path = Features;
 			sourceTree = "<group>";
@@ -1022,6 +1032,8 @@
 			isa = PBXGroup;
 			children = (
 				F4D76DD4BFDDBF33176F1331 /* WatchTransferService.swift */,
+				T20000070 /* WatchSettingsStore.swift */,
+				T20000071 /* WatchHistoryStore.swift */,
 			);
 			path = Services;
 			sourceTree = "<group>";
@@ -1382,6 +1394,10 @@
 				B197ECDEBDA86D4351A96898 /* RecordingView.swift in Sources */,
 				347B8BDADCBDDB2EDE830E66 /* WatchTransferService.swift in Sources */,
 				A46C6A46A2D76FF5DBFBD6C6 /* StartRecordingIntent.swift in Sources */,
+				T10000070 /* WatchSettingsStore.swift in Sources */,
+				T10000071 /* WatchHistoryStore.swift in Sources */,
+				T10000072 /* WatchSettingsView.swift in Sources */,
+				T10000073 /* WatchHistoryView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/DayPage/Services/VoiceAttachmentQueue.swift
+++ b/DayPage/Services/VoiceAttachmentQueue.swift
@@ -224,6 +224,10 @@ final class VoiceAttachmentQueue: ObservableObject {
         }
 
         var matched = false
+        // Capture watch-origin info so we can send the transcript summary back
+        // to the watch after a successful write (the "最近已同步" history feed).
+        var watchDuration: Double?
+        var isWatchSourced = false
         do {
             try RawStorage.mutate(for: date) { memos in
                 let updated = memos.map { memo -> Memo in
@@ -231,6 +235,10 @@ final class VoiceAttachmentQueue: ObservableObject {
                     copy.attachments = memo.attachments.map { att -> Memo.Attachment in
                         guard att.file == audioPath, att.kind == "audio" else { return att }
                         matched = true
+                        if memo.device == "Apple Watch" {
+                            isWatchSourced = true
+                            watchDuration = att.duration
+                        }
                         var a = att
                         a.transcript = transcript
                         a.transcriptionStatus = .done
@@ -259,6 +267,20 @@ final class VoiceAttachmentQueue: ObservableObject {
                 message: "applyTranscript: no matching attachment on \(memoDate)"
             )
             return false
+        }
+
+        // Reverse channel: tell the watch this clip is synced + transcribed so
+        // its history page can show it under "最近". Keyed by the source
+        // filename (the shared correlation key across the WCSession boundary).
+        if isWatchSourced {
+            let filename = (audioPath as NSString).lastPathComponent
+            Task { @MainActor in
+                WatchTranscriptSender.shared.send(
+                    filename: filename,
+                    summary: transcript,
+                    duration: watchDuration
+                )
+            }
         }
         return true
     }

--- a/DayPage/Services/WatchReceiveService.swift
+++ b/DayPage/Services/WatchReceiveService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WatchConnectivity
+import DayPageModels
 import DayPageStorage
 import DayPageServices
 
@@ -76,9 +77,25 @@ extension WatchReceiveService: WCSessionDelegate {
                 ? String(destURL.path.dropFirst(vaultRoot.path.count + 1))
                 : "raw/assets/\(destURL.lastPathComponent)"
 
+            // A single `now` shared by the memo's `created` date and the
+            // transcription enqueue: `VoiceAttachmentQueue.applyTranscript`
+            // resolves the day file from `memoDate`, and it must land on the
+            // same day as the memo we append below or the transcript can never
+            // match the attachment (att.file == audioPath) and would exhaust
+            // retries into `.failed`.
+            let now = Date()
+            let duration = metadata["duration"] as? Double
+
+            // Bug fix: the receiver previously only enqueued transcription,
+            // which bumped the "N pending" count but never created a memo — so
+            // the audio file arrived and the count showed, yet no card ever
+            // appeared in Today. Mirror the phone-side capture path by writing
+            // a voice memo into today's raw file.
+            Self.appendVoiceMemo(audioPath: audioPath, duration: duration, created: now)
+
             Task { @MainActor in
                 self.lastReceivedFile = destURL
-                VoiceAttachmentQueue.shared.enqueue(audioPath: audioPath, memoDate: Date())
+                VoiceAttachmentQueue.shared.enqueue(audioPath: audioPath, memoDate: now)
             }
         } catch {
             DayPageLogger.log(level: "ERROR", message: "WatchReceiveService failed to move file: \(error.localizedDescription)")
@@ -86,5 +103,39 @@ extension WatchReceiveService: WCSessionDelegate {
                 self.lastError = error.localizedDescription
             }
         }
+    }
+
+    /// Build and persist the voice memo for a received watch audio clip.
+    ///
+    /// Mirrors the phone-side capture path (`TodayViewModel.submit` →
+    /// `RawStorage.append`): a `.voice` memo carrying one `audio` attachment in
+    /// the `.pending` transcription state, so the Today timeline shows a card
+    /// immediately and `VoiceAttachmentQueue` can later patch the transcript
+    /// onto the exact attachment whose `file` matches `audioPath`.
+    ///
+    /// `internal static` and returns the memo purely for test access — the
+    /// production caller ignores the return value.
+    @discardableResult
+    nonisolated static func appendVoiceMemo(audioPath: String, duration: Double?, created: Date) -> Memo {
+        let attachment = Memo.Attachment(
+            file: audioPath,
+            kind: "audio",
+            duration: duration,
+            transcript: nil,
+            transcriptionStatus: .pending
+        )
+        let memo = Memo(
+            type: .voice,
+            created: created,
+            device: "Apple Watch",
+            attachments: [attachment]
+        )
+        do {
+            try RawStorage.append(memo)
+            DayPageLogger.log(level: "INFO", message: "WatchReceiveService appended voice memo \(memo.id) to \(created)")
+        } catch {
+            DayPageLogger.log(level: "ERROR", message: "WatchReceiveService failed to append memo: \(error.localizedDescription)")
+        }
+        return memo
     }
 }

--- a/DayPage/Services/WatchTranscriptSender.swift
+++ b/DayPage/Services/WatchTranscriptSender.swift
@@ -1,0 +1,50 @@
+import Foundation
+import WatchConnectivity
+
+// MARK: - WatchTranscriptSender
+
+/// Phone → watch reverse channel. After the phone transcribes a watch-sourced
+/// voice clip, it sends a compact summary back to the watch so the watch's
+/// history page can show the clip under "最近已同步".
+///
+/// Uses `transferUserInfo` (ordered, background-delivered queue) rather than
+/// `sendMessage` — the watch app is almost never reachable at transcription
+/// time, and every synced clip matters, in order. The payload is tiny metadata
+/// (filename, a truncated summary, duration); the audio itself never travels
+/// back.
+///
+/// `WCSession` activation + delegation is owned by `WatchReceiveService`; this
+/// type only enqueues outbound transfers.
+@MainActor
+final class WatchTranscriptSender {
+
+    static let shared = WatchTranscriptSender()
+
+    /// Cap the summary so the reverse payload stays small — the watch only
+    /// shows a one-line preview.
+    private let summaryLimit = 60
+
+    private init() {}
+
+    func send(filename: String, summary: String, duration: Double?) {
+        guard WCSession.isSupported() else { return }
+        let session = WCSession.default
+        // Only meaningful if a watch app is installed to receive it.
+        guard session.activationState == .activated, session.isWatchAppInstalled else { return }
+
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        let preview = trimmed.count > summaryLimit
+            ? String(trimmed.prefix(summaryLimit)) + "…"
+            : trimmed
+
+        var info: [String: Any] = [
+            "type": "watchTranscript",
+            "filename": filename,
+            "summary": preview,
+            "syncedAt": Date().timeIntervalSince1970,
+        ]
+        if let duration { info["duration"] = duration }
+
+        session.transferUserInfo(info)
+    }
+}

--- a/DayPageKit/Sources/DayPageServices/FeatureFlags.swift
+++ b/DayPageKit/Sources/DayPageServices/FeatureFlags.swift
@@ -70,6 +70,12 @@ public enum FeatureFlag: String, CaseIterable {
     /// **Default**: on
     case vaultExport
 
+    /// **Used in**: `RootView`（DayPageWatch/App/RootView.swift）
+    /// **When off**: 手表回退到旧的单屏录音（只 `RecordingView`），不显示三页 TabView / 历史 / 设置。
+    /// **Watch**: 手表捕获可配置化（三页导航 + 设置 + 历史）—— 给新交互一个无需 hot-fix 的兜底开关。
+    /// **Default**: on
+    case watchCaptureConfig
+
     /// Default state when the user has never touched the toggle. All Round 4
     /// flags default-on so the app behaves the way the user already expects
     /// after upgrading — Experiments only lets them *opt out*.
@@ -83,7 +89,8 @@ public enum FeatureFlag: String, CaseIterable {
              .offlineQueue,
              .onThisDay,
              .weeklyRecap,
-             .vaultExport:
+             .vaultExport,
+             .watchCaptureConfig:
             return true
         }
     }
@@ -102,6 +109,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .onThisDay:              return "时光胶囊"
         case .weeklyRecap:            return "周回顾"
         case .vaultExport:            return "Vault 导出"
+        case .watchCaptureConfig:     return "手表捕获配置"
         }
     }
 }

--- a/DayPageTests/WatchReceiveServiceTests.swift
+++ b/DayPageTests/WatchReceiveServiceTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+import DayPageModels
+import DayPageStorage
+import DayPageServices
+@testable import DayPage
+
+/// Regression tests for the watch-audio receive path.
+///
+/// Bug: when the iPhone received a voice clip from the Apple Watch, it saved
+/// the file and enqueued transcription (which bumped the "N pending" count),
+/// but never created a memo — so the audio arrived and the count showed, yet
+/// no card ever appeared in Today, and the transcript could never match a
+/// non-existent attachment (retries exhausted into `.failed`).
+///
+/// The fix mirrors the phone-side capture path: `appendVoiceMemo` writes a
+/// `.voice` memo with a `.pending` audio attachment into the day file, so the
+/// card shows immediately and `VoiceAttachmentQueue.applyTranscript` can patch
+/// the transcript onto the attachment whose `file` matches `audioPath`.
+final class WatchReceiveServiceTests: XCTestCase {
+
+    private var tempDir: URL!
+    private let fm = FileManager.default
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        tempDir = fm.temporaryDirectory
+            .appendingPathComponent("WatchReceiveServiceTests-\(UUID().uuidString)", isDirectory: true)
+        try fm.createDirectory(at: tempDir, withIntermediateDirectories: true)
+        VaultInitializer.testOverrideURL = tempDir
+    }
+
+    override func tearDownWithError() throws {
+        VaultInitializer.testOverrideURL = nil
+        try? fm.removeItem(at: tempDir)
+        tempDir = nil
+        try super.tearDownWithError()
+    }
+
+    // MARK: - appendVoiceMemo
+
+    /// The core regression: receiving a watch clip must produce exactly one
+    /// readable voice memo in today's file — not just an enqueued transcription.
+    func testAppendVoiceMemo_writesReadableVoiceMemoToDayFile() throws {
+        let now = Date()
+        let audioPath = "raw/assets/watch_20260714_101500_ABCD.m4a"
+
+        let memo = WatchReceiveService.appendVoiceMemo(audioPath: audioPath, duration: 12.0, created: now)
+
+        let readBack = try RawStorage.read(for: now)
+        XCTAssertEqual(readBack.count, 1, "Receiving a watch clip must create exactly one memo")
+        let saved = try XCTUnwrap(readBack.first)
+        XCTAssertEqual(saved.id, memo.id, "Read-back memo must be the one appendVoiceMemo returned")
+        XCTAssertEqual(saved.type, .voice, "Watch audio memo must be typed .voice")
+    }
+
+    /// The attachment must carry the audio metadata and start in `.pending` so
+    /// the card shows the shimmer placeholder and the queue can later match it.
+    func testAppendVoiceMemo_attachmentIsPendingAudioMatchingAudioPath() throws {
+        let now = Date()
+        let audioPath = "raw/assets/watch_20260714_101500_WXYZ.m4a"
+
+        WatchReceiveService.appendVoiceMemo(audioPath: audioPath, duration: 8.5, created: now)
+
+        let saved = try XCTUnwrap(try RawStorage.read(for: now).first)
+        XCTAssertEqual(saved.attachments.count, 1)
+        let att = try XCTUnwrap(saved.attachments.first)
+        XCTAssertEqual(att.kind, "audio")
+        XCTAssertEqual(att.file, audioPath,
+            "attachment.file must equal audioPath so VoiceAttachmentQueue.applyTranscript can match it")
+        XCTAssertEqual(att.transcriptionStatus, .pending,
+            "A freshly received clip must be pending — not done, not failed")
+        XCTAssertNil(att.transcript, "No transcript should exist yet")
+        XCTAssertEqual(att.duration, 8.5, "Duration from the transfer metadata must be preserved")
+    }
+
+    /// Duration is optional in the transfer metadata (older watch builds omit
+    /// it); a nil duration must still produce a valid pending audio memo.
+    func testAppendVoiceMemo_nilDurationStillProducesValidMemo() throws {
+        let now = Date()
+        let audioPath = "raw/assets/watch_nodur.m4a"
+
+        WatchReceiveService.appendVoiceMemo(audioPath: audioPath, duration: nil, created: now)
+
+        let saved = try XCTUnwrap(try RawStorage.read(for: now).first)
+        let att = try XCTUnwrap(saved.attachments.first)
+        XCTAssertNil(att.duration, "A missing duration must round-trip as nil, not crash or default")
+        XCTAssertEqual(att.transcriptionStatus, .pending)
+    }
+
+    /// The memo must be tagged so it's distinguishable from phone captures.
+    func testAppendVoiceMemo_taggedAsAppleWatch() throws {
+        let now = Date()
+        WatchReceiveService.appendVoiceMemo(audioPath: "raw/assets/watch_x.m4a", duration: 3, created: now)
+        let saved = try XCTUnwrap(try RawStorage.read(for: now).first)
+        XCTAssertEqual(saved.device, "Apple Watch", "Watch-sourced memos must be tagged for provenance")
+    }
+
+    /// A transcript written back through the queue's applyTranscript path must
+    /// land on the appended attachment — proving the end-to-end shape works:
+    /// append (pending) → applyTranscript (done). This is the exact failure the
+    /// bug caused (no attachment to match) inverted into a passing assertion.
+    func testAppendedMemo_canReceiveTranscriptWriteback() throws {
+        let now = Date()
+        let audioPath = "raw/assets/watch_writeback.m4a"
+        WatchReceiveService.appendVoiceMemo(audioPath: audioPath, duration: 5, created: now)
+
+        let f = DateFormatter()
+        f.dateFormat = "yyyy-MM-dd"
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = AppSettings.currentTimeZone()
+        let memoDate = f.string(from: now)
+
+        let matched = VoiceAttachmentQueue.applyTranscript(
+            transcript: "hello from the watch",
+            audioPath: audioPath,
+            memoDate: memoDate
+        )
+        XCTAssertTrue(matched, "applyTranscript must find the appended attachment by audioPath")
+
+        let saved = try XCTUnwrap(try RawStorage.read(for: now).first)
+        let att = try XCTUnwrap(saved.attachments.first)
+        XCTAssertEqual(att.transcript, "hello from the watch")
+        XCTAssertEqual(att.transcriptionStatus, .done)
+    }
+}

--- a/DayPageWatch/App/RootView.swift
+++ b/DayPageWatch/App/RootView.swift
@@ -1,13 +1,59 @@
 import SwiftUI
+import DayPageServices
 
+// MARK: - RootView
+
+/// Three-page vertical TabView — the Digital Crown scrolls between them:
+///
+///   ↑ History  ·  ● Record (default)  ·  Settings ↓
+///
+/// Record is the middle page and the default landing so a recording is always
+/// two seconds away (watchOS "glanceable first" principle). History sits above,
+/// Settings below. Each page owns its own NavigationStack for drill-downs
+/// (settings sub-pickers, future history detail).
 struct RootView: View {
 
     @StateObject private var watchSession = WatchSessionManager.shared
+    @StateObject private var settings = WatchSettingsStore.shared
+    @StateObject private var history = WatchHistoryStore.shared
+
+    /// Middle page selected by default. `.record` is the app's center of gravity.
+    @State private var page: Page = .record
+
+    private enum Page: Hashable {
+        case history, record, settings
+    }
 
     var body: some View {
-        NavigationStack {
-            RecordingView()
+        Group {
+            if FeatureFlagStore.shared.isEnabled(.watchCaptureConfig) {
+                threePageLayout
+            } else {
+                // Kill switch: fall back to the original single-screen record.
+                NavigationStack { RecordingView() }
+            }
         }
         .environmentObject(watchSession)
+        .environmentObject(settings)
+    }
+
+    private var threePageLayout: some View {
+        TabView(selection: $page) {
+            NavigationStack {
+                WatchHistoryView(history: history)
+            }
+            .tag(Page.history)
+
+            NavigationStack {
+                RecordingView()
+            }
+            .tag(Page.record)
+
+            NavigationStack {
+                WatchSettingsView(settings: settings)
+            }
+            .tag(Page.settings)
+        }
+        .tabViewStyle(.verticalPage)
     }
 }

--- a/DayPageWatch/App/WatchApp.swift
+++ b/DayPageWatch/App/WatchApp.swift
@@ -23,21 +23,48 @@ struct DayPageWatchApp: App {
 
 // MARK: - OrphanFileCleanup
 
-/// Deletes audio files in the Watch tmp directory that are older than 24 hours.
-/// These accumulate when transfers fail and the app is terminated before cleanup.
+/// Removes leftover audio files in the Watch tmp directory.
+///
+/// Every file here is, by construction, **undelivered**: a successful transfer
+/// deletes its source file in `WatchTransferService.handleTransferFinished`, so
+/// anything that lingers is from a failed or interrupted transfer. How long to
+/// keep such a file before giving up on it is the user's `WatchRetentionPolicy`:
+///
+///   - `.oneDay` / `.sevenDays` — delete once older than the window
+///   - `.untilDelivered`        — never age-delete; keep until the transfer
+///                                confirms delivery (the paired-device model's
+///                                answer to "watch was away from phone too long")
+///
+/// This replaces the old hardcoded 24h window, which silently dropped a memo
+/// when the watch stayed away from its phone for more than a day.
 enum OrphanFileCleanup {
 
     private static let logger = Logger(subsystem: "com.daypage.watch", category: "OrphanFileCleanup")
     private static let watchTmpDir = "com.daypage.watch"
-    private static let maxAge: TimeInterval = 86_400  // 24 hours
 
-    static func run() {
+    /// Pure age decision — `internal static` for test access. Returns true when
+    /// an undelivered file created at `created` should be removed under `policy`
+    /// as of `now`. `.untilDelivered` (nil max age) never age-deletes.
+    static func shouldDelete(created: Date, now: Date, policy: WatchRetentionPolicy) -> Bool {
+        guard let maxAge = policy.maxUndeliveredAge else { return false }
+        return now.timeIntervalSince(created) > maxAge
+    }
+
+    /// `policy` defaults to the user's current setting (resolved inside the
+    /// main-actor body — a default argument can't read the MainActor store).
+    @MainActor
+    static func run(policy: WatchRetentionPolicy? = nil) {
+        let policy = policy ?? WatchSettingsStore.shared.retentionPolicy
+
         let dir = FileManager.default.temporaryDirectory
             .appendingPathComponent(watchTmpDir, isDirectory: true)
 
         guard FileManager.default.fileExists(atPath: dir.path) else { return }
 
-        let cutoff = Date().addingTimeInterval(-maxAge)
+        // Nothing to age out — undelivered files are kept until delivered.
+        guard policy.maxUndeliveredAge != nil else { return }
+
+        let now = Date()
         var removed = 0
 
         do {
@@ -48,7 +75,7 @@ enum OrphanFileCleanup {
             )
             for file in files {
                 let created = (try? file.resourceValues(forKeys: [.creationDateKey]))?.creationDate ?? .distantPast
-                if created < cutoff {
+                if shouldDelete(created: created, now: now, policy: policy) {
                     try? FileManager.default.removeItem(at: file)
                     removed += 1
                 }

--- a/DayPageWatch/App/WatchApp.swift
+++ b/DayPageWatch/App/WatchApp.swift
@@ -139,4 +139,22 @@ extension WatchSessionManager: WCSessionDelegate {
             )
         }
     }
+
+    /// Reverse channel (P3): the phone reports a transcribed + synced clip.
+    /// Route it into the history store's "recent" feed.
+    nonisolated func session(_ session: WCSession, didReceiveUserInfo userInfo: [String : Any] = [:]) {
+        guard let type = userInfo["type"] as? String, type == "watchTranscript",
+              let filename = userInfo["filename"] as? String else { return }
+        let summary = userInfo["summary"] as? String ?? ""
+        let duration = Int((userInfo["duration"] as? Double) ?? 0)
+        let syncedAt = (userInfo["syncedAt"] as? TimeInterval).map(Date.init(timeIntervalSince1970:)) ?? Date()
+        Task { @MainActor in
+            WatchHistoryStore.shared.markSynced(
+                filename: filename,
+                summary: summary,
+                duration: duration,
+                syncedAt: syncedAt
+            )
+        }
+    }
 }

--- a/DayPageWatch/Features/RecordingView.swift
+++ b/DayPageWatch/Features/RecordingView.swift
@@ -12,11 +12,20 @@ struct RecordingView: View {
 
     @StateObject private var model = WatchRecordingModel()
 
+    /// Observed so switching capture mode in Settings re-renders the gestures.
+    @ObservedObject private var settings = WatchSettingsStore.shared
+
     /// Proxy value for the Digital Crown — mirrors model.maxDuration as a Double.
     @State private var crownValue: Double = 60
 
+    /// Press-mode: true while the finger has slid up far enough to arm cancel.
+    @State private var pressCancelArmed = false
+
     /// True when the watch is in Always-On Display (AOD) low-luminance mode.
     @Environment(\.isLuminanceReduced) private var isLuminanceReduced
+
+    /// Vertical drag distance (points) past which a press-mode hold arms cancel.
+    private let pressCancelThreshold: CGFloat = 40
 
     var body: some View {
         if model.isMicPermissionDenied {
@@ -115,33 +124,96 @@ struct RecordingView: View {
         model.state == .recording || model.state == .confirmStop
     }
 
-    /// The hero control — a tappable ring that pulses while recording and fills
-    /// with elapsed progress. Waveform bars animate inside during capture.
+    /// The hero control — a ring that pulses while recording and fills with
+    /// elapsed progress. Its gesture wiring depends on the capture mode:
+    ///   - `.tap`   a Button (tap start/stop) + a long-press-to-cancel gesture
+    ///   - `.press` a press-and-hold DragGesture (hold = record, release = send,
+    ///              slide up = cancel)
     private var recordingActionButton: some View {
         Group {
-            if !isLuminanceReduced {
-                Button(action: primaryAction) {
-                    RecordingRing(
-                        state: model.state,
-                        progress: model.maxDuration > 0 ? Double(model.elapsed) / Double(model.maxDuration) : 0,
-                        color: stateColor
-                    )
-                }
-                .buttonStyle(RingButtonStyle())
-                .accessibilityLabel(ringAccessibilityLabel)
-            } else {
+            if isLuminanceReduced {
                 // AOD: static ring only, no controls (OLED burn-in + not tappable).
                 RecordingRing(state: model.state, progress: 0, color: stateColor.opacity(0.6))
                     .allowsHitTesting(false)
+            } else {
+                switch settings.captureMode {
+                case .tap:   tapModeRing
+                case .press: pressModeRing
+                }
             }
         }
+    }
+
+    private var ring: some View {
+        RecordingRing(
+            state: model.state,
+            progress: model.maxDuration > 0 ? Double(model.elapsed) / Double(model.maxDuration) : 0,
+            color: pressCancelArmed ? .orange : stateColor
+        )
+    }
+
+    // MARK: Tap mode
+
+    private var tapModeRing: some View {
+        Button(action: tapPrimaryAction) {
+            ring
+        }
+        .buttonStyle(RingButtonStyle())
+        // Long-press while recording discards the clip (cancel affordance).
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.5).onEnded { _ in
+                if model.state == .recording || model.state == .confirmStop {
+                    model.cancelRecording()
+                }
+            }
+        )
+        .accessibilityLabel(ringAccessibilityLabel)
+        .accessibilityHint(model.state == .recording ? "长按取消录音" : "")
+    }
+
+    // MARK: Press mode
+
+    private var pressModeRing: some View {
+        ring
+            .contentShape(Circle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        // First touch of a hold starts recording.
+                        if model.state == .idle {
+                            model.start()
+                        }
+                        // Arm/disarm cancel based on how far up the finger slid.
+                        let slidUp = value.translation.height < -pressCancelThreshold
+                        if slidUp != pressCancelArmed {
+                            pressCancelArmed = slidUp
+                            WKInterfaceDevice.current().play(.click)
+                        }
+                    }
+                    .onEnded { _ in
+                        defer { pressCancelArmed = false }
+                        guard model.state == .recording || model.state == .confirmStop else {
+                            // Released on a non-recording state (e.g. failed) — reset.
+                            if case .failed = model.state { model.reset() }
+                            return
+                        }
+                        if pressCancelArmed {
+                            model.cancelRecording()   // slid up → discard
+                        } else {
+                            model.stopAndSendImmediately()  // released in place → send
+                        }
+                    }
+            )
+            .accessibilityLabel(ringAccessibilityLabel)
+            .accessibilityHint("按住录音，松手发送，上滑取消")
     }
 
     /// Bold primary caption under the ring — the CTA when idle, the clock when recording.
     private var primaryLine: String {
         switch model.state {
-        case .idle:        return "轻点录音"
+        case .idle:        return settings.captureMode == .press ? "按住录音" : "轻点录音"
         case .recording:
+            if pressCancelArmed { return "松手取消" }
             let remaining = model.maxDuration - model.elapsed
             return remaining <= 10 ? "还剩 \(remaining) 秒" : formattedTime(model.elapsed)
         case .confirmStop: return "松开即停"
@@ -156,7 +228,9 @@ struct RecordingView: View {
     private var secondaryLine: String {
         switch model.state {
         case .idle:        return "\(model.maxDuration) 秒 · 转表冠调节"
-        case .recording:   return "轻点停止"
+        case .recording:
+            if pressCancelArmed { return "松手丢弃这段" }
+            return settings.captureMode == .press ? "松手发送 · 上滑取消" : "轻点停止 · 长按取消"
         case .confirmStop: return "轻点继续"
         case .processing:  return "正在写入"
         case .uploading:   return "发送到 iPhone"
@@ -175,24 +249,23 @@ struct RecordingView: View {
         }
     }
 
-    private func primaryAction() {
+    /// Tap-mode primary action: toggles start / stop-with-confirm, cancels the
+    /// pending stop, or resets from failure. (Press mode routes through the
+    /// DragGesture instead and never calls this.)
+    private func tapPrimaryAction() {
         if case .confirmStop = model.state {
             model.cancelStop()
         } else {
-            handleTap()
-        }
-    }
-
-    private func handleTap() {
-        switch model.state {
-        case .idle:
-            model.start()
-        case .recording:
-            model.requestStop()
-        case .failed:
-            model.reset()
-        default:
-            break
+            switch model.state {
+            case .idle:
+                model.start()
+            case .recording:
+                model.requestStop()
+            case .failed:
+                model.reset()
+            default:
+                break
+            }
         }
     }
 
@@ -588,6 +661,44 @@ final class WatchRecordingModel: NSObject, ObservableObject {
         removeInterruptionObserver()
         state = .idle
         elapsed = 0
+    }
+
+    /// Discard an in-progress recording without sending it. Used by both
+    /// capture modes' cancel affordance (tap-mode long-press, press-mode
+    /// slide-up). Deletes the temp file so it never enters the transfer queue,
+    /// and returns straight to `.idle` — cancelling is not a failure.
+    func cancelRecording() {
+        guard state == .recording || state == .confirmStop else { return }
+        confirmStopTask?.cancel()
+        confirmStopTask = nil
+        stopTimer()
+        recorder?.stop()
+        recorder = nil
+        removeInterruptionObserver()
+        deactivateAudioSession()
+        if let url = currentFileURL {
+            try? FileManager.default.removeItem(at: url)
+            currentFileURL = nil
+        }
+        state = .idle
+        elapsed = 0
+        haptic(.click)
+    }
+
+    /// Press-mode stop: end the recording and send immediately, with no 2-second
+    /// confirmation window (the release *is* the deliberate action). Reuses the
+    /// same finalize+transfer path as the timed stop.
+    func stopAndSendImmediately() {
+        guard state == .recording || state == .confirmStop else { return }
+        confirmStopTask?.cancel()
+        confirmStopTask = nil
+        // A press shorter than ~1s is almost always an accidental tap in
+        // press-mode — discard rather than ship a 0-second clip.
+        if elapsed < 1 {
+            cancelRecording()
+            return
+        }
+        stopAndTransfer()
     }
 
     // MARK: - Helpers

--- a/DayPageWatch/Features/RecordingView.swift
+++ b/DayPageWatch/Features/RecordingView.swift
@@ -515,7 +515,7 @@ final class WatchRecordingModel: NSObject, ObservableObject {
 
         // Transfer via WCSession — file cleanup happens inside WatchTransferService
         // once session(_:didFinish:error:) confirms the transfer is complete.
-        WatchTransferService.shared.transferAudioFile(url) { [weak self] success in
+        WatchTransferService.shared.transferAudioFile(url, duration: Double(elapsed)) { [weak self] success in
             Task { @MainActor in
                 if success {
                     self?.state = .done

--- a/DayPageWatch/Features/RecordingView.swift
+++ b/DayPageWatch/Features/RecordingView.swift
@@ -361,8 +361,24 @@ final class WatchRecordingModel: NSObject, ObservableObject {
     @Published var elapsed: Int = 0
     @Published var isMicPermissionDenied: Bool = false
 
-    /// Maximum recording duration in seconds — adjusted via Digital Crown when idle.
-    @Published var maxDuration: Int = 60
+    /// Maximum recording duration in seconds — adjusted via Digital Crown when
+    /// idle, seeded from and persisted back to `WatchSettingsStore` so the
+    /// crown and the Settings page stay one source of truth.
+    @Published var maxDuration: Int = 60 {
+        didSet {
+            guard maxDuration != oldValue else { return }
+            settings.maxDuration = maxDuration
+        }
+    }
+
+    /// The watch's capture configuration (quality, haptics, max duration).
+    let settings: WatchSettingsStore
+
+    init(settings: WatchSettingsStore = .shared) {
+        self.settings = settings
+        super.init()
+        self.maxDuration = settings.maxDuration
+    }
 
     private var recorder: AVAudioRecorder?
     private var timer: Timer?
@@ -382,6 +398,14 @@ final class WatchRecordingModel: NSObject, ObservableObject {
     // MARK: - Haptic Feedback
 
     private func haptic(_ hapticType: WKHapticType) {
+        // Gate the two user-facing "you did a thing" haptics on their toggles;
+        // failure/click/confirm feedback always plays (it's error/safety UX,
+        // not a preference).
+        switch hapticType {
+        case .start where !settings.hapticsOnStart: return
+        case .stop where !settings.hapticsOnStop:   return
+        default: break
+        }
         WKInterfaceDevice.current().play(hapticType)
     }
 
@@ -413,16 +437,18 @@ final class WatchRecordingModel: NSObject, ObservableObject {
         let url = makeFileURL()
         currentFileURL = url
 
-        // Settings: 16 kHz Mono AAC (M4A) — smaller file, good enough for voice
-        let settings: [String: Any] = [
+        // Mono AAC (M4A). Sample rate + encoder quality come from the user's
+        // audio-quality setting (low/medium/high).
+        let quality = settings.audioQuality
+        let recorderSettings: [String: Any] = [
             AVFormatIDKey: Int(kAudioFormatMPEG4AAC),
-            AVSampleRateKey: 16_000,
+            AVSampleRateKey: quality.sampleRate,
             AVNumberOfChannelsKey: 1,
-            AVEncoderAudioQualityKey: AVAudioQuality.medium.rawValue,
+            AVEncoderAudioQualityKey: quality.encoderQuality.rawValue,
         ]
 
         do {
-            let rec = try AVAudioRecorder(url: url, settings: settings)
+            let rec = try AVAudioRecorder(url: url, settings: recorderSettings)
             rec.isMeteringEnabled = false
             rec.record()
             recorder = rec

--- a/DayPageWatch/Features/WatchHistoryView.swift
+++ b/DayPageWatch/Features/WatchHistoryView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+// MARK: - WatchHistoryView
+
+/// The history page — the top page of the three-page vertical TabView.
+///
+/// P1 ships the scaffold with an empty state. P2 fills the "在途" (in-flight)
+/// section from the watch's local transfer queue; P3 adds a "最近" (recently
+/// synced) section fed by transcript metadata the phone sends back over
+/// `transferUserInfo`.
+struct WatchHistoryView: View {
+
+    @ObservedObject var history: WatchHistoryStore
+
+    var body: some View {
+        Group {
+            if history.inFlight.isEmpty {
+                emptyState
+            } else {
+                list
+            }
+        }
+        .navigationTitle("最近")
+        .containerBackground(.teal.gradient, for: .navigation)
+    }
+
+    // MARK: - Empty state
+
+    private var emptyState: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "checkmark.circle")
+                .font(.system(size: 30))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+            Text("没有待同步的录音")
+                .font(.headline)
+                .multilineTextAlignment(.center)
+            Text("录音会自动发送到 iPhone")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .padding()
+        .accessibilityElement(children: .combine)
+    }
+
+    // MARK: - List
+
+    private var list: some View {
+        List {
+            Section("在途") {
+                ForEach(history.inFlight) { item in
+                    inFlightRow(item)
+                }
+            }
+        }
+    }
+
+    private func inFlightRow(_ item: WatchHistoryStore.InFlightItem) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "waveform")
+                .foregroundStyle(item.status.tint)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(item.durationText)
+                    .font(.body.monospacedDigit())
+                Text(item.status.label)
+                    .font(.caption2)
+                    .foregroundStyle(item.status.tint)
+            }
+            Spacer(minLength: 0)
+            if item.status == .failed {
+                Button {
+                    history.retry(item)
+                } label: {
+                    Image(systemName: "arrow.clockwise")
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("重试发送")
+            }
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(item.durationText)，\(item.status.label)")
+    }
+}

--- a/DayPageWatch/Features/WatchHistoryView.swift
+++ b/DayPageWatch/Features/WatchHistoryView.swift
@@ -14,7 +14,7 @@ struct WatchHistoryView: View {
 
     var body: some View {
         Group {
-            if history.inFlight.isEmpty {
+            if history.inFlight.isEmpty && history.recent.isEmpty {
                 emptyState
             } else {
                 list
@@ -48,12 +48,47 @@ struct WatchHistoryView: View {
 
     private var list: some View {
         List {
-            Section("在途") {
-                ForEach(history.inFlight) { item in
-                    inFlightRow(item)
+            if !history.inFlight.isEmpty {
+                Section("在途") {
+                    ForEach(history.inFlight) { item in
+                        inFlightRow(item)
+                    }
+                }
+            }
+            if !history.recent.isEmpty {
+                Section("最近") {
+                    ForEach(history.recent) { item in
+                        recentRow(item)
+                    }
                 }
             }
         }
+    }
+
+    private func recentRow(_ item: WatchHistoryStore.RecentItem) -> some View {
+        HStack(spacing: 8) {
+            Image(systemName: "checkmark.circle.fill")
+                .foregroundStyle(.green)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 6) {
+                    Text(item.durationText)
+                        .font(.footnote.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                    Text(item.syncedAt, style: .relative)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+                if !item.summary.isEmpty {
+                    Text(item.summary)
+                        .font(.caption)
+                        .lineLimit(2)
+                }
+            }
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("已同步，\(item.durationText)，\(item.summary)")
     }
 
     private func inFlightRow(_ item: WatchHistoryStore.InFlightItem) -> some View {

--- a/DayPageWatch/Features/WatchSettingsView.swift
+++ b/DayPageWatch/Features/WatchSettingsView.swift
@@ -1,0 +1,146 @@
+import SwiftUI
+
+// MARK: - WatchSettingsView
+
+/// The settings page — the bottom page of the three-page vertical TabView.
+/// Holds only the *day-to-day quick* settings that pass the "two-second
+/// attention" test; full / advanced configuration lives in the iPhone Watch
+/// app. Every control writes straight through to `WatchSettingsStore`, whose
+/// values `RecordingView` reads live.
+struct WatchSettingsView: View {
+
+    @ObservedObject var settings: WatchSettingsStore
+
+    var body: some View {
+        List {
+            // MARK: Capture mode
+            Section {
+                NavigationLink {
+                    captureModePicker
+                } label: {
+                    settingRow(title: "捕获模式", value: settings.captureMode.title)
+                }
+            } header: {
+                Text("捕获")
+            } footer: {
+                Text(settings.captureMode.subtitle)
+            }
+
+            // MARK: Recording
+            Section("录音") {
+                Stepper(value: $settings.maxDuration, in: 30...180, step: 10) {
+                    settingRow(title: "时长上限", value: "\(settings.maxDuration)s")
+                }
+                NavigationLink {
+                    audioQualityPicker
+                } label: {
+                    settingRow(title: "音质", value: settings.audioQuality.title)
+                }
+            }
+
+            // MARK: Sync & cleanup
+            Section {
+                NavigationLink {
+                    retentionPicker
+                } label: {
+                    settingRow(title: "未送达保留", value: settings.retentionPolicy.title)
+                }
+                Toggle("仅 Wi-Fi 传输", isOn: $settings.wifiOnlyTransfer)
+            } header: {
+                Text("同步与清理")
+            } footer: {
+                Text("已送达的录音会立即清理；未送达的按上面的策略保留。")
+            }
+
+            // MARK: Haptics
+            Section("触感与提示") {
+                Toggle("开始震动", isOn: $settings.hapticsOnStart)
+                Toggle("停止震动", isOn: $settings.hapticsOnStop)
+            }
+        }
+        .navigationTitle("设置")
+        .containerBackground(.gray.gradient, for: .navigation)
+    }
+
+    // MARK: - Row helper
+
+    private func settingRow(title: String, value: String) -> some View {
+        HStack {
+            Text(title)
+                .foregroundStyle(.primary)
+            Spacer(minLength: 8)
+            Text(value)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Sub-pickers
+
+    private var captureModePicker: some View {
+        List {
+            ForEach(WatchCaptureMode.allCases) { mode in
+                Button {
+                    settings.captureMode = mode
+                } label: {
+                    pickerRow(
+                        title: mode.title,
+                        subtitle: mode.subtitle,
+                        selected: settings.captureMode == mode
+                    )
+                }
+            }
+        }
+        .navigationTitle("捕获模式")
+    }
+
+    private var audioQualityPicker: some View {
+        List {
+            ForEach(WatchAudioQuality.allCases) { quality in
+                Button {
+                    settings.audioQuality = quality
+                } label: {
+                    pickerRow(
+                        title: quality.title,
+                        subtitle: "\(Int(quality.sampleRate / 1000)) kHz",
+                        selected: settings.audioQuality == quality
+                    )
+                }
+            }
+        }
+        .navigationTitle("音质")
+    }
+
+    private var retentionPicker: some View {
+        List {
+            ForEach(WatchRetentionPolicy.allCases) { policy in
+                Button {
+                    settings.retentionPolicy = policy
+                } label: {
+                    pickerRow(
+                        title: policy.title,
+                        subtitle: nil,
+                        selected: settings.retentionPolicy == policy
+                    )
+                }
+            }
+        }
+        .navigationTitle("未送达保留")
+    }
+
+    private func pickerRow(title: String, subtitle: String?, selected: Bool) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title).foregroundStyle(.primary)
+                if let subtitle {
+                    Text(subtitle).font(.caption2).foregroundStyle(.secondary)
+                }
+            }
+            Spacer(minLength: 8)
+            if selected {
+                Image(systemName: "checkmark")
+                    .foregroundStyle(.tint)
+                    .accessibilityLabel("已选中")
+            }
+        }
+    }
+}

--- a/DayPageWatch/Services/WatchHistoryStore.swift
+++ b/DayPageWatch/Services/WatchHistoryStore.swift
@@ -54,10 +54,33 @@ final class WatchHistoryStore: ObservableObject {
         }
     }
 
+    // MARK: Recent (synced) item
+
+    /// A clip the phone has confirmed synced + transcribed, fed back over
+    /// `transferUserInfo`. The watch stores only this lightweight metadata —
+    /// never the audio itself.
+    struct RecentItem: Identifiable, Equatable {
+        let id: String        // source filename — correlation key from the phone
+        let duration: Int     // seconds (0 if the phone didn't send one)
+        let summary: String
+        let syncedAt: Date
+
+        var durationText: String {
+            let m = duration / 60
+            let s = duration % 60
+            return String(format: "%d:%02d", m, s)
+        }
+    }
+
     // MARK: State
 
     /// Newest first.
     @Published private(set) var inFlight: [InFlightItem] = []
+
+    /// Newest first. Capped to the most recent `recentLimit` items.
+    @Published private(set) var recent: [RecentItem] = []
+
+    private let recentLimit = 20
 
     /// Injected by `WatchTransferService` so a retry tap can re-queue a failed
     /// transfer without the store importing WatchConnectivity itself.
@@ -87,6 +110,25 @@ final class WatchHistoryStore: ObservableObject {
     func markFailed(fileURL: URL) {
         guard let idx = inFlight.firstIndex(where: { $0.id == fileURL }) else { return }
         inFlight[idx].status = .failed
+    }
+
+    // MARK: - Synced (called from the phone's reverse channel, P3)
+
+    /// The phone confirmed this clip is synced + transcribed. Add it to the
+    /// "recent" feed and drop any lingering in-flight entry with the same
+    /// source filename. Keyed by filename because the phone only knows the
+    /// filename, not the watch's original file URL.
+    func markSynced(filename: String, summary: String, duration: Int, syncedAt: Date = Date()) {
+        // Remove any in-flight item whose file URL ends in this filename.
+        inFlight.removeAll { $0.id.lastPathComponent == filename }
+
+        let item = RecentItem(id: filename, duration: duration, summary: summary, syncedAt: syncedAt)
+        // De-dupe on filename (a resend could report twice).
+        recent.removeAll { $0.id == filename }
+        recent.insert(item, at: 0)
+        if recent.count > recentLimit {
+            recent.removeLast(recent.count - recentLimit)
+        }
     }
 
     // MARK: - Retry (called by the history UI)

--- a/DayPageWatch/Services/WatchHistoryStore.swift
+++ b/DayPageWatch/Services/WatchHistoryStore.swift
@@ -1,0 +1,101 @@
+import Foundation
+import Combine
+import SwiftUI
+
+// MARK: - WatchHistoryStore
+
+/// Observable model behind the watch history page.
+///
+/// P1 defines the shape and the in-flight tracking API; `WatchTransferService`
+/// reports enqueue / success / failure into it in P2. P3 adds a `recent`
+/// section fed by transcript metadata the phone returns over `transferUserInfo`.
+///
+/// `@MainActor` — drives SwiftUI. In-flight items are keyed by the source file
+/// URL so the transfer service can update a specific clip's status.
+@MainActor
+final class WatchHistoryStore: ObservableObject {
+
+    static let shared = WatchHistoryStore()
+
+    // MARK: In-flight item
+
+    /// A recording that has not yet been confirmed delivered to the phone.
+    struct InFlightItem: Identifiable, Equatable {
+        let id: URL           // source file URL — stable key for status updates
+        let duration: Int     // seconds
+        let createdAt: Date
+        var status: Status
+
+        var durationText: String {
+            let m = duration / 60
+            let s = duration % 60
+            return String(format: "%d:%02d", m, s)
+        }
+    }
+
+    // MARK: Status
+
+    enum Status: Equatable {
+        case sending
+        case failed
+
+        var label: String {
+            switch self {
+            case .sending: return "发送中…"
+            case .failed:  return "发送失败 · 点击重试"
+            }
+        }
+
+        var tint: Color {
+            switch self {
+            case .sending: return .cyan
+            case .failed:  return .orange
+            }
+        }
+    }
+
+    // MARK: State
+
+    /// Newest first.
+    @Published private(set) var inFlight: [InFlightItem] = []
+
+    /// Injected by `WatchTransferService` so a retry tap can re-queue a failed
+    /// transfer without the store importing WatchConnectivity itself.
+    var retryHandler: ((URL) -> Void)?
+
+    private init() {}
+
+    // MARK: - Mutations (called by WatchTransferService, P2)
+
+    /// Record a newly-queued transfer as in-flight.
+    func markSending(fileURL: URL, duration: Int, createdAt: Date = Date()) {
+        let item = InFlightItem(id: fileURL, duration: duration, createdAt: createdAt, status: .sending)
+        // De-dupe on the same URL (a retry re-marks an existing item).
+        if let idx = inFlight.firstIndex(where: { $0.id == fileURL }) {
+            inFlight[idx] = item
+        } else {
+            inFlight.insert(item, at: 0)
+        }
+    }
+
+    /// The transfer confirmed delivered — drop it from the in-flight list.
+    func markDelivered(fileURL: URL) {
+        inFlight.removeAll { $0.id == fileURL }
+    }
+
+    /// The transfer failed — flip it to the retryable failed state.
+    func markFailed(fileURL: URL) {
+        guard let idx = inFlight.firstIndex(where: { $0.id == fileURL }) else { return }
+        inFlight[idx].status = .failed
+    }
+
+    // MARK: - Retry (called by the history UI)
+
+    func retry(_ item: InFlightItem) {
+        guard item.status == .failed else { return }
+        if let idx = inFlight.firstIndex(where: { $0.id == item.id }) {
+            inFlight[idx].status = .sending
+        }
+        retryHandler?(item.id)
+    }
+}

--- a/DayPageWatch/Services/WatchSettingsStore.swift
+++ b/DayPageWatch/Services/WatchSettingsStore.swift
@@ -1,0 +1,194 @@
+import Foundation
+import Combine
+import AVFoundation
+
+// MARK: - Capture Mode
+
+/// How a recording is started and stopped on the watch. The user picks one in
+/// Settings; `RecordingView` adapts its gesture handling accordingly.
+///
+/// - `.tap`   点击式：点开始 / 录音中点停止发送 / 长按取消（从容记录，防误触）
+/// - `.press` 长按式：按住录 / 松手即发送 / 按住上滑取消（对讲机，单手快捕）
+enum WatchCaptureMode: String, CaseIterable, Identifiable {
+    case tap
+    case press
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .tap:   return "点击式"
+        case .press: return "长按式"
+        }
+    }
+
+    var subtitle: String {
+        switch self {
+        case .tap:   return "点击启停 · 长按取消"
+        case .press: return "按住录音 · 松手发送"
+        }
+    }
+}
+
+// MARK: - Audio Quality
+
+/// Recording quality preset. Trades file size / battery against transcription
+/// fidelity. Sample rate + AVAudioQuality feed straight into the recorder
+/// settings in `WatchRecordingModel`.
+enum WatchAudioQuality: String, CaseIterable, Identifiable {
+    case low
+    case medium
+    case high
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .low:    return "低"
+        case .medium: return "中"
+        case .high:   return "高"
+        }
+    }
+
+    /// Sample rate in Hz. Voice is intelligible from 12 kHz; 24 kHz is
+    /// comfortably above the Whisper sweet spot without bloating the file.
+    var sampleRate: Double {
+        switch self {
+        case .low:    return 12_000
+        case .medium: return 16_000
+        case .high:   return 24_000
+        }
+    }
+
+    var encoderQuality: AVAudioQuality {
+        switch self {
+        case .low:    return .low
+        case .medium: return .medium
+        case .high:   return .high
+        }
+    }
+}
+
+// MARK: - Cleanup Policy
+
+/// How long an *undelivered* recording lingers on the watch before the orphan
+/// cleaner may remove it. Delivered files are always removed immediately in
+/// `session(_:didFinish:)`; this only governs in-flight / failed clips so a
+/// watch that stays away from its phone doesn't silently lose a memo.
+enum WatchRetentionPolicy: String, CaseIterable, Identifiable {
+    case oneDay
+    case sevenDays
+    case untilDelivered
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .oneDay:         return "1 天"
+        case .sevenDays:      return "7 天"
+        case .untilDelivered: return "直到送达"
+        }
+    }
+
+    /// Max age for an undelivered file, in seconds. `nil` means "never expire
+    /// an undelivered file — keep it until it is confirmed delivered."
+    var maxUndeliveredAge: TimeInterval? {
+        switch self {
+        case .oneDay:         return 86_400
+        case .sevenDays:      return 604_800
+        case .untilDelivered: return nil
+        }
+    }
+}
+
+// MARK: - WatchSettingsStore
+
+/// The watch's local source of truth for capture configuration. Backed by
+/// `UserDefaults` on the watch; the phone-side Watch app mirrors key items via
+/// `updateApplicationContext` (wired in a later phase).
+///
+/// `@MainActor` because every value drives SwiftUI. Reads are served from the
+/// in-memory `@Published` properties, not from `UserDefaults` on each access.
+@MainActor
+final class WatchSettingsStore: ObservableObject {
+
+    static let shared = WatchSettingsStore()
+
+    // MARK: Keys
+
+    private enum Key {
+        static let captureMode  = "watch.captureMode"
+        static let maxDuration  = "watch.maxDuration"
+        static let audioQuality = "watch.audioQuality"
+        static let hapticsStart = "watch.haptics.start"
+        static let hapticsStop  = "watch.haptics.stop"
+        static let retention    = "watch.retention"
+        static let wifiOnly     = "watch.wifiOnlyTransfer"
+    }
+
+    private let defaults: UserDefaults
+
+    // MARK: Published state
+
+    @Published var captureMode: WatchCaptureMode {
+        didSet { defaults.set(captureMode.rawValue, forKey: Key.captureMode) }
+    }
+
+    /// Max recording duration in seconds. Clamped to the crown range 30…180.
+    @Published var maxDuration: Int {
+        didSet {
+            let clamped = min(180, max(30, maxDuration))
+            if clamped != maxDuration { maxDuration = clamped; return }
+            defaults.set(maxDuration, forKey: Key.maxDuration)
+        }
+    }
+
+    @Published var audioQuality: WatchAudioQuality {
+        didSet { defaults.set(audioQuality.rawValue, forKey: Key.audioQuality) }
+    }
+
+    /// Haptic on record start.
+    @Published var hapticsOnStart: Bool {
+        didSet { defaults.set(hapticsOnStart, forKey: Key.hapticsStart) }
+    }
+
+    /// Haptic on record stop / send.
+    @Published var hapticsOnStop: Bool {
+        didSet { defaults.set(hapticsOnStop, forKey: Key.hapticsStop) }
+    }
+
+    @Published var retentionPolicy: WatchRetentionPolicy {
+        didSet { defaults.set(retentionPolicy.rawValue, forKey: Key.retention) }
+    }
+
+    /// When true, only transfer files while on Wi-Fi (the phone-side transfer
+    /// path honors this in a later phase). Default off — Bluetooth transfer is
+    /// the whole point of the paired-device model.
+    @Published var wifiOnlyTransfer: Bool {
+        didSet { defaults.set(wifiOnlyTransfer, forKey: Key.wifiOnly) }
+    }
+
+    // MARK: Init
+
+    /// `defaults` is injectable so tests get an isolated suite instead of
+    /// mutating the shared `.standard` domain.
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+
+        self.captureMode = WatchCaptureMode(rawValue: defaults.string(forKey: Key.captureMode) ?? "") ?? .tap
+
+        let storedDuration = defaults.object(forKey: Key.maxDuration) as? Int ?? 60
+        self.maxDuration = min(180, max(30, storedDuration))
+
+        self.audioQuality = WatchAudioQuality(rawValue: defaults.string(forKey: Key.audioQuality) ?? "") ?? .medium
+
+        // Haptics default ON; `object(forKey:)` distinguishes "never set" from
+        // an explicit false so a user who turned them off keeps them off.
+        self.hapticsOnStart = defaults.object(forKey: Key.hapticsStart) as? Bool ?? true
+        self.hapticsOnStop  = defaults.object(forKey: Key.hapticsStop) as? Bool ?? true
+
+        self.retentionPolicy = WatchRetentionPolicy(rawValue: defaults.string(forKey: Key.retention) ?? "") ?? .sevenDays
+
+        self.wifiOnlyTransfer = defaults.object(forKey: Key.wifiOnly) as? Bool ?? false
+    }
+}

--- a/DayPageWatch/Services/WatchTransferService.swift
+++ b/DayPageWatch/Services/WatchTransferService.swift
@@ -17,10 +17,18 @@ import DayPageServices
 
     private let logger = Logger(subsystem: "com.daypage.watch", category: "WatchTransferService")
 
+    /// Retained duration (seconds) per in-flight file, so a retry re-sends the
+    /// same duration metadata without the caller having to thread it back in.
+    private var pendingDurations: [URL: Double] = [:]
+
     private override init() {
         super.init()
         // Do NOT set WCSession.default.delegate here — WatchSessionManager owns the delegate
         // and will forward didFinish events to this service.
+        // Let the history page's retry button re-drive a failed transfer.
+        WatchHistoryStore.shared.retryHandler = { [weak self] url in
+            self?.retryTransfer(url)
+        }
     }
 
     /// Transfer an audio file to the companion iPhone.
@@ -34,32 +42,63 @@ import DayPageServices
         }
 
         pendingCompletions[fileURL] = completion
+        if let duration { pendingDurations[fileURL] = duration }
 
+        // Reflect the queued transfer in the history page's "in-flight" section.
+        WatchHistoryStore.shared.markSending(fileURL: fileURL, duration: Int(duration ?? 0))
+
+        WCSession.default.transferFile(fileURL, metadata: metadata(for: fileURL, duration: duration))
+        logger.info("Queued transfer for \(fileURL.lastPathComponent)")
+    }
+
+    /// Re-drive a previously-failed transfer (history retry button). The source
+    /// file was kept on failure precisely so this can resend it.
+    func retryTransfer(_ fileURL: URL) {
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            // File is gone (cleaned up / already delivered) — drop it from history.
+            WatchHistoryStore.shared.markDelivered(fileURL: fileURL)
+            return
+        }
+        guard WCSession.default.activationState == .activated else {
+            WatchHistoryStore.shared.markFailed(fileURL: fileURL)
+            return
+        }
+        let duration = pendingDurations[fileURL]
+        WatchHistoryStore.shared.markSending(fileURL: fileURL, duration: Int(duration ?? 0))
+        WCSession.default.transferFile(fileURL, metadata: metadata(for: fileURL, duration: duration))
+        logger.info("Retrying transfer for \(fileURL.lastPathComponent)")
+    }
+
+    private func metadata(for fileURL: URL, duration: Double?) -> [String: Any] {
         var metadata: [String: Any] = [
             "type": "watchAudio",
             "source": "daypage-watch",
             "timestamp": Date().timeIntervalSince1970,
             "filename": fileURL.lastPathComponent,
         ]
-        if let duration {
-            metadata["duration"] = duration
-        }
-
-        WCSession.default.transferFile(fileURL, metadata: metadata)
-        logger.info("Queued transfer for \(fileURL.lastPathComponent)")
+        if let duration { metadata["duration"] = duration }
+        return metadata
     }
 
     /// Called by WatchSessionManager when a file transfer finishes.
     func handleTransferFinished(fileURL: URL, error: Error?) {
-        guard let completion = pendingCompletions.removeValue(forKey: fileURL) else { return }
+        let completion = pendingCompletions.removeValue(forKey: fileURL)
+
         if let error {
+            // Keep the source file so the history retry can resend it — do NOT
+            // delete on failure. It ages out per the retention policy instead.
             logger.error("Transfer failed for \(fileURL.lastPathComponent): \(error.localizedDescription)")
-            completion(false)
-        } else {
-            logger.info("Transfer succeeded: \(fileURL.lastPathComponent)")
-            completion(true)
+            WatchHistoryStore.shared.markFailed(fileURL: fileURL)
+            completion?(false)
+            return
         }
-        // Safe to remove the source file now that the transfer is confirmed finished.
+
+        logger.info("Transfer succeeded: \(fileURL.lastPathComponent)")
+        WatchHistoryStore.shared.markDelivered(fileURL: fileURL)
+        pendingDurations.removeValue(forKey: fileURL)
+        completion?(true)
+
+        // Delivered — safe to remove the source file.
         do {
             try FileManager.default.removeItem(at: fileURL)
         } catch {

--- a/DayPageWatch/Services/WatchTransferService.swift
+++ b/DayPageWatch/Services/WatchTransferService.swift
@@ -24,7 +24,9 @@ import DayPageServices
     }
 
     /// Transfer an audio file to the companion iPhone.
-    func transferAudioFile(_ fileURL: URL, completion: @escaping (Bool) -> Void) {
+    /// `duration` (seconds) is forwarded in the transfer metadata so the phone
+    /// can show the clip length on the voice memo card without re-probing the file.
+    func transferAudioFile(_ fileURL: URL, duration: Double? = nil, completion: @escaping (Bool) -> Void) {
         guard WCSession.default.activationState == .activated else {
             logger.error("WCSession not activated — cannot transfer \(fileURL.lastPathComponent)")
             completion(false)
@@ -33,12 +35,15 @@ import DayPageServices
 
         pendingCompletions[fileURL] = completion
 
-        let metadata: [String: Any] = [
+        var metadata: [String: Any] = [
             "type": "watchAudio",
             "source": "daypage-watch",
             "timestamp": Date().timeIntervalSince1970,
             "filename": fileURL.lastPathComponent,
         ]
+        if let duration {
+            metadata["duration"] = duration
+        }
 
         WCSession.default.transferFile(fileURL, metadata: metadata)
         logger.info("Queued transfer for \(fileURL.lastPathComponent)")


### PR DESCRIPTION
## 概述

把 Apple Watch 端从「单屏录音」升级为可配置的快速捕获入口:三页表冠导航、两种捕获手势、历史记录(在途 + 已同步)。核心骨架遵循 watchOS「两秒注意力 / glanceable-first」——录音永远是默认落点,复杂配置留在设置页,深度 ≤ 2 层。

三页导航:**↑ 最近 · ● 录音(默认) · 设置 ↓**,`TabView(.verticalPage)` 表冠翻页。

## 改动分期

### 前置修复 (`409ffd2`)
收到手表音频时只 enqueue 转写、从不建 memo → 文件到了、「N 条待转写」计数显示了,但 Today 时间线没有卡片,且转写永远匹配不到 attachment 标 `.failed`(录音丢失)。修复镜像手机侧捕获路径:`WatchReceiveService.appendVoiceMemo` 落盘后 `RawStorage.append` 一条 `.voice` memo。这是整条链路的地基。

### P1 三页骨架 + 设置 + 清理策略 (`785c1d2`)
- `RootView` → 三页 `TabView(.verticalPage)`;`FeatureFlag.watchCaptureConfig` off 回退旧单屏
- **WatchSettingsStore**:手表本地 `UserDefaults` 真相源(捕获模式/时长/音质/触感/保留策略/仅Wi-Fi),可注入 defaults 便于测试
- **WatchSettingsView**:设置页,日常快捷项;完整/高级留 iPhone Watch app
- **OrphanFileCleanup** 按 `WatchRetentionPolicy` 清理未送达文件(1天/7天/直到送达),取代硬编码 24h——堵住离身>24h 丢在途录音的洞

### P2 双捕获手势 + 历史在途段 (`79d2c5b`)
- **点击式**:点开始 / 点停止(2s confirm) / 长按取消
- **长按式**:按住录 / 松手发送 / 上滑取消(对讲机,单手快捕)
- 模型新增 `cancelRecording()`(丢弃)、`stopAndSendImmediately()`(松手即发,<1s 视误触丢弃)
- **关键修复**:`WatchTransferService` 失败时不再删源文件(旧代码成功失败都删,破坏重试),保留供重试;历史页失败行「重试」→ `retryTransfer` 重发

### P3 转写反向回传 + 历史「最近已同步」(`89016bc`)
- **WatchTranscriptSender**(手机):转写完用 `transferUserInfo` 把 `{filename, summary(截断60字), duration, syncedAt}` 回传手表;仅 `isWatchAppInstalled` 时发,音频不回传
- `VoiceAttachmentQueue.applyTranscript` 识别 `device=="Apple Watch"` 的 memo 触发回传;filename 作跨 WCSession 关联键
- `WatchSessionManager.didReceiveUserInfo` → `WatchHistoryStore.markSynced`;历史「最近」段:绿勾 + 时长 + 相对时间 + 转写摘要

## 验证

- ✅ watch + phone scheme 均 BUILD SUCCEEDED
- ✅ **185 个测试全绿**(含新增 5 个 `WatchReceiveServiceTests` 回归用例)
- ✅ **模拟器视觉实测**(Apple Watch Series 11 46mm):三页全部渲染正确、无崩溃、无布局破裂(录音默认页 / 设置页四个 section / 历史空态)

## 已知边界(需真机验证)

- **WCSession 双向传输**(手表→手机 `transferFile` + 手机→手表 `transferUserInfo`)双模拟器间无法真正 activate,只能真机端到端验;逻辑层已用测试覆盖
- **长按式手势**的按住/上滑,idb 驱动不了 SwiftUI 长按,需真机点按验证

## 设计稿

三页布局 / 双手势模型 / 数据架构 / 分期落地:见对话中的设计文档。