### PR TITLE
feat(redesign): 搜索/归档/侧边栏 W1 视觉重构

### DIFF
--- a/DayPage/App/SidebarHeatmapView.swift
+++ b/DayPage/App/SidebarHeatmapView.swift
@@ -198,7 +198,13 @@ struct SidebarHeatmapView: View {
 
             // Month labels along the top edge. Canvas clips to its bounds, so
             // a label anchored at the last column (e.g. "JUL") must be clamped
-            // back inside the canvas or it renders truncated ("JU").
+            // back inside the canvas or it renders truncated ("JU"). Clamping
+            // can also drag a label leftwards onto its neighbour (a 16-week
+            // window that opens late in a month puts two labels one column
+            // apart → "MARAPR"), so any label that would start before the
+            // previous one ended is dropped — a missing month reads better
+            // than two fused ones.
+            var prevLabelMaxX: CGFloat = -.infinity
             for label in grid.monthLabels {
                 let rawX = railWidth + CGFloat(label.column) * (cellW + cellSpacing)
                 let text = Text(label.text)
@@ -207,7 +213,9 @@ struct SidebarHeatmapView: View {
                 let resolved = context.resolve(text)
                 let textWidth = resolved.measure(in: CGSize(width: 60, height: 12)).width
                 let x = min(rawX, size.width - textWidth)
+                guard x >= prevLabelMaxX + 6 else { continue }
                 context.draw(resolved, at: CGPoint(x: x, y: 4.5), anchor: .leading)
+                prevLabelMaxX = x + textWidth
             }
 
             // Day cells.
@@ -343,7 +351,7 @@ struct SidebarHeatmapView: View {
             if streak > 0 {
                 streakPill(
                     icon: "flame.fill",
-                    text: "\(streak) DAYS",
+                    text: "\(streak) \(Self.dayUnit(streak))",
                     fg: DSColor.accentAmber,
                     bg: DSColor.accentSoft,
                     border: DSColor.accentBorder
@@ -351,7 +359,7 @@ struct SidebarHeatmapView: View {
             } else if longestStreak > 0 {
                 streakPill(
                     icon: "flame",
-                    text: "BEST \(longestStreak) DAYS",
+                    text: "BEST \(longestStreak) \(Self.dayUnit(longestStreak))",
                     fg: DSColor.inkSubtle,
                     bg: DSColor.glassStd,
                     border: DSColor.borderSubtle
@@ -359,6 +367,10 @@ struct SidebarHeatmapView: View {
             }
         }
     }
+
+    /// Archival mono label unit (intentionally untranslated, FINDING-010) —
+    /// but never "1 DAYS".
+    private static func dayUnit(_ n: Int) -> String { n == 1 ? "DAY" : "DAYS" }
 
     private func streakPill(icon: String, text: String, fg: Color, bg: Color, border: Color) -> some View {
         HStack(spacing: 5) {

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -55,14 +55,8 @@ struct SidebarView: View {
 
                         if !sidebarVM.recentDays.isEmpty {
                             recentSection
-                                .padding(.top, 18)
+                                .padding(.top, 22)
                         }
-
-                        // Always show feedback row at the bottom of the
-                        // scrollable area so it stays reachable even when the
-                        // Recent list grows.
-                        feedbackSection
-                            .padding(.top, 18)
                     }
                     .padding(.bottom, DSSpacing.xl2)
                 }
@@ -146,7 +140,7 @@ struct SidebarView: View {
                 .accessibilityHidden(true)
         }
         .padding(.horizontal, DSSpacing.xl)
-        .padding(.top, 58)
+        .padding(.top, 44)
         .padding(.bottom, DSSpacing.md)
     }
 
@@ -312,9 +306,13 @@ struct SidebarView: View {
         VStack(alignment: .leading, spacing: 2) {
             navItem(tab: .today, icon: "square.and.pencil",
                     label: NSLocalizedString("sidebar.nav.today", comment: "Today nav"))
-            navItem(tab: .archive, icon: "archivebox",
+            // Icon set rationale (W1 redesign): one optical family, all
+            // `.medium` weight. `books.vertical` reads "bound journals"
+            // (archivebox read "cardboard box"); `circle.hexagongrid` stays
+            // crisp at 16pt where the dotted-triangle graph glyph smeared.
+            navItem(tab: .archive, icon: "books.vertical",
                     label: NSLocalizedString("sidebar.nav.archive", comment: "Archive nav"))
-            navItem(tab: .graph, icon: "point.3.connected.trianglepath.dotted",
+            navItem(tab: .graph, icon: "circle.hexagongrid",
                     label: NSLocalizedString("sidebar.nav.graph", comment: "Graph nav"))
             // Issue #16 (2026-07-03): global-search row. Between the
             // structured tabs (Today/Archive/Graph) and the memory-chat
@@ -338,25 +336,22 @@ struct SidebarView: View {
             nav.pendingSearchQuery = ""
         } label: {
             HStack(spacing: DSSpacing.md) {
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(Color.clear)
-                    .frame(width: 2, height: 20)
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 16, weight: .regular))
-                    .frame(width: 20)
+                    .font(.system(size: 15, weight: .medium))
+                    .frame(width: 26, height: 26)
                     .foregroundColor(DSColor.inkMuted)
-                Text("搜索")
+                Text(NSLocalizedString("sidebar.nav.search", comment: "Search nav row"))
                     .font(DSType.bodyMD)
                     .foregroundColor(DSColor.inkMuted)
             }
-            .padding(.trailing, DSSpacing.lg)
-            .padding(.vertical, 11)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityIdentifier("sidebar.search")
-        .accessibilityLabel("全局搜索")
+        .accessibilityLabel(NSLocalizedString("sidebar.nav.search.a11y", comment: "Global search a11y label"))
     }
 
     /// In-app entry point for the D1 "和过去对话" memory-chat agent. Without
@@ -370,34 +365,25 @@ struct SidebarView: View {
             nav.pendingAskQuery = ""
         } label: {
             HStack(spacing: DSSpacing.md) {
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(Color.clear)
-                    .frame(width: 2, height: 20)
-                Image(systemName: "sparkle.magnifyingglass")
-                    .font(.system(size: 16, weight: .regular))
-                    .frame(width: 20)
+                // `sparkles` — the AI-voice glyph. The old compound
+                // `sparkle.magnifyingglass` collided with the search row's
+                // magnifier one row above.
+                Image(systemName: "sparkles")
+                    .font(.system(size: 15, weight: .medium))
+                    .frame(width: 26, height: 26)
                     .foregroundColor(DSColor.inkMuted)
                 Text(NSLocalizedString("sidebar.ask_past", comment: "Ask the past chat entry"))
                     .font(DSType.bodyMD)
                     .foregroundColor(DSColor.inkMuted)
             }
-            .padding(.trailing, DSSpacing.lg)
-            .padding(.vertical, 11)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(NSLocalizedString("sidebar.ask_past", comment: "Ask the past chat entry"))
         .accessibilityHint(NSLocalizedString("sidebar.ask_past.hint", comment: "Ask based on your notes"))
-    }
-
-    private var feedbackSection: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            sectionLabel("Support")
-            navItem(tab: .feedback, icon: "bubble.left.and.exclamationmark.bubble.right",
-                    label: NSLocalizedString("sidebar.nav.feedback", comment: "Feedback nav"))
-        }
-        .padding(.horizontal, DSSpacing.md)
     }
 
     @ViewBuilder
@@ -416,18 +402,20 @@ struct SidebarView: View {
             }
         } label: {
             HStack(spacing: DSSpacing.md) {
-                // Left amber accent strip
-                RoundedRectangle(cornerRadius: 1, style: .continuous)
-                    .fill(isActive ? DSColor.accentOnBg : Color.clear)
-                    .frame(width: 2, height: 20)
-
+                // Icon on a soft 26pt backing when active — the selection
+                // reads as one warm rounded block instead of the old edge-to-
+                // edge fill + 2pt "toothpick" strip.
                 Image(systemName: icon)
-                    .font(.system(size: 16, weight: .regular))
-                    .frame(width: 20)
+                    .font(.system(size: 15, weight: .medium))
                     .foregroundColor(
                         disabled ? DSColor.inkSubtle
                         : isActive ? DSColor.accentOnBg
                         : DSColor.inkMuted
+                    )
+                    .frame(width: 26, height: 26)
+                    .background(
+                        RoundedRectangle(cornerRadius: 7, style: .continuous)
+                            .fill(isActive ? DSColor.accentOnBg.opacity(0.12) : Color.clear)
                     )
 
                 Text(label)
@@ -448,11 +436,13 @@ struct SidebarView: View {
                         .background(DSColor.amberSoft, in: Capsule())
                 }
             }
-            .padding(.leading, 0)
-            .padding(.trailing, DSSpacing.lg)
-            .padding(.vertical, 11)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isActive ? DSColor.amberSoft : Color.clear)
+            .background(
+                RoundedRectangle(cornerRadius: 10, style: .continuous)
+                    .fill(isActive ? DSColor.amberSoft : Color.clear)
+            )
             .contentShape(Rectangle())
         }
         .disabled(disabled)
@@ -521,7 +511,7 @@ struct SidebarView: View {
                     .foregroundColor(DSColor.inkMuted)
                     .rotationEffect(.degrees(recentExpanded ? 0 : -90))
             }
-            .padding(.leading, 34)  // align with row text column (2 + 12 + 20)
+            .padding(.leading, 48)  // align with nav text column (10 + 26 + 12)
             .padding(.trailing, DSSpacing.lg)
             .padding(.vertical, DSSpacing.sm)
             .contentShape(Rectangle())
@@ -536,38 +526,34 @@ struct SidebarView: View {
         .accessibilityAddTraits(.isButton)
     }
 
+    /// Ledger-style jump row: relative date + one-line teaser, bare mono
+    /// count on the right. (W1: the 6pt amber dot carried no information and
+    /// the per-row count capsule duplicated the disclosure badge.)
     private func recentRow(day: RecentDay) -> some View {
         Button {
             nav.openArchive(at: day.dateString)
         } label: {
-            HStack(spacing: DSSpacing.md) {
-                Color.clear.frame(width: 2, height: 20)
+            HStack(alignment: .firstTextBaseline, spacing: DSSpacing.sm) {
+                Text(Self.formatRowTitle(day.dateString))
+                    .font(DSType.bodySM)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .layoutPriority(1)
 
-                Image(systemName: "circle.fill")
-                    .font(.system(size: 6))
-                    .frame(width: 20)
-                    .foregroundColor(DSColor.accentOnBg.opacity(0.75))
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(Self.formatRowTitle(day.dateString))
+                if let excerpt = day.excerpt, !excerpt.isEmpty {
+                    Text("· \(excerpt)")
                         .font(DSType.bodySM)
-                        .foregroundColor(DSColor.inkPrimary)
-                    Text(day.dateString)
-                        .font(DSType.mono9)
                         .foregroundColor(DSColor.inkMuted)
-                        .tracking(0.5)
-                        .textCase(.uppercase)
+                        .lineLimit(1)
+                        .truncationMode(.tail)
                 }
 
-                Spacer()
+                Spacer(minLength: DSSpacing.sm)
 
                 Text("\(day.memoCount)")
                     .font(DSType.mono10)
                     .foregroundColor(DSColor.inkMuted)
-                    .padding(.horizontal, 6)
-                    .padding(.vertical, 2)
-                    .background(DSColor.amberSoft, in: Capsule())
             }
+            .padding(.leading, 48)  // align with nav text column (10 + 26 + 12)
             .padding(.trailing, DSSpacing.lg)
             .padding(.vertical, 7)
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -581,40 +567,32 @@ struct SidebarView: View {
         .accessibilityAddTraits(.isButton)
     }
 
-    private func sectionLabel(_ text: String) -> some View {
-        Text(text)
-            .font(DSType.mono9)
-            .foregroundColor(DSColor.inkMuted)
-            .tracking(1.2)
-            .textCase(.uppercase)
-            .padding(.leading, 34)  // align with row text column (2 + 12 + 20)
-            .padding(.bottom, DSSpacing.xs)
-            // Use isHeader so VoiceOver rotor lists these as section titles
-            // rather than skipping them; users can jump between sections.
-            .accessibilityAddTraits(.isHeader)
-    }
-
     // MARK: - Bottom Section
 
     private var bottomSection: some View {
         VStack(alignment: .leading, spacing: 2) {
+            // Feedback — lives with Settings in the anchored bottom block
+            // (W1: the old scroll-area "Support" section label was one layer
+            // of hierarchy more than two utility rows deserve).
+            navItem(tab: .feedback, icon: "paperplane",
+                    label: NSLocalizedString("sidebar.nav.feedback", comment: "Feedback nav"))
+
             // Settings
             Button {
                 Haptics.tapConfirm()
                 showSettings = true
             } label: {
                 HStack(spacing: DSSpacing.md) {
-                    Color.clear.frame(width: 2, height: 20)
                     Image(systemName: "gearshape")
-                        .font(.system(size: 16, weight: .regular))
-                        .frame(width: 20)
+                        .font(.system(size: 15, weight: .medium))
+                        .frame(width: 26, height: 26)
                         .foregroundColor(DSColor.inkMuted)
                     Text(NSLocalizedString("sidebar.settings", comment: "Settings row"))
                         .font(DSType.bodyMD)
                         .foregroundColor(DSColor.inkMuted)
                 }
-                .padding(.trailing, DSSpacing.lg)
-                .padding(.vertical, 11)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 8)
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .contentShape(Rectangle())
             }
@@ -643,25 +621,24 @@ struct SidebarView: View {
             showAccountSheet = true
         } label: {
             HStack(spacing: DSSpacing.md) {
-                Color.clear.frame(width: 2, height: 20)
                 ZStack {
                     Circle()
                         .fill(DSColor.amberSoft)
-                        .frame(width: 28, height: 28)
+                        .frame(width: 24, height: 24)
                         .overlay(Circle().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
                     Text(initial)
                         .font(DSType.labelSM)
                         .foregroundColor(DSColor.accentOnBg)
                 }
-                .frame(width: 20)
+                .frame(width: 26, height: 26)
                 Text(email)
                     .font(DSType.bodySM)
                     .foregroundColor(DSColor.inkMuted)
                     .lineLimit(1)
                     .truncationMode(.middle)
             }
-            .padding(.trailing, DSSpacing.lg)
-            .padding(.vertical, 9)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 7)
             .frame(maxWidth: .infinity, alignment: .leading)
             .contentShape(Rectangle())
         }

--- a/DayPage/App/SidebarViewModel.swift
+++ b/DayPage/App/SidebarViewModel.swift
@@ -11,6 +11,10 @@ import DayPageServices
 struct RecentDay: Identifiable, Equatable {
     let dateString: String  // YYYY-MM-DD
     let memoCount: Int
+    /// One-line teaser for the jump list — compiled summary if the day has
+    /// one, else the first memo's opening words. nil when the TimelineIndex
+    /// hasn't warmed yet (row falls back to the bare date).
+    var excerpt: String? = nil
 
     var id: String { dateString }
 }
@@ -175,7 +179,22 @@ final class SidebarViewModel: ObservableObject {
         let (recentResult, streakResult, heatmapResult, statsResult) =
             await (recent, streak, heatmap, stats)
         await MainActor.run {
-            self.recentDays = recentResult
+            // Enrich the jump list with per-day teasers from the launch-warmed
+            // TimelineIndex (O(days) dictionary build, zero disk I/O). Prefer
+            // the compiled summary; fall back to the raw excerpt.
+            let teasers: [String: String] = Dictionary(
+                uniqueKeysWithValues: TimelineIndex.shared.entries().compactMap { entry in
+                    let teaser = (entry.summary?.isEmpty == false ? entry.summary : entry.excerpt)
+                    guard let teaser, !teaser.isEmpty else { return nil }
+                    // One-line jump-list teaser — fold markdown syntax out.
+                    return (entry.dateString, SearchView.strippedLineArtifacts(MemoMarkdown.plainText(teaser)))
+                }
+            )
+            self.recentDays = recentResult.map { day in
+                var enriched = day
+                enriched.excerpt = teasers[day.dateString]
+                return enriched
+            }
             self.streakDays = streakResult
             let counts = Dictionary(
                 heatmapResult.map { ($0.dateString, $0.memoCount) },

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -515,6 +515,12 @@ struct ArchiveView: View {
     @State private var rawDates: Set<String> = []
     @State private var dailyDates: Set<String> = []
 
+    /// Per-day one-line teasers for the ledger list (raw excerpt fallback for
+    /// days without a compiled summary). Snapshotted from the launch-warmed
+    /// TimelineIndex in `preScanVault` — a computed read per body pass would
+    /// rebuild the dictionary on every scroll frame.
+    @State private var dayTeasers: [String: String] = [:]
+
     /// Controls the year/month jump picker overlay (opened by tapping the
     /// Archive header's month title).
     @State private var showMonthPicker: Bool = false
@@ -790,50 +796,47 @@ struct ArchiveView: View {
         }.value
         rawDates = scanned.0
         dailyDates = scanned.1
+        dayTeasers = Dictionary(
+            uniqueKeysWithValues: TimelineIndex.shared.entries().compactMap { entry in
+                let teaser = (entry.summary?.isEmpty == false ? entry.summary : entry.excerpt)
+                guard let teaser, !teaser.isEmpty else { return nil }
+                // One-line ledger teaser — fold markdown syntax out.
+                return (entry.dateString, SearchView.strippedLineArtifacts(MemoMarkdown.plainText(teaser)))
+            }
+        )
     }
 
     // MARK: - Archive Header
 
     private var archiveHeader: some View {
-        HStack(alignment: .firstTextBaseline, spacing: 0) {
-            VStack(alignment: .leading, spacing: 2) {
-                // "Archive" title — opens the sidebar (tap), keeping the
-                // primary navigation affordance the rest of the app uses.
-                Button {
-                    nav.openSidebar()
-                } label: {
-                    Text(NSLocalizedString("archive.title", comment: "Archive page title"))
-                        .font(DSType.serifDisplay28)
-                        .foregroundColor(DSColor.inkPrimary)
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(NSLocalizedString("a11y.nav.open", comment: "Sidebar open button"))
-                .accessibilityIdentifier("sidebar-menu-button")
-
-                // Month subtitle — now a jump-to-month affordance. A chevron
-                // signals it's interactive; tapping opens the YearMonthPicker.
-                Button {
-                    Haptics.soft()
-                    withAnimation(reduceMotion ? nil : Motion.fade) { showMonthPicker = true }
-                } label: {
-                    HStack(spacing: DSSpacing.xs) {
-                        Text(viewModel.currentMonthTitle.uppercased())
-                            .font(DSType.mono10)
-                            .foregroundColor(DSColor.inkMuted)
-                            .tracking(1.0)
-                        Image(systemName: "chevron.down")
-                            .font(.system(size: 8, weight: .semibold))
-                            .foregroundColor(DSColor.inkMuted)
-                    }
-                    .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel(String(format: NSLocalizedString("archive.picker.open", comment: "Jump to month, current %@"), viewModel.currentMonthTitle))
-                .accessibilityHint(NSLocalizedString("archive.picker.open.hint", comment: "Opens the month picker"))
-                .accessibilityIdentifier("archive-month-picker-button")
+        HStack(alignment: .center, spacing: DSSpacing.md) {
+            // "Archive" title — opens the sidebar (tap), keeping the
+            // primary navigation affordance the rest of the app uses.
+            // (W1: the mono month subtitle moved down to the month row as a
+            // serif headline — the header kept two voices for one job.)
+            Button {
+                nav.openSidebar()
+            } label: {
+                Text(NSLocalizedString("archive.title", comment: "Archive page title"))
+                    .font(DSType.serifDisplay28)
+                    .foregroundColor(DSColor.inkPrimary)
             }
+            .buttonStyle(.plain)
+            .accessibilityLabel(NSLocalizedString("a11y.nav.open", comment: "Sidebar open button"))
+            .accessibilityIdentifier("sidebar-menu-button")
 
             Spacer()
+
+            // CAL / LIST view-mode toggle — page-level chrome, so it lives in
+            // the header instead of floating mid-content.
+            HStack(spacing: 2) {
+                toggleButton("CAL", isSelected: mode == .calendar) { mode = .calendar }
+                toggleButton("LIST", isSelected: mode == .list) { mode = .list }
+            }
+            .padding(3)
+            // #771: CAL/LIST view-mode toggle → glass engine (.pill).
+            .dpGlass(.pill, in: Capsule())
+            .clipShape(Capsule())
 
             Button(action: { showSearch = true }) {
                 Image(systemName: "magnifyingglass")
@@ -878,8 +881,65 @@ struct ArchiveView: View {
         .accessibilityElement(children: .combine)
     }
 
+    /// Localized "July 2026" headline for the month row (the export/a11y
+    /// string keeps using the archival en_US_POSIX `currentMonthTitle`).
+    private var localizedMonthTitle: String {
+        var comps = DateComponents()
+        comps.year = viewModel.currentYear
+        comps.month = viewModel.currentMonth
+        comps.day = 1
+        guard let date = Calendar.current.date(from: comps) else { return viewModel.currentMonthTitle }
+        return Self.monthHeaderFormatter.string(from: date)
+    }
+
+    /// One quiet mono line under the headline: "N days · M entries", plus an
+    /// inline "back to this month" affordance when browsing history — always
+    /// present, so its appearance never reflows the row (the old floating
+    /// TODAY capsule made the whole bar jump).
+    private var monthMetaLine: some View {
+        let days = viewModel.activeDayCount
+        let entries = viewModel.totalEntries
+        // Narrative line → per-count plural keys ("1 day · 2 entries"); a
+        // single "%d days" format would ship the very "1 days" bug this
+        // branch fixes elsewhere.
+        let dayPart = String(format: NSLocalizedString(
+            days == 1 ? "archive.month.meta.days.one" : "archive.month.meta.days",
+            comment: "Month meta line day part"), days)
+        let entryPart = String(format: NSLocalizedString(
+            entries == 1 ? "archive.month.meta.entries.one" : "archive.month.meta.entries",
+            comment: "Month meta line entry part"), entries)
+        return HStack(spacing: DSSpacing.sm) {
+            Text("\(dayPart) · \(entryPart)")
+            .font(DSType.mono10)
+            .tracking(0.8)
+            .foregroundColor(DSColor.inkMuted)
+
+            if !viewModel.isViewingCurrentMonth {
+                Button(action: {
+                    Haptics.tapConfirm()
+                    let now = Calendar.current.dateComponents([.year, .month], from: Date())
+                    let targetYear = now.year ?? viewModel.currentYear
+                    let targetMonth = now.month ?? viewModel.currentMonth
+                    let isFuture = (viewModel.currentYear, viewModel.currentMonth) > (targetYear, targetMonth)
+                    monthNavDirection = isFuture ? .leading : .trailing
+                    withAnimation(reduceMotion ? nil : Motion.spring) { viewModel.goToCurrentMonth() }
+                    UIAccessibility.post(notification: .announcement, argument: viewModel.currentMonthTitle)
+                }) {
+                    Text(NSLocalizedString("archive.today", comment: "Today button"))
+                        .font(DSType.mono10)
+                        .tracking(0.8)
+                        .foregroundColor(DSColor.accentOnBg)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel(NSLocalizedString("archive.a11y.currentMonth.label", comment: "A11y label: back-to-current-month button"))
+                .accessibilityHint(NSLocalizedString("archive.a11y.currentMonth.hint", comment: "A11y hint: back-to-current-month button"))
+                .transition(.opacity)
+            }
+        }
+    }
+
     private var monthNavigationRow: some View {
-        HStack {
+        HStack(alignment: .center) {
             Button(action: {
                 Haptics.rigid(intensity: 0.4)
                 monthNavDirection = .leading
@@ -898,41 +958,31 @@ struct ArchiveView: View {
 
             Spacer()
 
-            // CALENDAR / LIST toggle — glass pill
-            HStack(spacing: 2) {
-                toggleButton("CAL", isSelected: mode == .calendar) { mode = .calendar }
-                toggleButton("LIST", isSelected: mode == .list) { mode = .list }
-            }
-            .padding(3)
-            // #771: CAL/LIST view-mode toggle → glass engine (.pill).
-            .dpGlass(.pill, in: Capsule())
-            .clipShape(Capsule())
-
-            Spacer()
-
-            if !viewModel.isViewingCurrentMonth {
-                Button(action: {
-                    Haptics.tapConfirm()
-                    let now = Calendar.current.dateComponents([.year, .month], from: Date())
-                    let targetYear = now.year ?? viewModel.currentYear
-                    let targetMonth = now.month ?? viewModel.currentMonth
-                    let isFuture = (viewModel.currentYear, viewModel.currentMonth) > (targetYear, targetMonth)
-                    monthNavDirection = isFuture ? .leading : .trailing
-                    withAnimation(reduceMotion ? nil : Motion.spring) { viewModel.goToCurrentMonth() }
-                    UIAccessibility.post(notification: .announcement, argument: viewModel.currentMonthTitle)
-                }) {
-                    Text(NSLocalizedString("archive.today", comment: "Today button"))
-                        .monoLabelStyle(size: 10)
-                        .foregroundColor(.white)
-                        .padding(.horizontal, 10)
-                        .padding(.vertical, 6)
-                        .background(DSColor.amberDeep, in: Capsule())
-                        .overlay(Capsule().strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+            // Serif month headline = the jump-to-month affordance (tap →
+            // YearMonthPicker). The calendar's protagonist is the month, so
+            // the month gets the display voice.
+            VStack(spacing: 3) {
+                Button {
+                    Haptics.soft()
+                    withAnimation(reduceMotion ? nil : Motion.fade) { showMonthPicker = true }
+                } label: {
+                    HStack(spacing: DSSpacing.xs) {
+                        Text(localizedMonthTitle)
+                            .font(DSFonts.serif(size: 22, weight: .semibold, relativeTo: .title2))
+                            .foregroundColor(DSColor.inkPrimary)
+                        Image(systemName: "chevron.down")
+                            .font(.system(size: 10, weight: .semibold))
+                            .foregroundColor(DSColor.inkMuted)
+                            .padding(.top, 2)
+                    }
+                    .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
-                .accessibilityLabel(NSLocalizedString("archive.a11y.currentMonth.label", comment: "A11y label: back-to-current-month button"))
-                .accessibilityHint(NSLocalizedString("archive.a11y.currentMonth.hint", comment: "A11y hint: back-to-current-month button"))
-                .transition(.scale.combined(with: .opacity))
+                .accessibilityLabel(String(format: NSLocalizedString("archive.picker.open", comment: "Jump to month, current %@"), viewModel.currentMonthTitle))
+                .accessibilityHint(NSLocalizedString("archive.picker.open.hint", comment: "Opens the month picker"))
+                .accessibilityIdentifier("archive-month-picker-button")
+
+                monthMetaLine
             }
 
             Spacer()
@@ -975,7 +1025,16 @@ struct ArchiveView: View {
 
     // MARK: - Calendar Grid
 
-    private let weekdaySymbols = ["MON", "TUE", "WED", "THU", "FRI", "SAT", "SUN"]
+    /// Monday-first, locale-aware single-glyph weekday rail ("一 二 三…" in
+    /// Chinese, "M T W…" in English). The old hardcoded MON–SUN row shouted
+    /// over the day numbers it was only meant to caption.
+    private static let weekdaySymbols: [String] = {
+        let cal = Calendar.current
+        let symbols = cal.veryShortStandaloneWeekdaySymbols  // [Sun, Mon, …]
+        guard symbols.count == 7 else { return ["M", "T", "W", "T", "F", "S", "S"] }
+        return (1...7).map { symbols[$0 % 7] }               // Monday-first
+    }()
+    private var weekdaySymbols: [String] { Self.weekdaySymbols }
 
     private var calendarGrid: some View {
         // 4pt gutters + 8pt inset: with the previous 1pt gaps the amber cell
@@ -984,12 +1043,12 @@ struct ArchiveView: View {
         VStack(spacing: DSSpacing.xs) {
             // Weekday header row
             HStack(spacing: DSSpacing.xs) {
-                ForEach(weekdaySymbols, id: \.self) { day in
+                ForEach(Array(weekdaySymbols.enumerated()), id: \.offset) { _, day in
                     Text(day)
                         .monoLabelStyle(size: 9)
                         .foregroundColor(DSColor.onSurfaceVariant)
                         .frame(maxWidth: .infinity)
-                        .frame(height: 28)
+                        .frame(height: 24)
                 }
             }
 
@@ -1041,13 +1100,16 @@ struct ArchiveView: View {
 
             // Heatmap color from cached memo-count bucket; fall back to
             // pre-scanned file-existence state for days not yet loaded.
+            // Empty days deliberately drop to a near-white whisper — with the
+            // old densityNone fill the whole month fused with the amber glass
+            // panel into one salmon slab and the ramp stopped reading.
             let density = viewModel.dayStats[dateStr]?.densityLevel
             let fillColor: Color = {
-                if let d = density { return d.fillColor }
+                if let d = density, d != .empty { return d.fillColor }
                 switch data {
                 case .compiled: return DSColor.amberDeep
                 case .rawOnly:  return DSColor.densityLow
-                case .none:     return DSColor.densityNone
+                case .none:     return DSColor.surfaceWhite.opacity(0.38)
                 }
             }()
 
@@ -1087,8 +1149,8 @@ struct ArchiveView: View {
                             .allowsHitTesting(false)
                     }
 
-                    Text(String(format: "%02d", day))
-                        .monoLabelStyle(size: 9)
+                    Text("\(day)")
+                        .monoLabelStyle(size: 10)
                         .foregroundColor(textColor)
                         .padding(DSSpacing.xs)
 
@@ -1146,19 +1208,23 @@ struct ArchiveView: View {
 
     private var legendRow: some View {
         HStack(spacing: DSSpacing.sm) {
-            Text("Activity:")
+            // Narrative caption, not archival vocabulary → localized
+            // (unlike the FINDING-010 mono ledger labels).
+            Text(NSLocalizedString("archive.legend.density", comment: "Calendar legend caption: entry density"))
                 .monoLabelStyle(size: 9)
                 .foregroundColor(DSColor.inkMuted)
 
-            ForEach([DayStats.DensityLevel.empty, .low, .medium, .high], id: \.label) { level in
+            // First swatch mirrors the quiet empty-cell fill, then the ramp.
+            RoundedRectangle(cornerRadius: 3, style: .continuous)
+                .fill(DSColor.surfaceWhite.opacity(0.38))
+                .overlay(RoundedRectangle(cornerRadius: 3, style: .continuous)
+                    .strokeBorder(DSColor.glassRim, lineWidth: 0.5))
+                .frame(width: 10, height: 10)
+            ForEach([DayStats.DensityLevel.low, .medium, .high], id: \.label) { level in
                 RoundedRectangle(cornerRadius: 3, style: .continuous)
                     .fill(level.fillColor)
-                    .frame(width: 12, height: 12)
+                    .frame(width: 10, height: 10)
             }
-
-            Text(NSLocalizedString("archive.heatmap.higher", comment: "Heatmap legend higher"))
-                .monoLabelStyle(size: 9)
-                .foregroundColor(DSColor.inkMuted)
 
             Spacer()
         }
@@ -1171,25 +1237,56 @@ struct ArchiveView: View {
 
     private var monthlySummary: some View {
         VStack(alignment: .leading, spacing: DSSpacing.lg) {
-            HStack(spacing: DSSpacing.lg) {
-                Text(String(format: NSLocalizedString("archive.summary.title", comment: "Monthly summary section title; %@ = month title"), viewModel.currentMonthTitle))
-                    .font(DSType.sectionLabel)
-                    .foregroundColor(DSColor.inkMuted)
+            // "This month" — a diary's month-end note, not a dashboard.
+            // (W1: four 110pt shouting stat cards → one serif pillar row; the
+            // export/share buttons fold into a quiet overflow menu.)
+            HStack(alignment: .firstTextBaseline, spacing: DSSpacing.lg) {
+                Text(NSLocalizedString("archive.summary.thisMonth", comment: "Monthly summary section title"))
+                    .font(DSFonts.serif(size: 16, weight: .semibold, relativeTo: .headline))
+                    .foregroundColor(DSColor.inkPrimary)
                 Rectangle()
                     .fill(DSColor.inkFaint)
                     .frame(height: 0.5)
+                Menu {
+                    Button(action: exportMarkdown) {
+                        Label(NSLocalizedString("archive.export.markdown", comment: "Button: export monthly summary as Markdown"), systemImage: "square.and.arrow.up")
+                    }
+                    Button {
+                        Task { await shareScreenshot() }
+                    } label: {
+                        Label(NSLocalizedString("archive.export.screenshot", comment: "Button: share monthly summary as screenshot"), systemImage: "camera")
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(DSColor.inkMuted)
+                        .frame(width: 32, height: 32)
+                        .contentShape(Rectangle())
+                }
+                .accessibilityLabel(NSLocalizedString("archive.summary.menu.a11y", comment: "A11y: monthly summary actions menu"))
             }
 
-            LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: DSSpacing.md) {
-                summaryCard("TOTAL ENTRIES", value: "\(viewModel.totalEntries)", accentPrimary: true)
-                if viewModel.totalVoiceMinutes > 0 {
-                    summaryCard("VOICE DURATION", value: "\(viewModel.totalVoiceMinutes)", unit: "min", accentPrimary: false)
-                }
+            HStack(alignment: .top, spacing: 0) {
+                digestStat(value: "\(viewModel.totalEntries)",
+                           label: NSLocalizedString("archive.stat.entries", comment: "Stat pillar label: entries"),
+                           accent: true)
                 if viewModel.totalPhotos > 0 {
-                    summaryCard("PHOTOS CAPTURED", value: "\(viewModel.totalPhotos)", accentPrimary: false)
+                    digestDivider
+                    digestStat(value: "\(viewModel.totalPhotos)",
+                               label: NSLocalizedString("archive.stat.photos", comment: "Stat pillar label: photos"),
+                               accent: false)
+                }
+                if viewModel.totalVoiceMinutes > 0 {
+                    digestDivider
+                    digestStat(value: "\(viewModel.totalVoiceMinutes)",
+                               label: NSLocalizedString("archive.stat.voiceMin", comment: "Stat pillar label: voice minutes"),
+                               accent: false)
                 }
                 if viewModel.totalLocations > 0 {
-                    summaryCard("TRAVEL LOCATIONS", value: "\(viewModel.totalLocations)", accentPrimary: true)
+                    digestDivider
+                    digestStat(value: "\(viewModel.totalLocations)",
+                               label: NSLocalizedString("archive.stat.places", comment: "Stat pillar label: places"),
+                               accent: false)
                 }
             }
 
@@ -1245,32 +1342,6 @@ struct ArchiveView: View {
                 }
             }
 
-            // Export / Share actions
-            HStack(spacing: 10) {
-                Button(action: exportMarkdown) {
-                    Label(NSLocalizedString("archive.export.markdown", comment: "Button: export monthly summary as Markdown"), systemImage: "square.and.arrow.up")
-                        .monoLabelStyle(size: 11)
-                        .foregroundColor(DSColor.inkPrimary)
-                        .padding(.horizontal, DSSpacing.md)
-                        .padding(.vertical, DSSpacing.sm)
-                        .liquidGlassCard(cornerRadius: 8)
-                }
-                .buttonStyle(.plain)
-
-                Button {
-                    Task { await shareScreenshot() }
-                } label: {
-                    Label(NSLocalizedString("archive.export.screenshot", comment: "Button: share monthly summary as screenshot"), systemImage: "camera")
-                        .monoLabelStyle(size: 11)
-                        .foregroundColor(DSColor.inkPrimary)
-                        .padding(.horizontal, DSSpacing.md)
-                        .padding(.vertical, DSSpacing.sm)
-                        .liquidGlassCard(cornerRadius: 8)
-                }
-                .buttonStyle(.plain)
-
-                Spacer()
-            }
         }
         .sheet(isPresented: $showShareSheet) {
             ShareSheet(activityItems: shareItems)
@@ -1327,34 +1398,6 @@ struct ArchiveView: View {
                 totalLocations: viewModel.totalLocations
             )
         )
-    }
-
-    private func summaryCard(_ label: String, value: String, unit: String? = nil, accentPrimary: Bool) -> some View {
-        VStack(alignment: .leading, spacing: DSSpacing.sm) {
-            Text(label)
-                .monoLabelStyle(size: 10)
-                .foregroundColor(DSColor.onSurfaceVariant)
-
-            HStack(alignment: .firstTextBaseline, spacing: DSSpacing.xs) {
-                Text(value)
-                    .font(DSType.serifDisplay32)
-                    .foregroundColor(accentPrimary ? DSColor.accentOnBg : DSColor.inkPrimary)
-                    .lineLimit(1)
-                    .minimumScaleFactor(0.5)
-                if let unit {
-                    Text(unit.uppercased())
-                        .monoLabelStyle(size: 10)
-                        .foregroundColor(DSColor.inkMuted)
-                }
-            }
-        }
-        .padding(DSSpacing.lg)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .frame(height: 110)
-        .liquidGlassCard(cornerRadius: 12)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel(label)
-        .accessibilityValue(unit != nil ? "\(value) \(unit!)" : value)
     }
 
     // MARK: - List Content
@@ -1424,23 +1467,31 @@ struct ArchiveView: View {
         let headerTitle = Self.monthKeyParser.date(from: monthKey)
             .map { Self.monthHeaderFormatter.string(from: $0) } ?? monthKey
         let dayCountText = String(
-            format: NSLocalizedString("archive.section.dayCount", comment: "Month section header trailing label: %d days with entries"),
+            format: NSLocalizedString(
+                dayCount == 1 ? "archive.section.dayCount.one" : "archive.section.dayCount",
+                comment: "Month section header trailing label: %d days with entries"
+            ),
             dayCount
         )
 
-        return HStack(alignment: .firstTextBaseline) {
+        // Quiet ledger chapter head — mono caption + hairline, no material
+        // slab (W1: three container styles in one list was two too many).
+        return HStack(alignment: .firstTextBaseline, spacing: DSSpacing.md) {
             Text(headerTitle)
-                .font(DSType.titleSM)
-                .foregroundColor(DSColor.inkPrimary)
-            Spacer(minLength: 8)
+                .font(DSType.mono10)
+                .tracking(1.0)
+                .foregroundColor(DSColor.inkMuted)
+            Rectangle()
+                .fill(DSColor.inkFaint)
+                .frame(height: 0.5)
             Text(dayCountText)
-                .font(DSType.labelSM)
+                .font(DSType.mono10)
                 .foregroundColor(DSColor.inkMuted)
         }
-        .padding(.horizontal, DSSpacing.lg)
-        .padding(.vertical, DSSpacing.sm)
+        .padding(.horizontal, DSSpacing.xs)
+        .padding(.top, DSSpacing.lg)
+        .padding(.bottom, DSSpacing.xs)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(.ultraThinMaterial)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(headerTitle), \(dayCountText)")
     }
@@ -1465,20 +1516,30 @@ struct ArchiveView: View {
                 .foregroundColor(DSColor.inkMuted)
 
             HStack(alignment: .top, spacing: 0) {
-                digestStat(value: "\(activeDays)", label: "DAYS", accent: true)
+                digestStat(value: "\(activeDays)",
+                           label: NSLocalizedString("archive.stat.days", comment: "Stat pillar label: active days"),
+                           accent: true)
                 digestDivider
-                digestStat(value: "\(entries)", label: "ENTRIES", accent: false)
+                digestStat(value: "\(entries)",
+                           label: NSLocalizedString("archive.stat.entries", comment: "Stat pillar label: entries"),
+                           accent: false)
                 if photos > 0 {
                     digestDivider
-                    digestStat(value: "\(photos)", label: "PHOTOS", accent: false)
+                    digestStat(value: "\(photos)",
+                               label: NSLocalizedString("archive.stat.photos", comment: "Stat pillar label: photos"),
+                               accent: false)
                 }
                 if voice > 0 {
                     digestDivider
-                    digestStat(value: "\(voice)", label: "VOICE MIN", accent: false)
+                    digestStat(value: "\(voice)",
+                               label: NSLocalizedString("archive.stat.voiceMin", comment: "Stat pillar label: voice minutes"),
+                               accent: false)
                 }
                 if locations > 0 {
                     digestDivider
-                    digestStat(value: "\(locations)", label: "PLACES", accent: false)
+                    digestStat(value: "\(locations)",
+                               label: NSLocalizedString("archive.stat.places", comment: "Stat pillar label: places"),
+                               accent: false)
                 }
             }
         }
@@ -1573,59 +1634,74 @@ struct ArchiveView: View {
         RelativeDate.label(for: dateString, style: .caps)
     }
 
+    /// Journal-ledger row (W1): date column + one-line teaser + bare count.
+    /// Replaces the shouting per-day glass card — twice the days per screen,
+    /// and the scroll reads like flipping a ledger. Compiled days speak in
+    /// primary ink and an amber date; metadata-only days stay muted. Zero
+    /// photo/voice counters no longer occupy space (they said nothing).
     private func archiveListRow(stats: DayStats) -> some View {
-        let isMetadataOnly = !stats.isDailyPageCompiled
+        let isCompiled = stats.isDailyPageCompiled
+        let teaser: String? = {
+            if let s = stats.dailySummary, !s.isEmpty { return s }
+            return dayTeasers[stats.dateString]
+        }()
+        let stateLabel = isCompiled
+            ? NSLocalizedString("archive.a11y.day.compiled", comment: "A11y: day has a compiled daily page")
+            : NSLocalizedString("archive.a11y.day.rawOnly", comment: "A11y: day has raw memos only")
+
         return Button(action: {
             handleDateTap(dateStr: stats.dateString)
         }) {
-            VStack(alignment: .leading, spacing: 6) {
-                HStack {
-                    Text(relativeDateLabel(stats.dateString))
-                        .font(DSType.h2)
-                        .foregroundColor(DSColor.inkPrimary)
-                        .opacity(isMetadataOnly ? 0.7 : 1.0)
+            HStack(alignment: .firstTextBaseline, spacing: DSSpacing.md) {
+                Text(ledgerDateLabel(stats.dateString))
+                    .font(DSType.mono10)
+                    .tracking(0.5)
+                    .foregroundColor(isCompiled ? DSColor.accentOnBg : DSColor.inkMuted)
+                    .frame(width: 64, alignment: .leading)
 
-                    Spacer()
+                Text(teaser ?? "—")
+                    .font(DSType.bodySM)
+                    .foregroundColor(isCompiled ? DSColor.inkPrimary : DSColor.inkMuted)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
 
-                    StatusBadge(
-                        label: stats.isDailyPageCompiled ? "VERIFIED" : "METADATA",
-                        style: stats.isDailyPageCompiled ? .verified : .metadata
-                    )
-                }
+                Spacer(minLength: DSSpacing.sm)
 
-                if let summary = stats.dailySummary, !summary.isEmpty {
-                    Text(summary)
-                        .font(DSType.serifBody16)
-                        .foregroundColor(DSColor.inkMuted)
-                        .italic()
-                        .lineLimit(2)
-                        .opacity(isMetadataOnly ? 0.7 : 1.0)
-                }
-
-                HStack(spacing: DSSpacing.lg) {
-                    metaIcon("doc.text", count: stats.memoCount)
-                    metaIcon("photo", count: stats.photoCount)
-                    metaIcon("mic", count: stats.voiceMinutes, unit: "min")
-                }
-                .opacity(isMetadataOnly ? 0.7 : 1.0)
+                Text("\(stats.memoCount)")
+                    .font(DSType.mono10)
+                    .foregroundColor(DSColor.inkMuted)
             }
-            .padding(DSSpacing.cardGap)
+            .padding(.vertical, 13)
+            .padding(.horizontal, DSSpacing.xs)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .liquidGlassCard(cornerRadius: DSRadius.md)
-            .pressableCard()
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(DSColor.inkFaint)
+                .frame(height: 0.5)
+                .padding(.leading, 64 + DSSpacing.md)
+        }
         .modifier(ArchiveDayZoomSource(id: stats.dateString, namespace: dayZoomNamespace))
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(relativeDateLabel(stats.dateString))，\(stateLabel)，\(stats.memoCount)")
+        .accessibilityHint(NSLocalizedString("archive.a11y.day.hint", comment: "A11y hint: calendar day cell opens the day detail"))
     }
 
-    private func metaIcon(_ systemName: String, count: Int, unit: String? = nil) -> some View {
-        HStack(spacing: DSSpacing.xs) {
-            Image(systemName: systemName)
-                .font(DSType.labelXS)
-                .foregroundColor(DSColor.inkMuted)
-            Text(unit != nil ? "\(count) \(unit!)" : "\(count)")
-                .monoLabelStyle(size: 11)
-                .foregroundColor(DSColor.inkMuted)
+    /// Fixed-width mono date column: relative caps for today/yesterday,
+    /// "07·12" for everything older.
+    private func ledgerDateLabel(_ dateString: String) -> String {
+        guard let date = DateFormatters.isoDate.date(from: dateString) else { return dateString }
+        let cal = Calendar.current
+        let days = cal.dateComponents([.day], from: cal.startOfDay(for: date), to: cal.startOfDay(for: Date())).day ?? 99
+        switch days {
+        case 0: return NSLocalizedString("archive.ledger.today", comment: "Ledger date column: today")
+        case 1: return NSLocalizedString("archive.ledger.yesterday", comment: "Ledger date column: yesterday")
+        default:
+            let parts = dateString.split(separator: "-")
+            guard parts.count == 3 else { return dateString }
+            return "\(parts[1])·\(parts[2])"
         }
     }
 }

--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -250,19 +250,24 @@ struct SearchView: View {
     var body: some View {
         NavigationStack {
             ZStack {
-                DSColor.background.ignoresSafeArea()
+                // W1: the flat background made the sheet read like a cold
+                // sheet of printer paper against the warm archive behind it —
+                // search breathes the same ambient air as every other page.
+                AmbientBackground().ignoresSafeArea()
 
                 VStack(spacing: 0) {
+                    // The capsule floats on the ambient ground — no hard
+                    // divider slicing the sheet in two.
                     searchBar
                         .padding(.horizontal, DSSpacing.lg)
                         .padding(.vertical, DSSpacing.md)
 
-                    Divider().background(DSColor.outlineVariant)
-
                     if showFilters {
                         filterPanel
                             .transition(.opacity.combined(with: .move(edge: .top)))
-                        Divider().background(DSColor.outlineVariant)
+                        Rectangle()
+                            .fill(DSColor.inkFaint)
+                            .frame(height: 0.5)
                     }
 
                     contentArea
@@ -416,12 +421,12 @@ struct SearchView: View {
         HStack(spacing: DSSpacing.md) {
             HStack(spacing: DSSpacing.sm) {
                 Image(systemName: "magnifyingglass")
-                    .font(.system(size: 14, weight: .regular))
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .font(.system(size: 15, weight: .regular))
+                    .foregroundColor(DSColor.inkMuted)
 
                 TextField(NSLocalizedString("search.placeholder", comment: "Search text field placeholder"), text: $vm.query)
-                    .font(DSFonts.inter(size: 14, relativeTo: .subheadline))
-                    .foregroundColor(DSColor.onSurface)
+                    .font(DSFonts.inter(size: 15, relativeTo: .subheadline))
+                    .foregroundColor(DSColor.inkPrimary)
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)
                     .focused($isInputFocused)
@@ -442,7 +447,7 @@ struct SearchView: View {
                 if vm.isSearching {
                     ProgressView()
                         .scaleEffect(0.7)
-                        .tint(DSColor.onSurfaceVariant)
+                        .tint(DSColor.inkMuted)
                         .accessibilityLabel(NSLocalizedString("search.a11y.searching", comment: "Accessibility label for the searching progress indicator"))
                 } else if !vm.query.isEmpty {
                     Button(action: {
@@ -467,17 +472,19 @@ struct SearchView: View {
                     }) {
                         Image(systemName: "xmark.circle.fill")
                             .font(.system(size: 14))
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                             .scaleEffect(clearPressed ? 0.8 : 1.0)
                     }
                     .buttonStyle(.plain)
                     .accessibilityLabel(NSLocalizedString("search.a11y.clearSearch", comment: "Accessibility label for the clear search button"))
                 }
             }
-            .padding(.horizontal, DSSpacing.md)
-            .frame(height: 36)
-            .background(DSColor.surfaceContainer)
-            .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+            // W1: 36pt hard-stroked box → 44pt capsule on the glass engine,
+            // same family as the archive header's search control.
+            .padding(.horizontal, DSSpacing.lg)
+            .frame(height: 44)
+            .dpGlass(.control, in: Capsule())
+            .clipShape(Capsule())
 
             Button(action: {
                 Haptics.soft()
@@ -486,7 +493,7 @@ struct SearchView: View {
             }) {
                 Image(systemName: filters.isActive ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
                     .font(.system(size: 20))
-                    .foregroundColor(filters.isActive ? DSColor.primary : DSColor.onSurfaceVariant)
+                    .foregroundColor(filters.isActive ? DSColor.accentOnBg : DSColor.inkMuted)
             }
             .buttonStyle(.plain)
             .accessibilityLabel(NSLocalizedString("search.a11y.filter", comment: "Accessibility label for the filter button"))
@@ -496,7 +503,7 @@ struct SearchView: View {
             Button(action: { dismiss() }) {
                 Text(NSLocalizedString("search.cancel", comment: "Cancel button in search bar"))
                     .monoLabelStyle(size: 11)
-                    .foregroundColor(DSColor.primary)
+                    .foregroundColor(DSColor.accentOnBg)
             }
             .buttonStyle(.plain)
             .accessibilityLabel(NSLocalizedString("search.a11y.cancelSearch", comment: "Accessibility label for the cancel search button"))
@@ -510,12 +517,12 @@ struct SearchView: View {
             HStack(spacing: DSSpacing.sm) {
                 Image(systemName: "calendar")
                     .font(.system(size: 12))
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .foregroundColor(DSColor.inkMuted)
                     .frame(width: 16)
 
                 Text(NSLocalizedString("search.filter.dateRange", comment: "Filter panel label: date range"))
                     .monoLabelStyle(size: 11)
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .foregroundColor(DSColor.inkMuted)
                     .frame(width: 48, alignment: .leading)
 
                 Spacer()
@@ -530,7 +537,7 @@ struct SearchView: View {
                 .frame(maxWidth: 120)
                 .overlay(
                     filters.startDate == nil
-                        ? Text(NSLocalizedString("search.filter.startDate", comment: "Filter panel start date placeholder")).monoLabelStyle(size: 11).foregroundColor(DSColor.onSurfaceVariant).allowsHitTesting(false)
+                        ? Text(NSLocalizedString("search.filter.startDate", comment: "Filter panel start date placeholder")).monoLabelStyle(size: 11).foregroundColor(DSColor.inkMuted).allowsHitTesting(false)
                         : nil
                 )
 
@@ -555,7 +562,7 @@ struct SearchView: View {
                     }) {
                         Image(systemName: "xmark.circle.fill")
                             .font(.system(size: 12))
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                     }
                     .buttonStyle(.plain)
                 }
@@ -564,12 +571,12 @@ struct SearchView: View {
             HStack(spacing: DSSpacing.sm) {
                 Image(systemName: "tag")
                     .font(.system(size: 12))
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .foregroundColor(DSColor.inkMuted)
                     .frame(width: 16)
 
                 Text(NSLocalizedString("search.filter.type", comment: "Filter panel label: memo type"))
                     .monoLabelStyle(size: 11)
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .foregroundColor(DSColor.inkMuted)
                     .frame(width: 48, alignment: .leading)
 
                 ScrollView(.horizontal, showsIndicators: false) {
@@ -584,18 +591,18 @@ struct SearchView: View {
             HStack(spacing: DSSpacing.sm) {
                 Image(systemName: "mappin")
                     .font(.system(size: 12))
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .foregroundColor(DSColor.inkMuted)
                     .frame(width: 16)
 
                 Text(NSLocalizedString("search.filter.location", comment: "Filter panel label: location"))
                     .monoLabelStyle(size: 11)
-                    .foregroundColor(DSColor.onSurfaceVariant)
+                    .foregroundColor(DSColor.inkMuted)
                     .frame(width: 48, alignment: .leading)
 
                 HStack(spacing: 6) {
                     TextField(NSLocalizedString("search.filter.location.placeholder", comment: "Filter panel location text field placeholder"), text: $filters.locationQuery)
                         .font(DSFonts.inter(size: 13, relativeTo: .footnote))
-                        .foregroundColor(DSColor.onSurface)
+                        .foregroundColor(DSColor.inkPrimary)
                         .textInputAutocapitalization(.never)
                         .disableAutocorrection(true)
                         .onChange(of: filters.locationQuery) { _ in runSearch(keyword: vm.query) }
@@ -607,15 +614,15 @@ struct SearchView: View {
                         }) {
                             Image(systemName: "xmark.circle.fill")
                                 .font(.system(size: 12))
-                                .foregroundColor(DSColor.onSurfaceVariant)
+                                .foregroundColor(DSColor.inkMuted)
                         }
                         .buttonStyle(.plain)
                     }
                 }
-                .padding(.horizontal, 10)
-                .frame(height: 30)
-                .background(DSColor.surfaceContainer)
-                .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+                .padding(.horizontal, 12)
+                .frame(height: 32)
+                .dpGlass(.pill, in: Capsule())
+                .clipShape(Capsule())
             }
 
             if filters.isActive {
@@ -628,7 +635,7 @@ struct SearchView: View {
                     }) {
                         Text(NSLocalizedString("search.filter.clearAll", comment: "Clear all filters button"))
                             .monoLabelStyle(size: 10)
-                            .foregroundColor(DSColor.primary)
+                            .foregroundColor(DSColor.accentOnBg)
                     }
                     .buttonStyle(.plain)
                 }
@@ -636,7 +643,7 @@ struct SearchView: View {
         }
         .padding(.horizontal, DSSpacing.lg)
         .padding(.vertical, DSSpacing.md)
-        .background(DSColor.surfaceContainer.opacity(0.5))
+        .background(DSColor.surfaceWhite.opacity(0.35))
     }
 
     private func typeChip(_ type: Memo.MemoType) -> some View {
@@ -656,14 +663,10 @@ struct SearchView: View {
                 Text(type.displayName)
                     .monoLabelStyle(size: 10)
             }
-            .foregroundColor(isSelected ? DSColor.onPrimary : DSColor.onSurfaceVariant)
-            .padding(.horizontal, DSSpacing.sm)
-            .padding(.vertical, DSSpacing.xs)
-            .background(isSelected ? DSColor.primary : DSColor.surfaceContainer)
-            .overlay(
-                Rectangle()
-                    .stroke(isSelected ? DSColor.primary : DSColor.outlineVariant, lineWidth: 1)
-            )
+            .foregroundColor(isSelected ? DSColor.onAmber : DSColor.inkMuted)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(isSelected ? DSColor.amberDeep : DSColor.glassLo, in: Capsule())
         }
         .buttonStyle(.plain)
     }
@@ -687,43 +690,23 @@ struct SearchView: View {
     /// launch-warmed TimelineIndex synchronously (O(1) once built); shows
     /// em-dashes before warm-up so "loading" is distinguishable from a
     /// genuinely empty vault.
+    /// One quiet mono line ("1,284 MEMOS · 342 DAYS") — the old two serif
+    /// pillars gave a footnote the loudest voice on the sheet.
     private var vaultOverviewStrip: some View {
         let all = TimelineIndex.shared.entries()
         let totalMemos = all.reduce(0) { $0 + $1.memoCount }
         let totalDays = all.count
         let hasData = totalDays > 0 || totalMemos > 0
-        return HStack(alignment: .center, spacing: DSSpacing.xl) {
-            statPillar(
-                label: NSLocalizedString("search.overview.memos", comment: "Vault overview: all-time memo count label"),
-                value: hasData ? "\(totalMemos)" : "—"
-            )
-            Rectangle()
-                .fill(DSColor.glassRimD)
-                .frame(width: 0.5, height: 26)
-            statPillar(
-                label: NSLocalizedString("search.overview.days", comment: "Vault overview: all-time day count label"),
-                value: hasData ? "\(totalDays)" : "—"
-            )
-            Spacer()
-        }
-        .accessibilityElement(children: .combine)
-        .accessibilityLabel(String(
-            format: NSLocalizedString("search.overview.a11y", comment: "Vault overview a11y: %d memos across %d days"),
-            totalMemos, totalDays
-        ))
-    }
-
-    private func statPillar(label: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: DSSpacing.xs) {
-            Text(label)
-                .font(DSType.mono10)
-                .tracking(1.2)
-                .textCase(.uppercase)
-                .foregroundColor(DSColor.inkMuted)
-            Text(value)
-                .font(DSFonts.serif(size: 22, weight: .regular, relativeTo: .title2))
-                .foregroundColor(DSColor.inkPrimary)
-        }
+        return Text(hasData
+            ? String(format: NSLocalizedString("search.overview.line", comment: "Vault overview line: %1$d memos, %2$d days"), totalMemos, totalDays)
+            : "— · —")
+            .font(DSType.mono10)
+            .tracking(1.0)
+            .foregroundColor(DSColor.inkMuted)
+            .accessibilityLabel(String(
+                format: NSLocalizedString("search.overview.a11y", comment: "Vault overview a11y: %d memos across %d days"),
+                totalMemos, totalDays
+            ))
     }
 
     // MARK: - Empty-query state (recent searches + frequent entities)
@@ -742,19 +725,11 @@ struct SearchView: View {
                     .padding(.top, 10)
                     .padding(.bottom, 6)
 
-                if !recent.isEmpty || !entities.isEmpty {
-                    sectionHeader(title: NSLocalizedString("search.section.quickSearch", comment: "Quick search section header"), trailing: AnyView(EmptyView()))
-
-                    ScrollView(.horizontal, showsIndicators: false) {
-                        HStack(spacing: DSSpacing.sm) {
-                            ForEach(SearchView.starterSuggestions, id: \.self) { suggestion in
-                                entityChip(suggestion)
-                            }
-                        }
-                        .padding(.horizontal, DSSpacing.xl)
-                        .padding(.vertical, DSSpacing.xs)
-                    }
-                }
+                // W1: the "QUICK SEARCH" starter row is gone from the
+                // populated state — it stacked a fourth equal-weight section
+                // above the user's own history and mostly duplicated the
+                // entity chips below. Starters still carry the true-empty
+                // state further down.
 
                 if !recent.isEmpty {
                     sectionHeader(title: NSLocalizedString("search.section.recentSearches", comment: "Recent searches section header"), trailing: AnyView(
@@ -764,7 +739,7 @@ struct SearchView: View {
                         }) {
                             Text(NSLocalizedString("search.recent.clear", comment: "Clear recent searches button"))
                                 .monoLabelStyle(size: 10)
-                                .foregroundColor(DSColor.primary)
+                                .foregroundColor(DSColor.accentOnBg)
                         }
                         .buttonStyle(.plain)
                     ))
@@ -806,7 +781,7 @@ struct SearchView: View {
                                 .foregroundColor(DSColor.outlineVariant)
                             Text(NSLocalizedString("search.empty.prompt", comment: "Empty search state main prompt"))
                                 .bodySMStyle()
-                                .foregroundColor(DSColor.onSurfaceVariant)
+                                .foregroundColor(DSColor.inkMuted)
                             Text(NSLocalizedString("search.empty.hint", comment: "Empty search state hint text"))
                                 .monoLabelStyle(size: 10)
                                 .foregroundColor(DSColor.outline)
@@ -815,7 +790,7 @@ struct SearchView: View {
                         VStack(alignment: .leading, spacing: 10) {
                             Text(NSLocalizedString("search.empty.trySuggestion", comment: "Try a suggestion label in empty search state"))
                                 .monoLabelStyle(size: 10)
-                                .foregroundColor(DSColor.onSurfaceVariant)
+                                .foregroundColor(DSColor.inkMuted)
                                 .frame(maxWidth: .infinity, alignment: .leading)
                                 .padding(.horizontal, DSSpacing.xl)
 
@@ -839,16 +814,25 @@ struct SearchView: View {
         .scrollDismissesKeyboard(.interactively)
     }
 
+    /// "1 RESULTS" fix — mono archival label, code-side singular (the label
+    /// family is intentionally untranslated English; see FINDING-010).
+    static func resultCountText(_ n: Int) -> String {
+        String(format: NSLocalizedString(
+            n == 1 ? "search.result.count.one" : "search.result.count",
+            comment: "Total result count label; %d = count"
+        ), n)
+    }
+
     private func sectionHeader(title: String, trailing: AnyView) -> some View {
         HStack {
             Text(title)
                 .monoLabelStyle(size: 10)
-                .foregroundColor(DSColor.onSurfaceVariant)
+                .foregroundColor(DSColor.inkMuted)
             Spacer()
             trailing
         }
         .padding(.horizontal, DSSpacing.xl)
-        .padding(.top, DSSpacing.lg)
+        .padding(.top, 24)
         .padding(.bottom, DSSpacing.xs)
     }
 
@@ -881,11 +865,11 @@ struct SearchView: View {
         }) {
             Text(entity)
                 .font(DSFonts.inter(size: 13, relativeTo: .footnote))
-                .foregroundColor(DSColor.onSurface)
-                .padding(.horizontal, 10)
-                .padding(.vertical, 6)
-                .background(DSColor.surfaceContainer)
-                .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+                .foregroundColor(DSColor.inkPrimary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .dpGlass(.pill, in: Capsule())
+                .clipShape(Capsule())
         }
         .buttonStyle(ChipButtonStyle(reduceMotion: reduceMotion))
         .accessibilityLabel(String(format: NSLocalizedString("search.a11y.entityChip", comment: "Accessibility label for entity chip; %@ = entity name"), entity))
@@ -924,19 +908,19 @@ struct SearchView: View {
                     if vm.query.isEmpty && filters.isActive {
                         Text(NSLocalizedString("search.empty.noMatchFiltered", comment: "No results with active filters and no query"))
                             .bodySMStyle()
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 40)
                     } else if !vm.query.isEmpty && filters.isActive {
                         Text(String(format: NSLocalizedString("search.empty.noMatchQueryFiltered", comment: "No results for query with active filters; %@ = query"), vm.query))
                             .bodySMStyle()
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 40)
                     } else {
                         Text(String(format: NSLocalizedString("search.empty.noMatchQuery", comment: "No results for query; %@ = query"), vm.query))
                             .bodySMStyle()
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                             .multilineTextAlignment(.center)
                             .padding(.horizontal, 40)
                     }
@@ -950,10 +934,10 @@ struct SearchView: View {
                     }) {
                         Text(NSLocalizedString("search.empty.clearFilters", comment: "Clear filters button in empty result state"))
                             .monoLabelStyle(size: 11)
-                            .foregroundColor(DSColor.primary)
+                            .foregroundColor(DSColor.accentOnBg)
                             .padding(.horizontal, 14)
                             .padding(.vertical, 6)
-                            .background(Capsule().stroke(DSColor.primary, lineWidth: 1))
+                            .background(Capsule().stroke(DSColor.accentOnBg, lineWidth: 1))
                     }
                     .buttonStyle(.plain)
                 } else if !vm.query.isEmpty {
@@ -970,7 +954,7 @@ struct SearchView: View {
                     }) {
                         Text(NSLocalizedString("search.empty.clearSearch", comment: "Clear search button in empty result state"))
                             .monoLabelStyle(size: 11)
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                             .padding(.horizontal, 14)
                             .padding(.vertical, 6)
                             .background(Capsule().stroke(DSColor.outlineVariant, lineWidth: 1))
@@ -983,7 +967,7 @@ struct SearchView: View {
                     VStack(alignment: .leading, spacing: 10) {
                         Text(NSLocalizedString("search.empty.tryAnother", comment: "Try another keyword suggestion label"))
                             .monoLabelStyle(size: 10)
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, DSSpacing.xl)
 
@@ -1004,7 +988,7 @@ struct SearchView: View {
                     VStack(alignment: .leading, spacing: 10) {
                         Text(NSLocalizedString("search.section.topEntities", comment: "Top entities section header"))
                             .monoLabelStyle(size: 10)
-                            .foregroundColor(DSColor.onSurfaceVariant)
+                            .foregroundColor(DSColor.inkMuted)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.horizontal, DSSpacing.xl)
 
@@ -1061,17 +1045,17 @@ struct SearchView: View {
                 }) {
                 HStack {
                     Text(activeMatchKinds.isEmpty
-                         ? String(format: NSLocalizedString("search.result.count", comment: "Total result count label; %d = count"), total)
+                         ? Self.resultCountText(total)
                          : String(format: NSLocalizedString("search.result.countFiltered", comment: "Filtered result count label; first %d = visible, second %d = total"), visibleCount, total))
                         .monoLabelStyle(size: 10)
-                        .foregroundColor(DSColor.onSurfaceVariant)
+                        .foregroundColor(DSColor.inkMuted)
                         .modifier(NumericTextContentTransition(value: Double(visibleCount), reduceMotion: reduceMotion))
                         .animation(reduceMotion ? nil : Motion.spring, value: visibleCount)
                     Spacer()
                     if filters.isActive {
                         Label(NSLocalizedString("search.result.filtered", comment: "Filtered badge label"), systemImage: "line.3.horizontal.decrease.circle.fill")
                             .monoLabelStyle(size: 10)
-                            .foregroundColor(DSColor.primary)
+                            .foregroundColor(DSColor.accentOnBg)
                     }
                 }
                 .padding(.horizontal, DSSpacing.xl)
@@ -1108,14 +1092,16 @@ struct SearchView: View {
                         HStack {
                             Text(group.section.title)
                                 .monoLabelStyle(size: 10)
-                                .foregroundColor(DSColor.onSurfaceVariant)
+                                .foregroundColor(DSColor.inkMuted)
                             Rectangle()
-                                .fill(DSColor.outlineVariant)
-                                .frame(height: 1)
+                                .fill(DSColor.inkFaint)
+                                .frame(height: 0.5)
                         }
                         .padding(.horizontal, DSSpacing.xl)
                         .padding(.vertical, DSSpacing.sm)
-                        .background(DSColor.background)
+                        // Pinned header needs an opaque-ish mask over the
+                        // ambient ground — material keeps the warmth visible.
+                        .background(.ultraThinMaterial)
                     }
                 }
             }
@@ -1164,14 +1150,10 @@ struct SearchView: View {
                 Text(label)
                     .monoLabelStyle(size: 10)
             }
-            .foregroundColor(isActive ? DSColor.onPrimary : DSColor.onSurfaceVariant)
-            .padding(.horizontal, DSSpacing.sm)
-            .padding(.vertical, DSSpacing.xs)
-            .background(isActive ? DSColor.primary : DSColor.surfaceContainer)
-            .overlay(
-                Rectangle()
-                    .stroke(isActive ? DSColor.primary : DSColor.outlineVariant, lineWidth: 1)
-            )
+            .foregroundColor(isActive ? DSColor.onAmber : DSColor.inkMuted)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .background(isActive ? DSColor.amberDeep : DSColor.glassLo, in: Capsule())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(String(format: NSLocalizedString("search.a11y.kindChip", comment: "Accessibility label for match kind chip; %1$@ = kind label, %2$d = count"), matchLabel(for: kind), kindCount))
@@ -1187,54 +1169,51 @@ struct SearchView: View {
             format: NSLocalizedString("search.a11y.resultRow", comment: "Result row a11y: date, match kind, compile state, snippet"),
             formatDate(result.dateString), matchLabel(for: result.matchKind), badgeLabel, String(result.snippet.prefix(80))
         )
+        // W1: the 4pt alarm-bar + hard gray slab becomes a warm glass card;
+        // the date takes the serif voice. The memo-type icon pair is shown
+        // only when it adds information — "MEMO doc + TEXT doc" was the same
+        // glyph twice.
         return Button(action: {
             Haptics.tapConfirm()
             vm.recordSearch(vm.query)
             onSelect(result.dateString)
         }) {
-            HStack(spacing: 0) {
-                Rectangle()
-                    .fill(DSColor.primary)
-                    .frame(width: 4)
+            VStack(alignment: .leading, spacing: 6) {
+                HStack(alignment: .firstTextBaseline) {
+                    Text(formatDate(result.dateString))
+                        .font(DSFonts.serif(size: 15, weight: .semibold, relativeTo: .subheadline))
+                        .foregroundColor(DSColor.inkPrimary)
+                    Spacer()
+                    Text(badgeLabel)
+                        .monoLabelStyle(size: 9)
+                        .foregroundColor(result.isDailyPageCompiled ? DSColor.accentOnBg : DSColor.inkMuted)
+                }
 
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text(formatDate(result.dateString))
-                            .font(DSFonts.spaceGrotesk(size: 14, weight: .bold, relativeTo: .footnote))
-                            .foregroundColor(DSColor.onSurface)
-                        Spacer()
-                        StatusBadge(
-                            label: badgeLabel,
-                            style: result.isDailyPageCompiled ? .verified : .metadata
-                        )
-                    }
+                highlightedSnippet(result.snippet, keyword: vm.query)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
 
-                    highlightedSnippet(result.snippet, keyword: vm.query)
-                        .lineLimit(2)
-                        .frame(maxWidth: .infinity, alignment: .leading)
+                HStack(spacing: 6) {
+                    Image(systemName: matchIcon(for: result.matchKind))
+                        .font(.system(size: 10))
+                        .foregroundColor(DSColor.inkMuted)
+                    Text(matchLabel(for: result.matchKind))
+                        .monoLabelStyle(size: 10)
+                        .foregroundColor(DSColor.inkMuted)
 
-                    HStack(spacing: 6) {
-                        Image(systemName: matchIcon(for: result.matchKind))
+                    if let type = result.memoType, type != .text {
+                        Image(systemName: type.iconName)
                             .font(.system(size: 10))
-                            .foregroundColor(DSColor.onSurfaceVariant)
-                        Text(matchLabel(for: result.matchKind))
+                            .foregroundColor(DSColor.inkMuted)
+                        Text(type.displayName.uppercased())
                             .monoLabelStyle(size: 10)
-                            .foregroundColor(DSColor.onSurfaceVariant)
-
-                        if let type = result.memoType {
-                            Image(systemName: type.iconName)
-                                .font(.system(size: 10))
-                                .foregroundColor(DSColor.onSurfaceVariant)
-                            Text(type.displayName.uppercased())
-                                .monoLabelStyle(size: 10)
-                                .foregroundColor(DSColor.onSurfaceVariant)
-                        }
+                            .foregroundColor(DSColor.inkMuted)
                     }
                 }
-                .padding(DSSpacing.lg)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .background(DSColor.surfaceContainer)
             }
+            .padding(DSSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .liquidGlassCard(cornerRadius: DSRadius.md)
         }
         .buttonStyle(.plain)
         .accessibilityElement(children: .ignore)
@@ -1252,16 +1231,34 @@ struct SearchView: View {
 
     @ViewBuilder
     private func highlightedSnippet(_ snippet: String, keyword: String) -> some View {
+        // Fold raw markdown out of the excerpt first — backticks, task
+        // boxes and `---` dividers read as garbage in a one-line teaser
+        // (M1 renders memo bodies, but snippets bypassed that pipeline).
+        // Windowing + highlight offsets then operate on the cleaned text.
+        let cleaned = Self.strippedLineArtifacts(MemoMarkdown.plainText(snippet))
         let trimmed = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.isEmpty {
-            Text(snippet)
+            Text(cleaned)
                 .bodySMStyle()
-                .foregroundColor(DSColor.onSurface)
+                .foregroundColor(DSColor.inkPrimary)
         } else {
-            let windowed = snippetWindow(snippet, keyword: trimmed)
+            let windowed = snippetWindow(cleaned, keyword: trimmed)
             Text(buildHighlightedString(windowed, keyword: trimmed))
                 .bodySMStyle()
         }
+    }
+
+    /// Upstream snippet generation collapses newlines to spaces, so
+    /// line-level markdown (dividers, task boxes, heading hashes) loses the
+    /// line boundary `MemoMarkdown.plainText` needs to recognise it — the
+    /// tokens survive as mid-line litter (" --- ", "- [x] "). Salvage pass.
+    static func strippedLineArtifacts(_ s: String) -> String {
+        var out = s
+        out = out.replacingOccurrences(of: #"(^|\s)-{3,}(\s|$)"#, with: " ", options: .regularExpression)
+        out = out.replacingOccurrences(of: #"(^|\s)- \[[ xX]\]\s"#, with: " ", options: .regularExpression)
+        out = out.replacingOccurrences(of: #"(^|\s)#{1,4}\s"#, with: " ", options: .regularExpression)
+        out = out.replacingOccurrences(of: #"\s{2,}"#, with: " ", options: .regularExpression)
+        return out.trimmingCharacters(in: .whitespaces)
     }
 
     /// Returns a ~80-char window of `snippet` centered just before the first folded match of
@@ -1295,7 +1292,7 @@ struct SearchView: View {
 
     private func buildHighlightedString(_ text: String, keyword: String) -> AttributedString {
         var attributed = AttributedString(text)
-        attributed.foregroundColor = UIColor(DSColor.onSurface)
+        attributed.foregroundColor = UIColor(DSColor.inkPrimary)
 
         let foldedText = foldedForSearch(text)
         let foldedKeyword = foldedForSearch(keyword)
@@ -1312,8 +1309,12 @@ struct SearchView: View {
             let attrEnd = attributed.index(attrStart, offsetByCharacters: length)
             let attrRange = attrStart..<attrEnd
 
-            attributed[attrRange].backgroundColor = UIColor(DSColor.amberAccent).withAlphaComponent(0.28)
-            attributed[attrRange].foregroundColor = UIColor(DSColor.onSurface)
+            // W1: amber underline + semibold instead of a 28% background
+            // wash — crisper, and it needs no dark-mode recolouring.
+            // SwiftUI-scope LineStyle: the UIKit underline attributes are
+            // not reliably rendered by SwiftUI `Text`.
+            attributed[attrRange].foregroundColor = UIColor(DSColor.accentOnBg)
+            attributed[attrRange].underlineStyle = Text.LineStyle(pattern: .solid, color: DSColor.amberAccent)
             // Scaled font keeps highlight emphasis in lockstep with the snippet's Dynamic Type size.
             attributed[attrRange].font = UIFontMetrics(forTextStyle: .footnote).scaledFont(for: .systemFont(ofSize: 13, weight: .semibold))
 
@@ -1400,11 +1401,11 @@ private struct EntityFrequencyChip: View {
                 HStack(spacing: 6) {
                     Text(entity.name)
                         .font(DSFonts.inter(size: 13, relativeTo: .footnote))
-                        .foregroundColor(DSColor.onSurface)
+                        .foregroundColor(DSColor.inkPrimary)
 
                     Text("\(entity.count)")
                         .font(DSType.mono10)
-                        .foregroundColor(DSColor.onSurfaceVariant)
+                        .foregroundColor(DSColor.inkMuted)
                         .padding(.horizontal, DSSpacing.xs)
                         .padding(.vertical, 2)
                         .background(DSColor.outlineVariant.opacity(0.4))
@@ -1420,7 +1421,7 @@ private struct EntityFrequencyChip: View {
                             .frame(width: chipWidth, height: 3)
 
                         Capsule()
-                            .fill(DSColor.primary)
+                            .fill(DSColor.accentOnBg)
                             .frame(width: barAppeared ? chipWidth * ratio : 0, height: 3)
                             .animation(
                                 reduceMotion ? nil : .spring(response: 0.45, dampingFraction: 0.72)
@@ -1431,10 +1432,10 @@ private struct EntityFrequencyChip: View {
                 }
                 .frame(height: 3)
             }
-            .padding(.horizontal, 10)
-            .padding(.vertical, 6)
-            .background(DSColor.surfaceContainer)
-            .overlay(Rectangle().stroke(DSColor.outlineVariant, lineWidth: 1))
+            .padding(.horizontal, 12)
+            .padding(.vertical, 7)
+            .dpGlass(.pill, in: Capsule())
+            .clipShape(Capsule())
         }
         .buttonStyle(.plain)
         .accessibilityLabel(a11yLabel)
@@ -1565,7 +1566,7 @@ private struct SwipeableRecentRow: View {
                 }) {
                     Text(query)
                         .font(DSFonts.inter(size: 14, relativeTo: .subheadline))
-                        .foregroundColor(DSColor.onSurface)
+                        .foregroundColor(DSColor.inkPrimary)
                         .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .buttonStyle(.plain)

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -1318,3 +1318,25 @@
 "settings.analytics.clear"                   = "Clear debug events";
 "settings.analytics.section"                 = "Debug Board · Event Stream";
 "settings.analytics.footer"                  = "Shows today's event counts and the last 12 entries from vault/.analytics/events.jsonl. Visible on this device only.";
+
+/* W1 redesign (search / archive / sidebar) — 2026-07-16 */
+"sidebar.nav.search"              = "Search";
+"sidebar.nav.search.a11y"         = "Global search";
+"archive.month.meta"              = "%1$d days · %2$d entries";
+"archive.legend.density"          = "Density";
+"archive.summary.thisMonth"       = "This month";
+"archive.summary.menu.a11y"       = "Monthly summary actions";
+"archive.stat.entries"            = "ENTRIES";
+"archive.stat.photos"             = "PHOTOS";
+"archive.stat.voiceMin"           = "VOICE MIN";
+"archive.stat.places"             = "PLACES";
+"archive.stat.days"               = "DAYS";
+"archive.ledger.today"            = "TODAY";
+"archive.ledger.yesterday"        = "YESTERDAY";
+"search.result.count.one"         = "%d result";
+"search.overview.line"            = "%1$d MEMOS · %2$d DAYS";
+"archive.month.meta.days"         = "%d days";
+"archive.month.meta.days.one"     = "%d day";
+"archive.month.meta.entries"      = "%d entries";
+"archive.month.meta.entries.one"  = "%d entry";
+"archive.section.dayCount.one"    = "%d day";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -1325,3 +1325,25 @@
 "settings.analytics.clear"                   = "清空调试事件";
 "settings.analytics.section"                 = "调试看板 · 事件流";
 "settings.analytics.footer"                  = "显示 vault/.analytics/events.jsonl 里今天的事件计数与最近 12 条。仅本机可见。";
+
+/* W1 redesign (search / archive / sidebar) — 2026-07-16 */
+"sidebar.nav.search"              = "搜索";
+"sidebar.nav.search.a11y"         = "全局搜索";
+"archive.month.meta"              = "%1$d 天有记录 · %2$d 条";
+"archive.legend.density"          = "记录密度";
+"archive.summary.thisMonth"       = "这个月";
+"archive.summary.menu.a11y"       = "月度总结操作";
+"archive.stat.entries"            = "条记录";
+"archive.stat.photos"             = "张照片";
+"archive.stat.voiceMin"           = "分钟语音";
+"archive.stat.places"             = "个地点";
+"archive.stat.days"               = "天有记录";
+"archive.ledger.today"            = "今天";
+"archive.ledger.yesterday"        = "昨天";
+"search.result.count.one"         = "%d 条结果";
+"search.overview.line"            = "%1$d 条记录 · 跨 %2$d 天";
+"archive.month.meta.days"         = "%d 天有记录";
+"archive.month.meta.days.one"     = "%d 天有记录";
+"archive.month.meta.entries"      = "%d 条";
+"archive.month.meta.entries.one"  = "%d 条";
+"archive.section.dayCount.one"    = "%d 天";

--- a/DayPageKit/Sources/DayPageModels/MemoMarkdown.swift
+++ b/DayPageKit/Sources/DayPageModels/MemoMarkdown.swift
@@ -112,6 +112,47 @@ public enum MemoMarkdown {
         return doc
     }
 
+    // MARK: - Plain-text folding
+
+    /// Collapses markdown to its bare prose — no backticks, emphasis
+    /// markers, task boxes, heading hashes or dividers. Single-line output
+    /// (blocks joined by spaces), built for search snippets and other
+    /// one-line teasers where raw syntax reads as garbage.
+    public static func plainText(_ text: String) -> String {
+        let doc = cachedParse(text)
+        if doc.isPlain {
+            return text
+                .replacingOccurrences(of: "\n", with: " ")
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        func fold(_ runs: [InlineRun]) -> String {
+            runs.map(\.text).joined()
+        }
+
+        var parts: [String] = []
+        for block in doc.blocks {
+            switch block {
+            case .paragraph(let runs), .heading(let runs), .quote(let runs):
+                parts.append(fold(runs))
+            case .bullets(let items):
+                parts.append(items.map { fold($0.runs) }.joined(separator: " "))
+            case .ordered(_, let items):
+                parts.append(items.map { fold($0.runs) }.joined(separator: " "))
+            case .tasks(let items):
+                parts.append(items.map { fold($0.runs) }.joined(separator: " "))
+            case .codeBlock(let code):
+                parts.append(code.replacingOccurrences(of: "\n", with: " "))
+            case .divider:
+                continue
+            }
+        }
+        return parts
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     // MARK: - Block parsing
 
     public static func parse(_ text: String) -> Document {

--- a/DayPageTests/MemoMarkdownTests.swift
+++ b/DayPageTests/MemoMarkdownTests.swift
@@ -219,4 +219,45 @@ struct MemoMarkdownTests {
         #expect(MemoMarkdown.cachedParse(text) == MemoMarkdown.parse(text))
         #expect(MemoMarkdown.cachedParse(text) == MemoMarkdown.cachedParse(text))
     }
+
+    // MARK: - plainText folding (search snippets)
+
+    @Test("plainText strips inline syntax")
+    func plainTextInline() {
+        let folded = MemoMarkdown.plainText("`grab` 叫车比想象中便宜——机场线 `THB 120`。**先续签**再说，*不排队*。")
+        #expect(!folded.contains("`"))
+        #expect(!folded.contains("*"))
+        #expect(folded.contains("grab 叫车比想象中便宜"))
+        #expect(folded.contains("THB 120"))
+        #expect(folded.contains("先续签"))
+    }
+
+    @Test("plainText flattens blocks to one line and drops dividers")
+    func plainTextBlocks() {
+        let source = """
+        # 标题
+
+        - [x] TM.30 房东回执
+        - 照片 4×6
+
+        ---
+
+        > 引用一句
+        """
+        let folded = MemoMarkdown.plainText(source)
+        #expect(!folded.contains("#"))
+        #expect(!folded.contains("---"))
+        #expect(!folded.contains("[x]"))
+        #expect(!folded.contains(">"))
+        #expect(!folded.contains("\n"))
+        #expect(folded.contains("标题"))
+        #expect(folded.contains("TM.30 房东回执"))
+        #expect(folded.contains("引用一句"))
+    }
+
+    @Test("plainText keeps plain memos verbatim modulo newlines")
+    func plainTextPlain() {
+        #expect(MemoMarkdown.plainText("没有语法的一条 memo。") == "没有语法的一条 memo。")
+        #expect(MemoMarkdown.plainText("两行\n合一行") == "两行 合一行")
+    }
 }


### PR DESCRIPTION
## 概要

三界面深度重设计的第一波（纯视觉 + 实机取证 bug 修复，无新依赖）。设计方案与 before/after 对比：[Design Review Artifact](https://claude.ai/code/artifact/55d12e59-6173-4a5e-be11-92c528dd7734)

### 搜索页
- 方角硬描边全面退场：搜索框 44pt 胶囊玻璃（`dpGlass(.control)`）、五处 chips 胶囊化、结果卡 `liquidGlassCard` + 衬线日期
- sheet 底色 `AmbientBackground` — 修复冷白断层
- 命中高亮：28% 琥珀底色 → 琥珀下划线 + semibold（深色模式免调色）
- snippet 经 `MemoMarkdown.plainText` 折叠 + 行级 token 清理，不再漏 `` ` `` / `---` / `- [x]`
- 空态收敛三段；`1 RESULTS` 复数修复

### 归档页
- 月历刊物化：衬线月份大字 = YearMonthPicker 入口；meta 行内嵌「回到本月」；CAL/LIST 收进页头
- 空日格降为近白耳语 — 修复整月"盐粉一块板"、密度四档重新可读
- 月度总结 2×N 大卡 → 衬线三柱 + 溢出菜单；星期表头本地化
- 列表模式账本行：日期柱 + 一行 teaser + 裸计数，零值指标不占位；`1 days` 复数修复

### 侧边栏
- 图标系统重选：`books.vertical` / `circle.hexagongrid` / `sparkles` / `paperplane`（统一 .medium）
- active 态：2pt 牙签条 → 整行圆角暖玉底 + 图标胶囊衬底
- 热力图 **MAR/APR 标签叠印修复**（相邻标签让位）；`1 DAYS` 复数修复
- Recent 行去圆点加当日 teaser；「搜索」行接入 L10n

## 验证
- ✅ `xcodebuild build` 通过（仅存量 Swift 6 预警）
- ✅ `MemoMarkdownTests` 22/22（含 3 个新 `plainText` 测试）
- ✅ iPhone 17 模拟器种子数据实机验收：侧边栏 / 归档日历 / 归档列表 / 搜索空态 / 搜索结果，浅色 + 深色

## 后续（同一方案的 W2/W3，另开 PR）
- W2：键盘上方辅助条 + 豆包流式语音搜索（`searchVoiceInput` flag）
- W3：搜索 AI 回答卡（`searchAIAnswer` flag）