### PR TITLE
feat(reminder): 定时召唤记录 — AlarmKit 灵动岛 + 本地通知兜底

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,100 +10,47 @@ DayPage: a personal logging tool centered on daily raw data capture. Users dump,
 
 | Layer | Choice | Notes |
 |---|---|---|
-| Platform | **iOS 16.0+**, Swift 5 | Single Xcode target `DayPage.app`; direct SPM deps: **Supabase** (supabase-swift), **Sentry** (sentry-cocoa); transitive: swift-clocks, swift-concurrency-extras, swift-http-types, xctest-dynamic-overlay |
-| UI | **SwiftUI** (pure) | `UITabBarAppearance` is the primary UIKit touchpoint (`RootView.swift`). `UIViewControllerRepresentable` wrappers (`ShareSheet`, `CameraPickerView`, `DocumentPickerView`) are used where SwiftUI has no native equivalent (`UIActivityViewController`, `UIImagePickerController`, `UIDocumentPickerViewController`). |
+| Platform | **iOS 16.0+**, Swift 5 | Single Xcode target `DayPage.app`; SPM deps: Supabase, Sentry |
+| UI | **SwiftUI** (pure) | UIKit only via `UIViewControllerRepresentable` wrappers (ShareSheet, CameraPicker, DocumentPicker) and `UITabBarAppearance` in `RootView.swift` |
 | Navigation | **Sidebar** | Left drawer (280pt) — Today / Archive / Graph; no bottom TabBar |
 | State | `ObservableObject` + `@Published` + `@StateObject`, `@MainActor` services | No `@Observable` macro (Swift 5 constraint) |
 | Persistence | **File system** — YAML front-matter + Markdown | `vault/raw/YYYY-MM-DD.md`, multi-memo separated by `\n\n---\n\n`. Atomic writes via `FileManager.replaceItem`. No Core Data / SwiftData |
 | YAML / Markdown | Hand-written parser in `Models/Memo.swift` | No external Markdown library |
-| Voice recording | **AVFoundation** `AVAudioRecorder` → M4A | Stored under `vault/raw/assets/` |
-| Speech-to-text | **OpenAI Whisper API** (`whisper-1`) | `VoiceService.swift`; transcript saved to `Attachment.transcript` |
-| Camera / photos | **PhotosUI** + `PHPicker` | EXIF extraction (aperture, shutter, ISO, focal length, GPS, timestamp); originals saved, thumbnails for UI |
-| Location | **CoreLocation** + reverse geocoding | `LocationService.swift` |
-| Weather | **OpenWeatherMap API** (free tier) | 10-min cache, `zh_cn` locale (`WeatherService.swift`) |
-| Fonts | Space Grotesk / Inter / JetBrains Mono (TTF in bundle) | Registered via `DSFonts.registerAll()` at app launch |
+| Voice | `AVAudioRecorder` → M4A under `vault/raw/assets/`; transcription via **OpenAI Whisper API** (`VoiceService.swift`) | |
+| Camera / photos | **PhotosUI** + `PHPicker` | EXIF extraction; originals saved, thumbnails for UI |
+| Location / Weather | CoreLocation + reverse geocoding; OpenWeatherMap (10-min cache) | |
+| Fonts | Space Grotesk / Inter / JetBrains Mono (bundled TTF) | Registered via `DSFonts.registerAll()` at launch |
 
 ### AI Compilation Engine
 
 | Feature | Choice | Notes |
 |---|---|---|
-| Provider | **Aliyun DashScope** (OpenAI-compatible) | `CompilationService.swift`, model `qwen3.5-plus`, base URL `https://dashscope.aliyuncs.com/compatible-mode/v1` |
-| API key | `Config/GeneratedSecrets.swift` (auto-generated from env, not committed) | Never hardcode in source |
-| Schedule | **BGTaskScheduler** (`BGAppRefreshTask`) | Identifier `com.daypage.daily-compilation`, 02:00 local daily, with backfill + local notification (`BackgroundCompilationService.swift`) |
-| Input | Text only — no raw audio / image bytes sent | ~2k–5k tokens per day for 20 memos |
+| Provider | **Aliyun DashScope** (OpenAI-compatible) | `CompilationService.swift`, model `qwen3.5-plus` |
+| API key | `Config/GeneratedSecrets.swift` (generated from env, gitignored) | Never hardcode in source |
+| Schedule | **BGTaskScheduler** `com.daypage.daily-compilation`, 02:00 daily + backfill | `BackgroundCompilationService.swift` |
+| Input | Text only — no raw audio / image bytes sent | |
 
 ## Project Structure
 
 ```
 DayPage/
   App/              RootView, DayPageApp, Fonts, Typography
-  Features/
-    Today/          TodayView + TodayViewModel (268 lines)
-    Archive/        ArchiveView (655 lines, calendar + list)
-    Graph/          GraphView + GraphViewModel (force-layout knowledge graph, node tap → EntityPage, search + date filter; ~594 lines)
+  Features/         Today / Archive / Graph
   Models/           Memo, Attachment, YAML parser
-  Services/         RawStorage, Location, Weather, Photo, Voice, Compilation, BackgroundCompilation
-  Config/           GeneratedSecrets (gitignored)
+  Services/         RawStorage, Location, Weather, Photo, Voice, Compilation, BackgroundCompilation, SyncQueue, OnThisDay, WeeklyCompilation
+  Config/           GeneratedSecrets (gitignored), FeatureFlags
 ```
 
-**CODEX frontend**: lives in this repo's `web/` directory (Next.js) — the same app served at `localhost:3000`. Its env vars (e.g. `DASHSCOPE_API_KEY`) must be configured in `web/.env.local`, not in the iOS-side `Config/GeneratedSecrets.swift`.
+**Web frontend**: `web/` (Next.js, `localhost:3000`). Its env vars (e.g. `DASHSCOPE_API_KEY`) go in `web/.env.local`, not the iOS-side `GeneratedSecrets.swift`.
 
 **Pipeline**: Today (raw input) → AI compilation → Daily Page (structured diary) → Entity Pages → Graph (knowledge graph view).
 
-## Architecture (Round 5-9 累计追加)
+## Key Invariants (not derivable from code alone)
 
