### PR TITLE
feat: 定时召唤记录（Reminder vNext）+ AI 聊天历史 session 化（对话长河）

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -85,6 +85,8 @@
 		A10000046 /* OnThisDayCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000046 /* OnThisDayCard.swift */; };
 		A10000047 /* OnThisDayScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000047 /* OnThisDayScheduler.swift */; };
 		CRS0000001 /* CaptureReminderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRS1000001 /* CaptureReminderService.swift */; };
+		RMD0000001 /* Reminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMD1000001 /* Reminder.swift */; };
+		RTR0000001 /* RelativeTimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = RTR1000001 /* RelativeTimeResolver.swift */; };
 		CAM0000001 /* CaptureAlarmMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAM1000001 /* CaptureAlarmMetadata.swift */; };
 		CAMW000001 /* CaptureAlarmMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAM1000001 /* CaptureAlarmMetadata.swift */; };
 		CRL0000001 /* CaptureReminderLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRL1000001 /* CaptureReminderLiveActivity.swift */; };
@@ -351,6 +353,8 @@
 		A20000046 /* OnThisDayCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayCard.swift; sourceTree = "<group>"; };
 		A20000047 /* OnThisDayScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayScheduler.swift; sourceTree = "<group>"; };
 		CRS1000001 /* CaptureReminderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureReminderService.swift; sourceTree = "<group>"; };
+		RMD1000001 /* Reminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reminder.swift; sourceTree = "<group>"; };
+		RTR1000001 /* RelativeTimeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTimeResolver.swift; sourceTree = "<group>"; };
 		CAM1000001 /* CaptureAlarmMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureAlarmMetadata.swift; sourceTree = "<group>"; };
 		CRL1000001 /* CaptureReminderLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureReminderLiveActivity.swift; sourceTree = "<group>"; };
 		A20000048 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -789,6 +793,8 @@
 				A20000039 /* VoiceAttachmentQueue.swift */,
 				A20000047 /* OnThisDayScheduler.swift */,
 				CRS1000001 /* CaptureReminderService.swift */,
+				RMD1000001 /* Reminder.swift */,
+				RTR1000001 /* RelativeTimeResolver.swift */,
 				CAM1000001 /* CaptureAlarmMetadata.swift */,
 				A20000078 /* VaultMigrationService.swift */,
 				A20000070 /* AuthService.swift */,
@@ -1481,6 +1487,8 @@
 				INF0000001 /* InflightDraftStore.swift in Sources */,
 				A10000047 /* OnThisDayScheduler.swift in Sources */,
 				CRS0000001 /* CaptureReminderService.swift in Sources */,
+				RMD0000001 /* Reminder.swift in Sources */,
+				RTR0000001 /* RelativeTimeResolver.swift in Sources */,
 				CAM0000001 /* CaptureAlarmMetadata.swift in Sources */,
 				A10000050 /* CompileFooterButton.swift in Sources */,
 				A10000082 /* InputBarV4.swift in Sources */,

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -204,6 +204,7 @@
 		MD0000002 /* MemoDetailViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000002 /* MemoDetailViewModel.swift */; };
 		MD0000003 /* DropToAskGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = MD1000003 /* DropToAskGesture.swift */; };
 		MC0000001 /* MemoChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = MC1000001 /* MemoChatView.swift */; };
+		CRV0000001 /* ChatRiverSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRV1000001 /* ChatRiverSection.swift */; };
 		MSE0000001 /* MemoSyncE2EIntegrationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MSE1000001 /* MemoSyncE2EIntegrationTests.swift */; };
 		MST0000001 /* MemoSyncUploaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MST1000001 /* MemoSyncUploaderTests.swift */; };
 		MYT0000001 /* MemoYAMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MYT1000001 /* MemoYAMLTests.swift */; };
@@ -483,6 +484,7 @@
 		MD1000002 /* MemoDetailViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoDetailViewModel.swift; sourceTree = "<group>"; };
 		MD1000003 /* DropToAskGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DropToAskGesture.swift; sourceTree = "<group>"; };
 		MC1000001 /* MemoChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoChatView.swift; sourceTree = "<group>"; };
+		CRV1000001 /* ChatRiverSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatRiverSection.swift; sourceTree = "<group>"; };
 		MSE1000001 /* MemoSyncE2EIntegrationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSyncE2EIntegrationTests.swift; sourceTree = "<group>"; };
 		MST1000001 /* MemoSyncUploaderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MemoSyncUploaderTests.swift; sourceTree = "<group>"; };
 		MYT1000001 /* MemoYAMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemoYAMLTests.swift; sourceTree = "<group>"; };
@@ -586,6 +588,7 @@
 			children = (
 				1681BDF1E5113769618DA9B0 /* AskPastView.swift */,
 				MC1000001 /* MemoChatView.swift */,
+				CRV1000001 /* ChatRiverSection.swift */,
 			);
 			name = Ask;
 			path = Ask;
@@ -1561,6 +1564,7 @@
 				MD0000002 /* MemoDetailViewModel.swift in Sources */,
 				MD0000003 /* DropToAskGesture.swift in Sources */,
 				MC0000001 /* MemoChatView.swift in Sources */,
+				CRV0000001 /* ChatRiverSection.swift in Sources */,
 				WS0000001 /* WelcomeScreen.swift in Sources */,
 				A10000095 /* ComposerContextProvider.swift in Sources */,
 				457A17AB7F3B4BE7C2E77026 /* StartRecordingIntent.swift in Sources */,

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -87,6 +87,9 @@
 		CRS0000001 /* CaptureReminderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRS1000001 /* CaptureReminderService.swift */; };
 		RMD0000001 /* Reminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMD1000001 /* Reminder.swift */; };
 		RTR0000001 /* RelativeTimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = RTR1000001 /* RelativeTimeResolver.swift */; };
+		RCS0000001 /* ReminderCapsuleStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = RCS1000001 /* ReminderCapsuleStrip.swift */; };
+		RES0000001 /* ReminderEditSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = RES1000001 /* ReminderEditSheet.swift */; };
+		RIP0000001 /* ReminderIntentParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = RIP1000001 /* ReminderIntentParser.swift */; };
 		CAM0000001 /* CaptureAlarmMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAM1000001 /* CaptureAlarmMetadata.swift */; };
 		CAMW000001 /* CaptureAlarmMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAM1000001 /* CaptureAlarmMetadata.swift */; };
 		CRL0000001 /* CaptureReminderLiveActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRL1000001 /* CaptureReminderLiveActivity.swift */; };
@@ -206,6 +209,7 @@
 		MYT0000001 /* MemoYAMLTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = MYT1000001 /* MemoYAMLTests.swift */; };
 		NMT0000001 /* NetworkMonitorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = NMT1000001 /* NetworkMonitorTests.swift */; };
 		CRT0000001 /* CaptureReminderServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRT1000001 /* CaptureReminderServiceTests.swift */; };
+		RPT0000001 /* ReminderIntentParserTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = RPT1000001 /* ReminderIntentParserTests.swift */; };
 		OPS0000002 /* OrphanedPhotoScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OPS1000002 /* OrphanedPhotoScannerTests.swift */; };
 		OVS0000002 /* OrphanedVoiceScannerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = OVS1000002 /* OrphanedVoiceScannerTests.swift */; };
 		R4B0000001 /* RawStorageWriteFailedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = R4B1000001 /* RawStorageWriteFailedTests.swift */; };
@@ -355,6 +359,9 @@
 		CRS1000001 /* CaptureReminderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureReminderService.swift; sourceTree = "<group>"; };
 		RMD1000001 /* Reminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reminder.swift; sourceTree = "<group>"; };
 		RTR1000001 /* RelativeTimeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTimeResolver.swift; sourceTree = "<group>"; };
+		RCS1000001 /* ReminderCapsuleStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderCapsuleStrip.swift; sourceTree = "<group>"; };
+		RES1000001 /* ReminderEditSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderEditSheet.swift; sourceTree = "<group>"; };
+		RIP1000001 /* ReminderIntentParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderIntentParser.swift; sourceTree = "<group>"; };
 		CAM1000001 /* CaptureAlarmMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureAlarmMetadata.swift; sourceTree = "<group>"; };
 		CRL1000001 /* CaptureReminderLiveActivity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CaptureReminderLiveActivity.swift; sourceTree = "<group>"; };
 		A20000048 /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
@@ -481,6 +488,7 @@
 		MYT1000001 /* MemoYAMLTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemoYAMLTests.swift; sourceTree = "<group>"; };
 		NMT1000001 /* NetworkMonitorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NetworkMonitorTests.swift; sourceTree = "<group>"; };
 		CRT1000001 /* CaptureReminderServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureReminderServiceTests.swift; sourceTree = "<group>"; };
+		RPT1000001 /* ReminderIntentParserTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderIntentParserTests.swift; sourceTree = "<group>"; };
 		OPS1000002 /* OrphanedPhotoScannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrphanedPhotoScannerTests.swift; sourceTree = "<group>"; };
 		OVS1000002 /* OrphanedVoiceScannerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = OrphanedVoiceScannerTests.swift; sourceTree = "<group>"; };
 		R4B1000001 /* RawStorageWriteFailedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RawStorageWriteFailedTests.swift; sourceTree = "<group>"; };
@@ -795,6 +803,7 @@
 				CRS1000001 /* CaptureReminderService.swift */,
 				RMD1000001 /* Reminder.swift */,
 				RTR1000001 /* RelativeTimeResolver.swift */,
+				RIP1000001 /* ReminderIntentParser.swift */,
 				CAM1000001 /* CaptureAlarmMetadata.swift */,
 				A20000078 /* VaultMigrationService.swift */,
 				A20000070 /* AuthService.swift */,
@@ -840,6 +849,8 @@
 			children = (
 				A20000010 /* TodayView.swift */,
 				A20000804 /* TodayCoachView.swift */,
+				RCS1000001 /* ReminderCapsuleStrip.swift */,
+				RES1000001 /* ReminderEditSheet.swift */,
 				A20000013 /* TodayViewModel.swift */,
 				A20000014 /* MemoCardView.swift */,
 				A20000020 /* VoiceRecordingView.swift */,
@@ -1146,6 +1157,7 @@
 				VES1000002 /* VaultExportServiceTests.swift */,
 				NMT1000001 /* NetworkMonitorTests.swift */,
 				CRT1000001 /* CaptureReminderServiceTests.swift */,
+				RPT1000001 /* ReminderIntentParserTests.swift */,
 				MSE1000001 /* MemoSyncE2EIntegrationTests.swift */,
 				MST1000001 /* MemoSyncUploaderTests.swift */,
 				WRA1000001 /* WeeklyRecapAutoTriggerTests.swift */,
@@ -1489,6 +1501,9 @@
 				CRS0000001 /* CaptureReminderService.swift in Sources */,
 				RMD0000001 /* Reminder.swift in Sources */,
 				RTR0000001 /* RelativeTimeResolver.swift in Sources */,
+				RCS0000001 /* ReminderCapsuleStrip.swift in Sources */,
+				RES0000001 /* ReminderEditSheet.swift in Sources */,
+				RIP0000001 /* ReminderIntentParser.swift in Sources */,
 				CAM0000001 /* CaptureAlarmMetadata.swift in Sources */,
 				A10000050 /* CompileFooterButton.swift in Sources */,
 				A10000082 /* InputBarV4.swift in Sources */,
@@ -1620,6 +1635,7 @@
 				VES0000002 /* VaultExportServiceTests.swift in Sources */,
 				NMT0000001 /* NetworkMonitorTests.swift in Sources */,
 				CRT0000001 /* CaptureReminderServiceTests.swift in Sources */,
+				RPT0000001 /* ReminderIntentParserTests.swift in Sources */,
 				MSE0000001 /* MemoSyncE2EIntegrationTests.swift in Sources */,
 				MST0000001 /* MemoSyncUploaderTests.swift in Sources */,
 				WRA0000001 /* WeeklyRecapAutoTriggerTests.swift in Sources */,

--- a/DayPage/Features/Ask/AskPastView.swift
+++ b/DayPage/Features/Ask/AskPastView.swift
@@ -17,6 +17,8 @@ struct AskPastView: View {
 
     @StateObject private var chat = MemoryChatService()
     @StateObject private var voiceService = VoiceService.shared
+    /// 对话长河：封存会话的胶囊层，沉在当前对话上游（设计 v2 D4）。
+    @StateObject private var river = ChatRiverModel()
     @State private var draft: String = ""
     @State private var didSeed = false
     @State private var isRecordingVoice: Bool = false
@@ -27,12 +29,16 @@ struct AskPastView: View {
     /// Turn ID that just got pinned — drives a 1.5s success toast without
     /// having to plumb a Banner through the chat view.
     @State private var justPinnedTurnID: UUID? = nil
+    /// 初始落点只执行一次：河口（底部）。之后「更早的对话」扩窗
+    /// 不允许再把用户拽回底部。
+    @State private var didInitialLanding = false
     @FocusState private var inputFocused: Bool
 
     var body: some View {
         NavigationStack {
             VStack(spacing: 0) {
                 conversation
+                ChatRiverSelectionBar(river: river)
                 Divider().background(DSColor.borderSubtle)
                 inputBar
             }
@@ -44,22 +50,36 @@ struct AskPastView: View {
                     Button("关闭", action: onClose)
                 }
                 ToolbarItem(placement: .topBarTrailing) {
+                    // /clear 语义：封口当前会话——它以胶囊形态沉入长河，
+                    // 输入框归零。spring 让「封存」这件事被看见。
                     Button {
-                        chat.reset()
+                        Haptics.soft()
+                        withAnimation(Motion.spring) {
+                            chat.reset()
+                            river.refresh(excluding: nil)
+                        }
                         draft = ""
                     } label: { Image(systemName: "square.and.pencil") }
                         .disabled(chat.turns.isEmpty)
                         .accessibilityLabel("新对话")
                 }
             }
+            .sheet(isPresented: Binding(
+                get: { river.shareURLs != nil },
+                set: { if !$0 { river.shareURLs = nil } }
+            )) {
+                if let urls = river.shareURLs {
+                    ShareSheet(activityItems: urls)
+                }
+            }
         }
         .task {
             guard !didSeed else { return }
             didSeed = true
-            // D1: bring back today's persisted conversation before the
-            // first render finishes, so returning users see prior turns
-            // instead of an empty state.
-            chat.loadTodayHistory()
+            // D1: --continue 语义 —— 接上今天最近一段未封口会话，
+            // 让回访用户看到先前轮次而不是空态。
+            chat.resumeTodaySession()
+            river.refresh(excluding: chat.sessionRef?.id)
             if let seed = seedQuestion?.trimmingCharacters(in: .whitespacesAndNewlines), !seed.isEmpty {
                 await chat.ask(seed)
             } else if chat.turns.isEmpty {
@@ -74,6 +94,18 @@ struct AskPastView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 16) {
+                    // 长河：封存会话的沉积层。上滑即历史；点开原位回放，
+                    // 「继续这段对话」把整段交还给活跃会话。
+                    ChatRiverSection(river: river) { loaded in
+                        withAnimation(Motion.spring) {
+                            chat.resume(loaded)
+                            river.exitSelection()
+                            river.refresh(excluding: loaded.summary.id)
+                        }
+                    }
+                    if !river.summaries.isEmpty && !chat.turns.isEmpty {
+                        currentSessionMarker
+                    }
                     if chat.turns.isEmpty && !chat.isResponding {
                         emptyState
                     }
@@ -86,16 +118,47 @@ struct AskPastView: View {
                     if let err = chat.errorMessage {
                         errorRow(err)
                     }
+                    Color.clear.frame(height: 1).id("river-mouth")
                 }
                 .padding(16)
             }
+            .onAppear {
+                // 河从上游流向河口——初始落点必须在河口（底部），
+                // 历史靠上滑发现。
+                proxy.scrollTo("river-mouth", anchor: .bottom)
+            }
+            .onChange(of: river.summaries.count) { _ in
+                // 胶囊层在 .task 里异步落地；若此刻还没有活跃对话
+                // （turns 的 onChange 不会兜底），补一次落底。
+                guard !didInitialLanding, chat.turns.isEmpty else { return }
+                didInitialLanding = true
+                proxy.scrollTo("river-mouth", anchor: .bottom)
+            }
             .onChange(of: chat.turns.count) { _ in
+                didInitialLanding = true
                 withAnimation { proxy.scrollTo(chat.turns.last?.id, anchor: .bottom) }
             }
             .onChange(of: chat.isResponding) { responding in
                 if responding { withAnimation { proxy.scrollTo("responding", anchor: .bottom) } }
             }
         }
+    }
+
+    /// 长河与活跃对话的分界拍：「· · 当前对话 HH:mm · ·」。
+    private var currentSessionMarker: some View {
+        let timeLabel: String = {
+            guard let first = chat.turns.first else { return "" }
+            let f = DateFormatter()
+            f.locale = Locale(identifier: "en_US_POSIX")
+            f.dateFormat = "HH:mm"
+            f.timeZone = TimeZone.current
+            return f.string(from: first.createdAt)
+        }()
+        return Text("· · \(NSLocalizedString("chat.river.current_marker", value: "当前对话", comment: "Chat river — current conversation divider")) \(timeLabel) · ·")
+            .font(DSType.mono10)
+            .tracking(1.5)
+            .foregroundColor(DSColor.inkSubtle)
+            .frame(maxWidth: .infinity)
     }
 
     @ViewBuilder
@@ -319,6 +382,36 @@ struct AskPastView: View {
         let question = draft.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !question.isEmpty, !chat.isResponding else { return }
         draft = ""
+
+        // Reminder vNext：问过去的输入框同样接调度 —— 「明早提醒我看这段」
+        // 在对话里直接落统一调度器，不进 RAG 检索。与 TodayCoachView.submit
+        // 同一拦截逻辑；解析失败但含提醒动词时追问。
+        if FeatureFlagStore.shared.isEnabled(.captureReminder) {
+            if let parsed = ReminderIntentParser.parse(question) {
+                let reminder = CaptureReminderService.shared.addReminder(
+                    Reminder(trigger: parsed.trigger, label: parsed.label, source: .ai)
+                )
+                // 统一走 service —— 本地即答轮次同样落盘进会话文件。
+                chat.appendLocalExchange(
+                    user: question,
+                    assistant: TodayCoachView.reminderConfirmation(for: reminder)
+                )
+                Haptics.success()
+                return
+            }
+            if ReminderIntentParser.containsReminderVerb(question) {
+                chat.appendLocalExchange(
+                    user: question,
+                    assistant: NSLocalizedString(
+                        "coach.reminder.clarify",
+                        value: "好——几点提醒你？可以说「今晚」「明早」「一小时后」，或者给个具体时间，比如「明天 15:00」；重复的话说「每天 22:00」「周一三五 9 点」。",
+                        comment: "Coach follow-up when a reminder request lacks a parseable time"
+                    )
+                )
+                return
+            }
+        }
+
         Task { await chat.ask(question) }
     }
 

--- a/DayPage/Features/Ask/ChatRiverSection.swift
+++ b/DayPage/Features/Ask/ChatRiverSection.swift
@@ -1,0 +1,435 @@
+import SwiftUI
+import DayPageServices
+
+// MARK: - ChatRiverModel
+
+/// 「对话长河」的状态载体：封存会话的胶囊层（懒加载窗口）、原位展开
+/// 回放、多选导出、删除。历史不进侧边栏、不开独立 sheet——它就是对话
+/// 视图上游的沉积层（设计 v2 D4）。
+@MainActor
+final class ChatRiverModel: ObservableObject {
+
+    /// 胶囊列表（不含当前活跃会话），开始时间降序，展示前按天分组。
+    @Published private(set) var summaries: [ChatSessionSummary] = []
+    /// 原位展开的会话（只读回放）。同一时刻至多一段。
+    @Published private(set) var expanded: LoadedChatSession?
+    /// 多选导出模式。
+    @Published var selectionMode = false
+    @Published var selectedIDs: Set<UUID> = []
+    /// 还有更早的日目录未进窗口（驱动「更早的对话」按钮）。
+    @Published private(set) var hasMore = false
+    /// 待确认删除的会话（confirmationDialog 绑定）。
+    @Published var pendingDelete: ChatSessionSummary?
+    /// 生成好的导出文件，非 nil 时弹 ShareSheet。
+    @Published var shareURLs: [URL]?
+
+    /// 附加过滤（如 MemoChatView 只看锚定到同一条 memo 的会话）。
+    var filter: ((ChatSessionSummary) -> Bool)?
+
+    /// 懒加载窗口：首屏近 7 个自然日，「更早」每次扩一个月。
+    private var windowDays = 7
+    private var excludedSessionID: UUID?
+
+    var enabled: Bool { FeatureFlagStore.shared.isEnabled(.chatHistory) }
+
+    // MARK: Loading
+
+    /// 重扫窗口内的会话。`excluding` 是当前活跃会话——它在河口，不是沉积物。
+    func refresh(excluding currentID: UUID?) {
+        excludedSessionID = currentID
+        guard enabled else {
+            summaries = []
+            hasMore = false
+            return
+        }
+        var list = ChatSessionStore.listSessions(limitDays: windowDays)
+            .filter { $0.id != currentID }
+        if let filter { list = list.filter(filter) }
+        summaries = list
+        hasMore = ChatSessionStore.dayDirectoryCount() > windowDays
+        if let expandedID = expanded?.summary.id, !list.contains(where: { $0.id == expandedID }) {
+            expanded = nil
+        }
+    }
+
+    func loadEarlier() {
+        windowDays += 31
+        refresh(excluding: excludedSessionID)
+    }
+
+    // MARK: Expand / collapse
+
+    func toggleExpanded(_ summary: ChatSessionSummary) {
+        if expanded?.summary.id == summary.id {
+            expanded = nil
+        } else {
+            expanded = ChatSessionStore.load(summary: summary)
+        }
+    }
+
+    // MARK: Selection
+
+    func toggleSelected(_ summary: ChatSessionSummary) {
+        if selectedIDs.contains(summary.id) {
+            selectedIDs.remove(summary.id)
+        } else {
+            selectedIDs.insert(summary.id)
+        }
+    }
+
+    func enterSelection(with summary: ChatSessionSummary? = nil) {
+        selectionMode = true
+        expanded = nil
+        selectedIDs = summary.map { [$0.id] } ?? []
+    }
+
+    func exitSelection() {
+        selectionMode = false
+        selectedIDs = []
+    }
+
+    // MARK: Delete
+
+    func confirmDelete() {
+        guard let summary = pendingDelete else { return }
+        pendingDelete = nil
+        ChatSessionStore.delete(summary)
+        refresh(excluding: excludedSessionID)
+    }
+
+    // MARK: Export
+
+    /// 渲染并落地导出文件 → 弹 ShareSheet。多选即多文件（散 md，
+    /// Obsidian / Files 里比 zip 好用）；同名撞车追加序号。
+    func export(_ targets: [ChatSessionSummary]) {
+        let dir = MarkdownExportService.exportDirectory
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        MarkdownExportService.purgeStaleExports()
+
+        var urls: [URL] = []
+        for summary in targets.sorted(by: { $0.startedAt < $1.startedAt }) {
+            guard let loaded = ChatSessionStore.load(summary: summary) else { continue }
+            let content = ChatMarkdownRenderer.render(loaded)
+            let baseName = ChatMarkdownRenderer.exportFileName(for: summary)
+            var url = dir.appendingPathComponent(baseName)
+            var attempt = 2
+            while urls.contains(url) || FileManager.default.fileExists(atPath: url.path) {
+                let stem = (baseName as NSString).deletingPathExtension
+                url = dir.appendingPathComponent("\(stem)-\(attempt).md")
+                attempt += 1
+            }
+            guard (try? content.write(to: url, atomically: true, encoding: .utf8)) != nil else { continue }
+            urls.append(url)
+        }
+        guard !urls.isEmpty else { return }
+        shareURLs = urls
+    }
+
+    func exportSelected() {
+        export(summaries.filter { selectedIDs.contains($0.id) })
+        exitSelection()
+    }
+
+    // MARK: Grouping
+
+    /// 按天分组，天升序、天内升序——河从上游（更早）流向河口（当前对话）。
+    var dayGroups: [(day: String, sessions: [ChatSessionSummary])] {
+        let grouped = Dictionary(grouping: summaries, by: { $0.dayString })
+        return grouped.keys.sorted().map { day in
+            (day, grouped[day]!.sorted { $0.startedAt < $1.startedAt })
+        }
+    }
+}
+
+// MARK: - ChatRiverSection
+
+/// 对话长河的胶囊层。挂在会话 ScrollView 内容的最顶部：
+/// 「更早的对话」 → 按天分组的封存胶囊 → （下方）当前对话。
+struct ChatRiverSection: View {
+
+    @ObservedObject var river: ChatRiverModel
+    /// 续聊回调：把整段回放交还给宿主（宿主负责 `chat.resume` 并刷新河）。
+    let onResume: (LoadedChatSession) -> Void
+
+    var body: some View {
+        if !river.summaries.isEmpty {
+            VStack(alignment: .leading, spacing: 6) {
+                if river.hasMore {
+                    earlierButton
+                }
+                ForEach(river.dayGroups, id: \.day) { group in
+                    dayMarker(group.day)
+                    ForEach(group.sessions) { summary in
+                        capsuleRow(summary)
+                        if river.expanded?.summary.id == summary.id, let loaded = river.expanded {
+                            expandedReplay(loaded)
+                        }
+                    }
+                }
+            }
+            .confirmationDialog(
+                NSLocalizedString("chat.river.delete.confirm.title", value: "删除这段对话？", comment: "Chat river — delete confirm title"),
+                isPresented: Binding(
+                    get: { river.pendingDelete != nil },
+                    set: { if !$0 { river.pendingDelete = nil } }
+                ),
+                titleVisibility: .visible
+            ) {
+                Button(NSLocalizedString("chat.river.delete", value: "删除", comment: "Chat river — delete action"), role: .destructive) {
+                    Haptics.warn()
+                    withAnimation(Motion.spring) { river.confirmDelete() }
+                }
+                Button(NSLocalizedString("settings.common.cancel", value: "取消", comment: ""), role: .cancel) {}
+            } message: {
+                Text(NSLocalizedString("chat.river.delete.confirm.message", value: "对话文件将从 vault 中移除，不可恢复。", comment: "Chat river — delete confirm message"))
+            }
+        }
+    }
+
+    // MARK: Earlier
+
+    private var earlierButton: some View {
+        Button {
+            Haptics.soft()
+            withAnimation(Motion.spring) { river.loadEarlier() }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.up.circle")
+                    .font(.system(size: 12))
+                Text(NSLocalizedString("chat.river.earlier", value: "更早的对话", comment: "Chat river — load earlier sessions"))
+                    .font(DSType.labelSM)
+            }
+            .foregroundColor(DSColor.inkMuted)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 8)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(NSLocalizedString("chat.river.earlier", value: "更早的对话", comment: ""))
+    }
+
+    // MARK: Day marker
+
+    private func dayMarker(_ day: String) -> some View {
+        Text("—— \(relativeDayLabel(day)) ——")
+            .font(DSType.mono10)
+            .tracking(1.5)
+            .foregroundColor(DSColor.inkSubtle)
+            .frame(maxWidth: .infinity)
+            .padding(.top, 8)
+            .padding(.bottom, 2)
+    }
+
+    private func relativeDayLabel(_ day: String) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone.current
+        guard let date = f.date(from: day) else { return day }
+        if Calendar.current.isDateInToday(date) {
+            return NSLocalizedString("chat.river.today", value: "今天", comment: "Chat river — today group")
+        }
+        if Calendar.current.isDateInYesterday(date) {
+            return NSLocalizedString("chat.river.yesterday", value: "昨天", comment: "Chat river — yesterday group")
+        }
+        return day
+    }
+
+    // MARK: Capsule
+
+    @ViewBuilder
+    private func capsuleRow(_ summary: ChatSessionSummary) -> some View {
+        let isSelected = river.selectedIDs.contains(summary.id)
+        let isExpanded = river.expanded?.summary.id == summary.id
+
+        Button {
+            if river.selectionMode {
+                Haptics.selection()
+                river.toggleSelected(summary)
+            } else {
+                Haptics.soft()
+                withAnimation(Motion.spring) { river.toggleExpanded(summary) }
+            }
+        } label: {
+            HStack(spacing: 8) {
+                if river.selectionMode {
+                    Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                        .font(.system(size: 16))
+                        .foregroundColor(isSelected ? DSColor.accentOnBg : DSColor.inkSubtle)
+                }
+                entryBadge(summary)
+                Text(summary.title)
+                    .font(DSType.bodySM)
+                    .foregroundColor(DSColor.inkSecondary)
+                    .lineLimit(1)
+                Spacer(minLength: 8)
+                Text(String(format: NSLocalizedString("chat.river.turns", value: "%d 轮", comment: "Chat river — turn count"), summary.turnCount))
+                    .font(DSType.mono10)
+                    .foregroundColor(DSColor.inkMuted)
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(DSColor.inkSubtle)
+                    .opacity(river.selectionMode ? 0 : 1)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 9)
+            .background(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .fill(DSColor.surfaceContainerHigh.opacity(isSelected ? 0.9 : 0.55))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .strokeBorder(
+                        isSelected ? DSColor.accentOnBg : DSColor.borderSubtle,
+                        style: StrokeStyle(lineWidth: 1, dash: isSelected ? [] : [4, 3])
+                    )
+            )
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            if !river.selectionMode {
+                Button {
+                    if let loaded = ChatSessionStore.load(summary: summary) {
+                        Haptics.tapConfirm()
+                        onResume(loaded)
+                    }
+                } label: {
+                    Label(NSLocalizedString("chat.river.continue", value: "继续这段对话", comment: "Chat river — resume session"), systemImage: "arrow.uturn.down")
+                }
+                Button {
+                    river.export([summary])
+                } label: {
+                    Label(NSLocalizedString("chat.river.export", value: "导出 (.md)", comment: "Chat river — export one session"), systemImage: "square.and.arrow.up")
+                }
+                Button {
+                    river.enterSelection(with: summary)
+                } label: {
+                    Label(NSLocalizedString("chat.river.select", value: "选择多段…", comment: "Chat river — enter multi-select"), systemImage: "checkmark.circle")
+                }
+                Button(role: .destructive) {
+                    river.pendingDelete = summary
+                } label: {
+                    Label(NSLocalizedString("chat.river.delete", value: "删除", comment: ""), systemImage: "trash")
+                }
+            }
+        }
+        .accessibilityLabel("\(ChatMarkdownRenderer.entryLabel(summary.entry))：\(summary.title)")
+    }
+
+    private func entryBadge(_ summary: ChatSessionSummary) -> some View {
+        let text: String
+        switch summary.entry {
+        case .ask:
+            text = NSLocalizedString("chat.river.badge.ask", value: "问", comment: "Chat river — ask badge")
+        case .memo:
+            let suffix = summary.anchorMemoDate.map { String($0.suffix(5)) }
+            let anchor = NSLocalizedString("chat.river.badge.memo", value: "锚", comment: "Chat river — memo badge")
+            text = suffix.map { "\(anchor) \($0)" } ?? anchor
+        case .coach:
+            text = NSLocalizedString("chat.river.badge.coach", value: "陪写", comment: "Chat river — coach badge")
+        }
+        return Text(text)
+            .font(DSType.mono10)
+            .foregroundColor(DSColor.accentOnBg)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(DSColor.accentOnBg.opacity(0.12))
+            .clipShape(Capsule())
+    }
+
+    // MARK: Expanded replay
+
+    /// 原位展开的只读回放：降一档墨色的紧凑气泡 + 「继续这段对话」。
+    private func expandedReplay(_ loaded: LoadedChatSession) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            ForEach(loaded.turns) { turn in
+                switch turn.role {
+                case .user:
+                    HStack {
+                        Spacer(minLength: 40)
+                        Text(turn.text)
+                            .font(DSType.bodySM)
+                            .foregroundColor(DSColor.inkSecondary)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(DSColor.surfaceContainerHigh.opacity(0.7))
+                            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+                    }
+                case .assistant:
+                    Text(turn.text)
+                        .font(DSType.bodySM)
+                        .foregroundColor(DSColor.inkSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            Button {
+                Haptics.tapConfirm()
+                onResume(loaded)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "arrow.uturn.down")
+                        .font(.system(size: 12, weight: .semibold))
+                    Text(NSLocalizedString("chat.river.continue", value: "继续这段对话", comment: ""))
+                        .font(DSType.labelSM)
+                }
+                .foregroundColor(DSColor.accentOnBg)
+            }
+            .buttonStyle(.plain)
+            .padding(.top, 2)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                .fill(DSColor.surfaceContainerHigh.opacity(0.3))
+        )
+        .transition(.opacity.combined(with: .move(edge: .top)))
+    }
+}
+
+// MARK: - ChatRiverSelectionBar
+
+/// 多选模式的底部浮条：已选计数 + 导出。宿主 overlay 在输入栏上方。
+struct ChatRiverSelectionBar: View {
+    @ObservedObject var river: ChatRiverModel
+
+    var body: some View {
+        if river.selectionMode {
+            HStack(spacing: 12) {
+                Text(String(format: NSLocalizedString("chat.river.selected", value: "已选 %d 段", comment: "Chat river — selection count"), river.selectedIDs.count))
+                    .font(DSType.labelSM)
+                    .foregroundColor(DSColor.inkSecondary)
+                Spacer()
+                Button {
+                    Haptics.soft()
+                    withAnimation(Motion.spring) { river.exitSelection() }
+                } label: {
+                    Text(NSLocalizedString("chat.river.selection.done", value: "完成", comment: "Chat river — exit selection"))
+                        .font(DSType.labelSM)
+                        .foregroundColor(DSColor.inkSecondary)
+                }
+                .buttonStyle(.plain)
+                Button {
+                    Haptics.tapConfirm()
+                    river.exportSelected()
+                } label: {
+                    HStack(spacing: 6) {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 13, weight: .semibold))
+                        Text(String(format: NSLocalizedString("chat.river.export_n", value: "导出 %d 段", comment: "Chat river — export N sessions"), river.selectedIDs.count))
+                            .font(DSType.labelSM)
+                    }
+                    .foregroundColor(river.selectedIDs.isEmpty ? DSColor.inkSubtle : DSColor.accentOnBg)
+                }
+                .buttonStyle(.plain)
+                .disabled(river.selectedIDs.isEmpty)
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 10)
+            .background(DSColor.surfaceContainerHigh)
+            .clipShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
+            .padding(.horizontal, 16)
+            .padding(.bottom, 6)
+            .transition(.opacity.combined(with: .move(edge: .bottom)))
+        }
+    }
+}

