### PR TITLE
fix(island): 灵动岛精修满分版 — 状态感知/keyline/品牌锁屏卡/tint 单源

### DIFF
--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -439,8 +439,43 @@ struct DayPageApp: App {
                     // (提醒会静默退化成普通 UN 通知)。这一步不弹权限框。
                     if #available(iOS 26.0, *) {
                         CaptureReminderService.shared.refreshAlarmKitAuthorizationState()
+                        // 冷启动清掉上一会话遗留的 alerting alarm(灵动岛悬挂占位),
+                        // 并常驻观察前台触发(前台 iOS 不显示自家灵动岛,须转投横幅)。
+                        CaptureReminderService.shared.stopAlertingAlarms()
+                        CaptureReminderService.shared.startAlarmAlertObservation()
                     }
                     CaptureReminderService.shared.refreshSchedule()
+                    #if DEBUG
+                    // QA bridge (simulator only): `-qaAlarmInSeconds 90` schedules a
+                    // one-shot capture reminder N seconds out so the AlarmKit Dynamic
+                    // Island path can be exercised deterministically. Requests
+                    // AlarmKit authorization first (the system prompt is tapped by
+                    // the UI driver). Same launch-arg pattern as -dockVoiceDemo.
+                    if #available(iOS 26.0, *) {
+                        let args = ProcessInfo.processInfo.arguments
+                        if let idx = args.firstIndex(of: "-qaAlarmInSeconds"),
+                           args.indices.contains(idx + 1),
+                           let seconds = TimeInterval(args[idx + 1]), seconds > 0 {
+                            Task {
+                                await CaptureReminderService.shared.requestAlarmKitAuthorization()
+                                CaptureReminderService.shared.scheduleOnce(
+                                    at: Date().addingTimeInterval(seconds),
+                                    label: "QA 灵动岛测试"
+                                )
+                            }
+                        }
+                        // `-qaAlarmTimerSeconds 120`:起 countdown 计时器。
+                        // countdown 是唯一由自家 widget 渲染岛 compact/expanded
+                        // 的状态,QA 用它实测自定义岛 UI(.alert 由系统钉横幅)。
+                        if let idx = args.firstIndex(of: "-qaAlarmTimerSeconds"),
+                           args.indices.contains(idx + 1),
+                           let seconds = TimeInterval(args[idx + 1]), seconds > 0 {
+                            Task {
+                                await CaptureReminderService.shared.qaStartCountdownTimer(seconds: seconds)
+                            }
+                        }
+                    }
+                    #endif
                     // Issue #20 / Gate A fix (2026-07-03): 请求本地通知权限
                     // (用于 2am 编译完成回执)。原实现在 RootView.onAppear 无条件
                     // 触发，导致 onboarding 的 Welcome 页刚露头就弹系统授权框，