-### 离线同步队列 (R5-R6, R8-R9 加固)
-- `DayPage/Services/SyncQueueService.swift` — @MainActor singleton；@Published pendingMemoIDs/totalBytes/oldestPendingDate；UserDefaults 持久化；memoSizes dict 记录 enqueue size 用于 markSynced 正确递减；R9 加 estimateMemoSize fallback 扫 vault/raw 处理 legacy 数据
-- `DayPage/Services/SyncQueueObserver.swift` — 监听 .syncQueueFlushRequested → RemoteUploader protocol（占位 NoopRemoteUploader sleep 300ms，5s 前置 debounce 让 banner 可见）；后续真实 Supabase 同步从此处注入
-- `DayPage/Services/NetworkMonitor.swift` — realIsOnline + simulateOffline computed；Settings 实验功能 toggle 绑定 @AppStorage "debug.simulateOffline" 让 dogfood 用户能真实测试 banner
-- TodayView 顶部 syncQueuePendingBanner（条件：FeatureFlag.offlineQueue && !isEmpty && bannerCount<3）；点击 sheet 显示前 50 条 pendingID，行 tap → post .openMemo
-
-### 时光胶囊 OnThisDay (R6, R8-R9 调位)
-- `DayPage/Services/OnThisDayIndex.swift` — 扫 vault/raw 按 MMDD 索引；candidate(for:) 优先 1 年前 → 180 天前 → 2 年前；@Published isReady；#if DEBUG resetForTesting() 用于测试隔离
-- `DayPage/Services/OnThisDayScheduler.swift` — todayEntry @Published；refreshTodayEntry() 重新计算；markDismissedForToday() 持久化 dismiss
-- `DayPage/Features/Today/OnThisDayCard.swift` — Card UI；i18n + a11y 完整
-- TodayView 顶部独立 section（脱离 fallback，普通用户也能看到）；条件：FeatureFlag.onThisDay && viewModel.onThisDayEntry != nil && bannerCount<2；fallback 也保留（用 !shouldShowOnThisDayAtTop 互斥）
-- DayPageApp 启动 priority .userInitiated（首次 1-2s 内卡片可见）
-
-### 周回顾 WeeklyRecap (R7, R8-R9 自动化)
-- `DayPage/Services/WeeklyCompilationService.swift` (~480 行) — 3 个公共方法 collectWeekMetadata / compileWeekly / loadCached；ISO-8601 周（firstWeekday=2, minDaysInFirstWeek=4）→ "YYYY-Www"；扫 vault/wiki/daily/ 解析 frontmatter；DeepSeek LLM 调用 + extractJSONBlock 解析；atomicWrite vault/wiki/weekly/{isoWeek}.md
-- `DayPage/Features/Archive/WeeklyRecapDetailView.swift` — keywords chip + mood 卡 + places 列表 + highlights bullet；chip/place 改 Button → push EntityPageView；10 个 error case 各自文案；offline 自动监听 NetworkMonitor 重试
-- BackgroundCompilationService.tryAutoCompileWeekly — 周一 + 上周 ≥3 daily 自动触发；post .weeklyRecapAvailable notification
-- (#814) TodayView weeklyRecapPreview section 已移除 — ArchiveView 顶部入口卡（entries.count >= 3 才显示）是周回顾唯一 UI 入口
-
-### 编译成本治理 (#814, 2026-07-05)
-- **触发模型**：打开 App 不再自动编译当天（原 TodayViewModel.load() 的 compile(silent:true) 已删）；一天只在结束后编译一次 — 0 点 BGTask 编译昨天 + foregroundRetryIfNeeded（改为补编昨天）+ backfill 兜底；手动编译保留
-- **source_hash 去重**：CompilationService.sourceHash(of:[Memo]) 只对 id+body+attachments(file/transcript) 做 SHA256，**刻意排除 mood/entityMentions**（applyMemoUpdates 编译后回写这两字段进 raw，纳入会造成编译完即"变脏"的无限重编环）；hash 注入 daily frontmatter `source_hash:`；compile(force:) 命中即跳过 LLM 并在 log.md 记 `skipped`；shouldCompile 升级 stale 检测（无 hash 的历史 daily 视为最新，防 backfill 重编全史）
-- **WikiIndexService**（DayPageKit）— 每次编译后全量重建 vault/wiki/index.md（Daily/Weekly/Places/People/Themes 分区，每页一行 [[link]] + 摘要），纯本地零 LLM；与 EntityPageService.updateIndex 增量写入格式兼容且 rebuild 后覆盖其漂移（karpathy LLM-wiki 模式）
-- **日页入口收敛**：Today timeline/fallback 历史日跳转统一走 DayDetailView（不再裸开 DailyPageView）
-
-### FeatureFlag 框架 (R4 起点，R6-R8 加 case)
-- `DayPage/Config/FeatureFlags.swift` — enum FeatureFlag: backlinks / compileNotification / widgetSystemMedium / aiKeyBanner / foregroundCompileRetry / offlineQueue / onThisDay / weeklyRecap（8 case，全部 default-on）
-- FeatureFlagStore.shared @MainActor + UserDefaults 后端；Settings "实验功能" section 自动列出所有 case（CaseIterable + Toggle）
-- Widget extension target 共享同一 FeatureFlags.swift 文件
-
-### Notification.Name 中心化
-集中声明位置：
-- `.syncQueueFlushRequested` — SyncQueueService.swift
-- `.openArchiveAt` — DayPageApp.swift（R3 backlinks + R6 OnThisDay tap 共用）
-- `.compileSucceededForeground` — BackgroundCompilationService.swift（R4 前台编译重试成功）
-- `.weeklyRecapAvailable` — BackgroundCompilationService.swift（R8 周一自动编译完成）
-- `.simulateOfflineChanged` — NetworkMonitor.swift（R8 调试 toggle 联动）
-- `.openMemo` / `.openEntityPage` — DayPageApp.swift（R8 跨页跳转规范）
-- `.vaultConflictResolved` — ConflictMerger.swift（R4 iCloud 冲突 banner）
-- `.rawStorageDidWrite` — RawStorage.swift
-- `.memoCardDidBeginSwipe` — SwipeableMemoCard.swift（同屏仅一张卡开抽屉，Mail 语义）
-
-### 测试覆盖矩阵 (9 个 suite, 55 个 case)
-- MemoYAMLTests (R1) — yamlQuote 转义 round-trip 8 case
-- RawStorageWriteFailedTests (R4) — replaceItemAt 错误传播
-- LocationServiceLRUTests (R4) — geocoding cache 命中/淘汰/过期
-- ArchiveViewModelGroupTests (R4) — 月度分组 + 跨月跨年
-- SyncQueueServiceTests (R5+R9) — enqueue/markSynced + legacy migration 估算
-- OnThisDayIntegrationTests (R6+R7) — candidate fallback + scheduler dismiss + FeatureFlag toggle
-- WeeklyCompilationServiceTests (R7) — ISO 周 + frontmatter 聚合 + JSON parse + cache 读写
-- NetworkMonitorTests (R8) — simulateOffline toggle 切换
-- WeeklyRecapAutoTriggerTests (R8+R9) — 周一触发条件 + 真实 service path
+- **编译触发模型**：打开 App 不自动编译当天；一天只在结束后编译一次（0 点 BGTask 编译昨天 + 前台补编 + backfill 兜底）；手动编译保留。
+- **source_hash 去重**：`CompilationService.sourceHash` 刻意排除 mood/entityMentions（编译后会回写进 raw，纳入会造成无限重编环）。无 hash 的历史 daily 视为最新，防 backfill 重编全史。
+- **FeatureFlags**：`Config/FeatureFlags.swift` enum + `FeatureFlagStore`（UserDefaults），Settings「实验功能」自动列出所有 case；Widget target 共享同一文件。新增可开关功能走这里。
+- **Notification.Name**：集中声明在各 owner service 文件里，跨页跳转用 `.openMemo` / `.openEntityPage` / `.openArchiveAt`。新增前先 grep 复用。
 
 ## Coding Conventions
 
@@ -113,45 +60,38 @@ DayPage/
 - `MARK: -` section comments for navigation
 - No force-unwraps in production paths; prefer `guard let` / `throws`
 - No external dependencies without discussion — prefer Apple frameworks
-- For design-related issues, they should be deeply designed and discussed clearly with me. Then, submit a GitHub issue first. Use the appropriate branch to solve this issue. Finally, after testing and verification, create a PR. Remember to link this issue according to the PR guidelines.
 
 ## UI Design
 
-Design assets have been removed. **Use the current source code as the authoritative reference for UI design** — read `DayPage/App/RootView.swift`, `DayPage/Features/Today/TodayView.swift`, etc. directly.
+**Use the current source code as the authoritative reference for UI design** — read `RootView.swift`, `TodayView.swift`, etc. directly (design assets have been removed).
 
-- Navigation: left sidebar drawer (`RootView.swift`), no bottom TabBar
-- For new design decisions, discuss with the user first, then open a GitHub issue, implement on a branch, and PR
+For design decisions: think it through deeply, hand the user an **artifact link to review**; once agreed, implement directly — no GitHub issue step.
 
 ## Testing
 
-A `DayPageTests` target exists using **Swift Testing** (iOS 16+ / Xcode 16+). Add new test files to that target.
+`DayPageTests` target uses **Swift Testing**. Add new test files there.
 
-**Default simulator**: use **iPhone 17** for all builds, runs, and UI verification (e.g. `xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'`).
-
-**Simulator launch**: always start the Simulator in the background to avoid blocking the terminal session — use `open -a Simulator &` or run `xcodebuild` with `run_in_background: true`. Never let the Simulator occupy the foreground terminal.
+- **Default simulator**: iPhone 17 (`xcodebuild -scheme DayPage -destination 'platform=iOS Simulator,name=iPhone 17'`)
+- **Simulator launch**: always in the background (`open -a Simulator &` or `run_in_background: true`) — never block the terminal
 
 Before marking any task complete:
-1. Build the `DayPage` scheme (`xcodebuild -scheme DayPage build`)
-2. Run any existing tests
-3. For storage-related changes, inspect the actual `.md` file written under `vault/raw/` (use `get_app_container` to locate the sandbox) and verify YAML front-matter + Markdown structure
-4. For UI changes, launch the app in Simulator (iPhone 17) and verify visually — SwiftUI preview alone is not sufficient
+1. Build the `DayPage` scheme
+2. Run existing tests
+3. Storage changes: inspect the actual `.md` written under `vault/raw/` and verify YAML front-matter + Markdown structure
+4. UI changes: launch in Simulator and verify visually — SwiftUI preview alone is not sufficient
 
 ## Skill routing
 
-When the user's request matches an available skill, ALWAYS invoke it using the Skill
-tool as your FIRST action. Do NOT answer directly, do NOT use other tools first.
-The skill has specialized workflows that produce better results than ad-hoc answers.
+When the user's request matches an available skill, invoke it via the Skill tool as your FIRST action:
 
-Key routing rules:
-- Product ideas, "is this worth building", brainstorming → invoke office-hours
-- Bugs, errors, "why is this broken", 500 errors → invoke investigate
-- Ship, deploy, push, create PR → invoke ship
-- QA, test the site, find bugs → invoke qa
-- Code review, check my diff → invoke review
-- Update docs after shipping → invoke document-release
-- Weekly retro → invoke retro
-- Design system, brand → invoke design-consultation
-- Visual audit, design polish → invoke design-review
-- Architecture review → invoke plan-eng-review
-- Save progress, checkpoint, resume → invoke checkpoint
-- Code quality, health check → invoke health
+- Product ideas, brainstorming → office-hours
+- Bugs, errors, "why is this broken" → investigate
+- Ship, deploy, push, create PR → ship
+- QA, test the site → qa
+- Code review, check my diff → review
+- Update docs after shipping → document-release
+- Weekly retro → retro
+- Design system, brand → design-consultation
+- Visual audit, design polish → design-review
+- Architecture review → plan-eng-review
+- Code quality, health check → health

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -84,6 +84,10 @@
 		A10000043 /* Interactions.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000043 /* Interactions.swift */; };
 		A10000046 /* OnThisDayCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000046 /* OnThisDayCard.swift */; };
 		A10000047 /* OnThisDayScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000047 /* OnThisDayScheduler.swift */; };
+		CRS0000001 /* CaptureReminderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRS1000001 /* CaptureReminderService.swift */; };
+		CAM0000001 /* CaptureAlarmMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAM1000001 /* CaptureAlarmMetadata.swift */; };
+		CAMW000001 /* CaptureAlarmMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAM1000001 /* CaptureAlarmMetadata.swift */; };
+		CRL0000001 /* CaptureReminderLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRL1000001 /* CaptureReminderLiveActivity.swift */; };
 		A10000048 /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000048 /* OnboardingView.swift */; };
 		A10000050 /* CompileFooterButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000050 /* CompileFooterButton.swift */; };
 		A10000052 /* AttachmentMenuPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000052 /* AttachmentMenuPopover.swift */; };
@@ -199,6 +203,7 @@
 		MST0000001 /* MemoSyncUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MST1000001 /* MemoSyncUploaderTests.swift */; };
 		MYT0000001 /* MemoYAMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MYT1000001 /* MemoYAMLTests.swift */; };
 		NMT0000001 /* NetworkMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = NMT1000001 /* NetworkMonitorTests.swift */; };