--- a/DayPage/Features/Ask/MemoChatView.swift
+++ b/DayPage/Features/Ask/MemoChatView.swift
@@ -22,6 +22,9 @@ struct MemoChatView: View {
     let onClose: () -> Void
 
     @StateObject private var chat = MemoryChatService()
+    /// 这条 memo 的过往对话（长河的锚定支流）：只显示锚定到同一条
+    /// memo 的封存会话——全量历史在 AskPastView 的主河里。
+    @StateObject private var river = ChatRiverModel()
     @State private var draft: String = ""
     @State private var didAttach = false
     @State private var pinnedTurnIDs: Set<UUID> = []
@@ -40,6 +43,7 @@ struct MemoChatView: View {
         VStack(spacing: 0) {
             header
             conversation
+            ChatRiverSelectionBar(river: river)
             Divider().background(DSColor.borderSubtle)
             if chat.attachedMemo != nil {
                 memoryChip
@@ -53,7 +57,22 @@ struct MemoChatView: View {
             guard !didAttach else { return }
             didAttach = true
             chat.attach(memo: memo, clues: clues)
+            // --continue：同一天再次打开同一条 memo 的对话，接上原会话
+            // 而不是碎片化成多段。
+            chat.resumeTodaySession()
+            river.filter = { [memoID = memo.id] summary in
+                summary.entry == .memo && summary.anchorMemoID == memoID
+            }
+            river.refresh(excluding: chat.sessionRef?.id)
             inputFocused = true
+        }
+        .sheet(isPresented: Binding(
+            get: { river.shareURLs != nil },
+            set: { if !$0 { river.shareURLs = nil } }
+        )) {
+            if let urls = river.shareURLs {
+                ShareSheet(activityItems: urls)
+            }
         }
     }
 
@@ -106,6 +125,14 @@ struct MemoChatView: View {
         ScrollViewReader { proxy in
             ScrollView {
                 LazyVStack(alignment: .leading, spacing: 16) {
+                    // 这条 memo 的过往对话——沉在当前对话上游。
+                    ChatRiverSection(river: river) { loaded in
+                        withAnimation(Motion.spring) {
+                            chat.resume(loaded)
+                            river.exitSelection()
+                            river.refresh(excluding: loaded.summary.id)
+                        }
+                    }
                     if chat.turns.isEmpty && !chat.isResponding {
                         suggestions
                     }

--- a/DayPage/Features/Settings/SettingsView.swift
+++ b/DayPage/Features/Settings/SettingsView.swift
@@ -1360,23 +1360,20 @@ struct SettingsView: View {
                 }
             }
 
-            // 每个时间点:标签 + 时间 + 开关。
-            ForEach(reminderService.slots) { slot in
-                Toggle(isOn: Binding(
-                    get: { slot.enabled },
-                    set: { reminderService.setSlot(slot.id, enabled: $0) }
-                )) {
-                    HStack {
-                        Text(slot.label)
-                            .foregroundColor(DSColor.onSurface)
-                        Spacer()
-                        Text(slot.timeString)
-                            .font(.subheadline.monospacedDigit())
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                    }
-                }
-                .accessibilityIdentifier("reminder-slot-\(slot.timeString)")
+            // 已配置提醒的只读摘要 —— 具体增删改移到 Today 页胶囊 & AI 对话。
+            // 设置页只保留「频率预设 + 静音 + 灵动岛」这类粗粒度开关。
+            HStack {
+                Label(
+                    NSLocalizedString("settings.reminder.active", value: "已启用提醒", comment: "Active reminders summary"),
+                    systemImage: "bell.badge"
+                )
+                Spacer()
+                let count = reminderService.reminders.filter { $0.enabled }.count
+                Text(String(format: NSLocalizedString("settings.reminder.count", value: "%d 条", comment: "N reminders count"), count))
+                    .font(.subheadline.monospacedDigit())
+                    .foregroundColor(DSColor.onSurfaceVariant)
             }
+            .accessibilityIdentifier("reminder-active-count")
 
             // 静音时段。
             Toggle(isOn: Binding(
@@ -1420,7 +1417,7 @@ struct SettingsView: View {
         } footer: {
             Text(NSLocalizedString(
                 "settings.reminder.footer",
-                value: "到点时会发一条本地通知(灵动岛落点)召唤你记一句。长按通知可选「语音」或「文字」。静音时段内的提醒会自动跳过。",
+                value: "到点时会发一条本地通知(灵动岛落点)召唤你记一句。长按通知可选「语音」或「文字」。\n在 Today 页可增删提醒;也可在「问过去」里直接说「每天晚上 10 点提醒我」或「一小时后叫我」,让 AI 帮你排。静音时段内的重复提醒会自动跳过。",
                 comment: "Footer explaining capture reminders"
             ))
             .font(.caption)

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -1125,6 +1125,15 @@ private struct WaveformBars: View, Equatable {
 /// Compiled-day hero card — Liquid Glass amber style.
 struct DailyPageEntryCard: View {
     let summary: String?
+    /// Ribbon line above the serif excerpt. Defaults to the "today" wording;
+    /// the Yesterday section passes its own so the card never contradicts
+    /// its section header (the old hardcoded "Today's page compiled" did).
+    var ribbonText: String = NSLocalizedString(
+        "today.card.compiled.today",
+        comment: "Compiled-page card ribbon for today's own page")
+    /// Quiet meta coda ("6 条 memo") so the ribbon-only form still carries
+    /// information when the page has no summary. nil hides the line.
+    var metaText: String? = nil
     var onTap: (() -> Void)?
 
     private var hasSummary: Bool {
@@ -1145,7 +1154,7 @@ struct DailyPageEntryCard: View {
                         .fill(DSColor.accentOnBg)
                         .frame(width: 6, height: 6)
                         .shadow(color: DSColor.amberGlow, radius: 4, x: 0, y: 0)
-                    Text("Today's page compiled")
+                    Text(ribbonText)
                         .font(DSFonts.jetBrainsMono(size: 10, relativeTo: .caption2))
                         .tracking(1)
                         .textCase(.uppercase)
@@ -1158,6 +1167,12 @@ struct DailyPageEntryCard: View {
                         .foregroundColor(DSColor.inkPrimary)
                         .lineLimit(2)
                         .lineSpacing(2)
+                }
+
+                if let metaText, !metaText.isEmpty {
+                    Text(metaText)
+                        .font(DSFonts.inter(size: 11, weight: .regular, relativeTo: .caption))
+                        .foregroundColor(DSColor.inkMuted)
                 }
             }
             .frame(maxWidth: .infinity, alignment: .leading)

--- a/DayPage/Features/Today/ReminderCapsuleStrip.swift
+++ b/DayPage/Features/Today/ReminderCapsuleStrip.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+// MARK: - ReminderCapsuleStrip
+//
+// Today 页的轻量提醒条(vNext,2026-07-15)。横向列出「即将触发」的提醒
+// 胶囊(如「今晚 22:00 · 睡前」),点一下进编辑;尾部一个「＋ 提醒我」入口
+// 落一次性。设计原则:不抢 Today 主流,空态整条收起(不占高度)。
+//
+// 复杂的自定义(周几、精确时间)在编辑 sheet 里;更自然语言的调度走「问过去」
+// 对话。这条只是 Today 上的可见落点 + 快捷入口。
+//
+// 数据源:CaptureReminderService.shared(统一调度器)。整条受
+// FeatureFlag.captureReminder 门控 —— flag 关时调用方不挂载本视图。
+
+struct ReminderCapsuleStrip: View {
+    @ObservedObject var service: CaptureReminderService
+
+    /// 当前时钟(由父视图的 currentTime 传入,让胶囊文案随时间刷新)。
+    let now: Date
+
+    /// 点某条提醒 → 打开编辑 sheet。
+    var onEdit: (Reminder) -> Void
+    /// 点「＋ 提醒我」→ 打开快捷新建。
+    var onAdd: () -> Void
+
+    private var upcoming: [Reminder] {
+        service.upcoming(limit: 4, now: now)
+    }
+
+    var body: some View {
+        // 空态:没有即将触发的提醒时,只留一个极简的「＋ 提醒我」入口,
+        // 而不是整条消失 —— 给用户一个发现「可以排提醒」的钩子。
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                ForEach(upcoming) { reminder in
+                    capsule(for: reminder)
+                }
+                addButton
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 2)
+        }
+        .accessibilityIdentifier("reminder-capsule-strip")
+    }
+
+    // MARK: - Capsule
+
+    private func capsule(for reminder: Reminder) -> some View {
+        Button {
+            Haptics.selection()
+            onEdit(reminder)
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: reminder.isOneShot ? "clock" : "bell.fill")
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(DSColor.amberAccent)
+                Text(headline(for: reminder))
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(DSColor.inkPrimary)
+                    .lineLimit(1)
+                if !reminder.label.isEmpty {
+                    Text(reminder.label)
+                        .font(.system(size: 12))
+                        .foregroundColor(DSColor.inkSubtle)
+                        .lineLimit(1)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(
+                Capsule(style: .continuous)
+                    .fill(DSColor.glassLo)
+                    .overlay(Capsule(style: .continuous).strokeBorder(DSColor.amberRim, lineWidth: 1))
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("reminder-capsule-\(reminder.timeString)")
+        .accessibilityLabel("\(headline(for: reminder)) \(reminder.label)")
+    }
+
+    /// 胶囊主文案:一次性 = 相对日+时间(今晚 22:00);重复 = 重复规则+时间。
+    private func headline(for reminder: Reminder) -> String {
+        if reminder.isOneShot, let next = reminder.nextFireDate(after: now) {
+            return Reminder.relativeDayLabel(for: next, now: now)
+        }
+        return "\(reminder.repeatDescription) \(reminder.timeString)"
+    }
+
+    // MARK: - Add button
+
+    private var addButton: some View {
+        Button {
+            Haptics.light()
+            onAdd()
+        } label: {
+            HStack(spacing: 5) {
+                Image(systemName: "plus")
+                    .font(.system(size: 11, weight: .bold))
+                Text(NSLocalizedString("today.reminder.add", value: "提醒我", comment: "Add a capture reminder"))
+                    .font(.system(size: 13, weight: .medium))
+            }
+            .foregroundColor(DSColor.amberAccent)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .background(
+                Capsule(style: .continuous)
+                    .strokeBorder(DSColor.amberRim, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("reminder-capsule-add")
+    }
+}

--- a/DayPage/Features/Today/ReminderEditSheet.swift
+++ b/DayPage/Features/Today/ReminderEditSheet.swift
@@ -1,0 +1,307 @@
+import SwiftUI
+
+// MARK: - ReminderSheetTarget
+
+/// `.sheet(item:)` 的 Identifiable 包装：`reminder == nil` 表示新建。
+/// id 取 reminder 的稳定 id（新建用随机 UUID），编辑不同条目时 sheet 会
+/// 正确重建而不是复用旧编辑态。
+struct ReminderSheetTarget: Identifiable {
+    let reminder: Reminder?
+    var id: UUID { reminder?.id ?? Self.newItemID }
+    /// 新建场景的固定 id —— 连续点两次「＋」不会重复弹 sheet。
+    private static let newItemID = UUID()
+}
+
+// MARK: - ReminderEditSheet
+//
+// 提醒的编辑 / 新建 sheet(vNext,2026-07-15)。仿滴答清单的时间自定义:
+//   • 顶部分段:一次性 / 每天 / 指定周几
+//   • 时间轮盘(DatePicker .wheel .hourAndMinute)
+//   • 「指定周几」时露出周几 chips(每天/工作日/周末快捷 + 单独一~日)
+//   • 「一次性」时露出快捷 chips(1 小时后 / 今晚 / 明早)直接落时间
+//   • 标签输入(可空)
+//
+// 保存/删除都走 CaptureReminderService 统一 API。这是「设置页简化、复杂
+// 度藏调度」里 UI 侧的复杂落点 —— 但仍是可选路径,自然语言走 AI 对话。
+
+struct ReminderEditSheet: View {
+    @ObservedObject var service: CaptureReminderService
+    @Environment(\.dismiss) private var dismiss
+
+    /// 非 nil = 编辑现有;nil = 新建。
+    let editing: Reminder?
+
+    // MARK: Local edit state
+
+    private enum Kind: String, CaseIterable {
+        case once, daily, weekdays
+        var title: String {
+            switch self {
+            case .once:     return NSLocalizedString("reminder.kind.once", value: "一次", comment: "One-shot reminder")
+            case .daily:    return NSLocalizedString("reminder.kind.daily", value: "每天", comment: "Daily reminder")
+            case .weekdays: return NSLocalizedString("reminder.kind.weekdays", value: "周几", comment: "Weekday reminder")
+            }
+        }
+    }
+
+    @State private var kind: Kind
+    @State private var time: Date
+    @State private var selectedDays: Set<Int>
+    @State private var label: String
+
+    // MARK: Init
+
+    init(service: CaptureReminderService, editing: Reminder?) {
+        self.service = service
+        self.editing = editing
+
+        // 从现有 reminder 还原编辑态,或给合理默认(今天此刻的下一个整点)。
+        if let r = editing {
+            switch r.trigger {
+            case .once(let date):
+                _kind = State(initialValue: .once)
+                _time = State(initialValue: date)
+                _selectedDays = State(initialValue: [2, 3, 4, 5, 6])
+            case .daily(let h, let m):
+                _kind = State(initialValue: .daily)
+                _time = State(initialValue: Self.dateAt(hour: h, minute: m))
+                _selectedDays = State(initialValue: [2, 3, 4, 5, 6])
+            case .weekdays(let days, let h, let m):
+                _kind = State(initialValue: .weekdays)
+                _time = State(initialValue: Self.dateAt(hour: h, minute: m))
+                _selectedDays = State(initialValue: days)
+            }
+            _label = State(initialValue: r.label)
+        } else {
+            _kind = State(initialValue: .once)
+            _time = State(initialValue: Self.defaultOnceTime())
+            _selectedDays = State(initialValue: [2, 3, 4, 5, 6])
+            _label = State(initialValue: "")
+        }
+    }
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                // 类型分段。
+                Section {
+                    Picker("", selection: $kind) {
+                        ForEach(Kind.allCases, id: \.rawValue) { k in
+                            Text(k.title).tag(k)
+                        }
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityIdentifier("reminder-kind-picker")
+                }
+
+                // 一次性快捷 chips —— 直接落一个绝对时间点到轮盘。
+                if kind == .once {
+                    Section {
+                        ScrollView(.horizontal, showsIndicators: false) {
+                            HStack(spacing: 8) {
+                                ForEach(RelativeTimeResolver.quickChips.indices, id: \.self) { i in
+                                    let chip = RelativeTimeResolver.quickChips[i]
+                                    quickChip(title: chip.title, token: chip.token)
+                                }
+                            }
+                        }
+                    } header: {
+                        Text(NSLocalizedString("reminder.quick", value: "快捷", comment: "Quick relative times"))
+                    }
+                }
+
+                // 时间轮盘。
+                Section {
+                    DatePicker(
+                        NSLocalizedString("reminder.time", value: "时间", comment: "Reminder time"),
+                        selection: $time,
+                        displayedComponents: kind == .once ? [.date, .hourAndMinute] : [.hourAndMinute]
+                    )
+                    .datePickerStyle(.compact)
+                    .accessibilityIdentifier("reminder-time-picker")
+                }
+
+                // 周几选择(仅 .weekdays)。
+                if kind == .weekdays {
+                    Section {
+                        weekdayPresetRow
+                        weekdayGrid
+                    } header: {
+                        Text(NSLocalizedString("reminder.weekdays", value: "重复", comment: "Weekday repeat"))
+                    }
+                }
+
+                // 标签。
+                Section {
+                    TextField(
+                        NSLocalizedString("reminder.label.placeholder", value: "标签(可空)", comment: "Reminder label placeholder"),
+                        text: $label
+                    )
+                    .accessibilityIdentifier("reminder-label-field")
+                }
+
+                // 删除(仅编辑态)。
+                if let editing {
+                    Section {
+                        Button(role: .destructive) {
+                            Haptics.light()
+                            service.removeReminder(editing.id)
+                            dismiss()
+                        } label: {
+                            Text(NSLocalizedString("reminder.delete", value: "删除提醒", comment: "Delete reminder"))
+                                .frame(maxWidth: .infinity)
+                        }
+                        .accessibilityIdentifier("reminder-delete")
+                    }
+                }
+            }
+            .navigationTitle(editing == nil
+                ? NSLocalizedString("reminder.new.title", value: "新提醒", comment: "New reminder title")
+                : NSLocalizedString("reminder.edit.title", value: "编辑提醒", comment: "Edit reminder title"))
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(NSLocalizedString("common.cancel", value: "取消", comment: "Cancel")) { dismiss() }
+                }
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(NSLocalizedString("common.save", value: "保存", comment: "Save")) { save() }
+                        .disabled(!canSave)
+                        .accessibilityIdentifier("reminder-save")
+                }
+            }
+        }
+    }
+
+    // MARK: - Weekday UI
+
+    private var weekdayPresetRow: some View {
+        HStack(spacing: 8) {
+            presetChip("每天", days: [1, 2, 3, 4, 5, 6, 7])
+            presetChip("工作日", days: [2, 3, 4, 5, 6])
+            presetChip("周末", days: [1, 7])
+        }
+    }
+
+    private func presetChip(_ title: String, days: Set<Int>) -> some View {
+        Button {
+            Haptics.selection()
+            selectedDays = days
+        } label: {
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(selectedDays == days ? .white : DSColor.amberAccent)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(
+                    Capsule().fill(selectedDays == days ? DSColor.amberAccent : DSColor.amberSoft)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var weekdayGrid: some View {
+        // 周一…周日(把周日排最后,符合中文直觉)。
+        let order = [2, 3, 4, 5, 6, 7, 1]
+        let names = ["", "日", "一", "二", "三", "四", "五", "六"]
+        return HStack(spacing: 6) {
+            ForEach(order, id: \.self) { day in
+                let on = selectedDays.contains(day)
+                Button {
+                    Haptics.selection()
+                    if on { selectedDays.remove(day) } else { selectedDays.insert(day) }
+                } label: {
+                    Text(names[day])
+                        .font(.system(size: 14, weight: .semibold))
+                        .foregroundColor(on ? .white : DSColor.inkMuted)
+                        .frame(width: 34, height: 34)
+                        .background(
+                            Circle().fill(on ? DSColor.amberAccent : DSColor.glassLo)
+                        )
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("reminder-weekday-\(day)")
+            }
+        }
+    }
+
+    // MARK: - Quick chip (once)
+
+    private func quickChip(title: String, token: RelativeTimeResolver.Token) -> some View {
+        Button {
+            Haptics.selection()
+            if let resolved = RelativeTimeResolver.resolve(token) {
+                time = resolved
+            }
+        } label: {
+            Text(title)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(DSColor.amberAccent)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 6)
+                .background(Capsule().fill(DSColor.amberSoft))
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Save
+
+    private var canSave: Bool {
+        switch kind {
+        case .once:
+            return time > Date()
+        case .daily:
+            return true
+        case .weekdays:
+            return !selectedDays.isEmpty
+        }
+    }
+
+    private func save() {
+        let comps = Calendar.current.dateComponents([.hour, .minute], from: time)
+        let h = comps.hour ?? 21
+        let m = comps.minute ?? 0
+        let trimmedLabel = label.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        let trigger: Reminder.Trigger
+        switch kind {
+        case .once:      trigger = .once(time)
+        case .daily:     trigger = .daily(hour: h, minute: m)
+        case .weekdays:  trigger = .weekdays(days: selectedDays, hour: h, minute: m)
+        }
+
+        if let editing {
+            service.updateReminder(editing.id, trigger: trigger, label: trimmedLabel)
+        } else {
+            let fallbackLabel = trimmedLabel.isEmpty ? defaultLabel(for: kind) : trimmedLabel
+            service.addReminder(Reminder(trigger: trigger, label: fallbackLabel, source: .user))
+        }
+        Haptics.success()
+        dismiss()
+    }
+
+    private func defaultLabel(for kind: Kind) -> String {
+        switch kind {
+        case .once:     return NSLocalizedString("reminder.default.once", value: "稍后", comment: "Default one-shot label")
+        case .daily:    return NSLocalizedString("reminder.default.daily", value: "每日记录", comment: "Default daily label")
+        case .weekdays: return NSLocalizedString("reminder.default.weekdays", value: "定期记录", comment: "Default weekday label")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static func dateAt(hour: Int, minute: Int) -> Date {
+        var comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = hour
+        comps.minute = minute
+        return Calendar.current.date(from: comps) ?? Date()
+    }
+
+    /// 新建一次性的默认时间:下一个整点(至少 +1 小时)。
+    private static func defaultOnceTime() -> Date {
+        let cal = Calendar.current
+        let next = cal.date(byAdding: .hour, value: 1, to: Date()) ?? Date()
+        var comps = cal.dateComponents([.year, .month, .day, .hour], from: next)
+        comps.minute = 0
+        return cal.date(from: comps) ?? next
+    }
+}

--- a/DayPage/Features/Today/TodayCoachView.swift
+++ b/DayPage/Features/Today/TodayCoachView.swift
@@ -426,6 +426,36 @@ struct TodayCoachView: View {
         guard !text.isEmpty, !coach.isResponding else { return }
         draft = ""
 
+        // Reminder vNext：「提醒我…」在 IntentRouter 之前拦截，直接落统一
+        // 调度器 —— 排提醒是高频小意图，零 LLM 往返。解析出时间就排 +
+        // 确认；有提醒动词但时间模糊则追问，绝不猜时间。
+        if FeatureFlagStore.shared.isEnabled(.captureReminder) {
+            if let parsed = ReminderIntentParser.parse(text) {
+                let reminder = CaptureReminderService.shared.addReminder(
+                    Reminder(trigger: parsed.trigger, label: parsed.label, source: .ai)
+                )
+                coach.turns.append(CoachTurn(role: .user, text: text))
+                coach.turns.append(CoachTurn(
+                    role: .assistant,
+                    text: Self.reminderConfirmation(for: reminder)
+                ))
+                Haptics.success()
+                return
+            }
+            if ReminderIntentParser.containsReminderVerb(text) {
+                coach.turns.append(CoachTurn(role: .user, text: text))
+                coach.turns.append(CoachTurn(
+                    role: .assistant,
+                    text: NSLocalizedString(
+                        "coach.reminder.clarify",
+                        value: "好——几点提醒你？可以说「今晚」「明早」「一小时后」，或者给个具体时间，比如「明天 15:00」；重复的话说「每天 22:00」「周一三五 9 点」。",
+                        comment: "Coach follow-up when a reminder request lacks a parseable time"
+                    )
+                ))
+                return
+            }
+        }
+
         // IntentRouter：只有明确历史意图才提示切换到「问过去」；其余走 Coach。
         let intent = IntentRouter.classify(text, hasHistoryHints: false)
         if intent == .askPast {
@@ -440,6 +470,27 @@ struct TodayCoachView: View {
             return
         }
         Task { await coach.ask(text) }
+    }
+
+    /// 排好后的确认文案：一次性 = 「今晚 20:00」；重复 = 「每天 22:00」。
+    /// 落点提示指向 Today 胶囊条 —— AI 排的提醒在那里可见、可改、可删。
+    static func reminderConfirmation(for reminder: Reminder) -> String {
+        let when: String
+        if case .once(let date) = reminder.trigger {
+            // relativeDayLabel 已含时间(「今天 13:29」),不再拼 timeString。
+            when = Reminder.relativeDayLabel(for: date)
+        } else {
+            when = "\(reminder.repeatDescription) \(reminder.timeString)"
+        }
+        let labelPart = reminder.label.isEmpty ? "" : "「\(reminder.label)」"
+        return String(
+            format: NSLocalizedString(
+                "coach.reminder.confirmed",
+                value: "已排好：%@ %@。到点我会来敲你——在 Today 顶部的提醒条里随时可改可删。",
+                comment: "Coach confirmation after scheduling a reminder (1: when, 2: label)"
+            ),
+            when, labelPart
+        )
     }
 
     // MARK: - Static

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -291,6 +291,21 @@ struct TodayView: View {
     /// per scroll frame. Divide by 20.0 at the read site to recover 0.0–1.0.
     @State private var scrollProgressBucket: Int = 0
 
+    /// Canvas vNext: quantized hero-recede progress (0…8) across the first
+    /// 160pt of scroll. The empty-day orbHero reads this to fade/scale away
+    /// as the finger travels. Bucketed for the same reason as
+    /// `scrollProgressBucket` — the view body must never re-render per
+    /// scroll frame (input-smoothness lesson).
+    @State private var heroFadeBucket: Int = 0
+
+    /// 今日焦点 disclosure state — false = single ghost line, true = chips row.
+    @State private var focusExpanded: Bool = false
+
+    /// 0.0–1.0 hero recede progress recovered from the bucket.
+    private var heroFadeProgress: CGFloat {
+        CGFloat(heroFadeBucket) / 8.0
+    }
+
     private var isInSelectionMode: Bool { selectedMemoIds != nil }
 
     /// Progress of the scroll-to-top ring: 0 at 240pt (button appears), 1 after
@@ -346,66 +361,16 @@ struct TodayView: View {
                     // selectionToolbar) is NOT part of the slot.
                     statusSlotSection
 
-                    // MARK: Today Focus Chips (Issue #13, 2026-07-03)
-                    //
-                    // A quiet horizontal ScrollView of five toggle chips
-                    // (工作 / 情绪 / 健康 / 关系 / 学习). Selecting one
-                    // updates TodayFocusStore, which
-                    // CompilationService.buildPrompt reads at compile time
-                    // — no code path lives in TodayView beyond the toggle.
-                    // Rendered before the timeline so the user sees "the
-                    // AI knows what I care about today" as soon as they
-                    // land on Today.
-                    //
-                    // 2026-07-04: shown only while the day is EMPTY. Once
-                    // memos exist the chips stop earning their row — the
-                    // declared focus already flowed into TodayFocusStore and
-                    // the compile prompt, and the timeline needs the space.
-                    if viewModel.memos.isEmpty {
-                        todayFocusRow
-                            .padding(.bottom, DSSpacing.xs)
-                            .transition(.opacity.combined(with: .move(edge: .top)))
-                    }
-
-                    // MARK: On This Day Top Card (R8-CRITICAL)
-                    //
-                    // 顶部独立 OnThisDayCard section — 脱离 fallbackContentView
-                    // 那条只在 viewModel.memos.isEmpty 时才显示的死路。 普通用户
-                    // 每天都会写 memo， 之前永远看不到时光胶囊； 现在只要存在
-                    // viewModel.onThisDayEntry（由 OnThisDayIndex.candidate 或
-                    // .onThisDayShouldShow 注入）就在头条位置出现。
-                    //
-                    // Sits AFTER the status slot (the single sticky "system
-                    // status" row that must always own the very top) but
-                    // BEFORE every Today-content section (orbHero /
-                    // timeline / fallback). Dismiss persists for the rest
-                    // of the day via OnThisDayScheduler — same behavior the
-                    // fallback path uses, so users can't double-dismiss.
-                    //
-                    // R9-HIGH A2: gated by `shouldShowOnThisDayAtTop`, which
-                    // the fallback path negates in the same render pass. No
-                    // more lazy `.onAppear` flag flip — the two paths agree
-                    // synchronously, eliminating the brief double-card race.
-                    // R9-HIGH A3 (updated for the single status slot): the
-                    // same computed yields to error/conflict slot occupants
-                    // so the composer isn't pushed off the visible viewport
-                    // on small devices (iPhone 12 mini); with at most one
-                    // banner plus this card the low-priority info slots can
-                    // coexist with it.
-                    if shouldShowOnThisDayAtTop,
-                       let entry = viewModel.onThisDayEntry {
-                        OnThisDayCard(
-                            entry: entry,
-                            onDismiss: {
-                                OnThisDayScheduler.shared.markDismissedForToday()
-                                viewModel.onThisDayEntry = nil
-                            },
-                            onTap: { tapped in
-                                handleOnThisDayTap(tapped)
-                            }
-                        )
-                        .transition(.opacity.combined(with: .move(edge: .top)))
-                    }
+                    // Canvas vNext (2026-07-14): the focus chips, OnThisDay
+                    // card and orbHero used to be pinned HERE — outside the
+                    // timeline ScrollView. On an empty day that froze ~65% of
+                    // the screen around the hero and squeezed the only
+                    // scrollable region (yesterday + history) into a ~180pt
+                    // strip at the bottom. All three moved INTO the timeline's
+                    // LazyVStack so the whole page reads as one continuous
+                    // canvas: swipe up anywhere and the poem slides away,
+                    // history fills the screen. Only the status slot stays
+                    // sticky — system status must always own the very top.
 
                     // MARK: Location Draft Card
                     if !todayPendingDrafts.isEmpty {
@@ -432,16 +397,6 @@ struct TodayView: View {
                                 }
                             }
                         )
-                    }
-
-                    // MARK: Day Orb Hero — serif date + mono kicker + orb
-                    // Hide when memos exist: the header already shows the date,
-                    // and the 140pt orb wastes prime content space once there
-                    // are signals in the timeline. (#US-016)
-                    if viewModel.memos.isEmpty {
-                        orbHero
-                            .transition(.opacity.combined(with: .scale(scale: 0.95, anchor: .top)))
-                            .dsAnimation(Motion.dismiss, value: viewModel.memos.isEmpty)
                     }
 
                     // MARK: Selection toolbar (issue #309 W2)
@@ -1237,11 +1192,11 @@ struct TodayView: View {
         case compilationProgress
         /// "Sync your journal across devices" sign-in prompt.
         case syncPrompt
-        /// R3 — A2 info row: AI key missing. Museum-aesthetic (#793):
-        /// only on empty days; with memos present the same condition
-        /// shows as a small amber dot on the settings gear (set
-        /// elsewhere), so lowest priority is safe.
-        case aiKeyMissing
+        // Canvas vNext (2026-07-14): the `.aiKeyMissing` info row left the
+        // slot — a missing key only blocks the NIGHTLY compile, so it
+        // doesn't earn a sticky page-top surface. It now renders as a quiet
+        // footnote inside `orbHero` (empty days) and keeps the amber dot on
+        // the settings gear for memo days.
 
         /// Error/conflict occupants push non-status cards (OnThisDay)
         /// out of the top region; info/progress occupants coexist.
@@ -1265,7 +1220,6 @@ struct TodayView: View {
         }
         if compileService.stage != .idle || viewModel.isCompiling { return .compilationProgress }
         if showSyncBanner { return .syncPrompt }
-        if shouldShowAIKeyBanner && viewModel.memos.isEmpty { return .aiKeyMissing }
         return nil
     }
 
@@ -1309,9 +1263,6 @@ struct TodayView: View {
             case .syncPrompt:
                 syncBanner
                     .transition(.opacity.combined(with: .move(edge: .top)))
-            case .aiKeyMissing:
-                aiKeyMissingBanner
-                    .transition(.opacity.combined(with: .move(edge: .top)))
             case nil:
                 EmptyView()
             }
@@ -1346,6 +1297,13 @@ struct TodayView: View {
         FeatureFlagStore.shared.isEnabled(.onThisDay)
             && viewModel.onThisDayEntry != nil
             && !(activeStatusSlot?.isBlocking ?? false)
+    }
+
+    /// Canvas vNext: true once the user has ANY compiled/recorded past —
+    /// yesterday's page or any timeline day. Gates the sample-journal link
+    /// (proof-of-value for brand-new users only).
+    private var hasAnyHistory: Bool {
+        viewModel.yesterdayDailyPageModel != nil || !viewModel.timelineSections.isEmpty
     }
 
     /// True when the banner should appear in this render. Combines:
@@ -1551,41 +1509,113 @@ struct TodayView: View {
     private var todayFocusRow: some View {
         ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-                Text("今日焦点")
+                Text(NSLocalizedString("today.focus.label", comment: "Today focus chip-row label"))
                     .font(DSType.mono10)
                     .tracking(1.2)
                     .textCase(.uppercase)
                     .foregroundColor(DSColor.inkMuted)
                     .padding(.trailing, 4)
-                ForEach(TodayFocus.allCases, id: \.self) { focus in
-                    let isSelected = focusStore.focuses.contains(focus)
-                    Button {
-                        Haptics.soft()
-                        focusStore.toggle(focus)
-                    } label: {
-                        Text(focus.displayName)
-                            .font(DSType.bodySM)
-                            .foregroundColor(isSelected ? DSColor.surfaceWhite : DSColor.amberDeep)
-                            .lineLimit(1)
-                            .minimumScaleFactor(0.85)
-                            .padding(.horizontal, 12)
-                            .padding(.vertical, 6)
-                            .background(
-                                Capsule().fill(isSelected ? DSColor.amberDeep : DSColor.amberSoft)
-                            )
-                            .overlay(
-                                Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5)
-                            )
-                    }
-                    .buttonStyle(.plain)
-                    .accessibilityIdentifier("today.focus.chip.\(focus.rawValue)")
-                    .accessibilityLabel("\(focus.displayName) 焦点")
-                    .accessibilityValue(isSelected ? "已选中" : "未选中")
-                }
+                focusChips
             }
             .padding(.horizontal, DSSpacing.pageMargin)
         }
         .dynamicTypeSize(.xSmall ... .accessibility2)
+    }
+
+    /// Bare chip buttons, shared by the legacy always-on row (flag off) and
+    /// the expanded state of `focusDisclosureRow`.
+    private var focusChips: some View {
+        ForEach(TodayFocus.allCases, id: \.self) { focus in
+            let isSelected = focusStore.focuses.contains(focus)
+            Button {
+                Haptics.soft()
+                focusStore.toggle(focus)
+            } label: {
+                Text(focus.displayName)
+                    .font(DSType.bodySM)
+                    .foregroundColor(isSelected ? DSColor.surfaceWhite : DSColor.amberDeep)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.85)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 6)
+                    .background(
+                        Capsule().fill(isSelected ? DSColor.amberDeep : DSColor.amberSoft)
+                    )
+                    .overlay(
+                        Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5)
+                    )
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("today.focus.chip.\(focus.rawValue)")
+            .accessibilityLabel("\(focus.displayName) 焦点")
+            .accessibilityValue(isSelected ? "已选中" : "未选中")
+        }
+    }
+
+    /// Canvas vNext progressive disclosure for 今日焦点. Three states:
+    ///   - collapsed, nothing chosen  → ghost line "今日焦点 ›"
+    ///   - collapsed, lenses chosen   → summary "今日焦点 · 工作 · 学习"
+    ///   - expanded                   → the chip row, sans redundant label
+    /// The data layer (TodayFocusStore → compile prompt) is untouched; this
+    /// only changes when the chips earn pixels. Flag-off restores the legacy
+    /// always-expanded row.
+    @ViewBuilder
+    private var focusDisclosureRow: some View {
+        if FeatureFlagStore.shared.isEnabled(.todayFocusCollapsed) {
+            VStack(spacing: 8) {
+                Button {
+                    Haptics.soft()
+                    withAnimation(reduceMotion ? nil : Motion.spring) {
+                        focusExpanded.toggle()
+                    }
+                } label: {
+                    HStack(spacing: 5) {
+                        Text(focusSummaryLabel)
+                            .font(DSType.mono10)
+                            .tracking(1.2)
+                            .textCase(.uppercase)
+                            .foregroundColor(DSColor.inkMuted)
+                            .lineLimit(1)
+                        Image(systemName: "chevron.right")
+                            .font(.system(size: 8, weight: .semibold))
+                            .foregroundColor(DSColor.inkMuted.opacity(0.7))
+                            .rotationEffect(.degrees(focusExpanded ? 90 : 0))
+                    }
+                    .padding(.vertical, 6)
+                    .padding(.horizontal, 16)
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(NSLocalizedString("today.focus.label", comment: ""))
+                .accessibilityValue(focusExpanded
+                    ? NSLocalizedString("today.focus.a11y.expanded", comment: "Focus row expanded")
+                    : NSLocalizedString("today.focus.a11y.collapsed", comment: "Focus row collapsed"))
+                .accessibilityIdentifier("today.focus.disclosure")
+
+                if focusExpanded {
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        HStack(spacing: 8) {
+                            focusChips
+                        }
+                        .padding(.horizontal, DSSpacing.pageMargin)
+                    }
+                    .dynamicTypeSize(.xSmall ... .accessibility2)
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+            }
+        } else {
+            todayFocusRow
+        }
+    }
+
+    /// Ghost-line text: bare label when nothing is chosen, "· 工作 · 学习"
+    /// coda once lenses are selected so the collapsed state still tells the
+    /// user what tonight's compile will lean into.
+    private var focusSummaryLabel: String {
+        let base = NSLocalizedString("today.focus.label", comment: "")
+        let chosen = TodayFocus.allCases.filter { focusStore.focuses.contains($0) }
+        guard !chosen.isEmpty else { return base }
+        return base + " · " + chosen.map(\.displayName).joined(separator: " · ")
     }
 
     private var syncQueuePendingBanner: some View {
@@ -1816,8 +1846,14 @@ struct TodayView: View {
         case .onThisDay(let memos):
             onThisDayFallback(memos: memos)
         case .weekRecap(let entries):
-            WeeklyRecapSection(entries: entries) { dateString in
-                historicalDay = DayNavTarget(dateString: dateString)
+            // Canvas vNext: with the history timeline now rendering on empty
+            // days too, the recap would duplicate 本周 — only keep it for the
+            // (unusual) case where compiled pages exist but the timeline is
+            // empty.
+            if viewModel.timelineSections.isEmpty {
+                WeeklyRecapSection(entries: entries) { dateString in
+                    historicalDay = DayNavTarget(dateString: dateString)
+                }
             }
         case .pureEmpty:
             // R3 (#793 comp 4.png): orbHero now carries the full empty-state
@@ -1854,7 +1890,12 @@ struct TodayView: View {
     @ViewBuilder
     private func yesterdaySection(_ page: DailyPageModel) -> some View {
         VStack(alignment: .leading, spacing: 8) {
-            Text(NSLocalizedString("today.section.yesterday", comment: ""))
+            // Mono kicker stays English per the archive-label convention
+            // (FINDING-010); the date coda anchors WHICH yesterday this is.
+            let dateCoda = Self.yesterdayLabelDate(page.dateString)
+            Text(dateCoda.isEmpty
+                 ? NSLocalizedString("today.section.yesterday", comment: "")
+                 : "\(NSLocalizedString("today.section.yesterday", comment: "")) · \(dateCoda)")
                 .font(DSType.mono10)
                 .tracking(1.0)
                 .foregroundColor(DSColor.inkMuted)
@@ -1863,6 +1904,14 @@ struct TodayView: View {
 
             DailyPageEntryCard(
                 summary: page.summary.isEmpty ? nil : page.summary,
+                ribbonText: NSLocalizedString(
+                    "today.card.compiled.yesterday",
+                    comment: "Yesterday card ribbon: the page is compiled"),
+                metaText: page.memoCount > 0
+                    ? String(format: NSLocalizedString(
+                        "today.card.meta.memos",
+                        comment: "Yesterday card meta: N raw memos"), page.memoCount)
+                    : nil,
                 onTap: {
                     historicalDay = DayNavTarget(dateString: page.dateString)
                 }
@@ -1872,15 +1921,36 @@ struct TodayView: View {
         }
     }
 
+    /// "2026-07-13" → "JUL 13" for the yesterday kicker. en_US_POSIX keeps
+    /// the mono label inside the archive-label (English small-caps) system.
+    private static func yesterdayLabelDate(_ dateString: String) -> String {
+        let parse = DateFormatter()
+        parse.dateFormat = "yyyy-MM-dd"
+        parse.locale = Locale(identifier: "en_US_POSIX")
+        parse.timeZone = AppSettings.currentTimeZone()
+        guard let date = parse.date(from: dateString) else { return "" }
+        let out = DateFormatter()
+        out.dateFormat = "MMM d"
+        out.locale = Locale(identifier: "en_US_POSIX")
+        out.timeZone = AppSettings.currentTimeZone()
+        return out.string(from: date).uppercased()
+    }
+
     // MARK: - History Supplement (memos present — shown at timeline bottom)
 
     /// History supplement rendered below today's raw memos. Previously this
     /// only showed yesterday's compiled page or the weekly recap; now it owns
     /// the full historical timeline (#276) — this week's other days, last
     /// week, week-before-last, and older months as expandable cards.
+    ///
+    /// Canvas vNext: also renders on EMPTY days. An empty today used to give
+    /// the scroll region a single yesterday card and nothing else — "滑了也
+    /// 白滑". Now swiping up on an empty day reads the whole past. Yesterday
+    /// is de-duplicated via `supplementSections` when the fallback already
+    /// shows its hero card above.
     @ViewBuilder
     private var historySupplement: some View {
-        if !viewModel.memos.isEmpty && viewModel.loadState == .ready && !viewModel.timelineSections.isEmpty {
+        if viewModel.loadState == .ready && !supplementSections.isEmpty {
             // Quiet breathing room replaces the redundant "EARLIER" rule —
             // the timeline's own SectionHeader (本周/上周) already separates bands.
             // 12 here + the SectionHeader's own 20 top padding lands the
@@ -1888,7 +1958,7 @@ struct TodayView: View {
             Color.clear
                 .frame(height: 12)
                 .accessibilityLabel(Text(NSLocalizedString("today.section.earlier", comment: "")))
-            ForEach(viewModel.timelineSections) { section in
+            ForEach(supplementSections) { section in
                 TimelineSectionView(
                     section: section,
                     zoomNamespace: detailZoomNamespace,
@@ -1905,6 +1975,24 @@ struct TodayView: View {
     @ViewBuilder
     private func yesterdayDailyPageFallback(_ page: DailyPageModel) -> some View {
         yesterdaySection(page)
+    }
+
+    /// Timeline sections feeding `historySupplement`. On an empty day whose
+    /// fallback already shows yesterday's hero card, yesterday's entry is
+    /// filtered out of its time band so the day never appears twice.
+    private var supplementSections: [TimelineSection] {
+        let sections = viewModel.timelineSections
+        guard viewModel.memos.isEmpty,
+              case .yesterdayDailyPage(let page) = viewModel.fallbackContent else {
+            return sections
+        }
+        return sections.compactMap { section in
+            let days = section.days.filter { $0.dateString != page.dateString }
+            guard !days.isEmpty else { return nil }
+            return days.count == section.days.count
+                ? section
+                : TimelineSection(kind: section.kind, days: days)
+        }
     }
 
     @ViewBuilder
@@ -2226,38 +2314,52 @@ struct TodayView: View {
                 .padding(.top, 12)
             }
 
+            // Canvas vNext: AI-key footnote. Demoted from the sticky status
+            // slot — a missing key only affects the nightly compile, so it
+            // rides along with the hero and scrolls away with it.
+            if shouldShowAIKeyBanner {
+                aiKeyMissingBanner
+                    .padding(.top, 2)
+            }
+
             // Issue #2 (2026-07-02): "See a sample journal" fallback link.
             // For users who skipped or dismissed the Welcome CTA, the empty
             // Today gives no proof of what the AI will produce. Tapping this
             // seeds 3 sample memos + a paired compiled daily.md (see
             // SampleDataSeeder) and refreshes the timeline. Once seeded, the
             // label flips so the user knows exactly what to open next.
-            Button {
-                Haptics.tapConfirm()
-                SampleDataSeeder.seedIfNeeded()
-                // Issue #18: single call site records both the sample seed
-                // and the surface it came from — the Welcome CTA emits the
-                // same event with `surface:"welcome"`, so the debug board
-                // shows a real "empty→sample" funnel.
-                AnalyticsService.shared.record(
-                    AnalyticsService.Name.sampleSeeded,
-                    props: ["surface": "today_empty"]
-                )
-                sampleSeeded = true
-                Task { await viewModel.refresh() }
-            } label: {
-                Text(NSLocalizedString(
-                    sampleSeeded ? "today.empty.sample_active" : "today.empty.try_sample",
-                    comment: "Empty-state sample-data affordance"))
-                    .font(DSType.mono10)
-                    .tracking(1.2)
-                    .textCase(.uppercase)
-                    .foregroundColor(DSColor.inkMuted)
-                    .padding(.top, 6)
+            //
+            // Canvas vNext: zero-history users ONLY. Anyone with a compiled
+            // yesterday or any timeline history already has real proof —
+            // for them this link is pure noise.
+            if !hasAnyHistory {
+                Button {
+                    Haptics.tapConfirm()
+                    SampleDataSeeder.seedIfNeeded()
+                    // Issue #18: single call site records both the sample seed
+                    // and the surface it came from — the Welcome CTA emits the
+                    // same event with `surface:"welcome"`, so the debug board
+                    // shows a real "empty→sample" funnel.
+                    AnalyticsService.shared.record(
+                        AnalyticsService.Name.sampleSeeded,
+                        props: ["surface": "today_empty"]
+                    )
+                    sampleSeeded = true
+                    Task { await viewModel.refresh() }
+                } label: {
+                    Text(NSLocalizedString(
+                        sampleSeeded ? "today.empty.sample_active" : "today.empty.try_sample",
+                        comment: "Empty-state sample-data affordance"))
+                        .font(DSType.mono10)
+                        .tracking(1.2)
+                        .textCase(.uppercase)
+                        .foregroundColor(DSColor.inkMuted)
+                        .padding(.top, 6)
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("today-empty-try-sample")
+                .disabled(sampleSeeded)
             }
-            .buttonStyle(.plain)
-            .accessibilityIdentifier("today-empty-try-sample")
-            .disabled(sampleSeeded)
 
         }
         .frame(maxWidth: .infinity)
@@ -2700,9 +2802,12 @@ struct TodayView: View {
                 timelineScrollProxy?.scrollTo("timelineTop", anchor: .top)
             }
         } label: {
-            Text("\(weekdayName(currentTime)) · \(Self.headerDateFmt.string(from: currentTime))")
-                .font(DSFonts.serif(size: 15, weight: .regular, relativeTo: .subheadline))
-                .foregroundColor(DSColor.inkPrimary)
+            // Canvas vNext: date only, muted. On a day with content the
+            // calendar is chrome, not content — the weekday dropped out and
+            // the ink stepped back so the timeline owns the reader's eye.
+            Text(Self.headerDateFmt.string(from: currentTime))
+                .font(DSFonts.serif(size: 14, weight: .regular, relativeTo: .subheadline))
+                .foregroundColor(DSColor.inkMuted)
                 .lineLimit(1)
                 .minimumScaleFactor(0.7)
                 .frame(height: 36)
@@ -2778,6 +2883,30 @@ struct TodayView: View {
                 // Invisible anchor: scrollTo("timelineTop") brings the list to the very top.
                 Color.clear.frame(height: 0).id("timelineTop")
 
+                // MARK: On This Day Card (R8-CRITICAL → Canvas vNext)
+                //
+                // 时光胶囊在所有日子都可出现（只要 OnThisDayScheduler 注入了
+                // entry）。Canvas vNext 把它从固定顶栏移进滚动画布：它是内容，
+                // 不是系统状态——读完即可划走，不再永久占用首屏。
+                //
+                // R9-HIGH A2/A3 语义保留：`shouldShowOnThisDayAtTop` 与
+                // fallback 路径在同一 render pass 内互斥；error/conflict slot
+                // 占用时让位（guard 在 computed 里）。
+                if shouldShowOnThisDayAtTop,
+                   let entry = viewModel.onThisDayEntry {
+                    OnThisDayCard(
+                        entry: entry,
+                        onDismiss: {
+                            OnThisDayScheduler.shared.markDismissedForToday()
+                            viewModel.onThisDayEntry = nil
+                        },
+                        onTap: { tapped in
+                            handleOnThisDayTap(tapped)
+                        }
+                    )
+                    .transition(.opacity.combined(with: .move(edge: .top)))
+                }
+
                 // Museum-aesthetic "AI · 今日一句" — restrained one-liner pinned
                 // at the very top once the day has a compiled summary.
                 if let summary = viewModel.dailyPageSummary,
@@ -2847,8 +2976,22 @@ struct TodayView: View {
                             .padding(.top, 48)
                             .padding(.horizontal, 20)
                     } else {
+                        // Canvas vNext: the hero now scrolls WITH the page and
+                        // quietly recedes as the finger travels — opacity/scale
+                        // driven by the same bucketed offset the header glass
+                        // uses (never the raw 60Hz value; see the
+                        // `timelineScrollOffset` property doc).
+                        orbHero
+                            .opacity(reduceMotion ? 1 : 1 - 0.85 * heroFadeProgress)
+                            .scaleEffect(reduceMotion ? 1 : 1 - 0.05 * heroFadeProgress, anchor: .top)
+
+                        // 今日焦点 — collapsed to a single ghost line; expands
+                        // on tap, summarizes once lenses are chosen.
+                        focusDisclosureRow
+                            .padding(.top, 2)
+
                         fallbackContentView
-                            .padding(.top, 24)
+                            .padding(.top, 18)
                     }
                 } else {
                     ForEach(Array(viewModel.memos.enumerated()), id: \.element.id) { idx, memo in
@@ -3004,24 +3147,35 @@ struct TodayView: View {
             alignment: .bottom
         )
         .coordinateSpace(name: "todayScroll")
-        .onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
-            // Store the raw value only — DO NOT read this from any body path;
-            // see the property-doc for the perf rationale.
-            timelineScrollOffset = value
-            // Derive threshold-bucketed state so the surrounding view body
-            // invalidates O(1) times per scroll instead of O(60Hz).
-            let scrolled = value < -8
-            if scrolled != isTimelineScrolled { isTimelineScrolled = scrolled }
-            let showTop = value < -240
-            if showTop != showScrollToTopButton { showScrollToTopButton = showTop }
-            // Quantize the ring progress (0…20) — floor(clamp(-value - 240, 0, 1200) / 60).
-            let clamped = max(0, min(1200, -value - 240))
-            let bucket = Int(clamped / 60)
-            if bucket != scrollProgressBucket { scrollProgressBucket = bucket }
-        }
+        .modifier(TodayScrollOffsetWatcher(onChange: { value in
+            handleScrollOffset(value)
+        }))
         .frame(maxWidth: .infinity, maxHeight: .infinity)
         .onAppear { timelineScrollProxy = proxy }
         } // end ScrollViewReader
+    }
+
+    /// Single consumer for the timeline's scroll offset, regardless of which
+    /// mechanism delivered it (see `TodayScrollOffsetWatcher`). Convention:
+    /// 0 at rest, NEGATIVE as the user scrolls up — the historical
+    /// PreferenceKey minY convention every threshold below was written for.
+    ///
+    /// Only threshold-bucketed state is stored so the view body invalidates
+    /// O(1) times per scroll instead of O(60Hz) — the raw value goes into
+    /// `timelineScrollOffset`, which no body path may read (see property doc).
+    private func handleScrollOffset(_ value: CGFloat) {
+        timelineScrollOffset = value
+        let scrolled = value < -8
+        if scrolled != isTimelineScrolled { isTimelineScrolled = scrolled }
+        let showTop = value < -240
+        if showTop != showScrollToTopButton { showScrollToTopButton = showTop }
+        // Quantize the ring progress (0…20) — floor(clamp(-value - 240, 0, 1200) / 60).
+        let clamped = max(0, min(1200, -value - 240))
+        let bucket = Int(clamped / 60)
+        if bucket != scrollProgressBucket { scrollProgressBucket = bucket }
+        // Canvas vNext: hero recede over the first 160pt, 8 buckets.
+        let hero = Int(max(0, min(160, -value)) / 20)
+        if hero != heroFadeBucket { heroFadeBucket = hero }
     }
 
     /// Compose area: compile button + input bar.

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -43,6 +43,11 @@ struct TodayView: View {
     /// small chip row above the input surface; CompilationService reads
     /// the same store on the next compile.
     @StateObject private var focusStore = TodayFocusStore.shared
+    /// Reminder vNext (2026-07-15): 统一调度器 —— Today 胶囊条/编辑 sheet/AI
+    /// 对话调度共用的单一数据源。
+    @StateObject private var reminderService = CaptureReminderService.shared
+    /// 非 nil = 打开提醒编辑 sheet；`reminder == nil` 表示新建。
+    @State private var reminderSheetTarget: ReminderSheetTarget? = nil
     @AppStorage(AppSettings.Keys.aiFeaturesEnabled) private var aiFeaturesEnabled: Bool = true
     @EnvironmentObject private var sidebarVM: SidebarViewModel
 
@@ -884,6 +889,13 @@ struct TodayView: View {
             .sheet(isPresented: $showSettings) {
                 SettingsView()
             }
+            // Reminder vNext: 提醒编辑/新建 sheet。滴答式时间自定义收在这里，
+            // Today 面上只留胶囊条；自然语言路径走 Coach/问过去对话。
+            .sheet(item: $reminderSheetTarget) { target in
+                ReminderEditSheet(service: reminderService, editing: target.reminder)
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
+            }
             // Issue #804: Today sparkle → 陪写引导（TodayCoachView），不再是
             // AskPastView。前者引导写下一条今日 memo，后者是 RAG 历史检索——
             // 用户 tap "让 AI 陪你聊聊今天" 应该进入陪写而非搜索。
@@ -1605,6 +1617,25 @@ struct TodayView: View {
             }
         } else {
             todayFocusRow
+        }
+    }
+
+    /// Reminder vNext: 即将触发的提醒胶囊条。FeatureFlag.captureReminder 关
+    /// 时整条不挂载（kill switch 与调度器一致）。点胶囊 → 编辑；点「＋」→
+    /// 新建。数据源是统一调度器，AI 排的提醒也会出现在这里。
+    @ViewBuilder
+    private var reminderStrip: some View {
+        if FeatureFlagStore.shared.isEnabled(.captureReminder) {
+            ReminderCapsuleStrip(
+                service: reminderService,
+                now: currentTime,
+                onEdit: { reminder in
+                    reminderSheetTarget = ReminderSheetTarget(reminder: reminder)
+                },
+                onAdd: {
+                    reminderSheetTarget = ReminderSheetTarget(reminder: nil)
+                }
+            )
         }
     }
 
@@ -2990,10 +3021,20 @@ struct TodayView: View {
                         focusDisclosureRow
                             .padding(.top, 2)
 
+                        // Reminder vNext: 即将触发的提醒胶囊 + 快捷新建。
+                        // 空态放在焦点行之下 —— 与 chrome 同级，不与诗抢戏。
+                        reminderStrip
+                            .padding(.top, 6)
+
                         fallbackContentView
                             .padding(.top, 18)
                     }
                 } else {
+                    // Reminder vNext: memo 日的胶囊条 —— 一行薄 chrome，
+                    // 在今日信号之上给 AI/手动排的提醒一个可见落点，随画布滚走。
+                    reminderStrip
+                        .padding(.bottom, 2)
+
                     ForEach(Array(viewModel.memos.enumerated()), id: \.element.id) { idx, memo in
                         TimelineRow(
                             memo: memo,

--- a/DayPage/Features/Today/TodayViewModifiers.swift
+++ b/DayPage/Features/Today/TodayViewModifiers.swift
@@ -17,6 +17,38 @@ struct ScrollOffsetPreferenceKey: PreferenceKey {
     }
 }
 
+/// Delivers the Today timeline's scroll offset to `handleScrollOffset`.
+///
+/// Canvas vNext (2026-07-14): on iOS 18+ the classic GeometryReader →
+/// PreferenceKey pattern stopped firing during scrolls (verified on the
+/// iOS 26.1 simulator via app.log instrumentation: the callback ran exactly
+/// once at initial layout, then never again — scrolling no longer re-runs
+/// content layout, so the preference never republishes). That silently
+/// killed every offset-driven surface: glass header, scroll-to-top ring,
+/// and the new hero recede. On iOS 18+ we read `onScrollGeometryChange`
+/// instead; iOS 16–17 keep the preference path, which still works there.
+///
+/// Value convention (both paths): 0 at rest, NEGATIVE as the user scrolls
+/// up — the historical minY convention TodayView's thresholds are written
+/// against.
+struct TodayScrollOffsetWatcher: ViewModifier {
+    let onChange: (CGFloat) -> Void
+
+    func body(content: Content) -> some View {
+        if #available(iOS 18.0, *) {
+            content.onScrollGeometryChange(for: CGFloat.self) { geometry in
+                -(geometry.contentOffset.y + geometry.contentInsets.top)
+            } action: { _, newValue in
+                onChange(newValue)
+            }
+        } else {
+            content.onPreferenceChange(ScrollOffsetPreferenceKey.self) { value in
+                onChange(value)
+            }
+        }
+    }
+}
+
 // MARK: - Scroll entrance (iOS 17+)
 
 /// 美术馆入场: timeline memo cards settle in as they scroll into the

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -1164,3 +1164,23 @@
 "memo.chat.a11y.detach"              = "Detach memory";
 "memo.chat.a11y.source"              = "Open records of %@";
 "memo.chat.a11y.send"                = "Send";
+
+// MARK: - Chat River (session-ized AI chat history)
+
+"chat.river.earlier"                = "Earlier conversations";
+"chat.river.continue"               = "Continue this conversation";
+"chat.river.export"                 = "Export (.md)";
+"chat.river.select"                 = "Select…";
+"chat.river.delete"                 = "Delete";
+"chat.river.delete.confirm.title"   = "Delete this conversation?";
+"chat.river.delete.confirm.message" = "The conversation file will be removed from your vault. This cannot be undone.";
+"chat.river.selected"               = "%d selected";
+"chat.river.export_n"               = "Export %d";
+"chat.river.selection.done"         = "Done";
+"chat.river.current_marker"         = "Current conversation";
+"chat.river.turns"                  = "%d turns";
+"chat.river.today"                  = "Today";
+"chat.river.yesterday"              = "Yesterday";
+"chat.river.badge.ask"              = "ASK";
+"chat.river.badge.memo"             = "MEMO";
+"chat.river.badge.coach"            = "COACH";

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -592,6 +592,17 @@
 "today.section.earlier"   = "EARLIER";
 "today.section.yesterday" = "YESTERDAY";
 
+/* Canvas vNext — compiled-page card ribbons + meta (fixes the hardcoded
+   "Today's page compiled" appearing under the YESTERDAY header) */
+"today.card.compiled.today"     = "Today's page compiled";
+"today.card.compiled.yesterday" = "Yesterday compiled";
+"today.card.meta.memos"         = "%d memos";
+
+/* Canvas vNext — 今日焦点 progressive disclosure */
+"today.focus.label"          = "Today's focus";
+"today.focus.a11y.expanded"  = "Expanded";
+"today.focus.a11y.collapsed" = "Collapsed, double-tap to choose focus lenses";
+
 /* Banners */
 "today.banner.draft_restored" = "Restored your unsent draft";
 "today.banner.voice_queue"    = "You have %d voice notes pending transcription";

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -603,6 +603,26 @@
 "today.focus.a11y.expanded"  = "Expanded";
 "today.focus.a11y.collapsed" = "Collapsed, double-tap to choose focus lenses";
 
+/* Reminder vNext — Today capsule strip + edit sheet + AI scheduling */
+"today.reminder.add"          = "Remind me";
+"reminder.kind.once"          = "Once";
+"reminder.kind.daily"         = "Daily";
+"reminder.kind.weekdays"      = "Weekdays";
+"reminder.quick"              = "Quick";
+"reminder.time"               = "Time";
+"reminder.weekdays"           = "Repeat";
+"reminder.label.placeholder"  = "Label (optional)";
+"reminder.delete"             = "Delete reminder";
+"reminder.new.title"          = "New reminder";
+"reminder.edit.title"         = "Edit reminder";
+"reminder.default.once"       = "Later";
+"reminder.default.daily"      = "Daily journal";
+"reminder.default.weekdays"   = "Recurring journal";
+"common.cancel"               = "Cancel";
+"common.save"                 = "Save";
+"coach.reminder.confirmed"    = "Scheduled: %@ %@. I'll nudge you then — edit or remove it anytime from the reminder strip on Today.";
+"coach.reminder.clarify"      = "Sure — when should I remind you? Try \"tonight\", \"tomorrow morning\", \"in an hour\", or a concrete time like \"tomorrow 15:00\"; for repeats, say \"every day at 22:00\".";
+
 /* Banners */
 "today.banner.draft_restored" = "Restored your unsent draft";
 "today.banner.voice_queue"    = "You have %d voice notes pending transcription";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -374,6 +374,26 @@
 "today.focus.a11y.expanded"  = "已展开";
 "today.focus.a11y.collapsed" = "已折叠，轻点两下选择焦点";
 
+/* Reminder vNext — Today 胶囊条 + 编辑 sheet + AI 调度 */
+"today.reminder.add"          = "提醒我";
+"reminder.kind.once"          = "一次";
+"reminder.kind.daily"         = "每天";
+"reminder.kind.weekdays"      = "周几";
+"reminder.quick"              = "快捷";
+"reminder.time"               = "时间";
+"reminder.weekdays"           = "重复";
+"reminder.label.placeholder"  = "标签（可空）";
+"reminder.delete"             = "删除提醒";
+"reminder.new.title"          = "新提醒";
+"reminder.edit.title"         = "编辑提醒";
+"reminder.default.once"       = "稍后";
+"reminder.default.daily"      = "每日记录";
+"reminder.default.weekdays"   = "定期记录";
+"common.cancel"               = "取消";
+"common.save"                 = "保存";
+"coach.reminder.confirmed"    = "已排好：%@ %@。到点我会来敲你——在 Today 顶部的提醒条里随时可改可删。";
+"coach.reminder.clarify"      = "好——几点提醒你？可以说「今晚」「明早」「一小时后」，或者给个具体时间，比如「明天 15:00」；重复的话说「每天 22:00」「周一三五 9 点」。";
+
 /* LocationDraftCard */
 "today.location_draft.header" = "检测到位置到达";
 "today.location_draft.ignore_all" = "全部忽略";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -363,6 +363,17 @@
 "today.section.yesterday" = "YESTERDAY";
 "today.section.earlier" = "EARLIER";
 
+/* Canvas vNext — 编成卡 ribbon + meta（修复 YESTERDAY 下写死英文
+   "Today's page compiled" 的自相矛盾） */
+"today.card.compiled.today"     = "今日已编成";
+"today.card.compiled.yesterday" = "昨日已编成";
+"today.card.meta.memos"         = "%d 条 memo";
+
+/* Canvas vNext — 今日焦点渐进披露 */
+"today.focus.label"          = "今日焦点";
+"today.focus.a11y.expanded"  = "已展开";
+"today.focus.a11y.collapsed" = "已折叠，轻点两下选择焦点";
+
 /* LocationDraftCard */
 "today.location_draft.header" = "检测到位置到达";
 "today.location_draft.ignore_all" = "全部忽略";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -1171,3 +1171,23 @@
 "memo.chat.a11y.detach"              = "摘除这条记忆";
 "memo.chat.a11y.source"              = "查看 %@ 的记录";
 "memo.chat.a11y.send"                = "发送";
+
+// MARK: - Chat River (对话长河 — AI 聊天历史 session 化)
+
+"chat.river.earlier"                = "更早的对话";
+"chat.river.continue"               = "继续这段对话";
+"chat.river.export"                 = "导出 (.md)";
+"chat.river.select"                 = "选择多段…";
+"chat.river.delete"                 = "删除";
+"chat.river.delete.confirm.title"   = "删除这段对话？";
+"chat.river.delete.confirm.message" = "对话文件将从 vault 中移除，不可恢复。";
+"chat.river.selected"               = "已选 %d 段";
+"chat.river.export_n"               = "导出 %d 段";
+"chat.river.selection.done"         = "完成";
+"chat.river.current_marker"         = "当前对话";
+"chat.river.turns"                  = "%d 轮";
+"chat.river.today"                  = "今天";
+"chat.river.yesterday"              = "昨天";
+"chat.river.badge.ask"              = "问";
+"chat.river.badge.memo"             = "锚";
+"chat.river.badge.coach"            = "陪写";

--- a/DayPage/Services/CaptureReminderService.swift
+++ b/DayPage/Services/CaptureReminderService.swift
@@ -9,21 +9,26 @@ import AlarmKit
 
 // MARK: - CaptureReminderService
 //
-// 「定时召唤记录」的定时引擎。到配置的时间点,系统发一条本地通知(横幅 + 灵动岛
-// Live Activity 的落点),用户点一下就落进录音舱 / 文字输入,把当下记进 vault。
+// 「定时召唤记录」的统一调度器。到配置的时间点,系统发一条本地通知(横幅 +
+// 灵动岛落点),用户点一下就落进录音舱 / 文字输入,把当下记进 vault。
+//
+// vNext(2026-07-15):统一到单一 `Reminder` 模型 —— 一个 `reminders: [Reminder]`
+// 集合,一个 `schedule()` 入口,按 `trigger` 分派:
+//   • .once(Date)          → UNTimeInterval / AlarmKit .fixed(一次性,触发后剔除)
+//   • .daily / .weekdays   → UNCalendar / AlarmKit .relative(重复)
+// AI(对话调度)和 UI(Today 胶囊)都只调这一套 API。复杂度收在调度里。
 //
 // 设计要点:
-//   • 每个启用的时间点(ReminderSlot)注册一条 UNCalendarNotificationTrigger
-//     (repeats: true),identifier 稳定 = "daypage.capture.<slotID>",
-//     重排时先按前缀全部移除再重装,避免残留。
-//   • 通知带一个 category(kCategoryID),两个 action:「语音」「文字」+ 默认点击。
-//     长按/下拉通知 → 展开 action;action 与默认点击都路由到既有 deeplink
-//     (daypage://record / daypage://memo/new),复用 DayPageApp.onOpenURL,
-//     不新增录音 / 输入落地逻辑。
-//   • 静音时段(quiet hours)在注册时过滤:落在静音区间内的时间点直接跳过,
-//     不打扰用户。
-//   • 全部配置存 UserDefaults(JSON slots + preset + quiet hours),
+//   • identifier 稳定 = "daypage.capture.<reminderID>",重排时按前缀全清再重装。
+//   • 通知带 category(actions:语音/文字)+ 默认点击,路由到既有 deeplink,
+//     不新增录音/输入落地逻辑。
+//   • 静音时段(quiet hours)在注册时过滤重复提醒;一次性提醒不受静音影响
+//     (用户/AI 明确指定的精确时间,不该被静音吞掉)。
+//   • 一次性提醒触发后自动清理(启动 + 每次重排时剔除已过期的 .once)。
+//   • 配置存 UserDefaults(JSON reminders + preset + quiet hours),
 //     @MainActor singleton 驱动 SwiftUI。
+//   • 兼容:旧 `captureReminder.slots`(ReminderSlot 数组)一次性迁移成
+//     新 `captureReminder.reminders`(Reminder 数组),用户已配置不丢。
 //
 // 与 FeatureFlag.captureReminder 联动:flag 关 → refreshSchedule 清空所有
 // 已注册的提醒(kill switch,无需 hot-fix)。
@@ -53,14 +58,18 @@ final class CaptureReminderService: ObservableObject {
     // MARK: Published config
 
     @Published private(set) var preset: ReminderPreset
-    @Published private(set) var slots: [ReminderSlot]
+    /// 统一提醒集合 —— 重复 + 一次性都在这里。UI/AI 通过下面的 API 增删改。
+    @Published private(set) var reminders: [Reminder]
     @Published private(set) var quietHours: QuietHours
 
     // MARK: UserDefaults keys
 
     private enum Keys {
         static let preset = "captureReminder.preset"
-        static let slots = "captureReminder.slots"
+        /// 旧 key(ReminderSlot 数组)—— 仅用于一次性迁移读取。
+        static let legacySlots = "captureReminder.slots"
+        /// 新 key(Reminder 数组)。
+        static let reminders = "captureReminder.reminders"
         static let quiet = "captureReminder.quietHours"
         static let preferAlarmKit = "captureReminder.preferAlarmKit"
     }
@@ -72,61 +81,83 @@ final class CaptureReminderService: ObservableObject {
     init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         self.preset = Self.loadPreset(defaults)
-        self.slots = Self.loadSlots(defaults)
+        self.reminders = Self.loadReminders(defaults)
         self.quietHours = Self.loadQuietHours(defaults)
+        // 启动时清一次过期的一次性提醒(冷启动补账)。
+        pruneExpiredOneShots()
     }
 
-    // MARK: - Public API
+    // MARK: - Public API (presets)
 
-    /// 切换预设。`.custom` 保留用户手动编辑的 slots;`.once` / `.thrice` 覆盖
-    /// 成对应的默认时间点(晚 21:00 / 早中晚 09:00·13:00·21:00)。
+    /// 切换预设。`.custom` 保留用户手动编辑的提醒;`.once` / `.thrice` 覆盖
+    /// 成对应的默认时间点。仅影响重复提醒;一次性提醒不被预设切换清掉。
     func apply(preset newPreset: ReminderPreset) {
         preset = newPreset
+        let oneShots = reminders.filter { $0.isOneShot }
         switch newPreset {
         case .once:
-            slots = ReminderSlot.onceDefaults
+            reminders = Reminder.onceDefaults + oneShots
         case .thrice:
-            slots = ReminderSlot.thriceDefaults
+            reminders = Reminder.thriceDefaults + oneShots
         case .custom:
-            // 保留现有 slots;custom 只解锁「添加 / 删除时间点」的 UI。
-            if slots.isEmpty { slots = ReminderSlot.onceDefaults }
+            // 保留现有;custom 只解锁「增删提醒」的 UI。若空了给个默认。
+            if reminders.filter({ !$0.isOneShot }).isEmpty {
+                reminders = Reminder.onceDefaults + oneShots
+            }
         }
         persist()
         refreshSchedule()
     }
 
-    /// 开 / 关单个时间点。
-    func setSlot(_ id: UUID, enabled: Bool) {
-        guard let idx = slots.firstIndex(where: { $0.id == id }) else { return }
-        slots[idx].enabled = enabled
+    // MARK: - Public API (unified reminder mutations)
+
+    /// 开 / 关单条提醒。
+    func setReminder(_ id: UUID, enabled: Bool) {
+        guard let idx = reminders.firstIndex(where: { $0.id == id }) else { return }
+        reminders[idx].enabled = enabled
         persist()
         refreshSchedule()
     }
 
-    /// 编辑某个时间点的时分。
-    func updateSlot(_ id: UUID, hour: Int, minute: Int) {
-        guard let idx = slots.firstIndex(where: { $0.id == id }) else { return }
-        slots[idx].hour = max(0, min(23, hour))
-        slots[idx].minute = max(0, min(59, minute))
+    /// 整体替换某条提醒的 trigger(编辑 sheet 保存时用)。
+    func updateReminder(_ id: UUID, trigger: Reminder.Trigger, label: String? = nil) {
+        guard let idx = reminders.firstIndex(where: { $0.id == id }) else { return }
+        reminders[idx].trigger = trigger
+        if let label { reminders[idx].label = label }
+        sortReminders()
         persist()
         refreshSchedule()
     }
 
-    /// 添加一个自定义时间点(仅 `.custom` 预设下 UI 可达)。
-    func addSlot(hour: Int, minute: Int, label: String) {
-        let slot = ReminderSlot(hour: max(0, min(23, hour)),
-                                minute: max(0, min(59, minute)),
-                                label: label,
-                                enabled: true)
-        slots.append(slot)
-        slots.sort { ($0.hour, $0.minute) < ($1.hour, $1.minute) }
+    /// 添加一条提醒 —— UI 和 AI 的统一落地入口。返回新建的 Reminder。
+    @discardableResult
+    func addReminder(_ reminder: Reminder) -> Reminder {
+        reminders.append(reminder)
+        sortReminders()
         persist()
         refreshSchedule()
+        return reminder
     }
 
-    /// 删除一个时间点。
-    func removeSlot(_ id: UUID) {
-        slots.removeAll { $0.id == id }
+    /// 便捷:排一条一次性提醒到精确时间点(AI/Today「稍后」用)。
+    /// 传入的 fireDate 已过则不排,返回 nil。
+    @discardableResult
+    func scheduleOnce(at fireDate: Date, label: String, source: Reminder.Source = .user) -> Reminder? {
+        guard fireDate > Date() else { return nil }
+        let reminder = Reminder(trigger: .once(fireDate), label: label, source: source)
+        return addReminder(reminder)
+    }
+
+    /// 便捷:排一条重复提醒(AI/Today 新建重复用)。
+    @discardableResult
+    func scheduleRepeating(trigger: Reminder.Trigger, label: String, source: Reminder.Source = .user) -> Reminder {
+        let reminder = Reminder(trigger: trigger, label: label, source: source)
+        return addReminder(reminder)
+    }
+
+    /// 删除一条提醒。
+    func removeReminder(_ id: UUID) {
+        reminders.removeAll { $0.id == id }
         persist()
         refreshSchedule()
     }
@@ -138,12 +169,27 @@ final class CaptureReminderService: ObservableObject {
         refreshSchedule()
     }
 
+    // MARK: - Derived queries (Today 胶囊)
+
+    /// 即将触发的提醒,按 nextFireDate 升序。用于 Today 页轻量胶囊行。
+    /// 只返回启用且有下次触发的;limit 控制条数。
+    func upcoming(limit: Int = 3, now: Date = Date()) -> [Reminder] {
+        reminders
+            .compactMap { r -> (Reminder, Date)? in
+                guard let next = r.nextFireDate(after: now) else { return nil }
+                return (r, next)
+            }
+            .sorted { $0.1 < $1.1 }
+            .prefix(limit)
+            .map(\.0)
+    }
+
+    // MARK: - Onboarding
+
     /// onboarding 引导「一键开启」用:落地一个预设并请求权限、注册通知。
-    /// 返回是否拿到通知授权(供 UI 反馈)。
+    /// 返回是否拿到通知授权(供 UI 反馈)。签名保持不变(Onboarding 依赖)。
     @discardableResult
     func enableFromOnboarding(preset onboardPreset: ReminderPreset) async -> Bool {
-        // iOS 26+ 优先请求 AlarmKit 授权(真灵动岛);拿不到再退普通通知权限。
-        // 两个都请求:AlarmKit 走灵动岛,普通通知是 16.1–25 / AlarmKit 被拒时的回退。
         if #available(iOS 26.0, *) {
             #if canImport(AlarmKit)
             await requestAlarmKitAuthorization()
@@ -151,29 +197,52 @@ final class CaptureReminderService: ObservableObject {
         }
         let granted = await requestAuthorizationIfNeeded()
         preset = onboardPreset
-        slots = onboardPreset == .thrice ? ReminderSlot.thriceDefaults : ReminderSlot.onceDefaults
+        let base = onboardPreset == .thrice ? Reminder.thriceDefaults : Reminder.onceDefaults
+        // 保留可能已有的一次性提醒。
+        reminders = base + reminders.filter { $0.isOneShot }
         persist()
         registerCategoryIfNeeded()
         refreshSchedule()
         return granted
     }
 
+    /// 请求通知授权(AI/Today 首次排提醒前调,确保能真的响)。
+    @discardableResult
+    func ensureAuthorized() async -> Bool {
+        if #available(iOS 26.0, *) {
+            #if canImport(AlarmKit)
+            await requestAlarmKitAuthorization()
+            #endif
+        }
+        return await requestAuthorizationIfNeeded()
+    }
+
     // MARK: - Scheduling
 
-    /// 幂等重排。两条路径:
-    ///   • iOS 26+ 且 AlarmKit 已授权 → 用 AlarmKit 排系统级灵动岛/锁屏定时提醒
-    ///     (真·灵动岛),同时清掉 UNCalendar 侧的旧通知避免重复提醒。
-    ///   • iOS 16.1–25(或 AlarmKit 未授权)→ 回退 UNCalendarNotificationTrigger
-    ///     本地通知(通知到达时在灵动岛机型上也会短暂进灵动岛区域)。
+    /// 幂等重排。先剔除过期一次性,再按两条路径装载:
+    ///   • iOS 26+ 且 AlarmKit 已授权 → AlarmKit(真灵动岛),同时清 UNCalendar 侧。
+    ///   • 否则 → UN 通知(一次性用 TimeInterval,重复用 Calendar)。
     /// FeatureFlag 关时只清不装(两条路径都清)。
     func refreshSchedule() {
         registerCategoryIfNeeded()
+        pruneExpiredOneShots()
 
         if #available(iOS 26.0, *), useAlarmKit {
             refreshViaAlarmKit()
             return
         }
         refreshViaNotifications()
+    }
+
+    /// 剔除已过期的一次性提醒(fireDate < now)。重复提醒不受影响。
+    private func pruneExpiredOneShots() {
+        let now = Date()
+        let before = reminders.count
+        reminders.removeAll { r in
+            if case .once(let date) = r.trigger { return date <= now }
+            return false
+        }
+        if reminders.count != before { persist() }
     }
 
     private func refreshViaNotifications() {
@@ -191,38 +260,69 @@ final class CaptureReminderService: ObservableObject {
                     DayPageLogger.shared.info("[CaptureReminder] flag off — cleared \(stale.count) reminders")
                     return
                 }
-                self.installActiveSlots(into: center)
+                self.installActiveReminders(into: center)
             }
         }
     }
 
-    private func installActiveSlots(into center: UNUserNotificationCenter) {
-        let active = slots.filter { $0.enabled && !quietHours.contains(hour: $0.hour, minute: $0.minute) }
-        for slot in active {
-            var comps = DateComponents()
-            comps.hour = slot.hour
-            comps.minute = slot.minute
-            let trigger = UNCalendarNotificationTrigger(dateMatching: comps, repeats: true)
+    private func installActiveReminders(into center: UNUserNotificationCenter) {
+        var scheduled = 0
+        for reminder in reminders where reminder.enabled {
+            // 一条 Reminder 可能展开成多条 UN request(weekdays:每个周几一条)。
+            // sub-identifier 用 "<prefix><id>" 或 "<prefix><id>.w<weekday>",
+            // 都以 requestPrefix 打头,重排时被前缀清理统一带走。
+            for spec in notificationSpecs(for: reminder) {
+                let content = UNMutableNotificationContent()
+                content.title = "记录此刻"
+                content.body = reminder.promptBody
+                content.sound = .default
+                content.categoryIdentifier = Self.categoryID
+                content.userInfo = ["captureReminderID": reminder.id.uuidString]
 
-            let content = UNMutableNotificationContent()
-            content.title = "记录此刻"
-            content.body = slot.promptBody
-            content.sound = .default
-            content.categoryIdentifier = Self.categoryID
-            content.userInfo = ["captureReminderSlot": slot.id.uuidString]
-
-            let request = UNNotificationRequest(
-                identifier: Self.requestPrefix + slot.id.uuidString,
-                content: content,
-                trigger: trigger
-            )
-            center.add(request) { error in
-                if let error {
-                    DayPageLogger.shared.error("[CaptureReminder] add failed: \(error.localizedDescription)")
+                let request = UNNotificationRequest(
+                    identifier: spec.identifier,
+                    content: content,
+                    trigger: spec.trigger
+                )
+                center.add(request) { error in
+                    if let error {
+                        DayPageLogger.shared.error("[CaptureReminder] add failed: \(error.localizedDescription)")
+                    }
                 }
+                scheduled += 1
             }
         }
-        DayPageLogger.shared.info("[CaptureReminder] scheduled \(active.count) reminders")
+        DayPageLogger.shared.info("[CaptureReminder] scheduled \(scheduled) requests")
+    }
+
+    /// 把一条 Reminder 展开成 (identifier, trigger) 列表。
+    /// 静音时段只过滤重复提醒;一次性(明确指定)不被静音吞掉。
+    /// weekdays 展开成 N 条(UNCalendar 一条只能匹配一个 weekday)。
+    private func notificationSpecs(for reminder: Reminder) -> [(identifier: String, trigger: UNNotificationTrigger)] {
+        let base = Self.requestPrefix + reminder.id.uuidString
+        switch reminder.trigger {
+        case .once(let date):
+            let interval = date.timeIntervalSinceNow
+            guard interval > 0 else { return [] }
+            return [(base, UNTimeIntervalNotificationTrigger(timeInterval: interval, repeats: false))]
+
+        case .daily(let h, let m):
+            if quietHours.contains(hour: h, minute: m) { return [] }
+            var comps = DateComponents()
+            comps.hour = h
+            comps.minute = m
+            return [(base, UNCalendarNotificationTrigger(dateMatching: comps, repeats: true))]
+
+        case .weekdays(let days, let h, let m):
+            if quietHours.contains(hour: h, minute: m) { return [] }
+            return days.sorted().map { weekday in
+                var comps = DateComponents()
+                comps.weekday = weekday
+                comps.hour = h
+                comps.minute = m
+                return ("\(base).w\(weekday)", UNCalendarNotificationTrigger(dateMatching: comps, repeats: true))
+            }
+        }
     }
 
     // MARK: - Category (long-press actions)
@@ -251,7 +351,6 @@ final class CaptureReminderService: ObservableObject {
             intentIdentifiers: [],
             options: []
         )
-        // 合并已有 category,避免覆盖别处注册的(如未来其他通知类型)。
         UNUserNotificationCenter.current().getNotificationCategories { existing in
             var merged = existing
             merged.insert(category)
@@ -261,8 +360,6 @@ final class CaptureReminderService: ObservableObject {
 
     // MARK: - AlarmKit (iOS 26+ 真灵动岛路径)
 
-    /// 是否走 AlarmKit。仅当运行在 iOS 26+、flag 开、且 AlarmKit 已授权时为真。
-    /// 用户可通过设置里的「系统灵动岛」开关关掉,回退到普通通知。
     private var useAlarmKit: Bool {
         guard FeatureFlagStore.shared.isEnabled(.captureReminder) else { return false }
         guard preferAlarmKit else { return false }
@@ -284,10 +381,9 @@ final class CaptureReminderService: ObservableObject {
         }
     }
 
-    /// AlarmKit 是否已授权 —— 由 requestAlarmKitAuthorization 更新。
     @Published private(set) var alarmKitAuthorized = false
 
-    /// AlarmKit 在当前系统上是否可用(iOS 26+)。UI 用它决定是否显示「系统灵动岛」开关。
+    /// AlarmKit 在当前系统上是否可用(iOS 26+)。UI 用它决定是否显示开关。
     var isAlarmKitAvailable: Bool {
         if #available(iOS 26.0, *) { return true }
         return false
@@ -297,7 +393,6 @@ final class CaptureReminderService: ObservableObject {
     @available(iOS 26.0, *)
     private var alarmManager: AlarmManager { .shared }
 
-    /// 请求 AlarmKit 授权(onboarding「开启提醒」时,若在 iOS 26+ 上顺带请求)。
     @available(iOS 26.0, *)
     @discardableResult
     func requestAlarmKitAuthorization() async -> Bool {
@@ -319,11 +414,10 @@ final class CaptureReminderService: ObservableObject {
         }
     }
 
-    /// AlarmKit 重排:取消所有本 app 排的 alarm,清掉 UNCalendar 侧旧通知(避免
-    /// 双重提醒),再为每个「启用且不在静音时段」的 slot 排一条 weekly-repeat alarm。
+    /// AlarmKit 重排:清 UNCalendar 侧旧通知 → 取消旧 alarm → 为每条启用的
+    /// 提醒排 alarm(一次性 = .fixed;重复 = .relative)。
     @available(iOS 26.0, *)
     private func refreshViaAlarmKit() {
-        // 先清 UNCalendar 侧,避免与 AlarmKit 重复提醒。
         let center = UNUserNotificationCenter.current()
         center.getPendingNotificationRequests { requests in
             let stale = requests.map(\.identifier).filter { $0.hasPrefix(Self.requestPrefix) }
@@ -333,30 +427,47 @@ final class CaptureReminderService: ObservableObject {
         }
 
         Task { @MainActor in
-            // 取消旧 alarm。cancelAll 不存在,逐个 cancel 已知 slot id。
-            for slot in slots {
-                try? await alarmManager.cancel(id: slot.id)
+            for reminder in reminders {
+                try? await alarmManager.cancel(id: reminder.id)
             }
             guard FeatureFlagStore.shared.isEnabled(.captureReminder) else {
                 DayPageLogger.shared.info("[CaptureReminder] flag off — cancelled AlarmKit alarms")
                 return
             }
-            let active = slots.filter { $0.enabled && !quietHours.contains(hour: $0.hour, minute: $0.minute) }
-            for slot in active {
-                await scheduleAlarm(for: slot)
+            var scheduled = 0
+            for reminder in reminders where reminder.enabled {
+                if await scheduleAlarm(for: reminder) { scheduled += 1 }
             }
-            DayPageLogger.shared.info("[CaptureReminder] AlarmKit scheduled \(active.count) alarms")
+            DayPageLogger.shared.info("[CaptureReminder] AlarmKit scheduled \(scheduled) alarms")
         }
     }
 
+    /// 为一条 Reminder 排 AlarmKit alarm。返回是否真的排了(静音/过期跳过 = false)。
     @available(iOS 26.0, *)
-    private func scheduleAlarm(for slot: ReminderSlot) async {
-        let time = Alarm.Schedule.Relative.Time(hour: slot.hour, minute: slot.minute)
-        // 每天重复。weekly 全 7 天 = 每天。
-        let allWeekdays: [Locale.Weekday] = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
-        let schedule = Alarm.Schedule.relative(.init(time: time, repeats: .weekly(allWeekdays)))
+    @discardableResult
+    private func scheduleAlarm(for reminder: Reminder) async -> Bool {
+        let schedule: Alarm.Schedule
+        switch reminder.trigger {
+        case .once(let date):
+            guard date > Date() else { return false }
+            let comps = Calendar.current.dateComponents(
+                [.year, .month, .day, .hour, .minute], from: date)
+            schedule = .fixed(Calendar.current.date(from: comps) ?? date)
 
-        // 「记录此刻」的 alert:主按钮「知道了」停止,次按钮「记一句」打开 app 录音。
+        case .daily(let h, let m):
+            if quietHours.contains(hour: h, minute: m) { return false }
+            let time = Alarm.Schedule.Relative.Time(hour: h, minute: m)
+            let all: [Locale.Weekday] = [.sunday, .monday, .tuesday, .wednesday, .thursday, .friday, .saturday]
+            schedule = .relative(.init(time: time, repeats: .weekly(all)))
+
+        case .weekdays(let days, let h, let m):
+            if quietHours.contains(hour: h, minute: m) { return false }
+            let time = Alarm.Schedule.Relative.Time(hour: h, minute: m)
+            let weekdays = days.compactMap(Self.localeWeekday(from:))
+            guard !weekdays.isEmpty else { return false }
+            schedule = .relative(.init(time: time, repeats: .weekly(weekdays)))
+        }
+
         let alert = AlarmPresentation.Alert(
             title: LocalizedStringResource(stringLiteral: "记录此刻"),
             stopButton: AlarmButton(
@@ -372,14 +483,12 @@ final class CaptureReminderService: ObservableObject {
             secondaryButtonBehavior: .custom
         )
         let presentation = AlarmPresentation(alert: alert)
-        let metadata = CaptureAlarmMetadata(prompt: slot.promptBody, slotID: slot.id.uuidString)
+        let metadata = CaptureAlarmMetadata(prompt: reminder.promptBody, slotID: reminder.id.uuidString)
         let attributes = AlarmAttributes(
             presentation: presentation,
             metadata: metadata,
-            tintColor: Color(red: 0.74, green: 0.49, blue: 0.14) // 琥珀 amber,呼应品牌
+            tintColor: Color(red: 0.74, green: 0.49, blue: 0.14)
         )
-
-        // 次按钮打开 app → 走既有 daypage://record 录音路径。
         let config = AlarmManager.AlarmConfiguration(
             countdownDuration: nil,
             schedule: schedule,
@@ -388,11 +497,27 @@ final class CaptureReminderService: ObservableObject {
             secondaryIntent: nil,
             sound: .default
         )
-
         do {
-            _ = try await alarmManager.schedule(id: slot.id, configuration: config)
+            _ = try await alarmManager.schedule(id: reminder.id, configuration: config)
+            return true
         } catch {
             DayPageLogger.shared.error("[CaptureReminder] AlarmKit schedule failed: \(error.localizedDescription)")
+            return false
+        }
+    }
+
+    /// Calendar weekday(1=日…7=六) → AlarmKit Locale.Weekday。
+    @available(iOS 26.0, *)
+    private static func localeWeekday(from calendarWeekday: Int) -> Locale.Weekday? {
+        switch calendarWeekday {
+        case 1: return .sunday
+        case 2: return .monday
+        case 3: return .tuesday
+        case 4: return .wednesday
+        case 5: return .thursday
+        case 6: return .friday
+        case 7: return .saturday
+        default: return nil
         }
     }
 #endif
@@ -415,10 +540,24 @@ final class CaptureReminderService: ObservableObject {
 
     // MARK: - Persistence
 
+    private func sortReminders() {
+        // 一次性按 fireDate,重复按时分;整体一次性在前(临近感)。
+        reminders.sort { a, b in
+            switch (a.isOneShot, b.isOneShot) {
+            case (true, false): return true
+            case (false, true): return false
+            default:
+                let (ah, am) = a.timeComponents
+                let (bh, bm) = b.timeComponents
+                return (ah, am) < (bh, bm)
+            }
+        }
+    }
+
     private func persist() {
         defaults.set(preset.rawValue, forKey: Keys.preset)
-        if let data = try? JSONEncoder().encode(slots) {
-            defaults.set(data, forKey: Keys.slots)
+        if let data = try? JSONEncoder().encode(reminders) {
+            defaults.set(data, forKey: Keys.reminders)
         }
         if let data = try? JSONEncoder().encode(quietHours) {
             defaults.set(data, forKey: Keys.quiet)
@@ -433,13 +572,39 @@ final class CaptureReminderService: ObservableObject {
         return preset
     }
 
-    private static func loadSlots(_ defaults: UserDefaults) -> [ReminderSlot] {
-        guard let data = defaults.data(forKey: Keys.slots),
-              let slots = try? JSONDecoder().decode([ReminderSlot].self, from: data),
-              !slots.isEmpty else {
-            return ReminderSlot.onceDefaults
+    /// 加载提醒。优先读新 key;若无但有旧 slots → 迁移;都无 → 默认。
+    private static func loadReminders(_ defaults: UserDefaults) -> [Reminder] {
+        if let data = defaults.data(forKey: Keys.reminders),
+           let list = try? JSONDecoder().decode([Reminder].self, from: data),
+           !list.isEmpty {
+            return list
         }
-        return slots
+        // 迁移:旧 ReminderSlot 数组 → Reminder。
+        if let migrated = migrateLegacySlots(defaults) {
+            if let data = try? JSONEncoder().encode(migrated) {
+                defaults.set(data, forKey: Keys.reminders)
+            }
+            defaults.removeObject(forKey: Keys.legacySlots)
+            return migrated
+        }
+        return Reminder.onceDefaults
+    }
+
+    /// 旧 ReminderSlot(每日重复)→ Reminder(.daily)。仅在首次升级时跑一次。
+    private static func migrateLegacySlots(_ defaults: UserDefaults) -> [Reminder]? {
+        guard let data = defaults.data(forKey: Keys.legacySlots),
+              let slots = try? JSONDecoder().decode([LegacySlot].self, from: data),
+              !slots.isEmpty else {
+            return nil
+        }
+        return slots.map { slot in
+            Reminder(
+                trigger: .daily(hour: slot.hour, minute: slot.minute),
+                label: slot.label,
+                enabled: slot.enabled,
+                source: .user
+            )
+        }
     }
 
     private static func loadQuietHours(_ defaults: UserDefaults) -> QuietHours {
@@ -451,12 +616,24 @@ final class CaptureReminderService: ObservableObject {
     }
 }
 
-// MARK: - Models
+// MARK: - Legacy migration shape
+
+/// 旧 `ReminderSlot` 的解码用形状 —— 仅供一次性迁移读取旧 UserDefaults。
+/// 原类型已删,此处保留最小字段镜像避免破坏已升级用户的数据。
+private struct LegacySlot: Codable {
+    let id: UUID
+    var hour: Int
+    var minute: Int
+    var label: String
+    var enabled: Bool
+}
+
+// MARK: - Preset
 
 enum ReminderPreset: String, CaseIterable {
     case once    // 每天一次(晚)
     case thrice  // 早中晚三次
-    case custom  // 自定义时间点
+    case custom  // 自定义
 
     var title: String {
         switch self {
@@ -467,55 +644,13 @@ enum ReminderPreset: String, CaseIterable {
     }
 }
 
-struct ReminderSlot: Codable, Identifiable, Equatable {
-    let id: UUID
-    var hour: Int
-    var minute: Int
-    var label: String
-    var enabled: Bool
-
-    init(id: UUID = UUID(), hour: Int, minute: Int, label: String, enabled: Bool) {
-        self.id = id
-        self.hour = hour
-        self.minute = minute
-        self.label = label
-        self.enabled = enabled
-    }
-
-    /// "HH:mm" 展示用。
-    var timeString: String {
-        String(format: "%02d:%02d", hour, minute)
-    }
-
-    /// 通知正文 —— 随时段给一句轻的提示,不用命令式。
-    var promptBody: String {
-        switch hour {
-        case 5..<11:  return "早上好 · 记一句此刻在想什么"
-        case 11..<15: return "间隙里 · 留一条给今天"
-        case 15..<19: return "下午了 · 有什么值得记下的"
-        default:      return "睡前 · 把今天收进一句话"
-        }
-    }
-
-    // 预设默认时间点。id 固定生成,但预设切换时整组替换,不复用旧 id。
-    static var onceDefaults: [ReminderSlot] {
-        [ReminderSlot(hour: 21, minute: 0, label: "睡前", enabled: true)]
-    }
-
-    static var thriceDefaults: [ReminderSlot] {
-        [
-            ReminderSlot(hour: 9,  minute: 0, label: "早", enabled: true),
-            ReminderSlot(hour: 13, minute: 0, label: "午", enabled: true),
-            ReminderSlot(hour: 21, minute: 0, label: "晚", enabled: true)
-        ]
-    }
-}
+// MARK: - QuietHours
 
 /// 静音时段。start/end 用「一天中的分钟数」(0…1439),支持跨午夜(start > end)。
 struct QuietHours: Codable, Equatable {
     var enabled: Bool
-    var startMinutes: Int  // 例:23:30 → 1410
-    var endMinutes: Int    // 例:08:00 → 480
+    var startMinutes: Int
+    var endMinutes: Int
 
     static let defaultQuiet = QuietHours(enabled: true, startMinutes: 23 * 60 + 30, endMinutes: 8 * 60)
 
@@ -527,10 +662,8 @@ struct QuietHours: Codable, Equatable {
         guard enabled else { return false }
         let m = hour * 60 + minute
         if startMinutes <= endMinutes {
-            // 同日区间,如 01:00–06:00
             return m >= startMinutes && m < endMinutes
         } else {
-            // 跨午夜,如 23:30–08:00
             return m >= startMinutes || m < endMinutes
         }
     }

--- a/DayPage/Services/RelativeTimeResolver.swift
+++ b/DayPage/Services/RelativeTimeResolver.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+// MARK: - RelativeTimeResolver
+//
+// 把「一小时后 / 今晚 / 明早」这类相对时间语义解析成绝对触发时间点(Date)。
+// UI 的「稍后提醒」快捷 chips 和 AI 意图解析都调它 —— 单一事实源,避免两处
+// 各写一套「今晚是几点」的口径分叉。
+//
+// 语义约定(可被产品调):
+//   • tonight        今晚 → 当天 20:00;若已过则不顺延(返回过去时刻由调用方过滤)
+//   • tomorrowMorning明早 → 次日 08:00
+//   • tomorrowNight  明晚 → 次日 20:00
+//   • afterInterval  相对秒数(如 +3600 = 一小时后)
+//   • at             具体时分(今天该时分,已过则明天)
+//   • absolute       AI 已给出的绝对 Date,原样透传
+//
+// 纯静态、无副作用;传入 `now`/`calendar` 便于测试。
+
+enum RelativeTimeResolver {
+
+    /// 支持的相对时间 token。AI 意图 JSON 的 `relative` 字段映射到这里。
+    enum Token: Equatable {
+        case tonight
+        case tomorrowMorning
+        case tomorrowNight
+        case afterSeconds(TimeInterval)
+        case at(hour: Int, minute: Int)
+        case absolute(Date)
+    }
+
+    /// 今晚的钟点(20:00)。集中成常量,UI 文案与解析共用。
+    static let eveningHour = 20
+    /// 明早的钟点(08:00)。
+    static let morningHour = 8
+
+    /// 解析成绝对触发时间点。返回 nil 表示无法解析(调用方回退)。
+    /// 注意:一次性提醒若解析出的时间点已过(如 22:00 说「今晚」),
+    /// 返回该过去时刻 —— 由调用方决定顺延还是拒绝(调度器会剔除过期)。
+    static func resolve(_ token: Token, now: Date = Date(), calendar: Calendar = .current) -> Date? {
+        switch token {
+        case .tonight:
+            return dateToday(hour: eveningHour, minute: 0, now: now, calendar: calendar)
+        case .tomorrowMorning:
+            return dateTomorrow(hour: morningHour, minute: 0, now: now, calendar: calendar)
+        case .tomorrowNight:
+            return dateTomorrow(hour: eveningHour, minute: 0, now: now, calendar: calendar)
+        case .afterSeconds(let secs):
+            return now.addingTimeInterval(secs)
+        case .at(let h, let m):
+            // 今天该时分;已过则明天。
+            guard let today = dateToday(hour: h, minute: m, now: now, calendar: calendar) else { return nil }
+            return today > now ? today : calendar.date(byAdding: .day, value: 1, to: today)
+        case .absolute(let date):
+            return date
+        }
+    }
+
+    // MARK: - Quick chip tokens (Today「稍后提醒」)
+
+    /// Today 页「稍后提醒我…」的快捷选项。顺序即 UI 展示顺序。
+    static var quickChips: [(title: String, token: Token)] {
+        [
+            ("1 小时后", .afterSeconds(3600)),
+            ("今晚", .tonight),
+            ("明早", .tomorrowMorning)
+        ]
+    }
+
+    // MARK: - Helpers
+
+    private static func dateToday(hour: Int, minute: Int, now: Date, calendar: Calendar) -> Date? {
+        var comps = calendar.dateComponents([.year, .month, .day], from: now)
+        comps.hour = hour
+        comps.minute = minute
+        return calendar.date(from: comps)
+    }
+
+    private static func dateTomorrow(hour: Int, minute: Int, now: Date, calendar: Calendar) -> Date? {
+        guard let today = dateToday(hour: hour, minute: minute, now: now, calendar: calendar) else { return nil }
+        return calendar.date(byAdding: .day, value: 1, to: today)
+    }
+}

--- a/DayPage/Services/Reminder.swift
+++ b/DayPage/Services/Reminder.swift
@@ -1,0 +1,209 @@
+import Foundation
+
+// MARK: - Reminder
+//
+// 「记录提醒」的统一数据模型。取代旧的 ReminderSlot(每日重复)+ 想象中的
+// OneShot(一次性)两套 —— 一个 Reminder 用 `trigger` 表达所有节奏:
+//   • .once(Date)        —— 精确到某个绝对时间点,触发后自动消失
+//   • .daily(h, m)       —— 每天固定时分
+//   • .weekdays(days,h,m)—— 指定周几(1=周日…7=周六)的固定时分
+//
+// 设计动机(用户决策 2026-07-15):统一调度器,一个模型、一个 schedule 入口,
+// AI 和 UI 都只面对这一套 API。复杂度收在调度逻辑里,不外溢到多个类型。
+//
+// 归属:app target(DayPage/Services/)。只有 CaptureAlarmMetadata 需要
+// 跨 Widget target 共享;Reminder 本身不进 Widget,所以留在 app 侧。
+
+/// 一条记录提醒。`trigger` 决定何时触发,其余是展示与来源元信息。
+struct Reminder: Codable, Identifiable, Equatable {
+
+    // MARK: Trigger
+
+    /// 触发规则。Codable 用显式 tag,便于未来无损扩展(如 .monthly)。
+    enum Trigger: Codable, Equatable {
+        /// 一次性:精确到某个绝对时间点。触发后由调度器清理。
+        case once(Date)
+        /// 每天固定时分。
+        case daily(hour: Int, minute: Int)
+        /// 指定周几固定时分。weekdays 用 Calendar 周序:1=周日…7=周六。
+        case weekdays(days: Set<Int>, hour: Int, minute: Int)
+    }
+
+    /// 来源 —— 用户手动建 vs AI 在对话里排。用于 Today 页/埋点区分,不影响调度。
+    enum Source: String, Codable, Equatable {
+        case user
+        case ai
+    }
+
+    let id: UUID
+    var trigger: Trigger
+    var label: String
+    var enabled: Bool
+    var source: Source
+
+    init(
+        id: UUID = UUID(),
+        trigger: Trigger,
+        label: String,
+        enabled: Bool = true,
+        source: Source = .user
+    ) {
+        self.id = id
+        self.trigger = trigger
+        self.label = label
+        self.enabled = enabled
+        self.source = source
+    }
+
+    // MARK: - Derived display
+
+    /// 该 trigger 的「时分」—— 一次性取其本地时分,重复直接取字段。
+    var timeComponents: (hour: Int, minute: Int) {
+        switch trigger {
+        case .once(let date):
+            let c = Calendar.current.dateComponents([.hour, .minute], from: date)
+            return (c.hour ?? 0, c.minute ?? 0)
+        case .daily(let h, let m):
+            return (h, m)
+        case .weekdays(_, let h, let m):
+            return (h, m)
+        }
+    }
+
+    /// "HH:mm" 展示用。
+    var timeString: String {
+        let (h, m) = timeComponents
+        return String(format: "%02d:%02d", h, m)
+    }
+
+    /// 重复规则的一句人类可读描述(「每天」「工作日」「周六」「今晚一次」)。
+    var repeatDescription: String {
+        switch trigger {
+        case .once(let date):
+            return Self.relativeDayLabel(for: date)
+        case .daily:
+            return "每天"
+        case .weekdays(let days, _, _):
+            return Self.weekdayLabel(for: days)
+        }
+    }
+
+    /// 是否一次性 —— 用于调度器决定过期剔除,及 UI 分组。
+    var isOneShot: Bool {
+        if case .once = trigger { return true }
+        return false
+    }
+
+    /// 下次触发时间点。已启用时计算,禁用返回 nil。用于 Today 胶囊排序 &
+    /// 「即将触发」筛选。一次性直接返回 fireDate;重复算从 now 起最近一次。
+    func nextFireDate(after now: Date = Date(), calendar: Calendar = .current) -> Date? {
+        guard enabled else { return nil }
+        switch trigger {
+        case .once(let date):
+            return date > now ? date : nil
+        case .daily(let h, let m):
+            return Self.nextDaily(hour: h, minute: m, after: now, calendar: calendar)
+        case .weekdays(let days, let h, let m):
+            return Self.nextWeekday(days: days, hour: h, minute: m, after: now, calendar: calendar)
+        }
+    }
+
+    // MARK: - Next-fire helpers
+
+    private static func nextDaily(hour: Int, minute: Int, after now: Date, calendar: Calendar) -> Date? {
+        var comps = calendar.dateComponents([.year, .month, .day], from: now)
+        comps.hour = hour
+        comps.minute = minute
+        guard let today = calendar.date(from: comps) else { return nil }
+        if today > now { return today }
+        return calendar.date(byAdding: .day, value: 1, to: today)
+    }
+
+    private static func nextWeekday(days: Set<Int>, hour: Int, minute: Int, after now: Date, calendar: Calendar) -> Date? {
+        guard !days.isEmpty else { return nil }
+        // 从今天起最多看 7 天,命中第一个「周几匹配且时间在 now 之后」的点。
+        for offset in 0...7 {
+            guard let day = calendar.date(byAdding: .day, value: offset, to: now) else { continue }
+            let weekday = calendar.component(.weekday, from: day)
+            guard days.contains(weekday) else { continue }
+            var comps = calendar.dateComponents([.year, .month, .day], from: day)
+            comps.hour = hour
+            comps.minute = minute
+            guard let candidate = calendar.date(from: comps) else { continue }
+            if candidate > now { return candidate }
+        }
+        return nil
+    }
+
+    // MARK: - Label helpers
+
+    /// 周几集合 → 「每天」「工作日」「周末」「周一、三、五」这类描述。
+    static func weekdayLabel(for days: Set<Int>) -> String {
+        let all: Set<Int> = [1, 2, 3, 4, 5, 6, 7]
+        let workdays: Set<Int> = [2, 3, 4, 5, 6]
+        let weekend: Set<Int> = [1, 7]
+        if days == all { return "每天" }
+        if days == workdays { return "工作日" }
+        if days == weekend { return "周末" }
+        let names = ["", "日", "一", "二", "三", "四", "五", "六"]
+        let sorted = days.sorted { orderKey($0) < orderKey($1) }
+        let joined = sorted.map { names[$0] }.joined(separator: "、")
+        return "周\(joined)"
+    }
+
+    /// 排序键:周一→周日(把周日=1 排到最后,符合中文「周一到周日」直觉)。
+    private static func orderKey(_ weekday: Int) -> Int {
+        weekday == 1 ? 8 : weekday
+    }
+
+    /// 一次性提醒的日期标签:今天/明天/后天 + 时间,或具体日期。
+    static func relativeDayLabel(for date: Date, now: Date = Date(), calendar: Calendar = .current) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "zh_CN")
+        f.dateFormat = "HH:mm"
+        let time = f.string(from: date)
+
+        let startOfNow = calendar.startOfDay(for: now)
+        let startOfDate = calendar.startOfDay(for: date)
+        let dayDiff = calendar.dateComponents([.day], from: startOfNow, to: startOfDate).day ?? 0
+        switch dayDiff {
+        case 0: return "今天 \(time)"
+        case 1: return "明天 \(time)"
+        case 2: return "后天 \(time)"
+        default:
+            f.dateFormat = "M月d日 HH:mm"
+            return f.string(from: date)
+        }
+    }
+
+    // MARK: - Prompt body
+
+    /// 通知正文 —— 随时段给一句轻提示,不用命令式。沿用旧 ReminderSlot 语气。
+    var promptBody: String {
+        let (h, _) = timeComponents
+        switch h {
+        case 5..<11:  return "早上好 · 记一句此刻在想什么"
+        case 11..<15: return "间隙里 · 留一条给今天"
+        case 15..<19: return "下午了 · 有什么值得记下的"
+        default:      return "睡前 · 把今天收进一句话"
+        }
+    }
+}
+
+// MARK: - Preset defaults
+
+extension Reminder {
+    /// 每天一次(晚 21:00)。
+    static var onceDefaults: [Reminder] {
+        [Reminder(trigger: .daily(hour: 21, minute: 0), label: "睡前")]
+    }
+
+    /// 早中晚三次(09:00 / 13:00 / 21:00)。
+    static var thriceDefaults: [Reminder] {
+        [
+            Reminder(trigger: .daily(hour: 9, minute: 0), label: "早"),
+            Reminder(trigger: .daily(hour: 13, minute: 0), label: "午"),
+            Reminder(trigger: .daily(hour: 21, minute: 0), label: "晚")
+        ]
+    }
+}

--- a/DayPage/Services/ReminderIntentParser.swift
+++ b/DayPage/Services/ReminderIntentParser.swift
@@ -1,0 +1,376 @@
+import Foundation
+
+// MARK: - ReminderIntentParser
+//
+// 自然语言 → 提醒调度(vNext,2026-07-15)。把「每天 22:00 提醒我写日记」
+// 「一小时后提醒我」「今晚提醒我复盘」「周一三五 9 点提醒我晨记」解析成
+// `Reminder.Trigger + label`,直接落进 CaptureReminderService 统一调度器。
+//
+// 设计原则(与 IntentRouter 同一哲学):
+//   • 纯启发式规则,零 LLM 调用 —— 排提醒是高频小意图,不值一次网络往返;
+//     解析失败由对话层追问,而不是把模糊输入猜成错误时间。
+//   • 时间语义只有一个口径:相对词(今晚/明早/N 小时后)全部走
+//     RelativeTimeResolver,与 UI 快捷 chips 共用,避免两处「今晚是几点」分叉。
+//   • 拦截在视图层(Coach / 问过去)IntentRouter 之前;本解析器自带
+//     「必须包含提醒动词」的门 —— 没有「提醒/remind/叫我」不会误触发。
+//
+// 解析能力(超出即返回 nil,让对话层追问):
+//   重复:每天 / 工作日 / 周末 / 周一三五(任意周几组合)+ 时分
+//   一次:N 分钟后 / N 小时后 / 半小时后 / 今晚 / 明早 / 明晚 /
+//         今天|明天 + 时分 / 裸时分(已过顺延到明天,由 Resolver 处理)
+//   时分:22:00 / 22点 / 22 点半 / 晚上 10 点 / 早上八点(中文数字一~十二)
+//   标签:剥掉时间短语和提醒动词后的剩余文本(「今晚提醒我复盘」→「复盘」)
+
+struct ParsedReminder: Equatable {
+    let trigger: Reminder.Trigger
+    let label: String
+}
+
+enum ReminderIntentParser {
+
+    // MARK: - Public entry
+
+    /// 解析一句自然语言。返回 nil = 不是提醒请求,或时间无法可靠解析。
+    /// `now`/`calendar` 可注入便于测试。
+    static func parse(
+        _ text: String,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> ParsedReminder? {
+        let raw = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !raw.isEmpty else { return nil }
+
+        // 门:必须包含提醒动词,否则不是本解析器的事。
+        guard containsReminderVerb(raw) else { return nil }
+
+        var consumed = Set<Range<String.Index>>()
+
+        // 1. 重复规则(每天/工作日/周末/周几组合)优先于一次性。
+        if let days = parseRepeatDays(raw, consumed: &consumed) {
+            // 重复提醒必须有明确时分,否则语义不完整 → 交给对话层追问。
+            guard let (h, m) = parseClockTime(raw, consumed: &consumed) else { return nil }
+            let trigger: Reminder.Trigger = days.count == 7
+                ? .daily(hour: h, minute: m)
+                : .weekdays(days: days, hour: h, minute: m)
+            return ParsedReminder(trigger: trigger, label: extractLabel(raw, consumed: consumed))
+        }
+
+        // 2. 相对间隔:N 分钟/小时后。
+        if let interval = parseAfterInterval(raw, consumed: &consumed),
+           let date = RelativeTimeResolver.resolve(.afterSeconds(interval), now: now, calendar: calendar) {
+            return ParsedReminder(trigger: .once(date), label: extractLabel(raw, consumed: consumed))
+        }
+
+        // 3. 相对日词(今晚/明早/明晚/今天/明天)± 具体时分。
+        let dayWord = parseDayWord(raw, consumed: &consumed)
+        let clock = parseClockTime(raw, consumed: &consumed)
+
+        switch (dayWord, clock) {
+        case (.some(let word), .some(let hm)):
+            // 「明天下午 3 点」:相对日 + 显式时分。
+            guard let base = resolveDayWord(word, now: now, calendar: calendar) else { return nil }
+            var comps = calendar.dateComponents([.year, .month, .day], from: base)
+            comps.hour = hm.hour
+            comps.minute = hm.minute
+            guard let date = calendar.date(from: comps), date > now else {
+                // 「今晚 8 点」但已 21 点 —— 过去时刻不猜,追问。
+                return nil
+            }
+            return ParsedReminder(trigger: .once(date), label: extractLabel(raw, consumed: consumed))
+
+        case (.some(let word), .none):
+            // 裸相对日词:今晚→20:00 / 明早→08:00(RelativeTimeResolver 口径)。
+            guard let token = defaultToken(for: word),
+                  let date = RelativeTimeResolver.resolve(token, now: now, calendar: calendar),
+                  date > now else { return nil }
+            return ParsedReminder(trigger: .once(date), label: extractLabel(raw, consumed: consumed))
+
+        case (.none, .some(let hm)):
+            // 裸时分「10 点提醒我」:今天该时分,已过顺延明天(Resolver 语义)。
+            guard let date = RelativeTimeResolver.resolve(
+                .at(hour: hm.hour, minute: hm.minute), now: now, calendar: calendar
+            ) else { return nil }
+            return ParsedReminder(trigger: .once(date), label: extractLabel(raw, consumed: consumed))
+
+        case (.none, .none):
+            // 有提醒动词但没有任何可解析时间 —— 让对话层追问。
+            return nil
+        }
+    }
+
+    // MARK: - Reminder verb gate
+
+    private static let reminderVerbs: [String] = [
+        "提醒我", "提醒一下", "提醒", "叫我", "记得叫", "喊我",
+        "remind me", "remind", "wake me"
+    ]
+
+    static func containsReminderVerb(_ text: String) -> Bool {
+        let s = text.lowercased()
+        return reminderVerbs.contains { s.contains($0) }
+    }
+
+    // MARK: - Repeat days
+
+    /// 解析重复语义。返回 nil = 非重复;[1...7] 全集 = 每天。
+    /// Calendar weekday 口径:1=周日 … 7=周六。
+    private static func parseRepeatDays(
+        _ text: String, consumed: inout Set<Range<String.Index>>
+    ) -> Set<Int>? {
+        // 注意:range 必须在原文上取(caseInsensitive),不能用 lowercased()
+        // 副本的 String.Index 套回原文 —— 跨实例 index 是未定义行为。
+        for phrase in ["每天", "每日", "天天", "every day", "everyday", "daily"] {
+            if let r = text.range(of: phrase, options: [.caseInsensitive]) {
+                consumed.insert(r)
+                return [1, 2, 3, 4, 5, 6, 7]
+            }
+        }
+        for phrase in ["每个工作日", "工作日", "weekdays"] {
+            if let r = text.range(of: phrase, options: [.caseInsensitive]) {
+                consumed.insert(r)
+                return [2, 3, 4, 5, 6]
+            }
+        }
+        for phrase in ["每周末", "周末", "weekends"] {
+            if let r = text.range(of: phrase, options: [.caseInsensitive]) {
+                consumed.insert(r)
+                return [1, 7]
+            }
+        }
+
+        // 「每周一」「周一三五」「每周二、四」—— 抓「每?周/星期/礼拜」后面
+        // 连续的日字符序列(一二三四五六日天,允许顿号/逗号/空格分隔)。
+        let dayChars: [Character: Int] = [
+            "一": 2, "二": 3, "三": 4, "四": 5, "五": 6, "六": 7, "日": 1, "天": 1
+        ]
+        let pattern = "(每?)(周|星期|礼拜)([一二三四五六日天][、，,\\s]*)+"
+        if let regex = try? NSRegularExpression(pattern: pattern),
+           let m = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+           let whole = Range(m.range, in: text) {
+            var days = Set<Int>()
+            for ch in text[whole] {
+                if let d = dayChars[ch] { days.insert(d) }
+            }
+            if !days.isEmpty {
+                consumed.insert(whole)
+                return days
+            }
+        }
+        return nil
+    }
+
+    // MARK: - Relative interval (N 分钟/小时后)
+
+    private static func parseAfterInterval(
+        _ text: String, consumed: inout Set<Range<String.Index>>
+    ) -> TimeInterval? {
+        // 半小时后 / 半个小时后
+        for phrase in ["半小时后", "半个小时后", "半小时之后"] {
+            if let r = text.range(of: phrase) {
+                consumed.insert(r)
+                return 1800
+            }
+        }
+        // N 分钟后 / N 个?小时后 / in N minutes / in N hours(中文数字或阿拉伯数字)
+        let patterns: [(String, TimeInterval)] = [
+            ("([0-9一二两三四五六七八九十]+)\\s*分钟\\s*(后|之后)", 60),
+            ("([0-9一二两三四五六七八九十]+)\\s*个?\\s*小时\\s*(后|之后)", 3600),
+            ("in\\s+([0-9]+)\\s+minutes?", 60),
+            ("in\\s+([0-9]+)\\s+hours?", 3600),
+            ("in\\s+(an?)\\s+hour", 3600)
+        ]
+        for (pattern, unit) in patterns {
+            guard let regex = try? NSRegularExpression(pattern: pattern, options: [.caseInsensitive]),
+                  let m = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+                  let whole = Range(m.range, in: text) else { continue }
+            var numText = "1"
+            if m.numberOfRanges > 1, let nr = Range(m.range(at: 1), in: text) {
+                numText = String(text[nr]).lowercased()
+            }
+            let n: Int? = (numText == "an" || numText == "a") ? 1 : chineseOrArabicNumber(numText)
+            guard let n, n > 0 else { continue }
+            consumed.insert(whole)
+            return TimeInterval(n) * unit
+        }
+        return nil
+    }
+
+    // MARK: - Day words (今晚/明早/…)
+
+    private enum DayWord { case tonight, tomorrowMorning, tomorrowNight, today, tomorrow }
+
+    private static func parseDayWord(
+        _ text: String, consumed: inout Set<Range<String.Index>>
+    ) -> DayWord? {
+        let table: [(String, DayWord)] = [
+            ("今晚", .tonight), ("今天晚上", .tonight), ("tonight", .tonight),
+            ("明早", .tomorrowMorning), ("明天早上", .tomorrowMorning),
+            ("明天上午", .tomorrowMorning), ("tomorrow morning", .tomorrowMorning),
+            ("明晚", .tomorrowNight), ("明天晚上", .tomorrowNight), ("tomorrow night", .tomorrowNight),
+            ("明天", .tomorrow), ("tomorrow", .tomorrow),
+            ("今天", .today), ("today", .today)
+        ]
+        // 长词优先(「明天晚上」要在「明天」之前命中);range 取自原文。
+        for (phrase, word) in table.sorted(by: { $0.0.count > $1.0.count }) {
+            if let r = text.range(of: phrase, options: [.caseInsensitive]) {
+                consumed.insert(r)
+                return word
+            }
+        }
+        return nil
+    }
+
+    /// 裸相对日词的默认 token(与 UI 快捷 chips 完全同一口径)。
+    /// 裸「今天/明天」没有默认钟点 —— 返回 nil 走追问。
+    private static func defaultToken(for word: DayWord) -> RelativeTimeResolver.Token? {
+        switch word {
+        case .tonight:         return .tonight
+        case .tomorrowMorning: return .tomorrowMorning
+        case .tomorrowNight:   return .tomorrowNight
+        case .today, .tomorrow: return nil
+        }
+    }
+
+    /// 相对日词 → 当天零点(用于与显式时分组合)。
+    private static func resolveDayWord(_ word: DayWord, now: Date, calendar: Calendar) -> Date? {
+        switch word {
+        case .today, .tonight:
+            return calendar.startOfDay(for: now)
+        case .tomorrow, .tomorrowMorning, .tomorrowNight:
+            return calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: now))
+        }
+    }
+
+    // MARK: - Clock time (22:00 / 22点 / 晚上 10 点 / 早上八点半)
+
+    private static func parseClockTime(
+        _ text: String, consumed: inout Set<Range<String.Index>>
+    ) -> (hour: Int, minute: Int)? {
+        // 时段修饰词 → 12 小时制换算。
+        let s = text.lowercased()
+        var pmHint = false
+        var amHint = false
+        for phrase in ["下午", "晚上", "傍晚", "夜里", "pm"] where s.contains(phrase) { pmHint = true }
+        for phrase in ["早上", "上午", "凌晨", "清晨", "am"] where s.contains(phrase) { amHint = true }
+
+        // HH:mm / HH：mm
+        if let regex = try? NSRegularExpression(pattern: "([0-9]{1,2})[:：]([0-9]{2})"),
+           let m = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+           let whole = Range(m.range, in: text),
+           let hr = Range(m.range(at: 1), in: text), let mr = Range(m.range(at: 2), in: text),
+           let h = Int(text[hr]), let mm = Int(text[mr]), h < 24, mm < 60 {
+            consumed.insert(whole)
+            return (normalizeHour(h, pm: pmHint, am: amHint), mm)
+        }
+
+        // N 点 / N 点半 / N 点 M 分(N 支持中文数字一~十二)
+        let pattern = "([0-9一二两三四五六七八九十]{1,3})\\s*点\\s*(半|[0-9]{1,2}\\s*分)?"
+        if let regex = try? NSRegularExpression(pattern: pattern),
+           let m = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+           let whole = Range(m.range, in: text),
+           let hr = Range(m.range(at: 1), in: text),
+           let h = chineseOrArabicNumber(String(text[hr])), h <= 24 {
+            var minute = 0
+            if m.numberOfRanges > 2, let tail = Range(m.range(at: 2), in: text) {
+                let t = String(text[tail])
+                if t == "半" {
+                    minute = 30
+                } else if let mm = Int(t.replacingOccurrences(of: "分", with: "")
+                                        .trimmingCharacters(in: .whitespaces)), mm < 60 {
+                    minute = mm
+                }
+            }
+            consumed.insert(whole)
+            return (normalizeHour(h, pm: pmHint, am: amHint), minute)
+        }
+
+        // at H / at H:MM (英文)
+        if let regex = try? NSRegularExpression(pattern: "at\\s+([0-9]{1,2})(?::([0-9]{2}))?\\s*(am|pm)?", options: [.caseInsensitive]),
+           let m = regex.firstMatch(in: text, range: NSRange(text.startIndex..., in: text)),
+           let whole = Range(m.range, in: text),
+           let hr = Range(m.range(at: 1), in: text), let h = Int(text[hr]), h <= 24 {
+            var minute = 0
+            if m.numberOfRanges > 2, let mr = Range(m.range(at: 2), in: text), let mm = Int(text[mr]), mm < 60 {
+                minute = mm
+            }
+            var pm = pmHint, am = amHint
+            if m.numberOfRanges > 3, let sr = Range(m.range(at: 3), in: text) {
+                let suffix = text[sr].lowercased()
+                pm = pm || suffix == "pm"
+                am = am || suffix == "am"
+            }
+            consumed.insert(whole)
+            return (normalizeHour(h, pm: pm, am: am), minute)
+        }
+
+        return nil
+    }
+
+    /// 12 小时制换算:「晚上 10 点」→ 22;「早上 8 点」→ 8;无修饰不动。
+    private static func normalizeHour(_ h: Int, pm: Bool, am: Bool) -> Int {
+        if pm && h < 12 { return h + 12 }
+        if am && h == 12 { return 0 }
+        return h
+    }
+
+    // MARK: - Label extraction
+
+    /// 剥掉时间短语(consumed ranges)和提醒动词、连接词后,剩下的就是标签。
+    private static func extractLabel(_ text: String, consumed: Set<Range<String.Index>>) -> String {
+        // 按 range 挖空(从后往前,前缀 index 保持有效)。重叠的 range 跳过,
+        // 避免二次删除越界。
+        var result = text
+        var lastRemovedLower: String.Index? = nil
+        for r in consumed.sorted(by: { $0.lowerBound > $1.lowerBound }) {
+            if let bound = lastRemovedLower, r.upperBound > bound { continue }
+            result.removeSubrange(r)
+            lastRemovedLower = r.lowerBound
+        }
+        // 剥提醒动词、黏连的语气/连接词,以及仅作 12h 换算 hint 用的时段
+        // 修饰词(parseClockTime 只读不 consume,在这里统一清掉)。
+        let noise = [
+            "提醒我", "提醒一下", "提醒", "叫我", "记得叫", "喊我", "记得",
+            "remind me to", "remind me", "remind", "wake me up", "wake me",
+            "下午", "晚上", "早上", "上午", "凌晨", "傍晚", "夜里", "清晨",
+            "am", "pm",
+            "请", "帮我", "麻烦", "记录", "去", "要"
+        ]
+        for phrase in noise.sorted(by: { $0.count > $1.count }) {
+            result = result.replacingOccurrences(of: phrase, with: " ", options: [.caseInsensitive])
+        }
+        let cleaned = result
+            .components(separatedBy: CharacterSet(charactersIn: " ，。,.!？?、；;的"))
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return cleaned
+    }
+
+    // MARK: - Numbers
+
+    /// "22" → 22;"十" → 10;"两" → 2;"十一" → 11;"二十" → 20。
+    private static func chineseOrArabicNumber(_ s: String) -> Int? {
+        let trimmed = s.trimmingCharacters(in: .whitespaces)
+        if let n = Int(trimmed) { return n }
+        let digits: [Character: Int] = [
+            "一": 1, "二": 2, "两": 2, "三": 3, "四": 4, "五": 5,
+            "六": 6, "七": 7, "八": 8, "九": 9
+        ]
+        // 十 / 十N / N十 / N十M
+        if trimmed == "十" { return 10 }
+        if trimmed.count == 2, trimmed.hasPrefix("十"), let last = trimmed.last, let d = digits[last] {
+            return 10 + d
+        }
+        if trimmed.count == 2, trimmed.hasSuffix("十"), let first = trimmed.first, let d = digits[first] {
+            return d * 10
+        }
+        if trimmed.count == 3 {
+            let chars = Array(trimmed)
+            if chars[1] == "十", let tens = digits[chars[0]], let ones = digits[chars[2]] {
+                return tens * 10 + ones
+            }
+        }
+        if trimmed.count == 1, let ch = trimmed.first, let d = digits[ch] { return d }
+        return nil
+    }
+}

--- a/DayPageKit/Sources/DayPageServices/ChatMarkdownRenderer.swift
+++ b/DayPageKit/Sources/DayPageServices/ChatMarkdownRenderer.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+// MARK: - ChatMarkdownRenderer
+
+/// 把一段会话事件日志渲染成 Obsidian 兼容的 Markdown 导出件。
+///
+/// 分工与 memo 侧同构：JSONL 是机器可靠的存储格式（追加安全、流式友好），
+/// Markdown 是人类可读的导出格式——存储层永远不用 Markdown 做往返解析。
+/// 「依据」行渲染成 `[[yyyy-MM-dd]]` wikilink，在 Obsidian 里可点回当天。
+public enum ChatMarkdownRenderer {
+
+    /// 会话进入方式的导出标签。
+    public static func entryLabel(_ entry: ChatEntryKind) -> String {
+        switch entry {
+        case .ask:   return "问过去"
+        case .memo:  return "记忆锚定"
+        case .coach: return "陪写"
+        }
+    }
+
+    /// 渲染完整导出件（YAML front-matter + 逐轮正文）。
+    public static func render(_ session: LoadedChatSession) -> String {
+        let summary = session.summary
+        let timeFmt = Self.timeFormatter
+        let startTime = timeFmt.string(from: summary.startedAt)
+
+        var lines: [String] = ["---"]
+        lines.append("type: chat_session")
+        lines.append("date: \(summary.dayString)")
+        lines.append("time: \"\(startTime)\"")
+        lines.append("entry: \(entryLabel(summary.entry))")
+        if let anchorDate = summary.anchorMemoDate {
+            lines.append("anchor_memo_date: \(anchorDate)")
+        }
+        lines.append("turns: \(session.turns.count)")
+        lines.append("export_source: DayPage")
+        lines.append("---")
+        lines.append("")
+        lines.append("# 和过去对话 — \(summary.dayString) \(startTime)")
+        lines.append("")
+
+        for turn in session.turns {
+            let speaker = turn.role == .user ? "我" : "DayPage"
+            lines.append("**\(speaker)**（\(timeFmt.string(from: turn.createdAt))）")
+            lines.append("")
+            lines.append(turn.text)
+            lines.append("")
+
+            // assistant 轮的检索依据（来自 retrieval 事件的合成 context）。
+            if turn.role == .assistant, let context = turn.context, !context.isEmpty {
+                var parts: [String] = context.memoHits.map { "[[\($0.dateString)]]" }
+                parts.append(contentsOf: context.entityHits.map { $0.displayName })
+                if !parts.isEmpty {
+                    lines.append("> 依据：\(parts.joined(separator: " · "))")
+                    lines.append("")
+                }
+            }
+        }
+
+        return lines.joined(separator: "\n").trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
+    }
+
+    /// 导出文件名，与 memo 导出命名同族：`DayPage Chat 2026-07-15 1432.md`。
+    /// 同日多段会话靠 HHmm 区分；同分钟撞名由写入方追加序号。
+    public static func exportFileName(for summary: ChatSessionSummary) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "HHmm"
+        f.timeZone = TimeZone.current
+        return "DayPage Chat \(summary.dayString) \(f.string(from: summary.startedAt)).md"
+    }
+
+    private static var timeFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "HH:mm"
+        f.timeZone = TimeZone.current
+        return f
+    }
+}

--- a/DayPageKit/Sources/DayPageServices/ChatSessionStore.swift
+++ b/DayPageKit/Sources/DayPageServices/ChatSessionStore.swift
@@ -1,0 +1,505 @@
+import Foundation
+import DayPageStorage
+
+// MARK: - ChatEntryKind
+
+/// 会话的进入方式。三个入口本质上是同一个 agent 带不同初始上下文启动
+/// （对标 Claude Code：同一 transcript 机制，不同启动 prompt），因此
+/// entry 只是 session header 里的元数据，不是存储的分类轴。
+public enum ChatEntryKind: String, Codable, Sendable {
+    case ask      // 通用「问过去」（AskPastView）
+    case memo     // memo 锚定对话（MemoChatView）
+    case coach    // 陪写教练（TodayCoachView，Wave C 接入）
+}
+
+// MARK: - ChatSessionRef / Summary
+
+/// 一段活跃会话的句柄：追加事件只需要它。
+public struct ChatSessionRef: Equatable, Sendable {
+    public let id: UUID
+    public let fileURL: URL
+
+    public init(id: UUID, fileURL: URL) {
+        self.id = id
+        self.fileURL = fileURL
+    }
+}
+
+/// 历史列表里的一行胶囊。由 header 行 + 轻量行扫描构成，不做全量 JSON decode。
+public struct ChatSessionSummary: Identifiable, Equatable, Sendable {
+    public let id: UUID
+    public let entry: ChatEntryKind
+    public let title: String
+    public let startedAt: Date
+    /// 会话开始日（本地时区 yyyy-MM-dd）——即所在目录名。
+    public let dayString: String
+    public let turnCount: Int
+    public let isClosed: Bool
+    public let anchorMemoID: UUID?
+    public let anchorMemoDate: String?
+    public let fileURL: URL
+
+    public var ref: ChatSessionRef { ChatSessionRef(id: id, fileURL: fileURL) }
+}
+
+/// resume / 展开胶囊时的完整载入结果。
+public struct LoadedChatSession: Equatable {
+    public let summary: ChatSessionSummary
+    public let turns: [ChatTurn]
+}
+
+// MARK: - ChatEventLine (on-disk envelope)
+
+/// JSONL 单行信封。所有事件（含首行 header）共用一个扁平结构，未知
+/// `type` / 缺字段一律跳过——向前兼容即免迁移。字段按事件类型分组：
+/// - `session`（首行）：v/id/entry/startedAt/title/anchorMemoID/anchorMemoDate
+/// - `turn`：id/role/text/createdAt/memoDraft
+/// - `retrieval`：memoDates/entities（实体存显示名，导出可读）
+/// - `anchor`：action（attach/detach）
+/// - `closed`：at
+struct ChatEventLine: Codable {
+    var v: Int?
+    var type: String
+    var id: UUID?
+    var entry: String?
+    var startedAt: Date?
+    var title: String?
+    var anchorMemoID: UUID?
+    var anchorMemoDate: String?
+    var role: String?
+    var text: String?
+    var createdAt: Date?
+    var memoDraft: String?
+    var memoDates: [String]?
+    var entities: [String]?
+    var at: Date?
+    var action: String?
+}
+
+// MARK: - ChatSessionStore
+
+/// AI 对话的统一落盘层：一段会话 = 一个追加式 JSONL 事件日志，
+/// 按日期目录归档（`vault/wiki/chats/YYYY-MM-DD/HHmmss.jsonl`）。
+///
+/// 设计对标 Claude Code 的 session/transcript 机制：
+/// - 「新对话」= append `closed` 事件（/clear）——不改写文件、不引外部状态；
+/// - 打开聊天接上今天最近未封口会话（--continue）；
+/// - 历史胶囊点开续聊（/resume），新轮次 append 回原文件。
+///
+/// 全部为 nonisolated 静态函数 + 值类型返回：调用方（@MainActor service）
+/// 的 append 是小写入；测试直接打临时 root。写入 best-effort——丢一行
+/// 好过阻塞 UI（沿用 MemoryChatService.appendTurn 的既有取舍）。
+public enum ChatSessionStore {
+
+    /// 生产根目录。跟随 `VaultInitializer.vaultURL`（含 test override）。
+    public static var defaultRootURL: URL {
+        VaultInitializer.vaultURL.appendingPathComponent("wiki/chats", isDirectory: true)
+    }
+
+    // MARK: - Create / Append / Close
+
+    /// 建立新会话文件并写入 header 行。只在第一轮真正发出时调用——
+    /// 空会话永不落盘。`title` 取首问截断（≤40 字符）。
+    public static func createSession(
+        entry: ChatEntryKind,
+        title: String,
+        anchorMemoID: UUID? = nil,
+        anchorMemoDate: String? = nil,
+        now: Date = Date(),
+        root: URL = defaultRootURL
+    ) -> ChatSessionRef? {
+        let fm = FileManager.default
+        let dayDir = root.appendingPathComponent(Self.dayString(for: now), isDirectory: true)
+        do {
+            try fm.createDirectory(at: dayDir, withIntermediateDirectories: true)
+        } catch {
+            return nil
+        }
+
+        // HHmmss 命名；同秒撞名追加 -2 / -3 …（同秒覆盖丢数据的教训来自 memo 附件侧）
+        let base = Self.timeString(for: now)
+        var fileURL = dayDir.appendingPathComponent("\(base).jsonl")
+        var attempt = 2
+        while fm.fileExists(atPath: fileURL.path) {
+            fileURL = dayDir.appendingPathComponent("\(base)-\(attempt).jsonl")
+            attempt += 1
+        }
+
+        let id = UUID()
+        var header = ChatEventLine(type: "session")
+        header.v = 1
+        header.id = id
+        header.entry = entry.rawValue
+        header.startedAt = now
+        header.title = String(title.prefix(40))
+        header.anchorMemoID = anchorMemoID
+        header.anchorMemoDate = anchorMemoDate
+
+        guard var data = try? Self.encoder.encode(header) else { return nil }
+        data.append(0x0A)
+        do {
+            try data.write(to: fileURL, options: .atomic)
+        } catch {
+            return nil
+        }
+        return ChatSessionRef(id: id, fileURL: fileURL)
+    }
+
+    /// 追加一轮对话。`memoDraft` 仅 coach 会话使用。
+    public static func appendTurn(_ turn: ChatTurn, memoDraft: String? = nil, to ref: ChatSessionRef) {
+        var line = ChatEventLine(type: "turn")
+        line.id = turn.id
+        line.role = turn.role.rawValue
+        line.text = turn.text
+        line.createdAt = turn.createdAt
+        line.memoDraft = memoDraft
+        appendLine(line, to: ref.fileURL)
+    }
+
+    /// 追加一次检索事件（agent 的工具调用留痕）。回放时合成来源 chips，
+    /// 导出时渲染成「依据」行。`entities` 存显示名而非 slug——导出件可读。
+    public static func appendRetrieval(memoDates: [String], entities: [String], to ref: ChatSessionRef) {
+        guard !memoDates.isEmpty || !entities.isEmpty else { return }
+        var line = ChatEventLine(type: "retrieval")
+        line.memoDates = memoDates
+        line.entities = entities
+        appendLine(line, to: ref.fileURL)
+    }
+
+    /// 封口（/clear 语义）。之后该会话不再被 --continue 接上；
+    /// 从历史胶囊续聊时仍可 append（closed 只影响 resume 选择）。
+    public static func close(_ ref: ChatSessionRef) {
+        var line = ChatEventLine(type: "closed")
+        line.at = Date()
+        appendLine(line, to: ref.fileURL)
+    }
+
+    // MARK: - Resume (--continue)
+
+    /// 接上「今天」最近一段未封口、entry 匹配的会话；memo 锚定对话还要求
+    /// anchorMemoID 一致（反复进出同一条 memo 不碎片化）。没有则返回 nil。
+    public static func resumeTodaySession(
+        entry: ChatEntryKind,
+        anchorMemoID: UUID? = nil,
+        now: Date = Date(),
+        root: URL = defaultRootURL
+    ) -> LoadedChatSession? {
+        migrateLegacyDayFilesIfNeeded(root: root)
+        let dayDir = root.appendingPathComponent(Self.dayString(for: now), isDirectory: true)
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: dayDir, includingPropertiesForKeys: nil, options: .skipsHiddenFiles
+        ) else { return nil }
+
+        // 文件名即开始时间 → 逆序 = 最近优先。
+        let candidates = files
+            .filter { $0.pathExtension == "jsonl" }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+
+        for fileURL in candidates {
+            guard let summary = summarize(fileURL: fileURL) else { continue }
+            guard summary.entry == entry, !summary.isClosed else { continue }
+            if entry == .memo, summary.anchorMemoID != anchorMemoID { continue }
+            return load(summary: summary)
+        }
+        return nil
+    }
+
+    // MARK: - List / Load / Delete
+
+    /// 扫描历史会话，按开始时间降序。`limitDays` 限制只看最近 N 个自然日
+    /// 目录（长河懒加载用）；nil = 全量。每个文件只做 header decode +
+    /// 轻量行扫描（turn 计数 / closed 检测），不整段 decode。
+    public static func listSessions(limitDays: Int? = nil, root: URL = defaultRootURL) -> [ChatSessionSummary] {
+        migrateLegacyDayFilesIfNeeded(root: root)
+        let fm = FileManager.default
+        guard let dayDirs = try? fm.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: [.isDirectoryKey], options: .skipsHiddenFiles
+        ) else { return [] }
+
+        var days = dayDirs
+            .filter { (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true }
+            .sorted { $0.lastPathComponent > $1.lastPathComponent }
+        if let limitDays { days = Array(days.prefix(limitDays)) }
+
+        var summaries: [ChatSessionSummary] = []
+        for dayDir in days {
+            guard let files = try? fm.contentsOfDirectory(
+                at: dayDir, includingPropertiesForKeys: nil, options: .skipsHiddenFiles
+            ) else { continue }
+            for fileURL in files where fileURL.pathExtension == "jsonl" {
+                if let summary = summarize(fileURL: fileURL) {
+                    summaries.append(summary)
+                }
+            }
+        }
+        return summaries.sorted { $0.startedAt > $1.startedAt }
+    }
+
+    /// 会话日目录总数（长河「更早的对话」按钮的 hasMore 判据——比全量
+    /// header 扫描更廉价）。
+    public static func dayDirectoryCount(root: URL = defaultRootURL) -> Int {
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: [.isDirectoryKey], options: .skipsHiddenFiles
+        ) else { return 0 }
+        return entries.filter {
+            (try? $0.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+        }.count
+    }
+
+    /// 由活跃会话句柄取回 summary（当前会话的「导出本次对话」入口用）。
+    public static func summary(for ref: ChatSessionRef) -> ChatSessionSummary? {
+        summarize(fileURL: ref.fileURL)
+    }
+
+    /// 整段载入一段会话（展开胶囊 / 续聊）。retrieval 事件被折进下一条
+    /// assistant turn 的合成 context——chips 需要的只有日期与实体显示名。
+    public static func load(summary: ChatSessionSummary) -> LoadedChatSession? {
+        guard let text = try? String(contentsOf: summary.fileURL, encoding: .utf8) else { return nil }
+
+        var turns: [ChatTurn] = []
+        var pendingRetrieval: (dates: [String], entities: [String])?
+
+        for line in text.split(whereSeparator: \.isNewline) {
+            guard let event = try? Self.decoder.decode(ChatEventLine.self, from: Data(line.utf8)) else { continue }
+            switch event.type {
+            case "turn":
+                guard let roleRaw = event.role,
+                      let role = ChatTurn.Role(rawValue: roleRaw),
+                      let turnText = event.text else { continue }
+                var turn = ChatTurn(
+                    id: event.id ?? UUID(),
+                    role: role,
+                    text: turnText,
+                    createdAt: event.createdAt ?? summary.startedAt
+                )
+                if role == .assistant, let retrieval = pendingRetrieval {
+                    turn.context = Self.syntheticContext(dates: retrieval.dates, entities: retrieval.entities)
+                    pendingRetrieval = nil
+                }
+                turns.append(turn)
+            case "retrieval":
+                pendingRetrieval = (event.memoDates ?? [], event.entities ?? [])
+            default:
+                continue // session header / anchor / closed / 未来事件类型
+            }
+        }
+        return LoadedChatSession(summary: summary, turns: turns)
+    }
+
+    /// 删除一段会话；所在日目录空了顺手删掉。
+    public static func delete(_ summary: ChatSessionSummary) {
+        let fm = FileManager.default
+        try? fm.removeItem(at: summary.fileURL)
+        let dayDir = summary.fileURL.deletingLastPathComponent()
+        if let remaining = try? fm.contentsOfDirectory(atPath: dayDir.path), remaining.isEmpty {
+            try? fm.removeItem(at: dayDir)
+        }
+    }
+
+    // MARK: - Legacy migration
+
+    /// 把 session 化之前的顶层天文件（`wiki/chats/YYYY-MM-DD.jsonl`，一天
+    /// 一文件、无边界）升级为该日目录下的单段已封口会话
+    /// （`YYYY-MM-DD/000000.jsonl`）。幂等：目标存在则只清理源文件；
+    /// 每进程只全量检查一次（之后顶层不会再出现天文件）。
+    public static func migrateLegacyDayFiles(root: URL = defaultRootURL) {
+        let fm = FileManager.default
+        guard let entries = try? fm.contentsOfDirectory(
+            at: root, includingPropertiesForKeys: [.isDirectoryKey], options: .skipsHiddenFiles
+        ) else { return }
+
+        for fileURL in entries {
+            let isDir = (try? fileURL.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
+            guard !isDir, fileURL.pathExtension == "jsonl" else { continue }
+            let day = fileURL.deletingPathExtension().lastPathComponent
+            guard Self.isDayString(day) else { continue }
+
+            let dayDir = root.appendingPathComponent(day, isDirectory: true)
+            let target = dayDir.appendingPathComponent("000000.jsonl")
+
+            if fm.fileExists(atPath: target.path) {
+                // 上次迁移在删除源文件前中断——目标已完整（atomic 写入），直接清理。
+                try? fm.removeItem(at: fileURL)
+                continue
+            }
+
+            guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else { continue }
+            var turnLines: [ChatEventLine] = []
+            for line in text.split(whereSeparator: \.isNewline) {
+                guard let turn = try? Self.decoder.decode(ChatTurn.self, from: Data(line.utf8)) else { continue }
+                var event = ChatEventLine(type: "turn")
+                event.id = turn.id
+                event.role = turn.role.rawValue
+                event.text = turn.text
+                event.createdAt = turn.createdAt
+                turnLines.append(event)
+            }
+
+            let firstUser = turnLines.first { $0.role == ChatTurn.Role.user.rawValue }
+            let startedAt = turnLines.first?.createdAt ?? Self.dayFormatter.date(from: day) ?? Date()
+
+            var header = ChatEventLine(type: "session")
+            header.v = 1
+            header.id = UUID()
+            header.entry = ChatEntryKind.ask.rawValue
+            header.startedAt = startedAt
+            header.title = String((firstUser?.text ?? "对话").prefix(40))
+
+            var closed = ChatEventLine(type: "closed")
+            closed.at = startedAt
+
+            var lines: [Data] = []
+            for event in [header] + turnLines + [closed] {
+                guard let data = try? Self.encoder.encode(event) else { continue }
+                lines.append(data)
+            }
+            var blob = Data()
+            for data in lines {
+                blob.append(data)
+                blob.append(0x0A)
+            }
+
+            do {
+                try fm.createDirectory(at: dayDir, withIntermediateDirectories: true)
+                try blob.write(to: target, options: .atomic)
+                try fm.removeItem(at: fileURL)
+            } catch {
+                continue // 下次启动重试；atomic 写入保证不留半成品
+            }
+        }
+    }
+
+    /// 每进程一次的惰性触发。list / resume 是仅有的两个读入口，都会先过这里。
+    private static let migrationOnce = OnceFlag()
+    static func migrateLegacyDayFilesIfNeeded(root: URL) {
+        // 测试用非默认 root 时不走进程级去重，保证迁移单测可重复执行。
+        if root != defaultRootURL {
+            migrateLegacyDayFiles(root: root)
+            return
+        }
+        guard migrationOnce.tryClaim() else { return }
+        migrateLegacyDayFiles(root: root)
+    }
+
+    // MARK: - Private helpers
+
+    private static func summarize(fileURL: URL) -> ChatSessionSummary? {
+        guard let text = try? String(contentsOf: fileURL, encoding: .utf8) else { return nil }
+        var headerLine: Substring?
+        var turnCount = 0
+        var isClosed = false
+        for line in text.split(whereSeparator: \.isNewline) {
+            if headerLine == nil {
+                headerLine = line
+                continue
+            }
+            // 轻量扫描：不整行 decode，子串判断足够（key 由本文件自己序列化）。
+            if line.contains("\"type\":\"turn\"") { turnCount += 1 }
+            else if line.contains("\"type\":\"closed\"") { isClosed = true }
+        }
+        guard let headerLine,
+              let header = try? Self.decoder.decode(ChatEventLine.self, from: Data(headerLine.utf8)),
+              header.type == "session",
+              let id = header.id,
+              let entryRaw = header.entry,
+              let entry = ChatEntryKind(rawValue: entryRaw),
+              let startedAt = header.startedAt else { return nil }
+
+        return ChatSessionSummary(
+            id: id,
+            entry: entry,
+            title: header.title ?? "对话",
+            startedAt: startedAt,
+            dayString: fileURL.deletingLastPathComponent().lastPathComponent,
+            turnCount: turnCount,
+            isClosed: isClosed,
+            anchorMemoID: header.anchorMemoID,
+            anchorMemoDate: header.anchorMemoDate,
+            fileURL: fileURL
+        )
+    }
+
+    private static func appendLine(_ event: ChatEventLine, to fileURL: URL) {
+        guard var data = try? Self.encoder.encode(event) else { return }
+        data.append(0x0A)
+        let fm = FileManager.default
+        if fm.fileExists(atPath: fileURL.path) {
+            if let handle = try? FileHandle(forWritingTo: fileURL) {
+                defer { try? handle.close() }
+                _ = try? handle.seekToEnd()
+                try? handle.write(contentsOf: data)
+            }
+        } else {
+            // 会话文件被外部删除（如用户在 Files.app 里清理）——重建为孤行文件
+            // 好过静默丢失本轮。
+            try? data.write(to: fileURL, options: .atomic)
+        }
+    }
+
+    /// 回放/导出只需要日期与实体显示名——合成一个轻量 context 喂给
+    /// 既有 chips UI（`chipLabels` 只读 dateString / displayName）。
+    static func syntheticContext(dates: [String], entities: [String]) -> RetrievedContext {
+        RetrievedContext(
+            query: "",
+            memoHits: dates.map {
+                .init(dateString: $0, snippet: "", mood: nil, entityMentions: [])
+            },
+            entityHits: entities.map {
+                .init(slug: $0, displayName: $0, type: "themes", occurrenceCount: 0, summary: "")
+            }
+        )
+    }
+
+    // MARK: - Formatting
+
+    static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    static func dayString(for date: Date) -> String {
+        Self.dayFormatter.string(from: date)
+    }
+
+    private static func timeString(for date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "HHmmss"
+        f.timeZone = TimeZone.current
+        return f.string(from: date)
+    }
+
+    private static var dayFormatter: DateFormatter {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "yyyy-MM-dd"
+        f.timeZone = TimeZone.current
+        return f
+    }
+
+    private static func isDayString(_ s: String) -> Bool {
+        s.count == 10 && Self.dayFormatter.date(from: s) != nil
+    }
+}
+
+// MARK: - OnceFlag
+
+/// 线程安全的一次性闸门（进程级迁移去重用）。
+private final class OnceFlag: @unchecked Sendable {
+    private var claimed = false
+    private let lock = NSLock()
+    func tryClaim() -> Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        if claimed { return false }
+        claimed = true
+        return true
+    }
+}

--- a/DayPageKit/Sources/DayPageServices/FeatureFlags.swift
+++ b/DayPageKit/Sources/DayPageServices/FeatureFlags.swift
@@ -88,6 +88,13 @@ public enum FeatureFlag: String, CaseIterable {
     /// **Default**: on
     case todayFocusCollapsed
 
+    /// **Used in**: `MemoryChatService.resumeTodaySession` + `ChatRiverView`（Features/Ask/）
+    /// **When off**: 聊天不接续今日会话（每次打开都是新对话）、长河胶囊/多选导出 UI 隐藏；
+    /// 落盘仍走 session 文件（`wiki/chats/YYYY-MM-DD/HHmmss.jsonl`），数据不受影响。
+    /// **对话长河**: AI 聊天历史 session 化 —— 给 resume/回放/导出一个无需 hot-fix 的兜底开关。
+    /// **Default**: on
+    case chatHistory
+
     /// Default state when the user has never touched the toggle. All Round 4
     /// flags default-on so the app behaves the way the user already expects
     /// after upgrading — Experiments only lets them *opt out*.
@@ -104,7 +111,8 @@ public enum FeatureFlag: String, CaseIterable {
              .vaultExport,
              .watchCaptureConfig,
              .captureReminder,
-             .todayFocusCollapsed:
+             .todayFocusCollapsed,
+             .chatHistory:
             return true
         }
     }
@@ -126,6 +134,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .watchCaptureConfig:     return "手表捕获配置"
         case .captureReminder:        return "记录提醒"
         case .todayFocusCollapsed:    return "今日焦点折叠"
+        case .chatHistory:            return "聊天历史长河"
         }
     }
 }

--- a/DayPageKit/Sources/DayPageServices/FeatureFlags.swift
+++ b/DayPageKit/Sources/DayPageServices/FeatureFlags.swift
@@ -82,6 +82,12 @@ public enum FeatureFlag: String, CaseIterable {
     /// **Default**: on
     case captureReminder
 
+    /// **Used in**: `TodayView.focusDisclosureRow` (Features/Today/TodayView.swift)
+    /// **When off**: 今日焦点恢复为常驻整行 chips（旧形态）；折叠/展开交互不参与布局。
+    /// **Canvas vNext**: 空态渐进披露 —— 焦点默认收成一行幽灵文字，点击展开。
+    /// **Default**: on
+    case todayFocusCollapsed
+
     /// Default state when the user has never touched the toggle. All Round 4
     /// flags default-on so the app behaves the way the user already expects
     /// after upgrading — Experiments only lets them *opt out*.
@@ -97,7 +103,8 @@ public enum FeatureFlag: String, CaseIterable {
              .weeklyRecap,
              .vaultExport,
              .watchCaptureConfig,
-             .captureReminder:
+             .captureReminder,
+             .todayFocusCollapsed:
             return true
         }
     }
@@ -118,6 +125,7 @@ public enum FeatureFlag: String, CaseIterable {
         case .vaultExport:            return "Vault 导出"
         case .watchCaptureConfig:     return "手表捕获配置"
         case .captureReminder:        return "记录提醒"
+        case .todayFocusCollapsed:    return "今日焦点折叠"
         }
     }
 }

--- a/DayPageKit/Sources/DayPageServices/MemoryChatService.swift
+++ b/DayPageKit/Sources/DayPageServices/MemoryChatService.swift
@@ -84,6 +84,10 @@ public final class MemoryChatService: ObservableObject {
     /// 用于 `.retrieving` 阶段的文案——slug 直出对 CJK 用户不可读。
     public private(set) var attachedClues: [String] = []
 
+    /// 当前活跃会话句柄。首轮真正发出时才建文件（空会话不落盘）；
+    /// `reset()` 封口置 nil；从历史胶囊续聊时由 `resume(_:)` 注入。
+    public private(set) var sessionRef: ChatSessionRef?
+
     // MARK: Dependencies
 
     /// 注入式 LLM 调用闭包，便于测试替身。默认走云端 DeepSeek。
@@ -196,7 +200,8 @@ public final class MemoryChatService: ObservableObject {
         if appendUserTurn {
             let userTurn = ChatTurn(role: .user, text: question)
             turns.append(userTurn)
-            Self.appendTurn(userTurn)
+            ensureSession(firstQuestion: question)
+            if let ref = sessionRef { ChatSessionStore.appendTurn(userTurn, to: ref) }
         }
         isResponding = true
         defer {
@@ -226,6 +231,16 @@ public final class MemoryChatService: ObservableObject {
         // Allow caller (e.g. sheet dismissal) to cancel mid-flight.
         if Task.isCancelled { return }
 
+        // 检索是 agent 的工具调用——独立事件留痕（回放合成来源 chips，
+        // 导出渲染「依据」行）。实体存显示名，导出件可读。
+        if let ref = sessionRef {
+            ChatSessionStore.appendRetrieval(
+                memoDates: Array(Set(context.memoHits.map { $0.dateString })).sorted(by: >),
+                entities: context.entityHits.map { $0.displayName },
+                to: ref
+            )
+        }
+
         // Phase 2: 「找到 N 条」短拍——检索通常快到不可见，这一拍把
         // 结果数量讲给用户听，然后才进入等待 LLM 的阶段。
         phase = .thinking(found: context.memoHits.count)
@@ -250,7 +265,7 @@ public final class MemoryChatService: ObservableObject {
             if Task.isCancelled { return }
             let assistantTurn = ChatTurn(role: .assistant, text: answer, context: context)
             turns.append(assistantTurn)
-            Self.appendTurn(assistantTurn)
+            if let ref = sessionRef { ChatSessionStore.appendTurn(assistantTurn, to: ref) }
         } catch {
             let msg = (error as? LLMError)?.errorDescription ?? error.localizedDescription
             errorMessage = msg
@@ -258,69 +273,73 @@ public final class MemoryChatService: ObservableObject {
         }
     }
 
-    /// 清空对话（开始新会话）。历史记录仍保留在磁盘上；`reset` 只切换
-    /// UI session。若想连磁盘一起清，另用未来 API。
+    /// 「新对话」（/clear 语义）：封口当前会话、清空 UI。磁盘上会话原样
+    /// 保留，以胶囊形态沉入长河；下一次发问才建新文件。
     public func reset() {
+        if let ref = sessionRef { ChatSessionStore.close(ref) }
+        sessionRef = nil
         turns.removeAll()
         errorMessage = nil
     }
 
-    // MARK: - Persistence (D1 — history across launches)
+    // MARK: - Sessions (D1 — history across launches)
 
-    /// 从 `vault/wiki/chats/YYYY-MM-DD.jsonl` 追加式加载今天的历史。
-    /// 首次进入 AskPastView 时调用；无历史时静默返回。
-    public func loadTodayHistory() {
-        let url = Self.chatLogURL(for: Date())
-        guard FileManager.default.fileExists(atPath: url.path) else { return }
-        guard let data = try? Data(contentsOf: url),
-              let text = String(data: data, encoding: .utf8) else { return }
+    /// 当前对话的进入方式：有锚定 memo 即 memo 会话，否则通用问过去。
+    private var entryKind: ChatEntryKind { attachedMemo != nil ? .memo : .ask }
 
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        var loaded: [ChatTurn] = []
-        for line in text.split(whereSeparator: \.isNewline) {
-            let bytes = Data(line.utf8)
-            if let turn = try? decoder.decode(ChatTurn.self, from: bytes) {
-                loaded.append(turn)
-            }
-        }
-        // Reserve `turns` for freshly-created turns from this session by
-        // appending on top of what we loaded — the ScrollViewReader in
-        // AskPastView will land the user at the bottom either way.
-        turns = loaded + turns
+    /// --continue 语义：接上今天最近一段未封口、entry（+ 锚定 memo）匹配
+    /// 的会话。打开 AskPastView / MemoChatView 时调用；`chatHistory` flag
+    /// 关闭时不接（每次都是新对话，落盘照旧）。
+    public func resumeTodaySession() {
+        guard FeatureFlagStore.shared.isEnabled(.chatHistory) else { return }
+        guard turns.isEmpty, sessionRef == nil else { return }
+        guard let loaded = ChatSessionStore.resumeTodaySession(
+            entry: entryKind,
+            anchorMemoID: attachedMemo?.id
+        ) else { return }
+        sessionRef = loaded.summary.ref
+        turns = loaded.turns
     }
 
-    /// Append one turn's JSON to the day's log file. Best-effort; failures
-    /// are non-fatal (a lost line is preferable to blocking the UI).
-    fileprivate static func appendTurn(_ turn: ChatTurn) {
-        let url = chatLogURL(for: turn.createdAt)
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        guard let data = try? encoder.encode(turn) else { return }
-        var line = data
-        line.append(0x0A) // '\n'
+    /// /resume 语义：从历史胶囊续聊。整段回放进 UI，新轮次 append 回
+    /// 原文件（文件归属跟随会话开始日，不搬家）。
+    public func resume(_ loaded: LoadedChatSession) {
+        sessionRef = loaded.summary.ref
+        turns = loaded.turns
+        errorMessage = nil
+    }
 
-        let fm = FileManager.default
-        if fm.fileExists(atPath: url.path) {
-            if let handle = try? FileHandle(forWritingTo: url) {
-                defer { try? handle.close() }
-                _ = try? handle.seekToEnd()
-                try? handle.write(contentsOf: line)
-            }
-        } else {
-            try? line.write(to: url, options: .atomic)
+    /// 首轮真正发出时才建会话文件；title 取首问截断。已有会话则复用。
+    private func ensureSession(firstQuestion: String) {
+        guard sessionRef == nil else { return }
+        sessionRef = ChatSessionStore.createSession(
+            entry: entryKind,
+            title: firstQuestion,
+            anchorMemoID: attachedMemo?.id,
+            anchorMemoDate: attachedMemo.map { Self.dayString(from: $0.created) }
+        )
+    }
+
+    /// 本地即答的成对轮次（如提醒拦截：不走 LLM，UI 直接给确认话术）。
+    /// 之前 View 层直接改 `turns` 导致这类轮次不落盘——统一走这里。
+    public func appendLocalExchange(user: String, assistant: String) {
+        ensureSession(firstQuestion: user)
+        let userTurn = ChatTurn(role: .user, text: user)
+        let assistantTurn = ChatTurn(role: .assistant, text: assistant)
+        turns.append(userTurn)
+        turns.append(assistantTurn)
+        if let ref = sessionRef {
+            ChatSessionStore.appendTurn(userTurn, to: ref)
+            ChatSessionStore.appendTurn(assistantTurn, to: ref)
         }
     }
 
-    private static func chatLogURL(for date: Date) -> URL {
+    private static func dayString(from date: Date) -> String {
         let f = DateFormatter()
         f.locale = Locale(identifier: "en_US_POSIX")
         f.dateFormat = "yyyy-MM-dd"
         f.timeZone = TimeZone.current
-        let day = f.string(from: date)
-        return VaultInitializer.vaultURL
-            .appendingPathComponent("wiki/chats", isDirectory: true)
-            .appendingPathComponent("\(day).jsonl")
+        return f.string(from: date)
     }
 
     // MARK: - Pin to Diary

--- a/DayPageKit/Sources/DayPageServices/TimelineService.swift
+++ b/DayPageKit/Sources/DayPageServices/TimelineService.swift
@@ -66,6 +66,11 @@ public struct TimelineSection: Identifiable, Equatable {
     /// Newest-first within a section.
     public let days: [TimelineDayEntry]
 
+    public init(kind: TimelineSectionKind, days: [TimelineDayEntry]) {
+        self.kind = kind
+        self.days = days
+    }
+
     public var id: String {
         switch kind {
         case .pinned: return "pinned"

--- a/DayPageKit/Tests/DayPageServicesTests/ChatMarkdownRendererTests.swift
+++ b/DayPageKit/Tests/DayPageServicesTests/ChatMarkdownRendererTests.swift
@@ -1,0 +1,67 @@
+import Testing
+import Foundation
+@testable import DayPageServices
+
+@Suite("ChatMarkdownRenderer")
+struct ChatMarkdownRendererTests {
+
+    private func makeSession() -> LoadedChatSession {
+        let iso = ISO8601DateFormatter()
+        let startedAt = iso.date(from: "2026-07-15T06:32:00Z")!
+        let summary = ChatSessionSummary(
+            id: UUID(),
+            entry: .memo,
+            title: "这段时间我对独居的看法变了吗",
+            startedAt: startedAt,
+            dayString: "2026-07-15",
+            turnCount: 2,
+            isClosed: true,
+            anchorMemoID: UUID(),
+            anchorMemoDate: "2026-03-14",
+            fileURL: URL(fileURLWithPath: "/tmp/x.jsonl")
+        )
+        var assistant = ChatTurn(role: .assistant, text: "三月中你写到独处开始变得舒服。", createdAt: startedAt)
+        assistant.context = ChatSessionStore.syntheticContext(
+            dates: ["2026-03-14", "2026-05-02"],
+            entities: ["清迈"]
+        )
+        return LoadedChatSession(summary: summary, turns: [
+            ChatTurn(role: .user, text: "这段时间我对独居的看法变了吗", createdAt: startedAt),
+            assistant,
+        ])
+    }
+
+    @Test func rendersFrontmatterBodyAndSources() {
+        let md = ChatMarkdownRenderer.render(makeSession())
+
+        // YAML front-matter
+        #expect(md.hasPrefix("---\n"))
+        #expect(md.contains("type: chat_session"))
+        #expect(md.contains("date: 2026-07-15"))
+        #expect(md.contains("entry: 记忆锚定"))
+        #expect(md.contains("anchor_memo_date: 2026-03-14"))
+        #expect(md.contains("turns: 2"))
+        #expect(md.contains("export_source: DayPage"))
+
+        // 正文：角色 + 文本
+        #expect(md.contains("**我**"))
+        #expect(md.contains("**DayPage**"))
+        #expect(md.contains("这段时间我对独居的看法变了吗"))
+        #expect(md.contains("三月中你写到独处开始变得舒服。"))
+
+        // 依据行：日期渲染成 wikilink、实体显示名直出
+        #expect(md.contains("> 依据：[[2026-03-14]] · [[2026-05-02]] · 清迈"))
+    }
+
+    @Test func exportFileNameMatchesMemoNamingFamily() {
+        let name = ChatMarkdownRenderer.exportFileName(for: makeSession().summary)
+        #expect(name.hasPrefix("DayPage Chat 2026-07-15 "))
+        #expect(name.hasSuffix(".md"))
+    }
+
+    @Test func entryLabels() {
+        #expect(ChatMarkdownRenderer.entryLabel(.ask) == "问过去")
+        #expect(ChatMarkdownRenderer.entryLabel(.memo) == "记忆锚定")
+        #expect(ChatMarkdownRenderer.entryLabel(.coach) == "陪写")
+    }
+}

--- a/DayPageKit/Tests/DayPageServicesTests/ChatSessionStoreTests.swift
+++ b/DayPageKit/Tests/DayPageServicesTests/ChatSessionStoreTests.swift
@@ -1,0 +1,276 @@
+import Testing
+import Foundation
+@testable import DayPageServices
+
+// MARK: - Helpers
+
+/// 每个测试独立的临时 chats root，避免共享 vault 状态。
+private func makeTempRoot() throws -> URL {
+    let url = FileManager.default.temporaryDirectory
+        .appendingPathComponent("chat-store-tests-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+    return url
+}
+
+@Suite("ChatSessionStore")
+struct ChatSessionStoreTests {
+
+    // MARK: - Create / append / load roundtrip
+
+    @Test func createAppendLoadRoundtrip() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let longTitle = String(repeating: "我最近的情绪有什么变化？", count: 5)  // 60 字符
+        let ref = try #require(ChatSessionStore.createSession(
+            entry: .ask,
+            title: longTitle,
+            root: root
+        ))
+
+        let user = ChatTurn(role: .user, text: "我最近的情绪有什么变化？")
+        ChatSessionStore.appendTurn(user, to: ref)
+        ChatSessionStore.appendRetrieval(
+            memoDates: ["2026-03-14", "2026-05-02"],
+            entities: ["清迈"],
+            to: ref
+        )
+        let assistant = ChatTurn(role: .assistant, text: "三月中你写到独处开始变得舒服。")
+        ChatSessionStore.appendTurn(assistant, to: ref)
+
+        let sessions = ChatSessionStore.listSessions(root: root)
+        let summary = try #require(sessions.first)
+        #expect(sessions.count == 1)
+        #expect(summary.entry == .ask)
+        #expect(summary.title.count == 40)  // 首问截断到 40 字符
+        #expect(longTitle.hasPrefix(summary.title))
+        #expect(summary.turnCount == 2)
+        #expect(!summary.isClosed)
+
+        let loaded = try #require(ChatSessionStore.load(summary: summary))
+        #expect(loaded.turns.count == 2)
+        #expect(loaded.turns[0].role == .user)
+        #expect(loaded.turns[1].role == .assistant)
+        // retrieval 事件折进下一条 assistant turn 的合成 context。
+        let context = try #require(loaded.turns[1].context)
+        #expect(context.memoHits.map { $0.dateString } == ["2026-03-14", "2026-05-02"])
+        #expect(context.entityHits.map { $0.displayName } == ["清迈"])
+        #expect(loaded.turns[0].context == nil)
+    }
+
+    @Test func fileLandsInDayDirectory() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let now = Date()
+        let ref = try #require(ChatSessionStore.createSession(entry: .ask, title: "t", now: now, root: root))
+        let dayDir = ref.fileURL.deletingLastPathComponent()
+        #expect(dayDir.lastPathComponent == ChatSessionStore.dayString(for: now))
+        #expect(dayDir.deletingLastPathComponent().path == root.path)
+        #expect(ref.fileURL.pathExtension == "jsonl")
+    }
+
+    // MARK: - Same-second collision
+
+    @Test func sameSecondCollisionGetsSuffix() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let now = Date()
+        let a = try #require(ChatSessionStore.createSession(entry: .ask, title: "a", now: now, root: root))
+        let b = try #require(ChatSessionStore.createSession(entry: .ask, title: "b", now: now, root: root))
+        let c = try #require(ChatSessionStore.createSession(entry: .ask, title: "c", now: now, root: root))
+        #expect(a.fileURL != b.fileURL)
+        #expect(b.fileURL.lastPathComponent.hasSuffix("-2.jsonl"))
+        #expect(c.fileURL.lastPathComponent.hasSuffix("-3.jsonl"))
+        #expect(ChatSessionStore.listSessions(root: root).count == 3)
+    }
+
+    // MARK: - Resume (--continue)
+
+    @Test func resumesLatestUnclosedMatchingEntry() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let earlier = Date().addingTimeInterval(-60)
+        let old = try #require(ChatSessionStore.createSession(entry: .ask, title: "旧", now: earlier, root: root))
+        ChatSessionStore.appendTurn(ChatTurn(role: .user, text: "旧问题"), to: old)
+        ChatSessionStore.close(old)  // 封口 → 不应被接上
+
+        let fresh = try #require(ChatSessionStore.createSession(entry: .ask, title: "新", now: Date(), root: root))
+        ChatSessionStore.appendTurn(ChatTurn(role: .user, text: "新问题"), to: fresh)
+
+        let resumed = try #require(ChatSessionStore.resumeTodaySession(entry: .ask, root: root))
+        #expect(resumed.summary.id == fresh.id)
+        #expect(resumed.turns.map { $0.text } == ["新问题"])
+    }
+
+    @Test func closedSessionIsNotResumed() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let ref = try #require(ChatSessionStore.createSession(entry: .ask, title: "t", root: root))
+        ChatSessionStore.appendTurn(ChatTurn(role: .user, text: "q"), to: ref)
+        ChatSessionStore.close(ref)
+
+        #expect(ChatSessionStore.resumeTodaySession(entry: .ask, root: root) == nil)
+    }
+
+    @Test func memoResumeRequiresMatchingAnchor() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let memoA = UUID()
+        let memoB = UUID()
+        let ref = try #require(ChatSessionStore.createSession(
+            entry: .memo, title: "锚定", anchorMemoID: memoA, anchorMemoDate: "2026-03-14", root: root
+        ))
+        ChatSessionStore.appendTurn(ChatTurn(role: .user, text: "q"), to: ref)
+
+        // 同 memo → 接上；异 memo / 通用 ask → 不接。
+        #expect(ChatSessionStore.resumeTodaySession(entry: .memo, anchorMemoID: memoA, root: root) != nil)
+        #expect(ChatSessionStore.resumeTodaySession(entry: .memo, anchorMemoID: memoB, root: root) == nil)
+        #expect(ChatSessionStore.resumeTodaySession(entry: .ask, root: root) == nil)
+
+        let summary = try #require(ChatSessionStore.listSessions(root: root).first)
+        #expect(summary.anchorMemoID == memoA)
+        #expect(summary.anchorMemoDate == "2026-03-14")
+    }
+
+    // MARK: - Forward compatibility
+
+    @Test func unknownEventTypesAreSkipped() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let ref = try #require(ChatSessionStore.createSession(entry: .ask, title: "t", root: root))
+        ChatSessionStore.appendTurn(ChatTurn(role: .user, text: "q"), to: ref)
+
+        // 手工注入未来事件类型与坏行——load / summarize 均不得炸。
+        let handle = try FileHandle(forWritingTo: ref.fileURL)
+        defer { try? handle.close() }
+        _ = try handle.seekToEnd()
+        try handle.write(contentsOf: Data("""
+        {"type":"future_event","payload":"whatever"}
+        not-json-at-all
+        {"type":"turn","role":"assistant","text":"a","createdAt":"2026-07-15T06:00:00Z"}
+
+        """.utf8))
+
+        let summary = try #require(ChatSessionStore.listSessions(root: root).first)
+        #expect(summary.turnCount == 2)
+        let loaded = try #require(ChatSessionStore.load(summary: summary))
+        #expect(loaded.turns.map { $0.text } == ["q", "a"])
+    }
+
+    // MARK: - Delete
+
+    @Test func deleteRemovesFileAndEmptyDayDir() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let ref = try #require(ChatSessionStore.createSession(entry: .ask, title: "t", root: root))
+        let summary = try #require(ChatSessionStore.listSessions(root: root).first)
+        ChatSessionStore.delete(summary)
+
+        #expect(!FileManager.default.fileExists(atPath: ref.fileURL.path))
+        #expect(!FileManager.default.fileExists(atPath: ref.fileURL.deletingLastPathComponent().path))
+        #expect(ChatSessionStore.listSessions(root: root).isEmpty)
+    }
+
+    // MARK: - List ordering
+
+    @Test func listSessionsSortsNewestFirstAndHonorsLimitDays() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let now = Date()
+        let yesterday = now.addingTimeInterval(-86_400)
+        _ = ChatSessionStore.createSession(entry: .ask, title: "昨", now: yesterday, root: root)
+        _ = ChatSessionStore.createSession(entry: .ask, title: "今", now: now, root: root)
+
+        let all = ChatSessionStore.listSessions(root: root)
+        #expect(all.map { $0.title } == ["今", "昨"])
+
+        let recent = ChatSessionStore.listSessions(limitDays: 1, root: root)
+        #expect(recent.map { $0.title } == ["今"])
+    }
+}
+
+// MARK: - Legacy migration
+
+@Suite("ChatSessionStore legacy migration")
+struct ChatSessionStoreMigrationTests {
+
+    /// 旧格式：顶层天文件，逐行 ChatTurn（无 header / type 字段）。
+    private func writeLegacyDayFile(day: String, root: URL) throws -> URL {
+        let legacy = root.appendingPathComponent("\(day).jsonl")
+        try Data("""
+        {"id":"\(UUID().uuidString)","role":"user","text":"去年这个时候我在做什么","createdAt":"\(day)T02:00:00Z"}
+        {"id":"\(UUID().uuidString)","role":"assistant","text":"你在清迈。","createdAt":"\(day)T02:00:05Z"}
+
+        """.utf8).write(to: legacy, options: .atomic)
+        return legacy
+    }
+
+    @Test func migratesLegacyDayFileIntoClosedSession() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let legacy = try writeLegacyDayFile(day: "2026-06-01", root: root)
+        ChatSessionStore.migrateLegacyDayFiles(root: root)
+
+        // 源文件删除，目标落在日目录下。
+        #expect(!FileManager.default.fileExists(atPath: legacy.path))
+        let target = root.appendingPathComponent("2026-06-01/000000.jsonl")
+        #expect(FileManager.default.fileExists(atPath: target.path))
+
+        let summary = try #require(ChatSessionStore.listSessions(root: root).first)
+        #expect(summary.entry == .ask)
+        #expect(summary.title == "去年这个时候我在做什么")  // 首条 user 轮
+        #expect(summary.turnCount == 2)
+        #expect(summary.isClosed)  // 旧数据如实算作已封口的无边界会话
+
+        let loaded = try #require(ChatSessionStore.load(summary: summary))
+        #expect(loaded.turns.map { $0.text } == ["去年这个时候我在做什么", "你在清迈。"])
+    }
+
+    @Test func migrationIsIdempotent() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        _ = try writeLegacyDayFile(day: "2026-06-01", root: root)
+        ChatSessionStore.migrateLegacyDayFiles(root: root)
+        // 第二次：目标已在、源已删——不得重复/损坏。
+        ChatSessionStore.migrateLegacyDayFiles(root: root)
+        #expect(ChatSessionStore.listSessions(root: root).count == 1)
+
+        // 中断恢复：目标已在但源文件残留 → 只清理源，不覆盖目标。
+        let legacyAgain = try writeLegacyDayFile(day: "2026-06-01", root: root)
+        ChatSessionStore.migrateLegacyDayFiles(root: root)
+        #expect(!FileManager.default.fileExists(atPath: legacyAgain.path))
+        let summary = try #require(ChatSessionStore.listSessions(root: root).first)
+        #expect(summary.turnCount == 2)
+    }
+
+    @Test func listTriggersLegacyMigrationForNonDefaultRoot() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        _ = try writeLegacyDayFile(day: "2026-05-20", root: root)
+        // 不显式调迁移——listSessions 惰性触发。
+        let sessions = ChatSessionStore.listSessions(root: root)
+        #expect(sessions.count == 1)
+        #expect(sessions.first?.isClosed == true)
+    }
+
+    @Test func nonDayNamedJSONLFilesAreLeftAlone() throws {
+        let root = try makeTempRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let stray = root.appendingPathComponent("notes.jsonl")
+        try Data("{}".utf8).write(to: stray, options: .atomic)
+        ChatSessionStore.migrateLegacyDayFiles(root: root)
+        #expect(FileManager.default.fileExists(atPath: stray.path))
+    }
+}

--- a/DayPageTests/CaptureReminderServiceTests.swift
+++ b/DayPageTests/CaptureReminderServiceTests.swift
@@ -1,12 +1,16 @@
-// CaptureReminderServiceTests.swift — 「定时召唤记录」定时引擎
+// CaptureReminderServiceTests.swift — 「定时召唤记录」统一调度器
 //
-// 覆盖三块纯逻辑(不碰真实 UNUserNotificationCenter):
-//   * QuietHours.contains — 同日区间 + 跨午夜区间 + disabled 短路
-//   * 预设切换 apply(preset:) — once/thrice 覆盖 slots,custom 保留
-//   * slot 增删改 + 持久化 round-trip(注入独立 UserDefaults 隔离)
+// 覆盖纯逻辑(不碰真实 UNUserNotificationCenter):
+//   * QuietHours.contains — 同日区间 + 跨午夜 + disabled 短路
+//   * 预设切换 apply(preset:) — once/thrice 覆盖重复提醒,custom 保留,一次性不被清
+//   * Reminder CRUD + 持久化 round-trip(注入独立 UserDefaults 隔离)
+//   * 一次性提醒过期剔除
+//   * 旧 ReminderSlot(captureReminder.slots)→ 新 Reminder 迁移
+//   * Reminder 派生:timeString / repeatDescription / nextFireDate / weekdayLabel
+//   * RelativeTimeResolver 相对时间解析
 //
-// service 是 @MainActor singleton,但 init(defaults:) 允许注入独立的
-// UserDefaults suite,所以测试造独立实例、不污染 .standard / singleton。
+// service 是 @MainActor singleton,但 init(defaults:) 允许注入独立 suite,
+// 测试造独立实例、不污染 .standard / singleton。
 
 import Testing
 import Foundation
@@ -16,7 +20,6 @@ import Foundation
 @Suite(.serialized)
 struct CaptureReminderServiceTests {
 
-    /// 造一个用独立 UserDefaults suite 的 service,测试互不干扰。
     private func makeService(suite: String = "captureReminder.test.\(UUID().uuidString)") -> (CaptureReminderService, UserDefaults) {
         let defaults = UserDefaults(suiteName: suite)!
         defaults.removePersistentDomain(forName: suite)
@@ -26,118 +29,259 @@ struct CaptureReminderServiceTests {
     // MARK: - QuietHours
 
     @Test func quietHoursSameDayRange() {
-        // 01:00–06:00 静音。
         let q = QuietHours(enabled: true, startMinutes: 60, endMinutes: 360)
-        #expect(q.contains(hour: 0, minute: 30) == false)  // 00:30 区间外
-        #expect(q.contains(hour: 1, minute: 0) == true)    // 01:00 起点(含)
-        #expect(q.contains(hour: 3, minute: 0) == true)    // 03:00 区间内
-        #expect(q.contains(hour: 6, minute: 0) == false)   // 06:00 终点(不含)
-        #expect(q.contains(hour: 9, minute: 0) == false)   // 09:00 区间外
+        #expect(q.contains(hour: 0, minute: 30) == false)
+        #expect(q.contains(hour: 1, minute: 0) == true)
+        #expect(q.contains(hour: 3, minute: 0) == true)
+        #expect(q.contains(hour: 6, minute: 0) == false)
+        #expect(q.contains(hour: 9, minute: 0) == false)
     }
 
     @Test func quietHoursOvernightRange() {
-        // 23:30–08:00 跨午夜静音(默认值)。
         let q = QuietHours.defaultQuiet
-        #expect(q.contains(hour: 23, minute: 30) == true)  // 起点(含)
-        #expect(q.contains(hour: 23, minute: 45) == true)  // 午夜前
-        #expect(q.contains(hour: 0, minute: 0) == true)    // 午夜
-        #expect(q.contains(hour: 7, minute: 59) == true)   // 08:00 前
-        #expect(q.contains(hour: 8, minute: 0) == false)   // 终点(不含)
-        #expect(q.contains(hour: 21, minute: 0) == false)  // 晚上 21:00 区间外
+        #expect(q.contains(hour: 23, minute: 30) == true)
+        #expect(q.contains(hour: 0, minute: 0) == true)
+        #expect(q.contains(hour: 7, minute: 59) == true)
+        #expect(q.contains(hour: 8, minute: 0) == false)
+        #expect(q.contains(hour: 21, minute: 0) == false)
     }
 
     @Test func quietHoursDisabledNeverContains() {
         let q = QuietHours(enabled: false, startMinutes: 0, endMinutes: 1439)
-        // 即使区间覆盖几乎全天,disabled 时永远 false。
         #expect(q.contains(hour: 3, minute: 0) == false)
         #expect(q.contains(hour: 12, minute: 0) == false)
     }
 
     // MARK: - Preset switching
 
-    @Test func presetOnceProducesSingleEveningSlot() {
+    @Test func presetOnceProducesSingleEveningReminder() {
         let (service, _) = makeService()
         service.apply(preset: .once)
         #expect(service.preset == .once)
-        #expect(service.slots.count == 1)
-        #expect(service.slots.first?.hour == 21)
+        let repeating = service.reminders.filter { !$0.isOneShot }
+        #expect(repeating.count == 1)
+        #expect(repeating.first?.timeComponents.hour == 21)
     }
 
-    @Test func presetThriceProducesThreeSlots() {
+    @Test func presetThriceProducesThreeReminders() {
         let (service, _) = makeService()
         service.apply(preset: .thrice)
         #expect(service.preset == .thrice)
-        #expect(service.slots.count == 3)
-        #expect(service.slots.map(\.hour) == [9, 13, 21])
+        let repeating = service.reminders.filter { !$0.isOneShot }
+        #expect(repeating.count == 3)
+        #expect(repeating.map { $0.timeComponents.hour }.sorted() == [9, 13, 21])
     }
 
-    @Test func presetCustomKeepsExistingSlots() {
+    @Test func presetCustomKeepsExistingReminders() {
         let (service, _) = makeService()
-        service.apply(preset: .thrice)          // 先有 3 个
-        service.apply(preset: .custom)          // 切 custom
-        // custom 保留现有 slots,不清空。
-        #expect(service.preset == .custom)
-        #expect(service.slots.count == 3)
-    }
-
-    // MARK: - Slot CRUD + persistence
-
-    @Test func addAndRemoveSlot() {
-        let (service, _) = makeService()
-        service.apply(preset: .once)            // 1 个
+        service.apply(preset: .thrice)
         service.apply(preset: .custom)
-        service.addSlot(hour: 7, minute: 30, label: "晨跑后")
-        #expect(service.slots.count == 2)
-        // 新增后按时间排序:07:30 应排在 21:00 前。
-        #expect(service.slots.first?.hour == 7)
-
-        let toRemove = service.slots.first!.id
-        service.removeSlot(toRemove)
-        #expect(service.slots.count == 1)
-        #expect(service.slots.first?.hour == 21)
+        #expect(service.preset == .custom)
+        #expect(service.reminders.filter { !$0.isOneShot }.count == 3)
     }
 
-    @Test func updateSlotTimeClampsToValidRange() {
+    @Test func presetSwitchKeepsOneShots() {
         let (service, _) = makeService()
         service.apply(preset: .once)
-        let id = service.slots.first!.id
-        service.updateSlot(id, hour: 99, minute: 99)  // 越界
-        #expect(service.slots.first?.hour == 23)       // clamp 到 23
-        #expect(service.slots.first?.minute == 59)     // clamp 到 59
+        // 排一条未来的一次性。
+        let future = Date().addingTimeInterval(3600)
+        service.scheduleOnce(at: future, label: "一小时后")
+        #expect(service.reminders.contains { $0.isOneShot })
+        // 切预设不应清掉一次性。
+        service.apply(preset: .thrice)
+        #expect(service.reminders.contains { $0.isOneShot })
     }
 
-    @Test func setSlotEnabledToggles() {
+    // MARK: - Reminder CRUD
+
+    @Test func addAndRemoveReminder() {
         let (service, _) = makeService()
         service.apply(preset: .once)
-        let id = service.slots.first!.id
-        service.setSlot(id, enabled: false)
-        #expect(service.slots.first?.enabled == false)
+        service.apply(preset: .custom)
+        let added = service.addReminder(
+            Reminder(trigger: .daily(hour: 7, minute: 30), label: "晨跑后"))
+        #expect(service.reminders.filter { !$0.isOneShot }.count == 2)
+        service.removeReminder(added.id)
+        #expect(service.reminders.filter { !$0.isOneShot }.count == 1)
+    }
+
+    @Test func scheduleOnceRejectsPastTime() {
+        let (service, _) = makeService()
+        let past = Date().addingTimeInterval(-60)
+        let result = service.scheduleOnce(at: past, label: "过去")
+        #expect(result == nil)
+    }
+
+    @Test func setReminderEnabledToggles() {
+        let (service, _) = makeService()
+        service.apply(preset: .once)
+        let id = service.reminders.first!.id
+        service.setReminder(id, enabled: false)
+        #expect(service.reminders.first?.enabled == false)
+    }
+
+    @Test func updateReminderReplacesTrigger() {
+        let (service, _) = makeService()
+        service.apply(preset: .once)
+        let id = service.reminders.first!.id
+        service.updateReminder(id, trigger: .weekdays(days: [2, 4, 6], hour: 8, minute: 0), label: "隔天早")
+        let updated = service.reminders.first { $0.id == id }
+        #expect(updated?.repeatDescription == "周一、三、五")
+        #expect(updated?.label == "隔天早")
+    }
+
+    // MARK: - Expiry pruning
+
+    @Test func expiredOneShotPrunedOnReload() {
+        let suite = "captureReminder.test.expire.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        // 手写一条已过期的一次性 + 一条重复,直接进 UserDefaults。
+        let expired = Reminder(trigger: .once(Date().addingTimeInterval(-60)), label: "过期")
+        let daily = Reminder(trigger: .daily(hour: 21, minute: 0), label: "睡前")
+        let data = try! JSONEncoder().encode([expired, daily])
+        defaults.set(data, forKey: "captureReminder.reminders")
+        // 重新造实例 → init 里 pruneExpiredOneShots 应剔除过期一次性。
+        let service = CaptureReminderService(defaults: defaults)
+        #expect(service.reminders.count == 1)
+        #expect(service.reminders.first?.isOneShot == false)
+    }
+
+    // MARK: - Legacy migration
+
+    @Test func legacySlotsMigrateToReminders() {
+        let suite = "captureReminder.test.migrate.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        // 造旧 ReminderSlot 形状的 JSON(id/hour/minute/label/enabled)。
+        let legacy: [[String: Any]] = [
+            ["id": UUID().uuidString, "hour": 8, "minute": 30, "label": "晨间", "enabled": true],
+            ["id": UUID().uuidString, "hour": 22, "minute": 0, "label": "睡前", "enabled": false]
+        ]
+        // Codable 的 UUID 编码为字符串,与 JSONSerialization 兼容。
+        let data = try! JSONSerialization.data(withJSONObject: legacy)
+        defaults.set(data, forKey: "captureReminder.slots")
+
+        let service = CaptureReminderService(defaults: defaults)
+        let repeating = service.reminders.filter { !$0.isOneShot }
+        #expect(repeating.count == 2)
+        #expect(repeating.contains { $0.timeComponents == (8, 30) && $0.enabled })
+        #expect(repeating.contains { $0.timeComponents == (22, 0) && !$0.enabled })
+        // 迁移后旧 key 应被清除,新 key 应写入。
+        #expect(defaults.data(forKey: "captureReminder.slots") == nil)
+        #expect(defaults.data(forKey: "captureReminder.reminders") != nil)
     }
 
     @Test func configPersistsAcrossReload() {
         let suite = "captureReminder.test.persist.\(UUID().uuidString)"
         let (service, _) = makeService(suite: suite)
         service.apply(preset: .thrice)
-        service.setSlot(service.slots[1].id, enabled: false)  // 关掉午
+        let midID = service.reminders.filter { !$0.isOneShot }[1].id
+        service.setReminder(midID, enabled: false)
 
-        // 用同一个 suite 重新造实例 → 应从 UserDefaults 还原。
         let reloaded = CaptureReminderService(defaults: UserDefaults(suiteName: suite)!)
         #expect(reloaded.preset == .thrice)
-        #expect(reloaded.slots.count == 3)
-        #expect(reloaded.slots[1].enabled == false)
+        let repeating = reloaded.reminders.filter { !$0.isOneShot }
+        #expect(repeating.count == 3)
+        #expect(repeating.contains { !$0.enabled })
     }
 
-    // MARK: - ReminderSlot presentation
+    // MARK: - Reminder presentation
 
-    @Test func slotTimeStringPadsZeros() {
-        let slot = ReminderSlot(hour: 9, minute: 5, label: "早", enabled: true)
-        #expect(slot.timeString == "09:05")
+    @Test func reminderTimeStringPadsZeros() {
+        let r = Reminder(trigger: .daily(hour: 9, minute: 5), label: "早")
+        #expect(r.timeString == "09:05")
     }
 
-    @Test func slotPromptBodyVariesByTimeOfDay() {
-        let morning = ReminderSlot(hour: 9, minute: 0, label: "早", enabled: true)
-        let evening = ReminderSlot(hour: 21, minute: 0, label: "晚", enabled: true)
+    @Test func reminderPromptBodyVariesByTimeOfDay() {
+        let morning = Reminder(trigger: .daily(hour: 9, minute: 0), label: "早")
+        let evening = Reminder(trigger: .daily(hour: 21, minute: 0), label: "晚")
         #expect(morning.promptBody != evening.promptBody)
         #expect(morning.promptBody.contains("早上"))
+    }
+
+    @Test func weekdayLabelKnownGroups() {
+        #expect(Reminder.weekdayLabel(for: [1, 2, 3, 4, 5, 6, 7]) == "每天")
+        #expect(Reminder.weekdayLabel(for: [2, 3, 4, 5, 6]) == "工作日")
+        #expect(Reminder.weekdayLabel(for: [1, 7]) == "周末")
+        #expect(Reminder.weekdayLabel(for: [2, 4, 6]) == "周一、三、五")
+    }
+
+    @Test func nextFireDateDailyRollsToTomorrowWhenPast() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Shanghai")!
+        // now = 2026-07-15 22:00,提醒 21:00 → 应滚到明天 21:00。
+        let now = cal.date(from: DateComponents(year: 2026, month: 7, day: 15, hour: 22, minute: 0))!
+        let r = Reminder(trigger: .daily(hour: 21, minute: 0), label: "睡前")
+        let next = r.nextFireDate(after: now, calendar: cal)
+        let comps = cal.dateComponents([.day, .hour], from: next!)
+        #expect(comps.day == 16)
+        #expect(comps.hour == 21)
+    }
+
+    @Test func nextFireDateDisabledReturnsNil() {
+        let r = Reminder(trigger: .daily(hour: 21, minute: 0), label: "睡前", enabled: false)
+        #expect(r.nextFireDate() == nil)
+    }
+
+    @Test func nextFireDateOncePastReturnsNil() {
+        let r = Reminder(trigger: .once(Date().addingTimeInterval(-60)), label: "过去")
+        #expect(r.nextFireDate() == nil)
+    }
+
+    // MARK: - Upcoming query (Today capsule)
+
+    @Test func upcomingSortsByNextFire() {
+        let (service, _) = makeService()
+        service.apply(preset: .custom)
+        // 清掉默认,精确造两条重复。
+        for r in service.reminders { service.removeReminder(r.id) }
+        service.addReminder(Reminder(trigger: .daily(hour: 23, minute: 0), label: "晚"))
+        service.addReminder(Reminder(trigger: .daily(hour: 6, minute: 0), label: "早"))
+        let upcoming = service.upcoming(limit: 5)
+        #expect(upcoming.count == 2)
+        // 无论当前几点,两条下次触发时间点先后关系稳定可比。
+        let firstNext = upcoming[0].nextFireDate()!
+        let secondNext = upcoming[1].nextFireDate()!
+        #expect(firstNext <= secondNext)
+    }
+
+    // MARK: - RelativeTimeResolver
+
+    @Test func resolverAfterSeconds() {
+        let now = Date()
+        let resolved = RelativeTimeResolver.resolve(.afterSeconds(3600), now: now)
+        #expect(abs(resolved!.timeIntervalSince(now) - 3600) < 1)
+    }
+
+    @Test func resolverTonightIsEvening() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Shanghai")!
+        let now = cal.date(from: DateComponents(year: 2026, month: 7, day: 15, hour: 14, minute: 0))!
+        let resolved = RelativeTimeResolver.resolve(.tonight, now: now, calendar: cal)!
+        let comps = cal.dateComponents([.day, .hour], from: resolved)
+        #expect(comps.day == 15)
+        #expect(comps.hour == RelativeTimeResolver.eveningHour)
+    }
+
+    @Test func resolverTomorrowMorning() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Shanghai")!
+        let now = cal.date(from: DateComponents(year: 2026, month: 7, day: 15, hour: 23, minute: 0))!
+        let resolved = RelativeTimeResolver.resolve(.tomorrowMorning, now: now, calendar: cal)!
+        let comps = cal.dateComponents([.day, .hour], from: resolved)
+        #expect(comps.day == 16)
+        #expect(comps.hour == RelativeTimeResolver.morningHour)
+    }
+
+    @Test func resolverAtRollsToTomorrowWhenPast() {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "Asia/Shanghai")!
+        let now = cal.date(from: DateComponents(year: 2026, month: 7, day: 15, hour: 15, minute: 0))!
+        // 说「10 点」但现在 15 点 → 明天 10 点。
+        let resolved = RelativeTimeResolver.resolve(.at(hour: 10, minute: 0), now: now, calendar: cal)!
+        let comps = cal.dateComponents([.day, .hour], from: resolved)
+        #expect(comps.day == 16)
+        #expect(comps.hour == 10)
     }
 }

--- a/DayPageTests/MemoryChatTests.swift
+++ b/DayPageTests/MemoryChatTests.swift
@@ -1,6 +1,7 @@
 import Testing
 import Foundation
 import DayPageServices
+import DayPageStorage
 import DayPageModels
 @testable import DayPage
 
@@ -120,9 +121,29 @@ struct RetrievedContextTests {
 
 // MARK: - MemoryChatService
 
-@Suite("MemoryChatService")
+/// Serialized because tests mutate global `VaultInitializer.testOverrideURL`
+/// (session 化后 `ask` 会真实落盘 —— 不隔离会把测试会话泄漏进真机/模拟器
+/// 的 vault/wiki/chats，正是 2026-07-15 验收时撞见的污染源)。
+@Suite("MemoryChatService", .serialized)
 @MainActor
 struct MemoryChatServiceTests {
+
+    private let tempVault: URL
+
+    init() throws {
+        tempVault = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MemoryChatTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tempVault.appendingPathComponent("wiki/chats", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        VaultInitializer.testOverrideURL = tempVault
+    }
+
+    private func cleanup() {
+        VaultInitializer.testOverrideURL = nil
+        try? FileManager.default.removeItem(at: tempVault)
+    }
 
     // static + nonisolated so we can pass it into the @Sendable `retrieve`
     // closure that MemoryChatService now requires. The suite as a whole is
@@ -137,6 +158,7 @@ struct MemoryChatServiceTests {
     }
 
     @Test func askAppendsUserThenAssistantTurns() async {
+        defer { cleanup() }
         let service = MemoryChatService(
             send: { _ in "这是回答" },
             retrieve: { q, _ in Self.fixedContext(q) }
@@ -153,6 +175,7 @@ struct MemoryChatServiceTests {
     }
 
     @Test func askSurfacesErrorWithoutAssistantTurn() async {
+        defer { cleanup() }
         let service = MemoryChatService(
             send: { _ in throw LLMError.rateLimited },
             retrieve: { q, _ in Self.fixedContext(q) }
@@ -165,12 +188,14 @@ struct MemoryChatServiceTests {
     }
 
     @Test func emptyQuestionIsIgnored() async {
+        defer { cleanup() }
         let service = MemoryChatService(send: { _ in "x" }, retrieve: { q, _ in Self.fixedContext(q) })
         await service.ask("   ")
         #expect(service.turns.isEmpty)
     }
 
     @Test func buildMessagesIncludesSystemAndRetrievedContext() {
+        defer { cleanup() }
         let service = MemoryChatService(send: { _ in "" }, retrieve: { q, _ in Self.fixedContext(q) })
         let ctx = Self.fixedContext("问题")
         let messages = service.buildMessages(question: "我去过哪里？", context: ctx)
@@ -181,6 +206,7 @@ struct MemoryChatServiceTests {
     }
 
     @Test func resetClearsConversation() async {
+        defer { cleanup() }
         let service = MemoryChatService(send: { _ in "答" }, retrieve: { q, _ in Self.fixedContext(q) })
         await service.ask("Q")
         service.reset()
@@ -216,9 +242,27 @@ struct LLMClientSSETests {
 
 // MARK: - Memo-anchored chat (issue #837)
 
-@Suite("MemoryChatService memo anchoring")
+/// Serialized —— 同 MemoryChatServiceTests：ask() 落盘，须用临时 vault 隔离。
+@Suite("MemoryChatService memo anchoring", .serialized)
 @MainActor
 struct MemoAnchoredChatTests {
+
+    private let tempVault: URL
+
+    init() throws {
+        tempVault = FileManager.default.temporaryDirectory
+            .appendingPathComponent("MemoAnchoredChatTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: tempVault.appendingPathComponent("wiki/chats", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        VaultInitializer.testOverrideURL = tempVault
+    }
+
+    private func cleanup() {
+        VaultInitializer.testOverrideURL = nil
+        try? FileManager.default.removeItem(at: tempVault)
+    }
 
     nonisolated static func fixedContext(_ q: String) -> RetrievedContext {
         RetrievedContext(
@@ -239,6 +283,7 @@ struct MemoAnchoredChatTests {
     }
 
     @Test func buildMessagesIncludesAnchoredMemoBlockAndRule() {
+        defer { cleanup() }
         let service = MemoryChatService(send: { _ in "" }, retrieve: { q, _ in Self.fixedContext(q) })
         service.attach(memo: makeMemo(), clues: ["信息架构"])
         let messages = service.buildMessages(question: "当时我为什么这么想？", context: Self.fixedContext("x"))
@@ -256,6 +301,7 @@ struct MemoAnchoredChatTests {
     }
 
     @Test func detachRemovesMemoBlock() {
+        defer { cleanup() }
         let service = MemoryChatService(send: { _ in "" }, retrieve: { q, _ in Self.fixedContext(q) })
         service.attach(memo: makeMemo())
         service.detachMemo()
@@ -265,6 +311,7 @@ struct MemoAnchoredChatTests {
     }
 
     @Test func askSeedsRetrievalWithAttachedMemoEntities() async {
+        defer { cleanup() }
         // Capture the seed slugs the service hands to the retriever.
         let captured = CapturedSeeds()
         let service = MemoryChatService(
@@ -284,12 +331,14 @@ struct MemoAnchoredChatTests {
     }
 
     @Test func attachFallsBackToDehyphenatedSlugsAsClues() {
+        defer { cleanup() }
         let service = MemoryChatService(send: { _ in "" }, retrieve: { q, _ in Self.fixedContext(q) })
         service.attach(memo: makeMemo())
         #expect(service.attachedClues == ["xinxi jiagou", "daypage dev"])
     }
 
     @Test func streamSendPathAccumulatesStreamingTextInOrder() async {
+        defer { cleanup() }
         let service = MemoryChatService(
             send: { _ in "unused" },
             streamSend: { _, onDelta in
@@ -308,6 +357,7 @@ struct MemoAnchoredChatTests {
     }
 
     @Test func retryLastDoesNotDuplicateUserTurn() async {
+        defer { cleanup() }
         let flaky = FlipFlop()
         let service = MemoryChatService(
             send: { _ in

--- a/DayPageTests/ReminderIntentParserTests.swift
+++ b/DayPageTests/ReminderIntentParserTests.swift
@@ -1,0 +1,205 @@
+// ReminderIntentParserTests.swift — 自然语言 → 提醒调度解析
+//
+// 覆盖(全部纯函数,注入固定 now/calendar):
+//   * 提醒动词门:无「提醒/remind」不触发
+//   * 重复:每天 / 工作日 / 周末 / 周一三五组合(缺时分 → nil 追问)
+//   * 一次:N 分钟/小时后 / 半小时后 / 今晚 / 明早 / 明晚 / 明天+时分 / 裸时分顺延
+//   * 时分:HH:mm / N点半 / 晚上 10 点(12h 换算)/ 中文数字(十点/八点)
+//   * 过去时刻拒绝(今晚 8 点但已 21 点 → nil)
+//   * 标签萃取:「今晚提醒我复盘」→「复盘」;纯时间无标签 → 空串
+//   * 英文基础:remind me in an hour / tonight / every day at 22:00
+
+import Testing
+import Foundation
+@testable import DayPage
+
+struct ReminderIntentParserTests {
+
+    /// 固定基准:2026-07-15(周三)14:00 本地时区。
+    private var now: Date {
+        var comps = DateComponents()
+        comps.year = 2026; comps.month = 7; comps.day = 15
+        comps.hour = 14; comps.minute = 0
+        return Calendar.current.date(from: comps)!
+    }
+
+    private func parse(_ text: String) -> ParsedReminder? {
+        ReminderIntentParser.parse(text, now: now, calendar: .current)
+    }
+
+    private func hourMinute(_ date: Date) -> (Int, Int) {
+        let c = Calendar.current.dateComponents([.hour, .minute], from: date)
+        return (c.hour ?? -1, c.minute ?? -1)
+    }
+
+    // MARK: - 动词门
+
+    @Test func noReminderVerb_returnsNil() {
+        #expect(parse("每天 22:00 写日记") == nil)
+        #expect(parse("今晚复盘一下") == nil)
+    }
+
+    @Test func verbWithoutTime_returnsNil() {
+        #expect(parse("提醒我复盘") == nil)
+        #expect(parse("记得叫我") == nil)
+    }
+
+    // MARK: - 重复
+
+    @Test func daily_withClockTime() throws {
+        let r = try #require(parse("每天 22:00 提醒我写日记"))
+        #expect(r.trigger == .daily(hour: 22, minute: 0))
+        #expect(r.label == "写日记")
+    }
+
+    @Test func daily_chineseEveningNumeral() throws {
+        let r = try #require(parse("每天晚上十点提醒我"))
+        #expect(r.trigger == .daily(hour: 22, minute: 0))
+    }
+
+    @Test func weekdaysPreset() throws {
+        let r = try #require(parse("工作日 9 点提醒我晨记"))
+        #expect(r.trigger == .weekdays(days: [2, 3, 4, 5, 6], hour: 9, minute: 0))
+        #expect(r.label == "晨记")
+    }
+
+    @Test func weekendPreset() throws {
+        let r = try #require(parse("周末早上 8 点提醒我"))
+        #expect(r.trigger == .weekdays(days: [1, 7], hour: 8, minute: 0))
+    }
+
+    @Test func weekdayCombo_monWedFri() throws {
+        let r = try #require(parse("周一三五 9 点提醒我晨记"))
+        #expect(r.trigger == .weekdays(days: [2, 4, 6], hour: 9, minute: 0))
+    }
+
+    @Test func repeat_withoutClock_asksBack() {
+        #expect(parse("每天提醒我写日记") == nil)
+    }
+
+    @Test func daily_english() throws {
+        let r = try #require(parse("remind me every day at 22:00"))
+        #expect(r.trigger == .daily(hour: 22, minute: 0))
+    }
+
+    // MARK: - 相对间隔
+
+    @Test func afterOneHour() throws {
+        let r = try #require(parse("一小时后提醒我"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(abs(date.timeIntervalSince(now) - 3600) < 1)
+    }
+
+    @Test func afterThirtyMinutes() throws {
+        let r = try #require(parse("30 分钟后提醒我取快递"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(abs(date.timeIntervalSince(now) - 1800) < 1)
+        #expect(r.label == "取快递")
+    }
+
+    @Test func afterHalfHour() throws {
+        let r = try #require(parse("半小时后提醒我"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(abs(date.timeIntervalSince(now) - 1800) < 1)
+    }
+
+    @Test func english_inAnHour() throws {
+        let r = try #require(parse("remind me in an hour"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(abs(date.timeIntervalSince(now) - 3600) < 1)
+    }
+
+    // MARK: - 相对日词
+
+    @Test func tonight_defaultsToEight() throws {
+        let r = try #require(parse("今晚提醒我复盘"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(hourMinute(date) == (20, 0))
+        #expect(Calendar.current.isDate(date, inSameDayAs: now))
+        #expect(r.label == "复盘")
+    }
+
+    @Test func tomorrowMorning_defaultsToEight() throws {
+        let r = try #require(parse("明早提醒我"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(hourMinute(date) == (8, 0))
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: now)!
+        #expect(Calendar.current.isDate(date, inSameDayAs: tomorrow))
+    }
+
+    @Test func tomorrowWithExplicitClock() throws {
+        let r = try #require(parse("明天下午 3 点提醒我取快递"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(hourMinute(date) == (15, 0))
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: now)!
+        #expect(Calendar.current.isDate(date, inSameDayAs: tomorrow))
+        #expect(r.label == "取快递")
+    }
+
+    @Test func bareTomorrow_withoutClock_asksBack() {
+        #expect(parse("明天提醒我") == nil)
+    }
+
+    @Test func pastMomentToday_rejected() {
+        // now = 14:00,「今天上午 10 点」已过 → nil(追问,不猜)。
+        #expect(parse("今天上午 10 点提醒我") == nil)
+    }
+
+    // MARK: - 裸时分
+
+    @Test func bareClock_futureToday() throws {
+        let r = try #require(parse("18 点提醒我下班买菜"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(hourMinute(date) == (18, 0))
+        #expect(Calendar.current.isDate(date, inSameDayAs: now))
+    }
+
+    @Test func bareClock_pastRollsToTomorrow() throws {
+        // now = 14:00,「10 点」已过 → 顺延到明天(RelativeTimeResolver .at 语义)。
+        let r = try #require(parse("10 点提醒我"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(hourMinute(date) == (10, 0))
+        let tomorrow = Calendar.current.date(byAdding: .day, value: 1, to: now)!
+        #expect(Calendar.current.isDate(date, inSameDayAs: tomorrow))
+    }
+
+    @Test func halfPastClock() throws {
+        let r = try #require(parse("晚上 9 点半提醒我"))
+        guard case .once(let date) = r.trigger else {
+            Issue.record("expected .once"); return
+        }
+        #expect(hourMinute(date) == (21, 30))
+    }
+
+    // MARK: - 标签
+
+    @Test func labelEmpty_whenPureTime() throws {
+        let r = try #require(parse("一小时后提醒我"))
+        #expect(r.label.isEmpty)
+    }
+
+    @Test func labelStripsNoiseWords() throws {
+        let r = try #require(parse("今晚提醒我去复盘一下项目"))
+        #expect(r.label.contains("复盘"))
+        #expect(!r.label.contains("提醒"))
+        #expect(!r.label.contains("今晚"))
+    }
+}


### PR DESCRIPTION
## 概要

本分支包含两条主线，共 4 个 commit：

### 一、定时召唤记录 / Reminder vNext（前三个 commit）

- **A** `75af5e3`：统一 `Reminder` 模型 + 调度器（AlarmKit 灵动岛 + 本地通知兜底）
- **B/C** `6c6ad86`：Today 提醒胶囊条（`ReminderCapsuleStrip`）、编辑 sheet（一次/每天/周几）、零 LLM 中文意图解析（`ReminderIntentParser`——「明早提醒我」「每天 22:00」「周一三五 9 点」）；陪写/问过去输入框拦截提醒请求直落调度器，不进 RAG/LLM

### 二、AI 聊天历史 session 化 — 对话长河（`cccb26a`）

把「问过去 / 记忆锚定 / 陪写」统一为同一个 agent 的 session 机制，**对标 Claude Code 的 transcript 语义**：

| Claude Code | DayPage |
|---|---|
| session = JSONL 追加事件日志 | `vault/wiki/chats/YYYY-MM-DD/HHmmss.jsonl` |
| `/clear` | 「新对话」= append `closed` 封口 |
| `--continue` | 打开接今天最近未封口会话 |
| `/resume` 选择器 | 聊天框内的「对话长河」：上滑即历史胶囊 |

- 事件流：`session` header / `turn` / `retrieval`（检索留痕）/ `closed`；未知类型跳过（向前兼容）
- 长河 UI：虚线胶囊按天分组沉在对话上游；点击原位回放 + 续聊；长按菜单（续聊/导出/多选/删除）；多选导出 N 个 Obsidian 兼容 `.md`（依据渲染成 `[[日期]]` wikilink）走系统分享面板。**不进侧边栏**
- 旧天文件惰性迁移为已封口单会话（幂等）；`FeatureFlag.chatHistory` 兜底
- 顺带修复：提醒拦截轮次不落盘、`MemoryChatTests` 会话文件泄漏进真实 vault（补 `testOverrideURL` 隔离）

设计稿（v2，含线框与决策权衡）：https://claude.ai/code/artifact/ea83c071-f1c2-4196-8780-74dfc8857228

## 测试与验收

- ✅ DayPageKit：新增 16 个单测（store 13 + renderer 3），`swift test` 全绿
- ✅ App：`xcodebuild test`（iPhone 17 / iOS 26.1）全部通过
- ✅ Simulator 端到端：迁移胶囊 → 展开回放 → 续聊 → 新对话封存 → 长按菜单 → 单段导出（md 内容核对）→ 多选导出双文件 → 分享面板，全链路截图验证
- ✅ 落盘核对：`wiki/chats/` 目录结构、header/closed 事件、迁移产物均符合设计

## 遗留（后续 PR）

- Wave C：陪写教练会话留痕（`CoachTurn` Codable 化）
- Obsidian 全量导出补 `chats/` 子目录
- 英文 "1 turns" 复数（stringsdict）