### PR TITLE
Add self-hosted web production deployment

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -1,0 +1,39 @@
+name: Deploy web production
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+concurrency:
+  group: web-production
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          PORT: ${{ secrets.DEPLOY_PORT }}
+        run: |
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p "$PORT" -H "$HOST" >> ~/.ssh/known_hosts
+      - name: Synchronize and deploy
+        env:
+          HOST: ${{ secrets.DEPLOY_HOST }}
+          PORT: ${{ secrets.DEPLOY_PORT }}
+          USER: ${{ secrets.DEPLOY_USER }}
+          ENV_FILE: ${{ secrets.ENV_FILE }}
+        run: |
+          SSH="ssh -i ~/.ssh/deploy_key -p $PORT"
+          $SSH "$USER@$HOST" 'install -d -m 700 /srv/apps/daypage/current'
+          rsync -az --delete --exclude .git --exclude .env --exclude node_modules --exclude .next -e "$SSH" ./ "$USER@$HOST:/srv/apps/daypage/current/"
+          printf '%s' "$ENV_FILE" | $SSH "$USER@$HOST" 'umask 077; cat > /srv/apps/daypage/current/.env'
+          $SSH "$USER@$HOST" 'cd /srv/apps/daypage/current && bash deploy/deploy.sh'

--- a/deploy/Dockerfile.web
+++ b/deploy/Dockerfile.web
@@ -1,0 +1,9 @@
+FROM node:22-alpine
+RUN corepack enable
+WORKDIR /app
+COPY . .
+RUN pnpm install --frozen-lockfile
+RUN pnpm --filter daypage-web build
+ENV NODE_ENV=production
+EXPOSE 3000
+CMD ["pnpm", "--filter", "daypage-web", "start"]

--- a/deploy/compose.prod.yml
+++ b/deploy/compose.prod.yml
@@ -1,0 +1,14 @@
+services:
+  web:
+    build:
+      context: ..
+      dockerfile: deploy/Dockerfile.web
+    restart: unless-stopped
+    env_file: ../.env
+    ports:
+      - "127.0.0.1:13000:3000"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/ >/dev/null"]
+      interval: 30s
+      timeout: 5s
+      retries: 5

--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+set -euo pipefail
+docker compose -f deploy/compose.prod.yml --project-name daypage up -d --build --remove-orphans
+docker image prune -f


### PR DESCRIPTION
Adds a Dockerized DayPage web deployment and a GitHub Actions SSH/rsync release workflow. The service binds only to localhost and is intended for daypage.cubxxw.com. Supabase remains the production database.\n\nValidation: Docker Compose config, workflow YAML parsing, and shell syntax checks passed.