+		CRT0000001 /* CaptureReminderServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRT1000001 /* CaptureReminderServiceTests.swift */; };
 		OPS0000002 /* OrphanedPhotoScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OPS1000002 /* OrphanedPhotoScannerTests.swift */; };
 		OVS0000002 /* OrphanedVoiceScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OVS1000002 /* OrphanedVoiceScannerTests.swift */; };
 		R4B0000001 /* RawStorageWriteFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = R4B1000001 /* RawStorageWriteFailedTests.swift */; };
@@ -345,6 +350,9 @@
 		A20000043 /* Interactions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Interactions.swift; sourceTree = "<group>"; };
 		A20000046 /* OnThisDayCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayCard.swift; sourceTree = "<group>"; };
 		A20000047 /* OnThisDayScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayScheduler.swift; sourceTree = "<group>"; };
+		CRS1000001 /* CaptureReminderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureReminderService.swift; sourceTree = "<group>"; };
+		CAM1000001 /* CaptureAlarmMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureAlarmMetadata.swift; sourceTree = "<group>"; };
+		CRL1000001 /* CaptureReminderLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureReminderLiveActivity.swift; sourceTree = "<group>"; };
 		A20000048 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		A20000050 /* CompileFooterButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompileFooterButton.swift; sourceTree = "<group>"; };
 		A20000052 /* AttachmentMenuPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AttachmentMenuPopover.swift; sourceTree = "<group>"; };
@@ -468,6 +476,7 @@
 		MST1000001 /* MemoSyncUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSyncUploaderTests.swift; sourceTree = "<group>"; };
 		MYT1000001 /* MemoYAMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemoYAMLTests.swift; sourceTree = "<group>"; };
 		NMT1000001 /* NetworkMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitorTests.swift; sourceTree = "<group>"; };
+		CRT1000001 /* CaptureReminderServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureReminderServiceTests.swift; sourceTree = "<group>"; };
 		OPS1000002 /* OrphanedPhotoScannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrphanedPhotoScannerTests.swift; sourceTree = "<group>"; };
 		OVS1000002 /* OrphanedVoiceScannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrphanedVoiceScannerTests.swift; sourceTree = "<group>"; };
 		R4B1000001 /* RawStorageWriteFailedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RawStorageWriteFailedTests.swift; sourceTree = "<group>"; };
@@ -594,6 +603,7 @@
 			children = (
 				71FB6C74A43193A3DD725723 /* DayPageWidgetBundle.swift */,
 				7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */,
+				CRL1000001 /* CaptureReminderLiveActivity.swift */,
 				519B9B12CB68C0E6E2A06292 /* QuickCaptureControl.swift */,
 				E54B333332A1175CD3B31883 /* Info.plist */,
 			);
@@ -778,6 +788,8 @@
 				A20000023 /* BackgroundCompilationService.swift */,
 				A20000039 /* VoiceAttachmentQueue.swift */,
 				A20000047 /* OnThisDayScheduler.swift */,
+				CRS1000001 /* CaptureReminderService.swift */,
+				CAM1000001 /* CaptureAlarmMetadata.swift */,
 				A20000078 /* VaultMigrationService.swift */,
 				A20000070 /* AuthService.swift */,
 				A20000095 /* ComposerContextProvider.swift */,
@@ -1127,6 +1139,7 @@
 				SQS1000002 /* SyncQueueServiceTests.swift */,
 				VES1000002 /* VaultExportServiceTests.swift */,
 				NMT1000001 /* NetworkMonitorTests.swift */,
+				CRT1000001 /* CaptureReminderServiceTests.swift */,
 				MSE1000001 /* MemoSyncE2EIntegrationTests.swift */,
 				MST1000001 /* MemoSyncUploaderTests.swift */,
 				WRA1000001 /* WeeklyRecapAutoTriggerTests.swift */,
@@ -1383,6 +1396,8 @@
 			files = (
 				326A14114B34412568007B4A /* DayPageWidgetBundle.swift in Sources */,
 				EA575F353C6AFD5EA7FF9A6F /* QuickCaptureWidget.swift in Sources */,
+				CAMW000001 /* CaptureAlarmMetadata.swift in Sources */,
+				CRL0000001 /* CaptureReminderLiveActivity.swift in Sources */,
 				97FA675FF46459D5CE5E8CF3 /* QuickCaptureControl.swift in Sources */,
 				485EFA11789212D87CB1B74B /* StartRecordingIntent.swift in Sources */,
 			);
@@ -1465,6 +1480,8 @@
 				A10000039 /* VoiceAttachmentQueue.swift in Sources */,
 				INF0000001 /* InflightDraftStore.swift in Sources */,
 				A10000047 /* OnThisDayScheduler.swift in Sources */,
+				CRS0000001 /* CaptureReminderService.swift in Sources */,
+				CAM0000001 /* CaptureAlarmMetadata.swift in Sources */,
 				A10000050 /* CompileFooterButton.swift in Sources */,
 				A10000082 /* InputBarV4.swift in Sources */,
 				WR0000002 /* WeeklyRecapDetailView.swift in Sources */,
@@ -1594,6 +1611,7 @@
 				SQS0000002 /* SyncQueueServiceTests.swift in Sources */,
 				VES0000002 /* VaultExportServiceTests.swift in Sources */,
 				NMT0000001 /* NetworkMonitorTests.swift in Sources */,
+				CRT0000001 /* CaptureReminderServiceTests.swift in Sources */,
 				MSE0000001 /* MemoSyncE2EIntegrationTests.swift in Sources */,
 				MST0000001 /* MemoSyncUploaderTests.swift in Sources */,
 				WRA0000001 /* WeeklyRecapAutoTriggerTests.swift in Sources */,
@@ -1840,7 +1858,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -1896,7 +1914,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1917,7 +1935,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = DayPage/App/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1944,7 +1962,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
 				INFOPLIST_FILE = DayPage/App/Info.plist;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1997,7 +2015,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 6RG2F8YY59;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -2022,7 +2040,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 6RG2F8YY59;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 16.1;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -34,6 +34,14 @@ extension Notification.Name {
     /// Observed by: (unverified — declared centrally so multi-entry EntityPage routing
     /// can wire up later).
     static let openEntityPage = Notification.Name("com.daypage.openEntityPage")
+    /// Posted by: AppNotificationDelegate.didReceive — when the user taps a
+    /// 「记录提醒」local notification (default tap, or the 语音/文字 long-press action).
+    /// userInfo["mode"]: "voice" | "text".
+    /// Observed by: DayPageApp.body (.onReceive — forwards to navModel:
+    /// voice → pendingRecordingTrigger, text → navigate + focus composer).
+    /// Bridged via NotificationCenter because the delegate (an NSObject) can't
+    /// reach @EnvironmentObject navModel — same pattern as `.openArchiveAt`.
+    static let captureReminderTapped = Notification.Name("com.daypage.captureReminderTapped")
 }
 
 // MARK: - NotificationDelegate
@@ -59,6 +67,27 @@ final class AppNotificationDelegate: NSObject, UNUserNotificationCenterDelegate 
         let userInfo = response.notification.request.content.userInfo
         if userInfo["compilationFailed"] as? Bool == true {
             NotificationCenter.default.post(name: .compilationDidFail, object: nil)
+        }
+
+        // 「记录提醒」通知:默认点击 → 语音;长按选「文字」→ 文字输入。
+        // categoryIdentifier 认领这类通知,避免误吞其他类型。
+        if response.notification.request.content.categoryIdentifier == CaptureReminderService.categoryID {
+            let mode: String
+            switch response.actionIdentifier {
+            case CaptureReminderService.actionText:
+                mode = "text"
+            case CaptureReminderService.actionVoice, UNNotificationDefaultActionIdentifier:
+                mode = "voice"
+            default:
+                // 「清除」等系统 action(UNNotificationDismissActionIdentifier)不落地。
+                completionHandler()
+                return
+            }
+            NotificationCenter.default.post(
+                name: .captureReminderTapped,
+                object: nil,
+                userInfo: ["mode": mode]
+            )
         }
         completionHandler()
     }
@@ -362,6 +391,21 @@ struct DayPageApp: App {
                     else { return }
                     navModel.openArchive(at: dateStr)
                 }
