### PR TITLE
Load DayPage web production environment

### DIFF
--- a/deploy/deploy.sh
+++ b/deploy/deploy.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
 set -euo pipefail
+install -m 600 .env web/.env.local
 docker compose -f deploy/compose.prod.yml --project-name daypage up -d --build --remove-orphans
 docker image prune -f


### PR DESCRIPTION
Copies the encrypted deployment environment into the web directory before the Docker build so Next.js can collect server routes.