@@ -490,6 +525,14 @@ struct DayPageApp: App {
                     // re-check the raw/ mtime and rebuild the index only if it
                     // actually changed (issue #345).
                     if phase == .active {
+                        // AlarmKit 授权真源在系统,前台回填(启动路径注释所承诺的
+                        // 「每次前台读」此前只在 .task 做了一次,这里补齐);同时
+                        // 停掉 alerting 中的 alarm —— 用户已回到 App,提醒完成
+                        // 使命,不再让灵动岛挂着黑胶囊(实测会无限期占位)。
+                        if #available(iOS 26.0, *) {
+                            CaptureReminderService.shared.refreshAlarmKitAuthorizationState()
+                            CaptureReminderService.shared.stopAlertingAlarms()
+                        }
                         TimelineIndex.shared.refreshIfExternallyModified()
                         SearchIndex.shared.refreshIfExternallyModified()
                         // Re-warm generators after backgrounding so they're ready immediately.

--- a/DayPage/Services/CaptureReminderService.swift
+++ b/DayPage/Services/CaptureReminderService.swift
@@ -3,6 +3,7 @@ import UserNotifications
 import DayPageStorage
 import DayPageServices
 import SwiftUI
+import UIKit
 #if canImport(AlarmKit)
 import AlarmKit
 #endif
@@ -513,7 +514,10 @@ final class CaptureReminderService: ObservableObject {
         let attributes = AlarmAttributes(
             presentation: presentation,
             metadata: metadata,
-            tintColor: Color(red: 0.74, green: 0.49, blue: 0.14)
+            // 灵动岛恒黑底 → 取 tokens.json accent 的暗色变体 #C9883A
+            // (= DSTokens.Colors.accent dark)。widget 端一律读
+            // attributes.tintColor,不再各自硬编码副本(单源防漂移)。
+            tintColor: Color(red: 0.788, green: 0.533, blue: 0.227)
         )
         let config = AlarmManager.AlarmConfiguration(
             countdownDuration: nil,
@@ -529,6 +533,120 @@ final class CaptureReminderService: ObservableObject {
         } catch {
             DayPageLogger.shared.error("[CaptureReminder] AlarmKit schedule failed: \(error.localizedDescription)")
             return false
+        }
+    }
+
+    #if DEBUG
+    /// QA(模拟器专用):起一个 AlarmKit countdown 计时器。countdown 是唯一
+    /// 由我们的 widget 渲染灵动岛 compact/expanded 的状态(.alert 态由系统
+    /// 钉横幅接管),QA 用它实测自定义岛 UI。生产路径不会走到这里。
+    @available(iOS 26.0, *)
+    func qaStartCountdownTimer(seconds: TimeInterval) async {
+        _ = await requestAlarmKitAuthorization()
+        let alert = AlarmPresentation.Alert(
+            title: LocalizedStringResource(stringLiteral: "记录此刻"),
+            stopButton: AlarmButton(
+                text: LocalizedStringResource(stringLiteral: "稍后"),
+                textColor: .white,
+                systemImageName: "xmark"
+            ),
+            secondaryButton: AlarmButton(
+                text: LocalizedStringResource(stringLiteral: "记一句"),
+                textColor: .white,
+                systemImageName: "mic.fill"
+            ),
+            secondaryButtonBehavior: .custom
+        )
+        let countdown = AlarmPresentation.Countdown(
+            title: LocalizedStringResource(stringLiteral: "记录此刻"))
+        let presentation = AlarmPresentation(alert: alert, countdown: countdown)
+        let metadata = CaptureAlarmMetadata(prompt: "记一句给今天", slotID: UUID().uuidString)
+        let attributes = AlarmAttributes(
+            presentation: presentation,
+            metadata: metadata,
+            // 同 scheduleAlarm:tokens accent 暗色变体,widget 读 tintColor 单源。
+            tintColor: Color(red: 0.788, green: 0.533, blue: 0.227)
+        )
+        let config = AlarmManager.AlarmConfiguration.timer(
+            duration: seconds, attributes: attributes)
+        do {
+            _ = try await alarmManager.schedule(id: UUID(), configuration: config)
+            DayPageLogger.shared.info("[CaptureReminder] QA countdown timer scheduled (\(Int(seconds))s)")
+        } catch {
+            DayPageLogger.shared.error("[CaptureReminder] QA timer failed: \(error.localizedDescription)")
+        }
+    }
+    #endif
+
+    // MARK: AlarmKit alert lifecycle (2026-07-17)
+    //
+    // 实测发现的两个灵动岛硬伤:
+    //   1. alarm 触发后进入 .alerting,Live Activity 会无限期占住灵动岛 ——
+    //      cancel() 只撤未触发的调度,全工程没有任何一处调 stop()。用户点了
+    //      「记一句」进 App、录完音回桌面,岛上的黑胶囊还挂着。
+    //   2. App 在前台时触发:iOS 会隐藏本 App 自己的灵动岛呈现,而 App 内又
+    //      没有任何兜底 UI → 提醒完全不可见,静默被吞。
+    // 修法:观察 alarmUpdates;前台触发 → 立即 stop + 重投一条普通 UN 横幅
+    // (willPresent 已返回 .banner,category/action/深链全部复用既有轨道);
+    // 启动与回前台 → stop 所有 .alerting(用户已经回到 App,提醒完成使命)。
+
+    private var alarmObservationTask: Task<Void, Never>?
+
+    /// 停掉所有正在 alerting 的 alarm,释放灵动岛。重复提醒 stop 后自动
+    /// 重新武装到下一次触发;一次性提醒交给 pruneExpiredOneShots 收尾。
+    @available(iOS 26.0, *)
+    func stopAlertingAlarms() {
+        let alerting = ((try? alarmManager.alarms) ?? []).filter { $0.state == .alerting }
+        guard !alerting.isEmpty else { return }
+        for alarm in alerting {
+            try? alarmManager.stop(id: alarm.id)
+        }
+        DayPageLogger.shared.info("[CaptureReminder] stopped \(alerting.count) alerting alarm(s)")
+    }
+
+    /// 常驻观察 alarm 状态。App 处于前台时有 alarm 进入 .alerting →
+    /// 立即 stop(灵动岛对前台 App 本就不显示,留着只会在退到桌面后
+    /// 变成一个悬挂的黑胶囊)并重投一条前台 UN 横幅作为可见的提醒落点。
+    @available(iOS 26.0, *)
+    func startAlarmAlertObservation() {
+        guard alarmObservationTask == nil else { return }
+        alarmObservationTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            for await alarms in self.alarmManager.alarmUpdates {
+                let alerting = alarms.filter { $0.state == .alerting }
+                guard !alerting.isEmpty,
+                      UIApplication.shared.applicationState == .active else { continue }
+                for alarm in alerting {
+                    try? self.alarmManager.stop(id: alarm.id)
+                    self.postForegroundReminderBanner(alarmID: alarm.id)
+                }
+                DayPageLogger.shared.info("[CaptureReminder] foreground alert → stopped \(alerting.count), reposted as banner")
+                // 一次性提醒触发即过期;重排顺带剔除并让 Today 胶囊同步。
+                self.refreshSchedule()
+            }
+        }
+    }
+
+    /// 前台触发的可见落点:一条立即送达的 UN 横幅,复用既有 category
+    /// (语音 / 文字 action)与点击路由,与 UN 降级路径行为完全一致。
+    private func postForegroundReminderBanner(alarmID: UUID) {
+        let content = UNMutableNotificationContent()
+        content.title = "记录此刻"
+        content.body = reminders.first { $0.id == alarmID }?.promptBody ?? "记一句给今天"
+        content.sound = .default
+        content.categoryIdentifier = Self.categoryID
+        content.userInfo = ["captureReminderID": alarmID.uuidString]
+        let request = UNNotificationRequest(
+            identifier: Self.requestPrefix + "foreground." + alarmID.uuidString,
+            content: content,
+            trigger: nil
+        )
+        UNUserNotificationCenter.current().add(request) { error in
+            if let error {
+                Task { @MainActor in
+                    DayPageLogger.shared.error("[CaptureReminder] foreground banner failed: \(error.localizedDescription)")
+                }
+            }
         }
     }
 

--- a/DayPageWidget/CaptureReminderLiveActivity.swift
+++ b/DayPageWidget/CaptureReminderLiveActivity.swift
@@ -1,6 +1,7 @@
 #if canImport(AlarmKit)
 import WidgetKit
 import SwiftUI
+import UIKit
 import AlarmKit
 import AppIntents
 
@@ -9,91 +10,181 @@ import AppIntents
 // AlarmKit(iOS 26+)提醒的灵动岛/锁屏呈现。AlarmKit 用 AlarmAttributes<Metadata>
 // 作为 Live Activity 的 attributes,我们提供 metadata = CaptureAlarmMetadata。
 //
-// 设计(参考 Apple Design «Designing Fluid Interfaces» + HIG 灵动岛规范):
-//   • compact:leading 一颗琥珀麦克风,trailing 留白 —— 极简、不喧宾夺主。
+// 设计(参考 HIG 灵动岛规范 + 系统时钟/计时器的呈现语言):
+//   • compact:leading 琥珀麦克风(alerting 时呼吸),trailing「记一句」CTA 短文案
+//     —— compact 态必须可扫读,严禁「占位却乌黑」。
 //   • minimal:单颗琥珀麦克风(多活动并存时的最小态)。
-//   • expanded:leading 麦克风 + 标题「记录此刻」,trailing 一句轻提示(prompt),
-//     bottom 一个「记一句」按钮。琥珀 tint 呼应品牌,黑底玻璃质感由系统提供。
+//   • expanded:leading 图标+标题(标准布局:标题跟图标同侧),bottom 一句轻提示
+//     + 琥珀胶囊 CTA;keyline 同步品牌琥珀,黑底玻璃质感由系统提供。
+//   • 状态感知:context.state.mode == .alert 时麦克风 .breathe 呼吸、CTA 波形
+//     .variableColor 流动 —— 岛是「活」的,不是一张静态贴纸。
+//   • 品牌色单源:琥珀一律读 attributes.tintColor(service 侧唯一定义),
+//     widget 不再自持硬编码副本。
 //   • 文案克制、不命令式,呼应「悄悄召唤、不打扰」的产品气质。
 
 @available(iOS 26.0, *)
 struct CaptureReminderLiveActivity: Widget {
 
-    // 琥珀 amber —— 与 app 内品牌 accent 对齐。
-    private static let amber = Color(red: 0.74, green: 0.49, blue: 0.14)
+    private typealias Context = ActivityViewContext<AlarmAttributes<CaptureAlarmMetadata>>
+
+    // MARK: 锁屏卡品牌配色
+    //
+    // 镜像 design-tokens/tokens.json(widget target 不含生成的 DSTokens.swift;
+    // tokens 变更后须同步此处)。琥珀 accent 不在此镜像 —— 它经由
+    // AlarmAttributes.tintColor 从 app 侧单源下发,锁屏另取明暗自适应变体。
+    private enum Palette {
+        /// bg.warm — light #FAF8F6 / dark #1A1814
+        static let bgWarm = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.102, green: 0.094, blue: 0.078, alpha: 1.0)
+                : UIColor(red: 0.980, green: 0.973, blue: 0.965, alpha: 1.0)
+        })
+        /// fg.primary — light #2B2822 / dark #F0EDE8
+        static let ink = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.941, green: 0.929, blue: 0.910, alpha: 1.0)
+                : UIColor(red: 0.169, green: 0.157, blue: 0.133, alpha: 1.0)
+        })
+        /// fg.muted — light #6B6560 / dark #A39F99
+        static let inkMuted = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.639, green: 0.624, blue: 0.600, alpha: 1.0)
+                : UIColor(red: 0.420, green: 0.396, blue: 0.376, alpha: 1.0)
+        })
+        /// 琥珀 accent — light #A8541B(DSColor.amberAccent)/ dark #C9883A(tokens accent dark)
+        static let amber = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.788, green: 0.533, blue: 0.227, alpha: 1.0)
+                : UIColor(red: 0.659, green: 0.329, blue: 0.106, alpha: 1.0)
+        })
+        /// 琥珀底上的前景:浅色下白字够对比,暗色琥珀偏亮改用深墨。
+        static let onAmber = Color(UIColor { traits in
+            traits.userInterfaceStyle == .dark
+                ? UIColor(red: 0.102, green: 0.094, blue: 0.078, alpha: 1.0)
+                : UIColor.white
+        })
+    }
+
+    private static let recordURL = URL(string: "daypage://record")!
 
     var body: some WidgetConfiguration {
         ActivityConfiguration(for: AlarmAttributes<CaptureAlarmMetadata>.self) { context in
-            // 锁屏 / 横幅呈现。
+            // 锁屏 / 横幅呈现 —— 暖米色品牌卡,和 app 内「日式美术馆」同一语境。
             lockScreen(context)
                 .padding()
+                .activityBackgroundTint(Palette.bgWarm)
+                .activitySystemActionForegroundColor(Palette.amber)
         } dynamicIsland: { context in
             DynamicIsland {
                 DynamicIslandExpandedRegion(.leading) {
-                    Image(systemName: "mic.fill")
-                        .font(.title3)
-                        .foregroundStyle(Self.amber)
+                    HStack(spacing: 7) {
+                        Image(systemName: "mic.fill")
+                            .font(.title3)
+                            .foregroundStyle(context.attributes.tintColor)
+                            .symbolEffect(.breathe, options: .repeat(.continuous),
+                                          isActive: Self.isAlerting(context))
+                        Text("记录此刻")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(.white)
+                    }
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    Text("记录此刻")
-                        .font(.subheadline.weight(.semibold))
-                        .foregroundStyle(.white)
+                    // countdown 态给剩余时间(对齐系统计时器的数据位);
+                    // alerting 态由系统横幅接管 expanded,这里自然留白。
+                    if case .countdown(let cd) = context.state.mode {
+                        Text(timerInterval: cd.startDate...cd.fireDate, countsDown: true)
+                            .font(.subheadline.weight(.semibold).monospacedDigit())
+                            .foregroundStyle(context.attributes.tintColor)
+                            .multilineTextAlignment(.trailing)
+                            .padding(.trailing, 2)
+                    }
                 }
                 DynamicIslandExpandedRegion(.bottom) {
-                    HStack {
+                    HStack(spacing: 10) {
                         Text(context.attributes.metadata?.prompt ?? "记一句给今天")
                             .font(.footnote)
-                            .foregroundStyle(.white.opacity(0.7))
+                            .foregroundStyle(.white.opacity(0.65))
                             .lineLimit(1)
                         Spacer(minLength: 8)
-                        Link(destination: URL(string: "daypage://record")!) {
+                        Link(destination: Self.recordURL) {
                             Label("记一句", systemImage: "waveform")
                                 .font(.footnote.weight(.semibold))
                                 .foregroundStyle(.black)
+                                .symbolEffect(.variableColor.iterative.reversing,
+                                              options: .repeat(.continuous),
+                                              isActive: Self.isAlerting(context))
                                 .padding(.horizontal, 12)
                                 .padding(.vertical, 6)
-                                .background(Self.amber, in: Capsule())
+                                .background(context.attributes.tintColor, in: Capsule())
                         }
                     }
-                    .padding(.top, 2)
+                    .padding(.top, 6)
                 }
             } compactLeading: {
                 Image(systemName: "mic.fill")
-                    .foregroundStyle(Self.amber)
+                    .foregroundStyle(context.attributes.tintColor)
+                    .symbolEffect(.breathe, options: .repeat(.continuous),
+                                  isActive: Self.isAlerting(context))
             } compactTrailing: {
-                // 保持克制:compact 态只留一点点琥珀呼吸,不塞文字。
-                Circle()
-                    .fill(Self.amber.opacity(0.9))
-                    .frame(width: 6, height: 6)
+                // 2026-07-17 实测:只放 6pt 小圆点时,compact 岛拉宽后中间
+                // 大片乌黑、信息量为零,被用户点名「占了位置却什么都不显示」。
+                // 改成可扫读信息 —— compact 态的 trailing 本就该是数据位
+                // (参照系统计时器/Now Playing):countdown 态给实时倒计时,
+                // 其余(alerting)给 3 字 CTA,宽度预算内不会截断。
+                if case .countdown(let cd) = context.state.mode {
+                    Text(timerInterval: cd.startDate...cd.fireDate, countsDown: true)
+                        .font(.caption2.weight(.semibold).monospacedDigit())
+                        .foregroundStyle(context.attributes.tintColor)
+                        .frame(maxWidth: 44)
+                        .multilineTextAlignment(.trailing)
+                } else {
+                    Text("记一句")
+                        .font(.caption2.weight(.semibold))
+                        .foregroundStyle(context.attributes.tintColor)
+                }
             } minimal: {
                 Image(systemName: "mic.fill")
-                    .foregroundStyle(Self.amber)
+                    .foregroundStyle(context.attributes.tintColor)
             }
-            .widgetURL(URL(string: "daypage://record"))
+            .widgetURL(Self.recordURL)
+            .keylineTint(context.attributes.tintColor)
         }
     }
 
+    /// alarm 已触发(.alert)—— 呼吸/波形动画只在这个状态跑,
+    /// countdown/paused(本 app 不配置)保持静态。
+    private static func isAlerting(_ context: Context) -> Bool {
+        if case .alert = context.state.mode { return true }
+        return false
+    }
+
     @ViewBuilder
-    private func lockScreen(_ context: ActivityViewContext<AlarmAttributes<CaptureAlarmMetadata>>) -> some View {
+    private func lockScreen(_ context: Context) -> some View {
         HStack(spacing: 14) {
             Image(systemName: "mic.fill")
                 .font(.title2)
-                .foregroundStyle(Self.amber)
+                .foregroundStyle(Palette.amber)
+                .symbolEffect(.breathe, options: .repeat(.continuous),
+                              isActive: Self.isAlerting(context))
             VStack(alignment: .leading, spacing: 3) {
                 Text("记录此刻")
                     .font(.headline)
+                    .foregroundStyle(Palette.ink)
                 Text(context.attributes.metadata?.prompt ?? "记一句给今天")
                     .font(.subheadline)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(Palette.inkMuted)
                     .lineLimit(1)
             }
             Spacer(minLength: 0)
-            Link(destination: URL(string: "daypage://record")!) {
+            Link(destination: Self.recordURL) {
                 Image(systemName: "waveform")
                     .font(.title3.weight(.semibold))
-                    .foregroundStyle(.black)
+                    .foregroundStyle(Palette.onAmber)
+                    .symbolEffect(.variableColor.iterative.reversing,
+                                  options: .repeat(.continuous),
+                                  isActive: Self.isAlerting(context))
                     .frame(width: 40, height: 40)
-                    .background(Self.amber, in: Circle())
+                    .background(Palette.amber, in: Circle())
             }
         }
     }


### PR DESCRIPTION
## 背景

用户实测反馈灵动岛「乌漆嘛黑、占位不显示」+ 设计审计发现 5 个与系统级 app(时钟/计时器)的差距。本 PR 把灵动岛从「能用」修到「精致」,全部模拟器实测截图验证。

## 改动

1. **状态感知** — countdown 态 compact/expanded 显示实时倒计时(`Text(timerInterval:)` monospaced 琥珀);alerting 态麦克风 `.breathe` 呼吸、CTA 波形 `.variableColor` 流动
2. **`keylineTint`** 同步品牌琥珀,展开态外圈不再断色
3. **expanded 标准布局** — leading 图标+标题 / trailing 数据位(倒计时) / bottom 提示语+琥珀胶囊 CTA
4. **品牌色单源** — widget 一律读 `attributes.tintColor`(service 端唯一定义,tokens accent 暗色变体 #C9883A),消除三处硬编码漂移
5. **锁屏卡品牌化** — `activityBackgroundTint` 暖色自适应(镜像 tokens bgWarm/ink/amber),CTA 圆钮 onAmber 明暗自适配
6. 携带 2026-07-17 session 的 alert 生命周期兜底(启动/回前台 stop alerting、前台触发转 UN 横幅)+ 两个 QA 桥(`-qaAlarmInSeconds` / `-qaAlarmTimerSeconds`)

## 关键架构事实(评审须知)

`.alert` 态的岛由系统钉横幅接管(`AlarmPresentation.Alert` + tintColor 系统绘制),自定义 `DynamicIsland` regions 只在 `.countdown` 态渲染;锁屏 Live Activity 恒按 dark 解析。QA 实测自定义岛 UI 须走 `-qaAlarmTimerSeconds`(countdown 计时器桥,DEBUG-only)。

## 验证

- [x] iPhone 17 模拟器 iOS 26.1 实测四面截图:compact 倒计时 / expanded 完整布局 / alerting 琥珀横幅 / 锁屏品牌卡
- [x] `CaptureReminderServiceTests` 27/27 通过
- [x] BUILD SUCCEEDED(仅既有 warnings)

https://claude.ai/code/session_016go2R3p8oTUsZKdXSpe6Zw