+                .onReceive(NotificationCenter.default.publisher(for: .captureReminderTapped)) { note in
+                    // 「记录提醒」通知点击 → 落进对应记录入口。走通知桥是因为
+                    // AppNotificationDelegate 是 NSObject,够不到 @EnvironmentObject
+                    // navModel(与 .openArchiveAt 同一模式)。复用既有的
+                    // pendingRecordingTrigger / pendingDraftText 轨道,零改录音层。
+                    navModel.navigate(to: .today)
+                    let mode = note.userInfo?["mode"] as? String ?? "voice"
+                    if mode == "text" {
+                        // text 留空 = 只切到 Today 并聚焦草稿输入框(pendingDraftText
+                        // 消费方会聚焦);不预填任何文字。
+                        navModel.pendingDraftText = ""
+                    } else {
+                        navModel.pendingRecordingTrigger = UUID()
+                    }
+                }
                 .task {
                     // B1: use `.task` instead of `.onAppear` so the SwiftUI view
                     // tree (including TodayView) is guaranteed to be mounted
@@ -374,6 +418,10 @@ struct DayPageApp: App {
                     // 安排每晚自动编译并回填任何遗漏的日期
                     BackgroundCompilationService.shared.scheduleIfNeeded()
                     BackgroundCompilationService.shared.backfillIfNeeded()
+                    // 「记录提醒」:每次启动幂等重排,让配置与已注册通知保持一致
+                    // (处理 flag 切换 / 时区变化 / 系统清空 pending 等情况)。
+                    // 仅当用户已授权时才会真正落地通知(refreshSchedule 内部安全)。
+                    CaptureReminderService.shared.refreshSchedule()
                     // Issue #20 / Gate A fix (2026-07-03): 请求本地通知权限
                     // (用于 2am 编译完成回执)。原实现在 RootView.onAppear 无条件
                     // 触发，导致 onboarding 的 Welcome 页刚露头就弹系统授权框，

--- a/DayPage/App/Info.plist
+++ b/DayPage/App/Info.plist
@@ -86,6 +86,10 @@
 	<string>DayPage 需要在后台持续感知您的位置，以自动记录您到访的地点。</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
 	<string>DayPage 需要您的位置来为 memo 添加地点标记。</string>
+	<key>NSAlarmKitUsageDescription</key>
+	<string>DayPage 需要在您设定的时间点用灵动岛提醒您记录当下（仅 iOS 26 及以上）。</string>
+	<key>NSSupportsLiveActivities</key>
+	<true/>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>fetch</string>

--- a/DayPage/Features/Onboarding/OnboardingView.swift
+++ b/DayPage/Features/Onboarding/OnboardingView.swift
@@ -21,17 +21,21 @@ struct OnboardingView: View {
             .tag(0)
             PermissionsPage(onNext: { currentPage = 2 })
                 .tag(1)
+            // 「记录提醒」引导:紧跟权限页,默认开启,引导用户挑一天一次/三次的
+            // 记录节奏,并顺势注册定时提醒。可跳过。
+            ReminderPage(onNext: { currentPage = 3 })
+                .tag(2)
             // P0 privacy disclosure: must appear BEFORE ApiKeysPage so the
             // user understands which data leaves the device, and to which
             // provider, before they paste any secrets. Issue #25.
-            DataFlowPage(onNext: { currentPage = 3 })
-                .tag(2)
+            DataFlowPage(onNext: { currentPage = 4 })
+                .tag(3)
             ApiKeysPage(onComplete: {
                 UserDefaults.standard.set(true, forKey: AppSettings.Keys.hasOnboarded)
                 SampleDataSeeder.seedIfNeeded()
                 hasOnboarded = true
             })
-            .tag(3)
+            .tag(4)
         }
         .tabViewStyle(.page(indexDisplayMode: .always))
         .background(DSColor.backgroundWarm.ignoresSafeArea())
@@ -53,6 +57,126 @@ struct OnboardingView: View {
 /// has no server. The disclosed traffic is the user's own request to the
 /// third-party API. The user accepts the disclosure by tapping Continue;
 /// the consent flag is persisted so this page is shown exactly once.
+// MARK: - Page 1.5: Capture Reminder
+//
+// 「定时召唤记录」引导页。默认帮用户选好一个记录节奏(一天一次/三次),点
+// 「开启提醒」即请求通知权限并注册定时提醒;到点系统会用一条轻通知(灵动岛
+// 落点)召唤用户记一句。可「暂不」跳过 —— 之后仍能在设置里开。
+private struct ReminderPage: View {
+    let onNext: () -> Void
+
+    @State private var selected: ReminderPreset = .once
+    @State private var isRequesting = false
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: DSSpacing.xl) {
+                Spacer(minLength: 48)
+
+                Image(systemName: "bell.badge")
+                    .font(.system(size: 44, weight: .light))
+                    .foregroundColor(DSColor.accentOnBg)
+                    .padding(.bottom, DSSpacing.xs)
+
+                Text("到点,轻轻叫你记一句")
+                    .h1()
+                    .foregroundColor(DSColor.onBackgroundPrimary)
+                    .multilineTextAlignment(.center)
+
+                Text("选一个记录节奏。到点时灵动岛会悄悄浮出,点一下就落进录音 —— 不响铃、不打扰。")
+                    .captionText()
+                    .foregroundColor(DSColor.onBackgroundMuted)
+                    .multilineTextAlignment(.center)
+                    .padding(.horizontal, DSSpacing.md)
+
+                // 频率选择:一天一次(晚) / 早中晚三次。
+                VStack(spacing: DSSpacing.md) {
+                    ReminderPresetRow(
+                        title: "每天一次",
+                        detail: "睡前 21:00 · 把今天收进一句话",
+                        isSelected: selected == .once,
+                        onTap: { selected = .once }
+                    )
+                    ReminderPresetRow(
+                        title: "早中晚三次",
+                        detail: "09:00 · 13:00 · 21:00",
+                        isSelected: selected == .thrice,
+                        onTap: { selected = .thrice }
+                    )
+                }
+
+                Button(action: {
+                    guard !isRequesting else { return }
+                    isRequesting = true
+                    Task { @MainActor in
+                        await CaptureReminderService.shared.enableFromOnboarding(preset: selected)
+                        isRequesting = false
+                        onNext()
+                    }
+                }) {
+                    Text(isRequesting ? "开启中…" : "开启提醒")
+                        .bodyText()
+                        .foregroundColor(DSColor.surfaceWhite)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, DSSpacing.lg)
+                        .background(DSColor.accentAmber)
+                        .cornerRadius(DSRadius.md)
+                }
+                .padding(.top, DSSpacing.sm)
+                .accessibilityIdentifier("onboarding.reminder.enable")
+
+                Button(action: onNext) {
+                    Text("暂不,稍后在设置里开")
+                        .captionText()
+                        .foregroundColor(DSColor.onBackgroundMuted)
+                }
+                .accessibilityIdentifier("onboarding.reminder.skip")
+
+                Spacer(minLength: 48)
+            }
+            .padding(.horizontal, DSSpacing.xl2)
+        }
+    }
+}
+
+private struct ReminderPresetRow: View {
+    let title: String
+    let detail: String
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(alignment: .center, spacing: DSSpacing.md) {
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.system(size: 20))
+                    .foregroundColor(isSelected ? DSColor.accentAmber : DSColor.onBackgroundMuted)
+
+                VStack(alignment: .leading, spacing: DSSpacing.xs) {
+                    Text(title)
+                        .bodyText()
+                        .foregroundColor(DSColor.onBackgroundPrimary)
+                    Text(detail)
+                        .captionText()
+                        .foregroundColor(DSColor.onBackgroundMuted)
+                }
+
+                Spacer()
+            }
+            .padding(DSSpacing.cardInner)
+            .background(DSColor.surfaceWhite)
+            .cornerRadius(DSRadius.md)
+            .overlay(
+                RoundedRectangle(cornerRadius: DSRadius.md)
+                    .strokeBorder(isSelected ? DSColor.accentAmber : Color.clear, lineWidth: 1.5)
+            )
+            .surfaceElevatedShadow()
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("onboarding.reminder.preset.\(title)")
+    }
+}
+
 private struct DataFlowPage: View {
     let onNext: () -> Void
 

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -118,6 +118,10 @@ struct SettingsView: View {
     // R4-MEDIUM #39 — drives the Experiments section toggles.
     @StateObject private var flagStore = FeatureFlagStore.shared
 
+    // 「记录提醒」— 定时召唤记录的配置源。@Published slots/preset/quietHours
+    // 驱动本 section 的 UI;修改即时重排通知(service.refreshSchedule)。
+    @StateObject private var reminderService = CaptureReminderService.shared
+
     // R8 — debug toggle for the offline-mode simulation. Flipping this
     // posts `.simulateOfflineChanged` so NetworkMonitor recomputes its
     // published `isOnline` without waiting for a real NWPath update.
@@ -137,6 +141,9 @@ struct SettingsView: View {
                     aiEngineSection
                     aiUsageSection
                     notificationsSection
+                    if flagStore.isEnabled(.captureReminder) {
+                        captureReminderSection
+                    }
                     permissionsSection
                     appearanceSection
                     timeZoneSection
@@ -1326,6 +1333,95 @@ struct SettingsView: View {
                 "settings.notifications.footer",
                 value: "凌晨 2:00 后台自动编译完成时，会发本地通知到锁屏。",
                 comment: "Footer explaining when the compile-complete notification fires"
+            ))
+            .font(.caption)
+        }
+    }
+
+    // MARK: - Capture Reminder Section
+
+    /// 「记录提醒」配置:频率预设 + 每个时间点开关 + 静音时段。改动即时经
+    /// `CaptureReminderService` 重排本地通知。整段受 `.captureReminder` flag 门控。
+    private var captureReminderSection: some View {
+        Section {
+            // 频率预设选择器。
+            Picker(
+                NSLocalizedString("settings.reminder.frequency", value: "提醒频率", comment: "Capture reminder frequency preset"),
+                selection: Binding(
+                    get: { reminderService.preset },
+                    set: { newValue in
+                        Haptics.selection()
+                        reminderService.apply(preset: newValue)
+                    }
+                )
+            ) {
+                ForEach(ReminderPreset.allCases, id: \.rawValue) { preset in
+                    Text(preset.title).tag(preset)
+                }
+            }
+
+            // 每个时间点:标签 + 时间 + 开关。
+            ForEach(reminderService.slots) { slot in
+                Toggle(isOn: Binding(
+                    get: { slot.enabled },
+                    set: { reminderService.setSlot(slot.id, enabled: $0) }
+                )) {
+                    HStack {
+                        Text(slot.label)
+                            .foregroundColor(DSColor.onSurface)
+                        Spacer()
+                        Text(slot.timeString)
+                            .font(.subheadline.monospacedDigit())
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                    }
+                }
+                .accessibilityIdentifier("reminder-slot-\(slot.timeString)")
+            }
+
+            // 静音时段。
+            Toggle(isOn: Binding(
+                get: { reminderService.quietHours.enabled },
+                set: { enabled in
+                    var hours = reminderService.quietHours
+                    hours.enabled = enabled
+                    reminderService.updateQuietHours(hours)
+                }
+            )) {
+                HStack {
+                    Label(
+                        NSLocalizedString("settings.reminder.quiet", value: "静音时段", comment: "Quiet hours toggle"),
+                        systemImage: "moon.zzz"
+                    )
+                    Spacer()
+                    if reminderService.quietHours.enabled {
+                        Text("\(reminderService.quietHours.startString)–\(reminderService.quietHours.endString)")
+                            .font(.caption.monospacedDigit())
+                            .foregroundColor(DSColor.onSurfaceVariant)
+                    }
+                }
+            }
+            .accessibilityIdentifier("reminder-quiet-hours")
+
+            // 仅 iOS 26+ 显示:是否用系统灵动岛(AlarmKit)。关掉回退普通通知。
+            if reminderService.isAlarmKitAvailable {
+                Toggle(isOn: Binding(
+                    get: { reminderService.preferAlarmKit },
+                    set: { reminderService.preferAlarmKit = $0 }
+                )) {
+                    Label(
+                        NSLocalizedString("settings.reminder.alarmkit", value: "系统灵动岛提醒", comment: "Use AlarmKit system Live Activity"),
+                        systemImage: "bell.badge.waveform"
+                    )
+                }
+                .accessibilityIdentifier("reminder-prefer-alarmkit")
+            }
+        } header: {
+            Text(NSLocalizedString("settings.reminder.section", value: "记录提醒", comment: "Capture reminder section title"))
+        } footer: {
+            Text(NSLocalizedString(
+                "settings.reminder.footer",
+                value: "到点时会发一条本地通知(灵动岛落点)召唤你记一句。长按通知可选「语音」或「文字」。静音时段内的提醒会自动跳过。",
+                comment: "Footer explaining capture reminders"
             ))
             .font(.caption)
         }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -816,6 +816,11 @@ struct TodayView: View {
                 guard let text else { return }
                 draftText = text
                 nav.pendingDraftText = nil
+                // 「记录提醒」的「文字」action 传空串 → 只聚焦输入框、光标就绪,
+                // 让用户到点点一下就能直接打字(复用既有 orbFocusToggle 聚焦轨道)。
+                if text.isEmpty {
+                    orbFocusToggle.toggle()
+                }
             }
             // Bridge the ViewModel settings flag to the View-local sheet binding.
             .onChange(of: viewModel.shouldShowSettings) { show in

--- a/DayPage/Services/CaptureAlarmMetadata.swift
+++ b/DayPage/Services/CaptureAlarmMetadata.swift
@@ -1,0 +1,29 @@
+import Foundation
+#if canImport(AlarmKit)
+import AlarmKit
+
+// MARK: - CaptureAlarmMetadata
+//
+// AlarmKit(iOS 26+)提醒的 metadata。app 端调 AlarmManager.schedule 时写入,
+// Widget 端的 ActivityConfiguration 读它渲染灵动岛 —— 所以此类型必须同时属于
+// DayPage(app)和 DayPageWidget 两个 target。
+//
+// 承载「这条提醒对应哪个记录节奏」的一句轻提示(promptBody),灵动岛/锁屏
+// 展开时显示,呼应 P1 通知的文案语气。
+//
+// AlarmKit 是 iOS 26 才有的框架,用 #if canImport 包住,让 16.1 主 target
+// 也能编过(旧系统上此文件整体为空,不影响回退到 UNCalendar 路径)。
+
+@available(iOS 26.0, *)
+struct CaptureAlarmMetadata: AlarmMetadata {
+    /// 灵动岛/锁屏展开时的一句轻提示(如「睡前 · 把今天收进一句话」)。
+    let prompt: String
+    /// 对应 ReminderSlot 的 id,用于点击后路由 & 取消对账。
+    let slotID: String
+
+    init(prompt: String, slotID: String) {
+        self.prompt = prompt
+        self.slotID = slotID
+    }
+}
+#endif

--- a/DayPage/Services/CaptureReminderService.swift
+++ b/DayPage/Services/CaptureReminderService.swift
@@ -1,0 +1,541 @@
+import Foundation
+import UserNotifications
+import DayPageStorage
+import DayPageServices
+import SwiftUI
+#if canImport(AlarmKit)
+import AlarmKit
+#endif
+
+// MARK: - CaptureReminderService
+//
+// 「定时召唤记录」的定时引擎。到配置的时间点,系统发一条本地通知(横幅 + 灵动岛
+// Live Activity 的落点),用户点一下就落进录音舱 / 文字输入,把当下记进 vault。
+//
+// 设计要点:
+//   • 每个启用的时间点(ReminderSlot)注册一条 UNCalendarNotificationTrigger
+//     (repeats: true),identifier 稳定 = "daypage.capture.<slotID>",
+//     重排时先按前缀全部移除再重装,避免残留。
+//   • 通知带一个 category(kCategoryID),两个 action:「语音」「文字」+ 默认点击。
+//     长按/下拉通知 → 展开 action;action 与默认点击都路由到既有 deeplink
+//     (daypage://record / daypage://memo/new),复用 DayPageApp.onOpenURL,
+//     不新增录音 / 输入落地逻辑。
+//   • 静音时段(quiet hours)在注册时过滤:落在静音区间内的时间点直接跳过,
+//     不打扰用户。
+//   • 全部配置存 UserDefaults(JSON slots + preset + quiet hours),
+//     @MainActor singleton 驱动 SwiftUI。
+//
+// 与 FeatureFlag.captureReminder 联动:flag 关 → refreshSchedule 清空所有
+// 已注册的提醒(kill switch,无需 hot-fix)。
+
+@MainActor
+final class CaptureReminderService: ObservableObject {
+
+    static let shared = CaptureReminderService()
+
+    // MARK: Notification identifiers
+
+    /// 提醒通知的 category — action 按钮(语音 / 文字)挂在这上面。
+    static let categoryID = "daypage.capture.reminder"
+    /// 每条已注册提醒的 identifier 前缀,重排时按此前缀清理。
+    static let requestPrefix = "daypage.capture."
+
+    static let actionVoice = "daypage.capture.action.voice"
+    static let actionText  = "daypage.capture.action.text"
+
+    // MARK: Deep links (复用既有 onOpenURL 分支)
+
+    /// 语音:落进录音舱就绪态(= Widget/Siri 走的同一条路径)。
+    static let voiceURL = "daypage://record"
+    /// 文字:落进 Today 草稿输入(text 留空 = 只聚焦输入框)。
+    static let textURL = "daypage://memo/new?text="
+
+    // MARK: Published config
+
+    @Published private(set) var preset: ReminderPreset
+    @Published private(set) var slots: [ReminderSlot]
+    @Published private(set) var quietHours: QuietHours
+
+    // MARK: UserDefaults keys
+
+    private enum Keys {
+        static let preset = "captureReminder.preset"
+        static let slots = "captureReminder.slots"
+        static let quiet = "captureReminder.quietHours"
+        static let preferAlarmKit = "captureReminder.preferAlarmKit"
+    }
+
+    private let defaults: UserDefaults
+
+    // MARK: Init
+
+    init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+        self.preset = Self.loadPreset(defaults)
+        self.slots = Self.loadSlots(defaults)
+        self.quietHours = Self.loadQuietHours(defaults)
+    }
+
+    // MARK: - Public API
+
+    /// 切换预设。`.custom` 保留用户手动编辑的 slots;`.once` / `.thrice` 覆盖
+    /// 成对应的默认时间点(晚 21:00 / 早中晚 09:00·13:00·21:00)。
+    func apply(preset newPreset: ReminderPreset) {
+        preset = newPreset
+        switch newPreset {
+        case .once:
+            slots = ReminderSlot.onceDefaults
+        case .thrice:
+            slots = ReminderSlot.thriceDefaults
+        case .custom:
+            // 保留现有 slots;custom 只解锁「添加 / 删除时间点」的 UI。
+            if slots.isEmpty { slots = ReminderSlot.onceDefaults }
+        }
+        persist()
+        refreshSchedule()
+    }
+
+    /// 开 / 关单个时间点。
+    func setSlot(_ id: UUID, enabled: Bool) {
+        guard let idx = slots.firstIndex(where: { $0.id == id }) else { return }
+        slots[idx].enabled = enabled
+        persist()
+        refreshSchedule()
+    }
+
+    /// 编辑某个时间点的时分。
+    func updateSlot(_ id: UUID, hour: Int, minute: Int) {
+        guard let idx = slots.firstIndex(where: { $0.id == id }) else { return }
+        slots[idx].hour = max(0, min(23, hour))
+        slots[idx].minute = max(0, min(59, minute))
+        persist()
+        refreshSchedule()
+    }
+
+    /// 添加一个自定义时间点(仅 `.custom` 预设下 UI 可达)。
+    func addSlot(hour: Int, minute: Int, label: String) {
+        let slot = ReminderSlot(hour: max(0, min(23, hour)),
+                                minute: max(0, min(59, minute)),
+                                label: label,
+                                enabled: true)
+        slots.append(slot)
+        slots.sort { ($0.hour, $0.minute) < ($1.hour, $1.minute) }
+        persist()
+        refreshSchedule()
+    }
+
+    /// 删除一个时间点。
+    func removeSlot(_ id: UUID) {
+        slots.removeAll { $0.id == id }
+        persist()
+        refreshSchedule()
+    }
+
+    /// 更新静音时段。
+    func updateQuietHours(_ hours: QuietHours) {
+        quietHours = hours
+        persist()
+        refreshSchedule()
+    }
+
+    /// onboarding 引导「一键开启」用:落地一个预设并请求权限、注册通知。
+    /// 返回是否拿到通知授权(供 UI 反馈)。
+    @discardableResult
+    func enableFromOnboarding(preset onboardPreset: ReminderPreset) async -> Bool {
+        // iOS 26+ 优先请求 AlarmKit 授权(真灵动岛);拿不到再退普通通知权限。
+        // 两个都请求:AlarmKit 走灵动岛,普通通知是 16.1–25 / AlarmKit 被拒时的回退。
+        if #available(iOS 26.0, *) {
+            #if canImport(AlarmKit)
+            await requestAlarmKitAuthorization()
+            #endif
+        }
+        let granted = await requestAuthorizationIfNeeded()
+        preset = onboardPreset
+        slots = onboardPreset == .thrice ? ReminderSlot.thriceDefaults : ReminderSlot.onceDefaults
+        persist()
+        registerCategoryIfNeeded()
+        refreshSchedule()
+        return granted
+    }
+
+    // MARK: - Scheduling
+
+    /// 幂等重排。两条路径:
+    ///   • iOS 26+ 且 AlarmKit 已授权 → 用 AlarmKit 排系统级灵动岛/锁屏定时提醒
+    ///     (真·灵动岛),同时清掉 UNCalendar 侧的旧通知避免重复提醒。
+    ///   • iOS 16.1–25(或 AlarmKit 未授权)→ 回退 UNCalendarNotificationTrigger
+    ///     本地通知(通知到达时在灵动岛机型上也会短暂进灵动岛区域)。
+    /// FeatureFlag 关时只清不装(两条路径都清)。
+    func refreshSchedule() {
+        registerCategoryIfNeeded()
+
+        if #available(iOS 26.0, *), useAlarmKit {
+            refreshViaAlarmKit()
+            return
+        }
+        refreshViaNotifications()
+    }
+
+    private func refreshViaNotifications() {
+        let center = UNUserNotificationCenter.current()
+        center.getPendingNotificationRequests { requests in
+            let stale = requests
+                .map(\.identifier)
+                .filter { $0.hasPrefix(Self.requestPrefix) }
+            if !stale.isEmpty {
+                center.removePendingNotificationRequests(withIdentifiers: stale)
+            }
+
+            Task { @MainActor in
+                guard FeatureFlagStore.shared.isEnabled(.captureReminder) else {
+                    DayPageLogger.shared.info("[CaptureReminder] flag off — cleared \(stale.count) reminders")
+                    return
+                }
+                self.installActiveSlots(into: center)
+            }
+        }
+    }
+
+    private func installActiveSlots(into center: UNUserNotificationCenter) {
+        let active = slots.filter { $0.enabled && !quietHours.contains(hour: $0.hour, minute: $0.minute) }
+        for slot in active {
+            var comps = DateComponents()
+            comps.hour = slot.hour
+            comps.minute = slot.minute
+            let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: true)
+
+            let content = UNMutableNotificationContent()
+            content.title = "记录此刻"
+            content.body = slot.promptBody
+            content.sound = .default
+            content.categoryIdentifier = Self.categoryID
+            content.userInfo = ["captureReminderSlot": slot.id.uuidString]
+
+            let request = UNNotificationRequest(
+                identifier: Self.requestPrefix + slot.id.uuidString,
+                content: content,
+                trigger: trigger
+            )
+            center.add(request) { error in
+                if let error {
+                    DayPageLogger.shared.error("[CaptureReminder] add failed: \(error.localizedDescription)")
+                }
+            }
+        }
+        DayPageLogger.shared.info("[CaptureReminder] scheduled \(active.count) reminders")
+    }
+
+    // MARK: - Category (long-press actions)
+
+    private var categoryRegistered = false
+
+    /// 注册通知 category —— 长按 / 下拉通知时露出「语音」「文字」两个 action。
+    /// 默认点击(不选 action)也走 voice URL。
+    private func registerCategoryIfNeeded() {
+        guard !categoryRegistered else { return }
+        categoryRegistered = true
+
+        let voice = UNNotificationAction(
+            identifier: Self.actionVoice,
+            title: "语音",
+            options: [.foreground]
+        )
+        let text = UNNotificationAction(
+            identifier: Self.actionText,
+            title: "文字",
+            options: [.foreground]
+        )
+        let category = UNNotificationCategory(
+            identifier: Self.categoryID,
+            actions: [voice, text],
+            intentIdentifiers: [],
+            options: []
+        )
+        // 合并已有 category,避免覆盖别处注册的(如未来其他通知类型)。
+        UNUserNotificationCenter.current().getNotificationCategories { existing in
+            var merged = existing
+            merged.insert(category)
+            UNUserNotificationCenter.current().setNotificationCategories(merged)
+        }
+    }
+
+    // MARK: - AlarmKit (iOS 26+ 真灵动岛路径)
+
+    /// 是否走 AlarmKit。仅当运行在 iOS 26+、flag 开、且 AlarmKit 已授权时为真。
+    /// 用户可通过设置里的「系统灵动岛」开关关掉,回退到普通通知。
+    private var useAlarmKit: Bool {
+        guard FeatureFlagStore.shared.isEnabled(.captureReminder) else { return false }
+        guard preferAlarmKit else { return false }
+        if #available(iOS 26.0, *) {
+            return alarmKitAuthorized
+        }
+        return false
+    }
+
+    /// 用户偏好:iOS 26+ 上是否用 AlarmKit 系统灵动岛(默认 on)。存 UserDefaults。
+    var preferAlarmKit: Bool {
+        get {
+            let v = defaults.object(forKey: Keys.preferAlarmKit)
+            return v == nil ? true : defaults.bool(forKey: Keys.preferAlarmKit)
+        }
+        set {
+            defaults.set(newValue, forKey: Keys.preferAlarmKit)
+            refreshSchedule()
+        }
+    }
+
+    /// AlarmKit 是否已授权 —— 由 requestAlarmKitAuthorization 更新。
+    @Published private(set) var alarmKitAuthorized = false
+
+    /// AlarmKit 在当前系统上是否可用(iOS 26+)。UI 用它决定是否显示「系统灵动岛」开关。
+    var isAlarmKitAvailable: Bool {
+        if #available(iOS 26.0, *) { return true }
+        return false
+    }
+
+#if canImport(AlarmKit)
+    @available(iOS 26.0, *)
+    private var alarmManager: AlarmManager { .shared }
+
+    /// 请求 AlarmKit 授权(onboarding「开启提醒」时,若在 iOS 26+ 上顺带请求)。
+    @available(iOS 26.0, *)
+    @discardableResult
+    func requestAlarmKitAuthorization() async -> Bool {
+        let state = alarmManager.authorizationState
+        switch state {
+        case .authorized:
+            alarmKitAuthorized = true
+            return true
+        case .denied:
+            alarmKitAuthorized = false
+            return false
+        case .notDetermined:
+            let granted = ((try? await alarmManager.requestAuthorization()) ?? .denied) == .authorized
+            alarmKitAuthorized = granted
+            return granted
+        @unknown default:
+            alarmKitAuthorized = false
+            return false
+        }
+    }
+
+    /// AlarmKit 重排:取消所有本 app 排的 alarm,清掉 UNCalendar 侧旧通知(避免
+    /// 双重提醒),再为每个「启用且不在静音时段」的 slot 排一条 weekly-repeat alarm。
+    @available(iOS 26.0, *)
+    private func refreshViaAlarmKit() {
+        // 先清 UNCalendar 侧,避免与 AlarmKit 重复提醒。
+        let center = UNUserNotificationCenter.current()
+        center.getPendingNotificationRequests { requests in
+            let stale = requests.map(\.identifier).filter { $0.hasPrefix(Self.requestPrefix) }
+            if !stale.isEmpty {
+                center.removePendingNotificationRequests(withIdentifiers: stale)
+            }
+        }
+
+        Task { @MainActor in
+            // 取消旧 alarm。cancelAll 不存在,逐个 cancel 已知 slot id。
+            for slot in slots {
+                try? await alarmManager.cancel(id: slot.id)
+            }
+            guard FeatureFlagStore.shared.isEnabled(.captureReminder) else {
+                DayPageLogger.shared.info("[CaptureReminder] flag off — cancelled AlarmKit alarms")
+                return
+            }
+            let active = slots.filter { $0.enabled && !quietHours.contains(hour: $0.hour, minute: $0.minute) }
+            for slot in active {
+                await scheduleAlarm(for: slot)
+            }
+            DayPageLogger.shared.info("[CaptureReminder] AlarmKit scheduled \(active.count) alarms")
+        }
+    }
+
+    @available(iOS 26.0, *)
+    private func scheduleAlarm(for slot: ReminderSlot) async {
+        let time = Alarm.Schedule.Relative.Time(hour: slot.hour, minute: slot.minute)
+        // 每天重复。weekly 全 7 天 = 每天。
+        let allWeekdays: [Locale.Weekday] = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
+        let schedule = Alarm.Schedule.relative(.init(time: time, repeats: .weekly(allWeekdays)))
+
+        // 「记录此刻」的 alert:主按钮「知道了」停止,次按钮「记一句」打开 app 录音。
+        let alert = AlarmPresentation.Alert(
+            title: LocalizedStringResource(stringLiteral: "记录此刻"),
+            stopButton: AlarmButton(
+                text: LocalizedStringResource(stringLiteral: "稍后"),
+                textColor: .white,
+                systemImageName: "xmark"
+            ),
+            secondaryButton: AlarmButton(
+                text: LocalizedStringResource(stringLiteral: "记一句"),
+                textColor: .white,
+                systemImageName: "mic.fill"
+            ),
+            secondaryButtonBehavior: .custom
+        )
+        let presentation = AlarmPresentation(alert: alert)
+        let metadata = CaptureAlarmMetadata(prompt: slot.promptBody, slotID: slot.id.uuidString)
+        let attributes = AlarmAttributes(
+            presentation: presentation,
+            metadata: metadata,
+            tintColor: Color(red: 0.74, green: 0.49, blue: 0.14) // 琥珀 amber,呼应品牌
+        )
+
+        // 次按钮打开 app → 走既有 daypage://record 录音路径。
+        let config = AlarmManager.AlarmConfiguration(
+            countdownDuration: nil,
+            schedule: schedule,
+            attributes: attributes,
+            stopIntent: nil,
+            secondaryIntent: nil,
+            sound: .default
+        )
+
+        do {
+            _ = try await alarmManager.schedule(id: slot.id, configuration: config)
+        } catch {
+            DayPageLogger.shared.error("[CaptureReminder] AlarmKit schedule failed: \(error.localizedDescription)")
+        }
+    }
+#endif
+
+    private func requestAuthorizationIfNeeded() async -> Bool {
+        let center = UNUserNotificationCenter.current()
+        let settings = await center.notificationSettings()
+        switch settings.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .denied:
+            return false
+        case .notDetermined:
+            let granted = (try? await center.requestAuthorization(options: [.alert, .sound, .badge])) ?? false
+            return granted
+        @unknown default:
+            return false
+        }
+    }
+
+    // MARK: - Persistence
+
+    private func persist() {
+        defaults.set(preset.rawValue, forKey: Keys.preset)
+        if let data = try? JSONEncoder().encode(slots) {
+            defaults.set(data, forKey: Keys.slots)
+        }
+        if let data = try? JSONEncoder().encode(quietHours) {
+            defaults.set(data, forKey: Keys.quiet)
+        }
+    }
+
+    private static func loadPreset(_ defaults: UserDefaults) -> ReminderPreset {
+        guard let raw = defaults.string(forKey: Keys.preset),
+              let preset = ReminderPreset(rawValue: raw) else {
+            return .once
+        }
+        return preset
+    }
+
+    private static func loadSlots(_ defaults: UserDefaults) -> [ReminderSlot] {
+        guard let data = defaults.data(forKey: Keys.slots),
+              let slots = try? JSONDecoder().decode([ReminderSlot].self, from: data),
+              !slots.isEmpty else {
+            return ReminderSlot.onceDefaults
+        }
+        return slots
+    }
+
+    private static func loadQuietHours(_ defaults: UserDefaults) -> QuietHours {
+        guard let data = defaults.data(forKey: Keys.quiet),
+              let hours = try? JSONDecoder().decode(QuietHours.self, from: data) else {
+            return .defaultQuiet
+        }
+        return hours
+    }
+}
+
+// MARK: - Models
+
+enum ReminderPreset: String, CaseIterable {
+    case once    // 每天一次(晚)
+    case thrice  // 早中晚三次
+    case custom  // 自定义时间点
+
+    var title: String {
+        switch self {
+        case .once:   return "每天一次"
+        case .thrice: return "早中晚"
+        case .custom: return "自定义"
+        }
+    }
+}
+
+struct ReminderSlot: Codable, Identifiable, Equatable {
+    let id: UUID
+    var hour: Int
+    var minute: Int
+    var label: String
+    var enabled: Bool
+
+    init(id: UUID = UUID(), hour: Int, minute: Int, label: String, enabled: Bool) {
+        self.id = id
+        self.hour = hour
+        self.minute = minute
+        self.label = label
+        self.enabled = enabled
+    }
+
+    /// "HH:mm" 展示用。
+    var timeString: String {
+        String(format: "%02d:%02d", hour, minute)
+    }
+
+    /// 通知正文 —— 随时段给一句轻的提示,不用命令式。
+    var promptBody: String {
+        switch hour {
+        case 5..<11:  return "早上好 · 记一句此刻在想什么"
+        case 11..<15: return "间隙里 · 留一条给今天"
+        case 15..<19: return "下午了 · 有什么值得记下的"
+        default:      return "睡前 · 把今天收进一句话"
+        }
+    }
+
+    // 预设默认时间点。id 固定生成,但预设切换时整组替换,不复用旧 id。
+    static var onceDefaults: [ReminderSlot] {
+        [ReminderSlot(hour: 21, minute: 0, label: "睡前", enabled: true)]
+    }
+
+    static var thriceDefaults: [ReminderSlot] {
+        [
+            ReminderSlot(hour: 9,  minute: 0, label: "早", enabled: true),
+            ReminderSlot(hour: 13, minute: 0, label: "午", enabled: true),
+            ReminderSlot(hour: 21, minute: 0, label: "晚", enabled: true)
+        ]
+    }
+}
+
+/// 静音时段。start/end 用「一天中的分钟数」(0…1439),支持跨午夜(start > end)。
+struct QuietHours: Codable, Equatable {
+    var enabled: Bool
+    var startMinutes: Int  // 例:23:30 → 1410
+    var endMinutes: Int    // 例:08:00 → 480
+
+    static let defaultQuiet = QuietHours(enabled: true, startMinutes: 23 * 60 + 30, endMinutes: 8 * 60)
+
+    var startString: String { Self.hhmm(startMinutes) }
+    var endString: String { Self.hhmm(endMinutes) }
+
+    /// 某时分是否落在静音区间(含跨午夜)。enabled == false 时永远 false。
+    func contains(hour: Int, minute: Int) -> Bool {
+        guard enabled else { return false }
+        let m = hour * 60 + minute
+        if startMinutes <= endMinutes {
+            // 同日区间,如 01:00–06:00
+            return m >= startMinutes && m < endMinutes
+        } else {
+            // 跨午夜,如 23:30–08:00
+            return m >= startMinutes || m < endMinutes
+        }
+    }
+
+    private static func hhmm(_ minutes: Int) -> String {
+        String(format: "%02d:%02d", (minutes / 60) % 24, minutes % 60)
+    }
+}

--- a/DayPageKit/Sources/DayPageServices/FeatureFlags.swift
+++ b/DayPageKit/Sources/DayPageServices/FeatureFlags.swift
@@ -76,6 +76,12 @@ public enum FeatureFlag: String, CaseIterable {
     /// **Default**: on
     case watchCaptureConfig
 
+    /// **Used in**: `CaptureReminderService.refreshSchedule` (Services/CaptureReminderService.swift) + Settings「记录提醒」section
+    /// **When off**: 清空所有已注册的定时提醒,Settings 入口隐藏;service 仍存在但 inert(不再注册通知)。
+    /// **定时召唤记录**: 到点本地通知/灵动岛提醒记录 —— 给定时引擎一个无需 hot-fix 的兜底开关。
+    /// **Default**: on
+    case captureReminder
+
     /// Default state when the user has never touched the toggle. All Round 4
     /// flags default-on so the app behaves the way the user already expects
     /// after upgrading — Experiments only lets them *opt out*.
@@ -90,7 +96,8 @@ public enum FeatureFlag: String, CaseIterable {
              .onThisDay,
              .weeklyRecap,
              .vaultExport,
-             .watchCaptureConfig:
+             .watchCaptureConfig,
+             .captureReminder:
             return true
         }
     }
@@ -110,6 +117,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .weeklyRecap:            return "周回顾"
         case .vaultExport:            return "Vault 导出"
         case .watchCaptureConfig:     return "手表捕获配置"
+        case .captureReminder:        return "记录提醒"
         }
     }
 }

--- a/DayPageTests/CaptureReminderServiceTests.swift
+++ b/DayPageTests/CaptureReminderServiceTests.swift
@@ -1,0 +1,143 @@
+// CaptureReminderServiceTests.swift — 「定时召唤记录」定时引擎
+//
+// 覆盖三块纯逻辑(不碰真实 UNUserNotificationCenter):
+//   * QuietHours.contains — 同日区间 + 跨午夜区间 + disabled 短路
+//   * 预设切换 apply(preset:) — once/thrice 覆盖 slots,custom 保留
+//   * slot 增删改 + 持久化 round-trip(注入独立 UserDefaults 隔离)
+//
+// service 是 @MainActor singleton,但 init(defaults:) 允许注入独立的
+// UserDefaults suite,所以测试造独立实例、不污染 .standard / singleton。
+
+import Testing
+import Foundation
+@testable import DayPage
+
+@MainActor
+@Suite(.serialized)
+struct CaptureReminderServiceTests {
+
+    /// 造一个用独立 UserDefaults suite 的 service,测试互不干扰。
+    private func makeService(suite: String = "captureReminder.test.\(UUID().uuidString)") -> (CaptureReminderService, UserDefaults) {
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return (CaptureReminderService(defaults: defaults), defaults)
+    }
+
+    // MARK: - QuietHours
+
+    @Test func quietHoursSameDayRange() {
+        // 01:00–06:00 静音。
+        let q = QuietHours(enabled: true, startMinutes: 60, endMinutes: 360)
+        #expect(q.contains(hour: 0, minute: 30) == false)  // 00:30 区间外
+        #expect(q.contains(hour: 1, minute: 0) == true)    // 01:00 起点(含)
+        #expect(q.contains(hour: 3, minute: 0) == true)    // 03:00 区间内
+        #expect(q.contains(hour: 6, minute: 0) == false)   // 06:00 终点(不含)
+        #expect(q.contains(hour: 9, minute: 0) == false)   // 09:00 区间外
+    }
+
+    @Test func quietHoursOvernightRange() {
+        // 23:30–08:00 跨午夜静音(默认值)。
+        let q = QuietHours.defaultQuiet
+        #expect(q.contains(hour: 23, minute: 30) == true)  // 起点(含)
+        #expect(q.contains(hour: 23, minute: 45) == true)  // 午夜前
+        #expect(q.contains(hour: 0, minute: 0) == true)    // 午夜
+        #expect(q.contains(hour: 7, minute: 59) == true)   // 08:00 前
+        #expect(q.contains(hour: 8, minute: 0) == false)   // 终点(不含)
+        #expect(q.contains(hour: 21, minute: 0) == false)  // 晚上 21:00 区间外
+    }
+
+    @Test func quietHoursDisabledNeverContains() {
+        let q = QuietHours(enabled: false, startMinutes: 0, endMinutes: 1439)
+        // 即使区间覆盖几乎全天,disabled 时永远 false。
+        #expect(q.contains(hour: 3, minute: 0) == false)
+        #expect(q.contains(hour: 12, minute: 0) == false)
+    }
+
+    // MARK: - Preset switching
+
+    @Test func presetOnceProducesSingleEveningSlot() {
+        let (service, _) = makeService()
+        service.apply(preset: .once)
+        #expect(service.preset == .once)
+        #expect(service.slots.count == 1)
+        #expect(service.slots.first?.hour == 21)
+    }
+
+    @Test func presetThriceProducesThreeSlots() {
+        let (service, _) = makeService()
+        service.apply(preset: .thrice)
+        #expect(service.preset == .thrice)
+        #expect(service.slots.count == 3)
+        #expect(service.slots.map(\.hour) == [9, 13, 21])
+    }
+
+    @Test func presetCustomKeepsExistingSlots() {
+        let (service, _) = makeService()
+        service.apply(preset: .thrice)          // 先有 3 个
+        service.apply(preset: .custom)          // 切 custom
+        // custom 保留现有 slots,不清空。
+        #expect(service.preset == .custom)
+        #expect(service.slots.count == 3)
+    }
+
+    // MARK: - Slot CRUD + persistence
+
+    @Test func addAndRemoveSlot() {
+        let (service, _) = makeService()
+        service.apply(preset: .once)            // 1 个
+        service.apply(preset: .custom)
+        service.addSlot(hour: 7, minute: 30, label: "晨跑后")
+        #expect(service.slots.count == 2)
+        // 新增后按时间排序:07:30 应排在 21:00 前。
+        #expect(service.slots.first?.hour == 7)
+
+        let toRemove = service.slots.first!.id
+        service.removeSlot(toRemove)
+        #expect(service.slots.count == 1)
+        #expect(service.slots.first?.hour == 21)
+    }
+
+    @Test func updateSlotTimeClampsToValidRange() {
+        let (service, _) = makeService()
+        service.apply(preset: .once)
+        let id = service.slots.first!.id
+        service.updateSlot(id, hour: 99, minute: 99)  // 越界
+        #expect(service.slots.first?.hour == 23)       // clamp 到 23
+        #expect(service.slots.first?.minute == 59)     // clamp 到 59
+    }
+
+    @Test func setSlotEnabledToggles() {
+        let (service, _) = makeService()
+        service.apply(preset: .once)
+        let id = service.slots.first!.id
+        service.setSlot(id, enabled: false)
+        #expect(service.slots.first?.enabled == false)
+    }
+
+    @Test func configPersistsAcrossReload() {
+        let suite = "captureReminder.test.persist.\(UUID().uuidString)"
+        let (service, _) = makeService(suite: suite)
+        service.apply(preset: .thrice)
+        service.setSlot(service.slots[1].id, enabled: false)  // 关掉午
+
+        // 用同一个 suite 重新造实例 → 应从 UserDefaults 还原。
+        let reloaded = CaptureReminderService(defaults: UserDefaults(suiteName: suite)!)
+        #expect(reloaded.preset == .thrice)
+        #expect(reloaded.slots.count == 3)
+        #expect(reloaded.slots[1].enabled == false)
+    }
+
+    // MARK: - ReminderSlot presentation
+
+    @Test func slotTimeStringPadsZeros() {
+        let slot = ReminderSlot(hour: 9, minute: 5, label: "早", enabled: true)
+        #expect(slot.timeString == "09:05")
+    }
+
+    @Test func slotPromptBodyVariesByTimeOfDay() {
+        let morning = ReminderSlot(hour: 9, minute: 0, label: "早", enabled: true)
+        let evening = ReminderSlot(hour: 21, minute: 0, label: "晚", enabled: true)
+        #expect(morning.promptBody != evening.promptBody)
+        #expect(morning.promptBody.contains("早上"))
+    }
+}

--- a/DayPageWidget/CaptureReminderLiveActivity.swift
+++ b/DayPageWidget/CaptureReminderLiveActivity.swift
@@ -1,0 +1,101 @@
+#if canImport(AlarmKit)
+import WidgetKit
+import SwiftUI
+import AlarmKit
+import AppIntents
+
+// MARK: - CaptureReminderLiveActivity
+//
+// AlarmKit(iOS 26+)提醒的灵动岛/锁屏呈现。AlarmKit 用 AlarmAttributes<Metadata>
+// 作为 Live Activity 的 attributes,我们提供 metadata = CaptureAlarmMetadata。
+//
+// 设计(参考 Apple Design «Designing Fluid Interfaces» + HIG 灵动岛规范):
+//   • compact:leading 一颗琥珀麦克风,trailing 留白 —— 极简、不喧宾夺主。
+//   • minimal:单颗琥珀麦克风(多活动并存时的最小态)。
+//   • expanded:leading 麦克风 + 标题「记录此刻」,trailing 一句轻提示(prompt),
+//     bottom 一个「记一句」按钮。琥珀 tint 呼应品牌,黑底玻璃质感由系统提供。
+//   • 文案克制、不命令式,呼应「悄悄召唤、不打扰」的产品气质。
+
+@available(iOS 26.0, *)
+struct CaptureReminderLiveActivity: Widget {
+
+    // 琥珀 amber —— 与 app 内品牌 accent 对齐。
+    private static let amber = Color(red: 0.74, green: 0.49, blue: 0.14)
+
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: AlarmAttributes<CaptureAlarmMetadata>.self) { context in
+            // 锁屏 / 横幅呈现。
+            lockScreen(context)
+                .padding()
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "mic.fill")
+                        .font(.title3)
+                        .foregroundStyle(Self.amber)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    Text("记录此刻")
+                        .font(.subheadline.weight(.semibold))
+                        .foregroundStyle(.white)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    HStack {
+                        Text(context.attributes.metadata?.prompt ?? "记一句给今天")
+                            .font(.footnote)
+                            .foregroundStyle(.white.opacity(0.7))
+                            .lineLimit(1)
+                        Spacer(minLength: 8)
+                        Link(destination: URL(string: "daypage://record")!) {
+                            Label("记一句", systemImage: "waveform")
+                                .font(.footnote.weight(.semibold))
+                                .foregroundStyle(.black)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 6)
+                                .background(Self.amber, in: Capsule())
+                        }
+                    }
+                    .padding(.top, 2)
+                }
+            } compactLeading: {
+                Image(systemName: "mic.fill")
+                    .foregroundStyle(Self.amber)
+            } compactTrailing: {
+                // 保持克制:compact 态只留一点点琥珀呼吸,不塞文字。
+                Circle()
+                    .fill(Self.amber.opacity(0.9))
+                    .frame(width: 6, height: 6)
+            } minimal: {
+                Image(systemName: "mic.fill")
+                    .foregroundStyle(Self.amber)
+            }
+            .widgetURL(URL(string: "daypage://record"))
+        }
+    }
+
+    @ViewBuilder
+    private func lockScreen(_ context: ActivityViewContext<AlarmAttributes<CaptureAlarmMetadata>>) -> some View {
+        HStack(spacing: 14) {
+            Image(systemName: "mic.fill")
+                .font(.title2)
+                .foregroundStyle(Self.amber)
+            VStack(alignment: .leading, spacing: 3) {
+                Text("记录此刻")
+                    .font(.headline)
+                Text(context.attributes.metadata?.prompt ?? "记一句给今天")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+            Link(destination: URL(string: "daypage://record")!) {
+                Image(systemName: "waveform")
+                    .font(.title3.weight(.semibold))
+                    .foregroundStyle(.black)
+                    .frame(width: 40, height: 40)
+                    .background(Self.amber, in: Circle())
+            }
+        }
+    }
+}
+#endif

--- a/DayPageWidget/DayPageWidgetBundle.swift
+++ b/DayPageWidget/DayPageWidgetBundle.swift
@@ -19,5 +19,12 @@ struct DayPageWidgetBundle: WidgetBundle {
         if #available(iOS 18.0, *) {
             QuickCaptureControl()
         }
+
+        // 「记录提醒」的 AlarmKit 灵动岛/锁屏呈现(iOS 26+ 真灵动岛)。
+        #if canImport(AlarmKit)
+        if #available(iOS 26.0, *) {
+            CaptureReminderLiveActivity()
+        }
+        #endif
     }
 }


### PR DESCRIPTION
## 做了什么

到点用系统主动召唤用户记录当下 —— 把 DayPage 从「想起来才记」变成「被优雅召唤」。

## 门控双路径架构

| 系统 | 路径 |
|---|---|
| **iOS 26+** | AlarmKit 真·系统灵动岛/锁屏定时提醒(琥珀 tint、三态、「记一句」按钮),突破静音、到点自动亮起 |
| **iOS 16.1–25** | UNCalendarNotificationTrigger 本地通知兜底,长按露「语音/文字」action |

`#available(iOS 26)` 门控 → **target 保持 16.1,一个用户不丢**。纯本地无法让灵动岛到点自动浮现,AlarmKit 是 iOS 26 才有的正解。

## 主要改动

- **CaptureReminderService** — 定时引擎:预设(每天一次/三次)+ 自定义时间点 + 静音时段过滤 + 幂等重排;AlarmKit / 通知双调度路径
- **CaptureAlarmMetadata + CaptureReminderLiveActivity** — AlarmKit 灵动岛三态 UI(DayPageWidget,app+widget 共享 metadata)
- **通知 action → `.captureReminderTapped` → navModel** — 复用既有 `daypage://record`(语音)/ `pendingDraftText`(文字聚焦),**零改录音层**
- **Onboarding** 加引导页:默认帮选节奏、顺势请求权限
- **Settings** 加「记录提醒」section + iOS26「系统灵动岛」开关
- **FeatureFlag.captureReminder**(default-on kill switch)

## target

iOS 16.0 → **16.1**(AlarmKit 门控前置)

## 验证

- ✅ BUILD SUCCEEDED(P1 + P2 AlarmKit)
- ✅ 12 个单元测试全过(静音跨午夜 / 预设切换 / 持久化 round-trip)
- ✅ iOS 26.4 模拟器实测:通知权限流生效、启动 refreshSchedule 正常注册(app.log 印证 `scheduled N reminders`)、未授权 AlarmKit 时正确回退通知路径
- ⚠️ AlarmKit 灵动岛最终视觉需真机确认(模拟器灵动岛渲染不完整)

## 附带

精简 CLAUDE.md:设计类工作走 artifact-review 轻流程,移除「先提 issue → 开分支 → 再 PR」的冗余步骤规定。