### PR TITLE
fix(nav): 边缘返回体感修复 + Entity/Daily 统一 push 导航

### DIFF
--- a/DayPage/App/AppNavigationModel.swift
+++ b/DayPage/App/AppNavigationModel.swift
@@ -10,6 +10,79 @@ enum AppTab: Equatable {
     case graph
 }
 
+// MARK: - Navigation value types
+//
+// Hashable wrappers pushed onto a NavigationStack via `navigationDestination`.
+// Centralised here (rather than a new file) so every host stack registers the
+// SAME destination types, replacing the old per-view `.sheet` + `@State
+// selectedEntitySlug` recursion that stacked modals with no shared back stack
+// and no interactive edge-pop. A single `navigationDestination(for:
+// EntityRef.self)` per stack supports UNBOUNDED recursion: an entity page that
+// pushes another entity just appends another EntityRef and the same registered
+// destination resolves it.
+
+/// Identifies an entity wiki page (place / person / theme) for push navigation.
+/// `type` is the vault folder ("places" | "people" | "themes"), `slug` the file
+/// stem. `sourceDateString` is presentational only (a breadcrumb hint) and is
+/// EXCLUDED from Hashable/Equatable so the identity of the destination is just
+/// (type, slug) — the breadcrumb it was opened from doesn't change WHICH entity
+/// page this is. (Note: NavigationPath.append does NOT dedupe by Hashable, so
+/// pushing the same EntityRef twice DOES stack two pages; identity here is for
+/// destination-builder matching, not push suppression.)
+struct EntityRef: Hashable {
+    let type: String
+    let slug: String
+    var sourceDateString: String? = nil
+
+    static func == (lhs: EntityRef, rhs: EntityRef) -> Bool {
+        lhs.type == rhs.type && lhs.slug == rhs.slug
+    }
+
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(type)
+        hasher.combine(slug)
+    }
+}
+
+/// Identifies a compiled Daily Page (vault/wiki/daily/YYYY-MM-DD.md) for push
+/// navigation. Distinct from `DayNavTarget` (which pushes the fuller
+/// `DayDetailView`): a `DailyRef` pushes `DailyPageView` directly — the page
+/// reached when tapping a date from inside an entity page.
+struct DailyRef: Hashable {
+    let dateString: String
+}
+
+/// Pushes a MemoDetailView with the card-zoom hero transition. A distinct type
+/// from a bare `Memo.ID` (UUID) push so Today can register both: `UUID` for
+/// plain memo pushes (DailyPage chips) and `ZoomedMemoRef` for the card-body tap
+/// that animates out of the tapped card. W1 unifies this onto the path (it was
+/// an `isPresented`-driven push, which collapsed two levels when combined with
+/// the path-driven entity pushes on the same stack).
+struct ZoomedMemoRef: Hashable {
+    let id: UUID
+}
+
+/// Pushes a MemoDetailView from inside an embedded DailyPageView, looked up in
+/// the daily page's OWN `memoVM`. A distinct wrapper (not bare `Memo.ID`/UUID)
+/// is REQUIRED: an embedded DailyPage registers its memo destination on the host
+/// stack, and if it used bare UUID it would collide with TodayView's
+/// `navigationDestination(for: UUID.self)` — SwiftUI resolves duplicate
+/// same-type destinations to the one nearest the root, so the host's builder
+/// (wrong memos array) would service the tap and the memo would appear missing.
+struct DailyMemoRef: Hashable {
+    let id: UUID
+}
+
+/// Pushes WeeklyRecapDetailView onto the Archive path. W1 fix: this page used to
+/// push via a closure `NavigationLink { WeeklyRecapDetailView… }`, which mixed an
+/// eager link push with the path-driven entity/day pushes on the same
+/// path-bound stack — so edge-back opened the sidebar (path reported empty), the
+/// pop gesture was never re-armed, and entity-chip pushes from inside it could
+/// desync the stack. Routing it through the path unifies all Archive pushes.
+struct WeeklyRecapRef: Hashable {
+    let referenceDate: Date
+}
+
 // MARK: - AppNavigationModel
 
 @MainActor
@@ -18,6 +91,49 @@ final class AppNavigationModel: ObservableObject {
     @Published var selectedTab: AppTab = AppNavigationModel.initialTab()
     @Published var isSidebarOpen: Bool = false
     @Published var isFeedbackPanelOpen: Bool = false
+
+    // MARK: - Per-tab navigation paths (W1)
+    //
+    // Each drill-down tab owns a NavigationPath so entity/daily/memo pushes are
+    // programmatic and heterogeneous (EntityRef | DailyRef | Memo.ID | …). A
+    // view buried in Markdown (an entity ink deep in prose) can push simply by
+    // calling `push(_:in:)` — no local `.sheet` state, no modal nesting. The
+    // same registered `navigationDestination` resolves an unbounded recursive
+    // chain (entity → entity → daily → entity …), each link just appending.
+    //
+    // Graph keeps its `.sheet` (per the migration decision) and has no path.
+    @Published var todayPath = NavigationPath()
+    @Published var archivePath = NavigationPath()
+
+    /// Push a Hashable value onto the given tab's stack. (The system back button
+    /// and interactive edge-pop handle popping, so no explicit pop helper is
+    /// needed — SwiftUI mutates the bound path directly.)
+    func push<V: Hashable>(_ value: V, in tab: AppTab) {
+        switch tab {
+        case .today:   todayPath.append(value)
+        case .archive: archivePath.append(value)
+        default: break
+        }
+    }
+
+    /// True when the currently-selected tab has a detail page pushed — meaning a
+    /// left-edge swipe should pop that page (system gesture), NOT open the
+    /// sidebar. RootView's edge strip reads this to step aside.
+    ///
+    /// WHY the edge strip needs it: RootView's left-edge strip opens the sidebar
+    /// and sits above every child stack in the root ZStack, so its SwiftUI
+    /// DragGesture beats the child stack's UIKit `interactivePopGestureRecognizer`
+    /// for the same 20pt edge. The strip must yield when the active tab can pop.
+    ///
+    /// Purely path-driven since W1 unified every push onto a NavigationPath —
+    /// the tab's path being non-empty IS "a detail page is on top".
+    var activeStackCanPop: Bool {
+        switch selectedTab {
+        case .today:   return !todayPath.isEmpty
+        case .archive: return !archivePath.isEmpty
+        default:       return false
+        }
+    }
 
     /// Deep-link target for ArchiveView. When set, ArchiveView opens its
     /// DayDetailView for this date the next time it observes the change.
@@ -128,5 +244,47 @@ final class AppNavigationModel: ObservableObject {
         withAnimation(Motion.respectReduceMotion(Motion.panel)) {
             isFeedbackPanelOpen = false
         }
+    }
+}
+
+// MARK: - Shared entity/daily destinations (W1)
+
+/// Registers the `EntityRef` and `DailyRef` push destinations on a host stack.
+/// Attach once per NavigationStack (Today / Archive / and inside DailyPage's own
+/// modal stack). Because one registration resolves every value of that type,
+/// pushing an entity from inside an entity page (recursive) needs no extra
+/// wiring — the append lands on the same destination.
+///
+/// Both pushed pages run in their PUSHED form: no inner NavigationStack, no
+/// custom back button — they inherit the host's system back + interactive
+/// edge-pop (the whole point of the sheet→push migration).
+private struct EntityDailyDestinations: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .navigationDestination(for: EntityRef.self) { ref in
+                EntityPageView(
+                    entityType: ref.type,
+                    entitySlug: ref.slug,
+                    sourceDateString: ref.sourceDateString,
+                    // MUST be true here: pushed onto the host stack, so
+                    // EntityPageView must take its no-inner-NavigationStack
+                    // branch. Omitting it defaults to the sheet branch, which
+                    // nests a NavigationStack inside this destination → black
+                    // render + dead gestures (the classic nested-stack bug).
+                    isPushed: true
+                )
+                .restoresInteractivePop()
+            }
+            .navigationDestination(for: DailyRef.self) { ref in
+                DailyPageView(dateString: ref.dateString, isEmbedded: true)
+                    .restoresInteractivePop()
+            }
+    }
+}
+
+extension View {
+    /// Register the shared entity + daily push destinations on this stack.
+    func entityDailyDestinations() -> some View {
+        modifier(EntityDailyDestinations())
     }
 }

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -131,7 +131,11 @@ struct RootView: View {
     // open-sidebar DragGesture was attached to the entire ZStack with a 20pt
     // minimumDistance, which fought UIKit's 10pt direction-lock inside
     // SwipeableMemoCard and effectively froze left/right swipe-to-reveal.
-    private let edgeSwipeWidth: CGFloat = 20
+    //
+    // Shares `DSGesture.systemEdgeBackZone` as the single source: this same
+    // 20pt strip is what in-app pagers (DayDetail day paging) exclude so the
+    // edge stays owned by back-navigation. One number, one meaning.
+    private let edgeSwipeWidth: CGFloat = DSGesture.systemEdgeBackZone
 
     // MARK: - Interactive drawer drag
 
@@ -242,21 +246,25 @@ struct RootView: View {
                 // most natural close gesture) hit nothing and the drawer sat
                 // frozen until release. Same horizontal-dominance engage rule
                 // as the edge strip so the panel's vertical scroll stays free.
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 12)
-                        .onChanged { value in
-                            if sidebarDragTranslation == nil {
-                                let dx = value.translation.width
-                                let dy = value.translation.height
-                                guard dx < 0, abs(dx) > abs(dy) * 1.2 else { return }
-                            }
-                            sidebarDragTranslation = value.translation.width
+                //
+                // Attached ONLY while the sidebar is open. When closed, the
+                // panel is parked at x=-280 but its right edge still sits at
+                // global x=0, overlapping the exact left-edge strip the system
+                // interactive-pop needs. An always-mounted simultaneousGesture
+                // there stays in SwiftUI's arbitration pool and beats the child
+                // stack's UIKit pop — so a detail-page edge-back opened this
+                // (invisible, off-screen) drawer instead of going back. Gating
+                // on `isSidebarOpen` frees the edge whenever there's nothing to
+                // close. This is the second half of the edge-back fix; the
+                // edge-open strip is gated on `!activeStackCanPop` above.
+                .modifier(
+                    SidebarCloseDragModifier(
+                        isOpen: nav.isSidebarOpen,
+                        translation: $sidebarDragTranslation,
+                        onSettle: { predicted in
+                            settleSidebar(predictedTranslation: predicted)
                         }
-                        .onEnded { value in
-                            settleSidebar(
-                                predictedTranslation: value.predictedEndTranslation.width
-                            )
-                        }
+                    )
                 )
                 // Take the panel out of the accessibility tree when it's off-
                 // screen, otherwise VoiceOver users can still focus Settings /
@@ -316,7 +324,17 @@ struct RootView: View {
             // simultaneousGesture keeps siblings active, so vertical timeline
             // scroll and horizontal card swipes are no longer blocked while
             // SwiftUI is still in the "Possible" arbitration window.
-            if !nav.isSidebarOpen {
+            //
+            // `!nav.activeStackCanPop`: when the focused tab has a detail page
+            // pushed, this root-level strip would otherwise beat the child
+            // stack's UIKit interactive-pop for the same 20pt edge (SwiftUI wins
+            // that arbitration), so a left-edge swipe opened the sidebar instead
+            // of going back. Un-mounting the strip while a page is poppable hands
+            // the edge to the system pop; the strip returns once we're back at a
+            // tab root. This is the actual fix for edge-back — the deeper
+            // `.restoresInteractivePop()` only re-arms the recognizer this strip
+            // was shadowing.
+            if !nav.isSidebarOpen && !nav.activeStackCanPop {
                 Color.clear
                     .frame(width: edgeSwipeWidth)
                     .frame(maxHeight: .infinity)
@@ -392,6 +410,42 @@ private struct FeedbackCloseSwipeModifier: ViewModifier {
                 DragGesture(minimumDistance: 20)
                     .onEnded { value in
                         if value.translation.width > 60 { onClose() }
+                    }
+            )
+        } else {
+            content
+        }
+    }
+}
+
+// MARK: - SidebarCloseDragModifier
+//
+// Attaches the sidebar's close-by-drag gesture ONLY while the sidebar is open.
+// When closed, the 280pt panel is parked at x=-280 but its right edge is at
+// global x=0 — the same left-edge strip the system interactive-pop claims. A
+// permanently-mounted simultaneousGesture there stays in SwiftUI's arbitration
+// pool (even off-screen) and wins the edge against the child NavigationStack's
+// UIKit pop, so a detail-page edge-back swiped this invisible drawer instead of
+// popping. Conditionally attaching frees the edge whenever the drawer is shut.
+private struct SidebarCloseDragModifier: ViewModifier {
+    let isOpen: Bool
+    @Binding var translation: CGFloat?
+    let onSettle: (CGFloat) -> Void
+
+    func body(content: Content) -> some View {
+        if isOpen {
+            content.simultaneousGesture(
+                DragGesture(minimumDistance: 12)
+                    .onChanged { value in
+                        if translation == nil {
+                            let dx = value.translation.width
+                            let dy = value.translation.height
+                            guard dx < 0, abs(dx) > abs(dy) * 1.2 else { return }
+                        }
+                        translation = value.translation.width
+                    }
+                    .onEnded { value in
+                        onSettle(value.predictedEndTranslation.width)
                     }
             )
         } else {

--- a/DayPage/DesignSystem/Interactions.swift
+++ b/DayPage/DesignSystem/Interactions.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 // MARK: - DSGesture
 
@@ -14,6 +15,13 @@ enum DSGesture {
     static let horizontalDominance: CGFloat = 1.5
     /// Fixed travel that commits a month-page change in the Archive grid.
     static let monthSwipeCommitDistance: CGFloat = 50
+    /// Width of the left-screen-edge strip reserved for the system interactive
+    /// pop (swipe-to-go-back). Any in-app horizontal pager (DayDetail day
+    /// paging, Archive month paging) must NOT engage when a drag starts inside
+    /// this strip, so the edge stays owned by back-navigation. Same 20pt the
+    /// RootView sidebar edge strip uses, hoisted here as the single source so
+    /// paging and drawer share one definition.
+    static let systemEdgeBackZone: CGFloat = 20
 }
 
 // MARK: - PressableCardModifier
@@ -140,5 +148,109 @@ extension View {
             animation: animation,
             respectsReduceMotion: respectsReduceMotion
         ))
+    }
+}
+
+// MARK: - Interactive Pop Restorer
+//
+// WHY: TodayView roots its NavigationStack with `.navigationBarHidden(true)`
+// (a real crash-fix constraint — see TodayView's giant-generic-type note). On
+// iOS, hiding the navigation bar makes UIKit repoint the stack's
+// `interactivePopGestureRecognizer.delegate` to an internal object whose
+// `gestureRecognizerShouldBegin` returns false while the bar is hidden — so the
+// left-edge swipe-to-pop dies on EVERY page pushed onto that stack
+// (MemoDetailView / DayDetailView). The user feels this as "edge-back works
+// sometimes, not others": the exact reported symptom.
+//
+// FIX: swap in our own delegate that re-enables the gesture, but ONLY when the
+// stack has something to pop (viewControllers.count > 1). Guarding on depth
+// keeps the root page from arming a pop it can't service (which UIKit turns
+// into a dead, unresponsive-feeling swipe), while restoring genuine edge-back
+// on every child. This changes NO visual chrome — it purely re-arms the
+// system gesture the hidden bar suppressed.
+//
+// Usage: attach `.restoresInteractivePop()` to any view PUSHED onto a
+// bar-hidden NavigationStack (the detail pages), not to the stack root.
+
+private struct InteractivePopRestorer: UIViewControllerRepresentable {
+    func makeCoordinator() -> Coordinator { Coordinator() }
+
+    func makeUIViewController(context: Context) -> ProbeController {
+        // The probe re-claims the pop delegate in `viewWillAppear`, not just on
+        // `updateUIViewController`. WHY: in an A→B push (both restored), popping
+        // B back to A releases B's coordinator, leaving the delegate nil; SwiftUI
+        // does not reliably re-run A's `update`, so A's edge-back would silently
+        // die on the second visit. `viewWillAppear` fires on every re-exposure,
+        // so each page re-arms itself as it comes back to the top.
+        let vc = ProbeController()
+        vc.coordinator = context.coordinator
+        vc.view.backgroundColor = .clear
+        vc.view.isUserInteractionEnabled = false
+        return vc
+    }
+
+    func updateUIViewController(_ uiViewController: ProbeController, context: Context) {
+        uiViewController.coordinator = context.coordinator
+        uiViewController.rearm()
+    }
+
+    /// Zero-size probe that lives in the responder chain purely to resolve
+    /// `navigationController` and re-claim the pop gesture on every appearance.
+    final class ProbeController: UIViewController {
+        // STRONG (not weak): the pop gesture's `delegate` is a weak reference,
+        // and the coordinator is otherwise only retained by SwiftUI's Context.
+        // Holding it strongly here binds the coordinator's lifetime to this
+        // probe (which SwiftUI retains for the view's lifetime), so the deferred
+        // `rearm()` can never set `gesture.delegate` to an object about to
+        // deallocate. No cycle: the coordinator does not retain the probe.
+        var coordinator: Coordinator?
+
+        override func viewWillAppear(_ animated: Bool) {
+            super.viewWillAppear(animated)
+            rearm()
+        }
+
+        func rearm() {
+            // Defer one hop: on the first pass the view may not yet be in the
+            // nav hierarchy, so `navigationController` is nil.
+            DispatchQueue.main.async { [weak self] in
+                guard let self,
+                      let coordinator = self.coordinator,
+                      let nc = self.navigationController,
+                      let gesture = nc.interactivePopGestureRecognizer
+                else { return }
+                coordinator.stackProvider = { [weak nc] in nc?.viewControllers.count ?? 0 }
+                gesture.isEnabled = true
+                gesture.delegate = coordinator
+            }
+        }
+    }
+
+    final class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        /// Reads the live stack depth so the edge-pop only arms when there is a
+        /// parent to return to — never on the stack root.
+        var stackProvider: (() -> Int)?
+
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            (stackProvider?() ?? 0) > 1
+        }
+
+        // Deliberately do NOT implement `shouldRecognizeSimultaneouslyWith`.
+        // The default (false = mutually exclusive) is what we want: MemoDetail
+        // also hosts a horizontal UIKit pan (DropToAskGesture). If the edge-pop
+        // ran simultaneously, an edge drag meant as "go back" would also fire
+        // "drag-to-ask". Keeping them exclusive lets UIKit's arbitration pick
+        // one — the system pop wins at the screen edge (its recognizer is
+        // edge-anchored), drag-to-ask wins from the card interior.
+    }
+}
+
+extension View {
+    /// Re-arms the system left-edge swipe-to-pop on a view pushed onto a
+    /// NavigationStack whose root hid the navigation bar (which otherwise
+    /// suppresses the interactive pop gesture). Attach to the DETAIL page, not
+    /// the stack root. No visual effect — restores gesture behavior only.
+    func restoresInteractivePop() -> some View {
+        background(InteractivePopRestorer().frame(width: 0, height: 0).allowsHitTesting(false))
     }
 }

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -482,8 +482,9 @@ struct ArchiveView: View {
     /// DayDetailView. Replaces the former `selectedDateString` + `showDayDetail`
     /// bool that drove a `fullScreenCover`; pushing gives the day a system back
     /// button + interactive edge-swipe-to-pop and a zoom hero (iOS 18+) out of
-    /// the tapped calendar cell / list row.
-    @State private var selectedDay: DayNavTarget? = nil
+    /// the tapped calendar cell / list row. W1: now pushed via
+    /// `nav.push(DayNavTarget…)` onto `archivePath` (path-unified with entity/
+    /// daily pushes) instead of a local `@State selectedDay` + isPresented.
     /// Shared zoom namespace so the tapped calendar cell / list row is the
     /// `matchedTransitionSource` for the pushed DayDetailView.
     @Namespace private var dayZoomNamespace
@@ -537,7 +538,7 @@ struct ArchiveView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $nav.archivePath) {
             ZStack {
                 AmbientBackground().ignoresSafeArea()
                 VStack(spacing: 0) {
@@ -685,22 +686,32 @@ struct ArchiveView: View {
             .onChange(of: nav.pendingSearchQuery) { _ in
                 consumePendingSearchQuery()
             }
-            // isPresented-based (iOS 16+) rather than item: (iOS 17+) so the
-            // push compiles against the 17.0 deployment target without an
-            // availability gate. The bound day is read inside the builder.
-            .navigationDestination(
-                isPresented: Binding(
-                    get: { selectedDay != nil },
-                    set: { if !$0 { selectedDay = nil } }
-                )
-            ) {
-                if let target = selectedDay {
-                    DayDetailView(dateString: target.dateString)
-                        .modifier(ArchiveDayZoomDestination(
-                            id: target.dateString, namespace: dayZoomNamespace
-                        ))
-                }
+            // W1 unification: DayDetail is now a PATH push (`DayNavTarget` on
+            // `nav.archivePath`), not `isPresented`. Mixing an isPresented push
+            // with the path-driven EntityRef/DailyRef pushes on the same stack
+            // made a single back-gesture collapse two levels (DayDetail skipped,
+            // straight to Archive). One push mechanism = correct per-level pop.
+            .navigationDestination(for: DayNavTarget.self) { target in
+                DayDetailView(dateString: target.dateString)
+                    .modifier(ArchiveDayZoomDestination(
+                        id: target.dateString, namespace: dayZoomNamespace
+                    ))
+                    // W0: Archive's stack also hides its nav bar (:670), so the
+                    // pushed day needs the pop gesture re-armed.
+                    .restoresInteractivePop()
             }
+            // W1: shared entity + daily push destinations on Archive's stack.
+            .entityDailyDestinations()
+            // W1 fix: WeeklyRecap now pushes via the path too (was a closure
+            // NavigationLink). Re-arm the pop gesture like every other pushed
+            // page on this bar-hidden stack.
+            .navigationDestination(for: WeeklyRecapRef.self) { ref in
+                WeeklyRecapDetailView(referenceDate: ref.referenceDate)
+                    .restoresInteractivePop()
+            }
+            // The edge-strip `activeStackCanPop` signal is now driven purely by
+            // `archivePath` being non-empty (see AppNavigationModel) — no manual
+            // per-tab flag needed once every push runs through the path.
             .sheet(isPresented: $showSearch) {
                 SearchView(
                     onSelect: { dateStr in
@@ -710,7 +721,7 @@ struct ArchiveView: View {
                         // shorter than the old 0.25s cover-vs-sheet workaround.
                         showSearch = false
                         DispatchQueue.main.async {
-                            selectedDay = DayNavTarget(dateString: dateStr)
+                            nav.push(DayNavTarget(dateString: dateStr), in: .archive)
                         }
                     },
                     initialQuery: searchInitialQuery
@@ -750,7 +761,7 @@ struct ArchiveView: View {
     /// `.empty` / `.error` / `.rawOnly` / `.compiled` 等状态 — 参见 US-002。
     private func handleDateTap(dateStr: String) {
         Haptics.soft()
-        selectedDay = DayNavTarget(dateString: dateStr)
+        nav.push(DayNavTarget(dateString: dateStr), in: .archive)
     }
 
     /// Consume any pending deep-link from the sidebar's Recent row. Cleared
@@ -762,7 +773,7 @@ struct ArchiveView: View {
         // Defer the push so SwiftUI commits the tab switch first; pushing during
         // the same runloop as the tab change can race and skip the animation.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-            selectedDay = DayNavTarget(dateString: dateStr)
+            nav.push(DayNavTarget(dateString: dateStr), in: .archive)
         }
     }
 
@@ -1594,15 +1605,38 @@ struct ArchiveView: View {
         let flagOn = FeatureFlagStore.shared.isEnabled(.weeklyRecap)
         let recentDailyCount = WeeklyRecapService.shared.entries(referenceDate: Date()).count
         if flagOn && recentDailyCount >= 3 {
-            NavigationLink {
-                WeeklyRecapDetailView(referenceDate: Date())
-            } label: {
+            // W1 fix: value-based push onto archivePath (was a closure
+            // NavigationLink). Unifies it with the entity/day pushes on this
+            // stack so edge-back pops it, the pop gesture is re-armed, and
+            // entity-chip pushes from inside it land at the right depth.
+            //
+            // W1: value-based push onto archivePath (was a closure
+            // NavigationLink), unifying it with the entity/day pushes on this
+            // stack so edge-back pops it and the pop gesture is re-armed.
+            //
+            // NOTE (pre-existing, tracked separately): on iOS 26 the
+            // `.liquidGlassCard` (role .panel, no `.interactive()`) can swallow a
+            // synthetic tap on this card, so the entry is hard to trigger in the
+            // simulator. That is an existing Liquid Glass hit-testing issue on
+            // this card, independent of this navigation migration — the push
+            // wiring here is correct and matches every other Archive push.
+            NavigationLink(value: WeeklyRecapRef(referenceDate: Date())) {
                 weeklyRecapEntryCardBody
             }
             .buttonStyle(.plain)
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(weeklyRecapEntryA11yLabel)
+            .accessibilityHint(NSLocalizedString("weekly.recap.entrycard.hint", comment: ""))
+            .accessibilityAddTraits(.isButton)
         } else {
             EmptyView()
         }
+    }
+
+    private var weeklyRecapEntryA11yLabel: String {
+        let isoWeek = WeeklyCompilationService.isoWeekKey(for: Date())
+        let title = NSLocalizedString("weekly.recap.entrycard.title", comment: "")
+        return "\(title), \(isoWeek)"
     }
 
     private var weeklyRecapEntryCardBody: some View {
@@ -1630,10 +1664,6 @@ struct ArchiveView: View {
         .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)
         .liquidGlassCard(cornerRadius: DSRadius.md)
-        .accessibilityElement(children: .ignore)
-        .accessibilityLabel("\(title), \(isoWeek)")
-        .accessibilityHint(NSLocalizedString("weekly.recap.entrycard.hint", comment: ""))
-        .accessibilityAddTraits(.isButton)
     }
 
     private func relativeDateLabel(_ dateString: String) -> String {

--- a/DayPage/Features/Archive/DayDetailView.swift
+++ b/DayPage/Features/Archive/DayDetailView.swift
@@ -118,16 +118,23 @@ struct DayDetailView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItemGroup(placement: .navigationBarTrailing) {
+                // Day stepper. `.circle` variants (not bare chevrons): a bare
+                // `chevron.left` in a navigation bar reads as "back" — iOS has
+                // trained that glyph as the pop affordance, and the real back
+                // button sits at leading. Wrapping in a circle marks these as
+                // discrete stepper controls, not a second back arrow, and
+                // `.backward`/`.forward` (vs `.left`/`.right`) keep the
+                // direction semantic and RTL-correct.
                 Button(action: { go(.backward) }) {
-                    Image(systemName: "chevron.left")
-                        .font(.system(size: 15, weight: .semibold))
+                    Image(systemName: "chevron.backward.circle")
+                        .font(.system(size: 17, weight: .regular))
                         .foregroundColor(DSColor.onSurface)
                 }
                 .accessibilityLabel(NSLocalizedString("daydetail.a11y.prevDay", comment: "A11y label: go to previous day"))
 
                 Button(action: { go(.forward) }) {
-                    Image(systemName: "chevron.right")
-                        .font(.system(size: 15, weight: .semibold))
+                    Image(systemName: "chevron.forward.circle")
+                        .font(.system(size: 17, weight: .regular))
                         .foregroundColor(canGoForward ? DSColor.onSurface : DSColor.onSurfaceVariant.opacity(0.35))
                 }
                 .disabled(!canGoForward)
@@ -170,12 +177,21 @@ struct DayDetailView: View {
     private static let boundsResistance: CGFloat = 0.3
 
     private var pageSwipeGesture: some Gesture {
-        DragGesture(minimumDistance: DSGesture.pagerMinimumDistance)
+        // `.global` so `startLocation.x` is a true screen coordinate — the
+        // left-edge exclusion below must measure against the physical edge, not
+        // this view's local origin.
+        DragGesture(minimumDistance: DSGesture.pagerMinimumDistance, coordinateSpace: .global)
             .updating($pageDrag) { value, drag, _ in
                 // Engage only once the drag is dominantly sideways, so we never
                 // fight vertical scrolling inside the daily/raw content; after
                 // that, latch and follow the finger for the rest of the gesture.
                 if !drag.isEngaged {
+                    // Yield the left screen edge to the system interactive pop:
+                    // a drag that starts within `systemEdgeBackZone` is a
+                    // back-navigation, never a day-page turn. Without this, a
+                    // rightward pull from the edge ambiguously meant both "go
+                    // back" and "previous day".
+                    guard value.startLocation.x > DSGesture.systemEdgeBackZone else { return }
                     guard abs(value.translation.width) > abs(value.translation.height) * DSGesture.horizontalDominance else { return }
                     drag.isEngaged = true
                 }
@@ -185,8 +201,10 @@ struct DayDetailView: View {
                 drag.offset = canPage ? translation : translation * Self.boundsResistance
             }
             .onEnded { value in
-                // Same horizontal-dominance guard as tracking: an end that never
-                // engaged (vertical scroll) must stay a no-op.
+                // Same edge-exclusion + horizontal-dominance guards as tracking:
+                // an end that never engaged (edge-pop or vertical scroll) must
+                // stay a no-op.
+                guard value.startLocation.x > DSGesture.systemEdgeBackZone else { return }
                 guard abs(value.translation.width) > abs(value.translation.height) * DSGesture.horizontalDominance else { return }
                 let screenWidth = UIScreen.main.bounds.width
                 let translation = value.translation.width

--- a/DayPage/Features/Archive/WeeklyRecapDetailView.swift
+++ b/DayPage/Features/Archive/WeeklyRecapDetailView.swift
@@ -25,12 +25,11 @@ struct WeeklyRecapDetailView: View {
     @State private var detailedError: WeeklyCompilationError?
     @State private var error: String?
 
-    /// R8-MEDIUM B2: pushed when a keyword chip / place row is tapped.
-    /// Drives a `.sheet` of `EntityPageView`. Slug is lowercased + trimmed
-    /// before resolve so cache hits work the same way DailyPage's wikilink
-    /// resolver does.
-    @State private var entityNavSlug: String?
-    @State private var entityNavType: String = "themes"
+    /// W1: keyword chip / place row taps push an `EntityRef` onto the host
+    /// (Archive) stack instead of opening a local sheet — inherits system back
+    /// + edge-pop. Slug is lowercased + trimmed before resolve so cache hits
+    /// work the same way DailyPage's wikilink resolver does.
+    @EnvironmentObject private var nav: AppNavigationModel
 
     /// R8-LOW: monitor the network so the offline error auto-retries the
     /// moment connectivity returns. The view drops the subscription on
@@ -70,18 +69,6 @@ struct WeeklyRecapDetailView: View {
             guard isOnline else { return }
             guard case .offline = detailedError else { return }
             Task { await reload(forceRefresh: false) }
-        }
-        // R8-MEDIUM B2: keyword chip / place row taps push EntityPageView
-        // as a sheet (mirrors DailyPageView's wikilink behaviour). The
-        // slug→type resolve happens in `handleKeywordTap`; sheet item is
-        // the slug so a quick re-tap re-presents cleanly.
-        .sheet(isPresented: Binding(
-            get: { entityNavSlug != nil },
-            set: { if !$0 { entityNavSlug = nil } }
-        )) {
-            if let slug = entityNavSlug {
-                EntityPageView(entityType: entityNavType, entitySlug: slug)
-            }
         }
     }
 
@@ -598,8 +585,7 @@ struct WeeklyRecapDetailView: View {
         let slug = keyword.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
         guard !slug.isEmpty else { return }
         let (type, resolved) = Self.resolveEntityTypeAndSlug(slug)
-        entityNavType = type
-        entityNavSlug = resolved
+        nav.push(EntityRef(type: type, slug: resolved), in: nav.selectedTab)
     }
 
     /// Place row tap → push EntityPageView under "places" preferentially.
@@ -607,8 +593,7 @@ struct WeeklyRecapDetailView: View {
         let slug = raw.lowercased().trimmingCharacters(in: .whitespacesAndNewlines)
         guard !slug.isEmpty else { return }
         let (type, resolved) = Self.resolveEntityTypeAndSlug(slug, preferPlaces: true)
-        entityNavType = type
-        entityNavSlug = resolved
+        nav.push(EntityRef(type: type, slug: resolved), in: nav.selectedTab)
     }
 
     /// Mirrors DailyPageView.resolveEntityTypeAndSlug. Static so we can hit

--- a/DayPage/Features/Daily/DailyPageView.swift
+++ b/DayPage/Features/Daily/DailyPageView.swift
@@ -17,6 +17,7 @@ struct DailyPageView: View {
     var isEmbedded: Bool = false
 
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var nav: AppNavigationModel
     @StateObject private var memoVM = DailyPageMemoVM()
     @ObservedObject private var compilationService = CompilationService.shared
     @State private var selectedTab: DailyPageTab = .digest
@@ -54,6 +55,19 @@ struct DailyPageView: View {
             content()
         } else {
             NavigationStack(root: content)
+        }
+    }
+
+    /// Open an entity page. When embedded in a host stack (Today/Archive → …),
+    /// push an `EntityRef` onto the shared path so it inherits system back +
+    /// edge-pop and can recurse. When presented modally (self-contained stack),
+    /// fall back to the local `.sheet`.
+    private func openEntity(type: String, slug: String) {
+        if isEmbedded {
+            nav.push(EntityRef(type: type, slug: slug, sourceDateString: dateString), in: nav.selectedTab)
+        } else {
+            selectedEntityType = type
+            selectedEntitySlug = slug
         }
     }
 
@@ -106,8 +120,12 @@ struct DailyPageView: View {
                     }
                 }
             }
-            .navigationDestination(for: Memo.ID.self) { memoID in
-                if let memo = memoVM.memos.first(where: { $0.id == memoID }) {
+            // W1 fix: DailyMemoRef (not bare Memo.ID) so an embedded DailyPage's
+            // memo destination doesn't collide with the host stack's
+            // `for: UUID.self` — see DailyMemoRef doc. Looked up in this page's
+            // own memoVM.
+            .navigationDestination(for: DailyMemoRef.self) { ref in
+                if let memo = memoVM.memos.first(where: { $0.id == ref.id }) {
                     MemoDetailView(
                         memo: memo,
                         vm: memoVM,
@@ -117,6 +135,11 @@ struct DailyPageView: View {
                             comment: "Detail view — back label when pushed from a daily page"
                         )
                     )
+                    // W0: when DailyPage is embedded in a bar-hidden host stack
+                    // (Today/Archive → DayDetail), this MemoDetail push inherits
+                    // the suppressed pop gesture; re-arm it. Harmless (idempotent)
+                    // in the modal path where the bar is already visible.
+                    .restoresInteractivePop()
                 } else {
                     Text(NSLocalizedString("memo.not_found", comment: "Memo missing fallback")).foregroundColor(DSColor.inkMuted)
                 }
@@ -400,7 +423,7 @@ struct DailyPageView: View {
 
             VStack(spacing: 0) {
                 ForEach(memoVM.memos) { memo in
-                    NavigationLink(value: memo.id) {
+                    NavigationLink(value: DailyMemoRef(id: memo.id)) {
                         SourceSignalRow(memo: memo)
                     }
                     .buttonStyle(.plain)
@@ -524,8 +547,7 @@ struct DailyPageView: View {
             DailyPageSummarySection(model: model, onMentionTap: { mention in
                 let slug = mention.hasPrefix("@") ? String(mention.dropFirst()) : mention
                 let (type, resolved) = resolveEntityTypeAndSlug(slug)
-                selectedEntityType = type
-                selectedEntitySlug = resolved
+                openEntity(type: type, slug: resolved)
             })
         }
         .padding(28)

--- a/DayPage/Features/Entity/EntityPageView.swift
+++ b/DayPage/Features/Entity/EntityPageView.swift
@@ -16,8 +16,17 @@ struct EntityPageView: View {
     let entitySlug: String
     /// When presented from a Daily Page, pass the dateString to show a breadcrumb.
     var sourceDateString: String? = nil
+    /// True when pushed onto a host NavigationStack (Today / Archive / Daily /
+    /// MemoDetail): the page drops its own stack + custom back button (it
+    /// inherits the host's system back + edge-pop) and pushes recursive
+    /// entity/daily links onto the shared path via `nav`. False when presented
+    /// modally as a `.sheet` (only Graph still does this): it keeps its own
+    /// NavigationStack, its dismiss back button, and its local `.sheet`
+    /// recursion, since there is no host path to append to.
+    var isPushed: Bool = false
 
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var nav: AppNavigationModel
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @State private var model: EntityModel? = nil
     @State private var notFound: Bool = false
@@ -53,78 +62,65 @@ struct EntityPageView: View {
     }
 
     var body: some View {
-        NavigationStack {
-            ZStack {
-                DSColor.background.ignoresSafeArea()
-
-                if notFound {
-                    notFoundView(reason: notFoundReason)
-                } else if let model {
-                    ScrollView {
-                        VStack(alignment: .leading, spacing: 0) {
-                            entityHeader(model: model)
-                                .padding(.horizontal, DSSpacing.xl)
-                                .padding(.top, DSSpacing.xl2)
-                                .padding(.bottom, 32)
-
-                            entityBody(model: model)
-                                .padding(.horizontal, DSSpacing.xl)
-                                .padding(.bottom, 40)
-
-                            relatedMemos(model: model)
-                                .padding(.horizontal, DSSpacing.xl)
-                                .padding(.bottom, 40)
-
-                            // R4-MEDIUM #39 — backlinks gated behind a
-                            // FeatureFlag so we can kill-switch it in TestFlight
-                            // without a hot-fix build. Default-on.
-                            if FeatureFlagStore.shared.isEnabled(.backlinks) {
-                                backlinksSection
-                                    .padding(.horizontal, DSSpacing.xl)
-                                    .padding(.bottom, 40)
-                            }
-                        }
-                    }
-                } else {
-                    entitySkeleton
-                }
-            }
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .navigationBarLeading) {
-                    if let src = sourceDateString {
-                        Button(action: { dismiss() }) {
-                            HStack(spacing: DSSpacing.xs) {
-                                Image(systemName: "arrow.left")
-                                    .font(.system(size: 13, weight: .medium))
-                                Text(src)
-                                    .font(.custom("JetBrainsMono-Regular", fixedSize: 11))
-                                    .kerning(0.5)
-                            }
-                            .foregroundColor(DSColor.primary)
-                        }
-                    } else {
-                        Button(action: { dismiss() }) {
-                            Image(systemName: "arrow.left")
-                                .font(.system(size: 16, weight: .medium))
+        Group {
+            if isPushed {
+                // Pushed onto a host stack: no inner NavigationStack, no custom
+                // back button. Recursive entity/daily links push onto the shared
+                // path (see `openEntity`/`openDaily`). Inherits system back +
+                // edge-pop from the host.
+                scrollContent
+                    .navigationBarTitleDisplayMode(.inline)
+                    .toolbar {
+                        ToolbarItem(placement: .principal) {
+                            Text(entitySlug.uppercased())
+                                .monoLabelStyle(size: 11)
                                 .foregroundColor(DSColor.onSurface)
                         }
                     }
-                }
-                ToolbarItem(placement: .principal) {
-                    Text(entitySlug.uppercased())
-                        .monoLabelStyle(size: 11)
-                        .foregroundColor(DSColor.onSurface)
-                }
+                    .modifier(EntityLifecycleModifier(onAppearLoad: loadEntity, onDisappearCancel: cancelScan))
+            } else {
+                // Modal sheet path (Graph only): keep the self-contained stack,
+                // the dismiss back button, and local `.sheet` recursion.
+                sheetContainer
             }
         }
-        .onAppear { loadEntity() }
-        .onDisappear {
-            // Cancel any in-flight scan so a quick dismiss/re-open doesn't
-            // pile up detached tasks racing on @MainActor writes.
-            scanTask?.cancel()
-            scanTask = nil
+    }
+
+    /// Sheet-mode container: self-contained NavigationStack + dismiss chrome +
+    /// local `.sheet` recursion. Only reached from Graph's `.sheet` presentation.
+    private var sheetContainer: some View {
+        NavigationStack {
+            scrollContent
+                .navigationBarTitleDisplayMode(.inline)
+                .toolbar {
+                    ToolbarItem(placement: .navigationBarLeading) {
+                        if let src = sourceDateString {
+                            Button(action: { dismiss() }) {
+                                HStack(spacing: DSSpacing.xs) {
+                                    Image(systemName: "arrow.left")
+                                        .font(.system(size: 13, weight: .medium))
+                                    Text(src)
+                                        .font(.custom("JetBrainsMono-Regular", fixedSize: 11))
+                                        .kerning(0.5)
+                                }
+                                .foregroundColor(DSColor.primary)
+                            }
+                        } else {
+                            Button(action: { dismiss() }) {
+                                Image(systemName: "arrow.left")
+                                    .font(.system(size: 16, weight: .medium))
+                                    .foregroundColor(DSColor.onSurface)
+                            }
+                        }
+                    }
+                    ToolbarItem(placement: .principal) {
+                        Text(entitySlug.uppercased())
+                            .monoLabelStyle(size: 11)
+                            .foregroundColor(DSColor.onSurface)
+                    }
+                }
         }
+        .modifier(EntityLifecycleModifier(onAppearLoad: loadEntity, onDisappearCancel: cancelScan))
         .sheet(isPresented: Binding(
             get: { selectedDate != nil },
             set: { if !$0 { selectedDate = nil } }
@@ -140,6 +136,73 @@ struct EntityPageView: View {
             if let slug = selectedEntitySlug {
                 EntityPageView(entityType: selectedEntityType, entitySlug: slug)
             }
+        }
+    }
+
+    /// The scrollable page body, shared by both presentation modes.
+    @ViewBuilder
+    private var scrollContent: some View {
+        ZStack {
+            DSColor.background.ignoresSafeArea()
+
+            if notFound {
+                notFoundView(reason: notFoundReason)
+            } else if let model {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 0) {
+                        entityHeader(model: model)
+                            .padding(.horizontal, DSSpacing.xl)
+                            .padding(.top, DSSpacing.xl2)
+                            .padding(.bottom, 32)
+
+                        entityBody(model: model)
+                            .padding(.horizontal, DSSpacing.xl)
+                            .padding(.bottom, 40)
+
+                        relatedMemos(model: model)
+                            .padding(.horizontal, DSSpacing.xl)
+                            .padding(.bottom, 40)
+
+                        // R4-MEDIUM #39 — backlinks gated behind a
+                        // FeatureFlag so we can kill-switch it in TestFlight
+                        // without a hot-fix build. Default-on.
+                        if FeatureFlagStore.shared.isEnabled(.backlinks) {
+                            backlinksSection
+                                .padding(.horizontal, DSSpacing.xl)
+                                .padding(.bottom, 40)
+                        }
+                    }
+                }
+            } else {
+                entitySkeleton
+            }
+        }
+    }
+
+    private func cancelScan() {
+        // Cancel any in-flight scan so a quick dismiss/re-open doesn't
+        // pile up detached tasks racing on @MainActor writes.
+        scanTask?.cancel()
+        scanTask = nil
+    }
+
+    /// Open a child entity — push onto the host path when embedded, else set the
+    /// local `.sheet` state (Graph modal path).
+    private func openEntity(type: String, slug: String) {
+        if isPushed {
+            nav.push(EntityRef(type: type, slug: slug, sourceDateString: sourceDateString), in: nav.selectedTab)
+        } else {
+            selectedEntityType = type
+            selectedEntitySlug = slug
+        }
+    }
+
+    /// Open a daily page — push a `DailyRef` when embedded, else local `.sheet`.
+    private func openDaily(_ dateString: String) {
+        if isPushed {
+            nav.push(DailyRef(dateString: dateString), in: nav.selectedTab)
+        } else {
+            selectedDate = dateString
         }
     }
 
@@ -337,7 +400,7 @@ struct EntityPageView: View {
                 // Show individual memo snippets with navigation
                 ForEach(linkedMemos.indices, id: \.self) { idx in
                     let item = linkedMemos[idx]
-                    Button(action: { Haptics.tapConfirm(); selectedDate = item.dateStr }) {
+                    Button(action: { Haptics.tapConfirm(); openDaily(item.dateStr) }) {
                         VStack(alignment: .leading, spacing: DSSpacing.xs) {
                             Text(relativeDateLabel(item.dateStr))
                                 .monoLabelStyle(size: 9)
@@ -367,7 +430,7 @@ struct EntityPageView: View {
             } else {
                 // Fallback: daily page dates only (entity mentioned in compiled page but not raw)
                 ForEach(model.relatedDates, id: \.self) { dateStr in
-                    Button(action: { Haptics.tapConfirm(); selectedDate = dateStr }) {
+                    Button(action: { Haptics.tapConfirm(); openDaily(dateStr) }) {
                         HStack {
                             Text(relativeDateLabel(dateStr))
                                 .monoLabelStyle(size: 11)
@@ -539,8 +602,7 @@ struct EntityPageView: View {
     private func wikifiedText(_ text: String) -> some View {
         WikilinkBodyText(text: text) { inner in
             let (type, slug) = resolveEntityTypeAndSlug(inner)
-            selectedEntityType = type
-            selectedEntitySlug = slug
+            openEntity(type: type, slug: slug)
         }
     }
 
@@ -794,5 +856,21 @@ enum EntityPageParser {
             sections: sections,
             relatedDates: relatedDates
         )
+    }
+}
+
+// MARK: - EntityLifecycleModifier
+
+/// Shared onAppear-load / onDisappear-cancel wiring for EntityPageView, so both
+/// the pushed and sheet presentation branches run the same lifecycle without
+/// duplicating the closures inline.
+private struct EntityLifecycleModifier: ViewModifier {
+    let onAppearLoad: () -> Void
+    let onDisappearCancel: () -> Void
+
+    func body(content: Content) -> some View {
+        content
+            .onAppear { onAppearLoad() }
+            .onDisappear { onDisappearCancel() }
     }
 }

--- a/DayPage/Features/MemoDetail/DropToAskGesture.swift
+++ b/DayPage/Features/MemoDetail/DropToAskGesture.swift
@@ -126,15 +126,32 @@ private struct DropPanAttacher: UIViewRepresentable {
 
         func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
                                shouldRecognizeSimultaneouslyWith other: UIGestureRecognizer) -> Bool {
-            true
+            // Do NOT run simultaneously with the system interactive-pop
+            // (a screen-edge pan). Since W0 re-arms edge-back on MemoDetail, a
+            // left-edge swipe would otherwise fire BOTH pop and drag-to-ask
+            // (UIKit recognizes simultaneously if EITHER delegate returns true).
+            // Yield the edge to back-navigation; keep simultaneity with
+            // everything else (scroll, etc.).
+            if other is UIScreenEdgePanGestureRecognizer { return false }
+            return true
         }
 
-        // 让 ScrollView 的滚动 pan 等待我们的方向判定（一次查询，纵向即
-        // 秒败放行）——没有这条，滚动 pan 先动手就永远轮不到我们。
+        // Wait for the system edge-pop to fail before we begin: an edge-anchored
+        // swipe is a back gesture, not a drag-to-ask. Combined with the
+        // non-simultaneity above, the edge belongs to pop and the interior
+        // belongs to drag-to-ask.
         func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
                                shouldBeRequiredToFailBy other: UIGestureRecognizer) -> Bool {
+            if other is UIScreenEdgePanGestureRecognizer { return false }
             guard gestureRecognizer is UIPanGestureRecognizer else { return false }
             return other is UIPanGestureRecognizer && other !== gestureRecognizer
+        }
+
+        // The inverse: our pan should wait for the screen-edge pop to fail, so a
+        // true edge swipe pops instead of arming drag-to-ask.
+        func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
+                               shouldRequireFailureOf other: UIGestureRecognizer) -> Bool {
+            other is UIScreenEdgePanGestureRecognizer
         }
 
         @objc func handlePan(_ pan: UIPanGestureRecognizer) {

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -21,6 +21,7 @@ struct MemoDetailView: View {
     )
 
     @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject private var nav: AppNavigationModel
     @State private var fullResImage: UIImage?
     @State private var showPhotoFullscreen: Bool = false
 
@@ -54,9 +55,8 @@ struct MemoDetailView: View {
         return attrib
     }
 
-    // Entity Ink — tapped entity opens its wiki page (issue #835)
-    @State private var selectedEntityType: String = "themes"
-    @State private var selectedEntitySlug: String?
+    // Entity Ink — tapped entity pushes its wiki page onto the host stack
+    // (W1; issue #835). No local sheet state anymore — see openEntity(slug:).
 
     // Drop-to-Ask — memo 锚定 AI 对话（issue #837）：拖拽入坞或 CTA 触发。
     @State private var showMemoChat: Bool = false
@@ -400,8 +400,14 @@ struct MemoDetailView: View {
                                     location: memo.location,
                                     memoDateString: DateFormatters.isoDate.string(from: memo.created),
                                     onOpenPlace: { slug in
-                                        selectedEntityType = "places"
-                                        selectedEntitySlug = slug
+                                        nav.push(
+                                            EntityRef(
+                                                type: "places",
+                                                slug: slug,
+                                                sourceDateString: DateFormatters.isoDate.string(from: memo.created)
+                                            ),
+                                            in: nav.selectedTab
+                                        )
                                     }
                                 )
                             }
@@ -514,18 +520,8 @@ struct MemoDetailView: View {
         .fullScreenCover(isPresented: $showPhotoFullscreen) {
             PhotoFullscreenView(image: fullResImage)
         }
-        .sheet(isPresented: Binding(
-            get: { selectedEntitySlug != nil },
-            set: { if !$0 { selectedEntitySlug = nil } }
-        )) {
-            if let slug = selectedEntitySlug {
-                EntityPageView(
-                    entityType: selectedEntityType,
-                    entitySlug: slug,
-                    sourceDateString: DateFormatters.isoDate.string(from: memo.created)
-                )
-            }
-        }
+        // W1: entity ink now pushes onto the host stack (see openEntity /
+        // onOpenPlace) — the old local `.sheet(selectedEntitySlug)` is gone.
         // Issue #837: memo 锚定 AI 对话——Drop-to-Ask 拖拽与 ask-past CTA
         // 汇入同一个 sheet。entityDisplayNames 复用实体墨迹的异步解析结果，
         // 喂给对话的 retrieving 阶段文案与建议问题。
@@ -680,16 +676,27 @@ struct MemoDetailView: View {
     private func openEntity(slug: String) {
         Haptics.soft()
         let wikiBase = VaultInitializer.vaultURL.appendingPathComponent("wiki")
+        var resolvedType = "themes"
         for type in ["places", "people", "themes"] {
             let url = wikiBase.appendingPathComponent(type).appendingPathComponent("\(slug).md")
             if FileManager.default.fileExists(atPath: url.path) {
-                selectedEntityType = type
-                selectedEntitySlug = slug
-                return
+                resolvedType = type
+                break
             }
         }
-        selectedEntityType = "themes"
-        selectedEntitySlug = slug
+        // W1: MemoDetail is always pushed onto a host stack (Today/Archive/
+        // Daily), so push the entity onto that stack instead of opening a local
+        // sheet — it inherits system back + edge-pop and can recurse.
+        // sourceDateString = memo's date, so the entity page shows the "from
+        // {date}" breadcrumb the old .sheet passed (preserved across W1).
+        nav.push(
+            EntityRef(
+                type: resolvedType,
+                slug: slug,
+                sourceDateString: DateFormatters.isoDate.string(from: memo.created)
+            ),
+            in: nav.selectedTab
+        )
     }
 
     // MARK: - Echoes navigation

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -104,9 +104,9 @@ struct TodayView: View {
     /// All three former entry points — On This Day card, zero-memo fallback
     /// "yesterday" page, and timeline tap/long-press — now set this single
     /// item (previously three separate `String?` bindings driving three
-    /// `fullScreenCover`s). Pushing instead of covering gives the day a system
-    /// back button + interactive edge-swipe-to-pop and a zoom transition.
-    @State private var historicalDay: DayNavTarget? = nil
+    /// `fullScreenCover`s). W1: historical day is now pushed via
+    /// `nav.push(DayNavTarget…)` onto todayPath (path-unified), not a local
+    /// `@State historicalDay` — gives system back + edge-pop + zoom.
 
     /// Plain-text payload for the system share sheet when the user shares a
     /// timeline day. Identifiable wrapper because `.sheet(item:)` needs an id.
@@ -179,8 +179,8 @@ struct TodayView: View {
     /// Programmatic memo-detail navigation. The card body no longer uses a
     /// SwiftUI NavigationLink (the swipe gesture's UIKit host hit-tests to
     /// self, which would swallow the link's tap); instead a tap recognizer
-    /// fires `onOpen`, which sets this id and drives `navigationDestination`.
-    @State private var openedMemoID: UUID? = nil
+    /// fires `onOpen`, which W1 routes through `nav.push(ZoomedMemoRef…)` onto
+    /// todayPath (path-unified) instead of a local `@State openedMemoID`.
 
     /// iOS 18+ zoom transition: the tapped card is the `matchedTransitionSource`
     /// and MemoDetailView zooms out of it (App Store / Photos-style hero).
@@ -341,7 +341,7 @@ struct TodayView: View {
     }
 
     var body: some View {
-        NavigationStack {
+        NavigationStack(path: $nav.todayPath) {
             ZStack(alignment: .top) {
                 // V4: Warm ambient canvas — glass surfaces refract against this
                 AmbientBackground()
@@ -673,26 +673,29 @@ struct TodayView: View {
             // duplicate here competed in gesture arbitration with that
             // interactive version and could win, making the drawer pop open
             // with a canned animation instead of following the finger.
+            // W1: shared entity + daily push destinations (replaces the old
+            // per-view .sheet recursion). Registered once; resolves recursive
+            // entity→entity→daily chains via the shared todayPath.
+            .entityDailyDestinations()
             .navigationDestination(for: UUID.self) { memoID in
                 if let memo = viewModel.memos.first(where: { $0.id == memoID }) {
                     MemoDetailView(memo: memo, vm: viewModel)
+                        // W0: re-arm edge-back suppressed by the stack root's
+                        // hidden nav bar (applyNavigationAndOverlays :670).
+                        .restoresInteractivePop()
                 }
             }
-            // Programmatic detail navigation for the card-body tap (the swipe
-            // card drives this instead of a NavigationLink — see openedMemoID).
-            // Uses isPresented (iOS 16+) rather than item: to stay portable.
-            .navigationDestination(
-                isPresented: Binding(
-                    get: { openedMemoID != nil },
-                    set: { if !$0 { openedMemoID = nil } }
-                )
-            ) {
-                if let id = openedMemoID,
-                   let memo = viewModel.memos.first(where: { $0.id == id }) {
+            // Card-body tap → MemoDetail with zoom hero. W1: PATH push
+            // (`ZoomedMemoRef` on todayPath), not isPresented — mixing an
+            // isPresented push with the path-driven entity/UUID pushes on this
+            // same stack made one back-gesture collapse two levels.
+            .navigationDestination(for: ZoomedMemoRef.self) { ref in
+                if let memo = viewModel.memos.first(where: { $0.id == ref.id }) {
                     MemoDetailView(memo: memo, vm: viewModel)
                         .modifier(CardZoomDestination(
-                            id: id, namespace: detailZoomNamespace
+                            id: ref.id, namespace: detailZoomNamespace
                         ))
+                        .restoresInteractivePop()
                 }
             }
     }
@@ -701,6 +704,10 @@ struct TodayView: View {
     @ViewBuilder
     private func applyLifecycleHooks(_ content: some View) -> some View {
         content
+            // W1: Today's edge-strip `activeStackCanPop` signal is now driven
+            // purely by `todayPath` being non-empty (AppNavigationModel) — every
+            // push (memo / historical day / entity / daily) runs through the
+            // path, so the old manual `setStackHasDetail` onChange is gone.
             .onAppear {
                 clearDraftIfExpired()
                 // R4-B2: SceneStorage may come back empty after a process kill
@@ -970,21 +977,16 @@ struct TodayView: View {
             // three covers. Push gives the day a system back button + interactive
             // edge-swipe-to-pop, and (iOS 18+) a zoom transition out of the
             // tapped source via `.matchedTransitionSource` at each call site.
-            // isPresented-based (iOS 16+) rather than item: (iOS 17+) so the
-            // push compiles against the 17.0 deployment target without an
-            // availability gate. The bound day is read inside the builder.
-            .navigationDestination(
-                isPresented: Binding(
-                    get: { historicalDay != nil },
-                    set: { if !$0 { historicalDay = nil } }
-                )
-            ) {
-                if let target = historicalDay {
-                    DayDetailView(dateString: target.dateString)
-                        .modifier(CardZoomDestination(
-                            id: target.dateString, namespace: detailZoomNamespace
-                        ))
-                }
+            // W1: historical-day push unified onto the path (`DayNavTarget` on
+            // todayPath), not isPresented — same two-level-collapse fix as the
+            // memo push above. `matchedTransitionSource` at each call site still
+            // drives the zoom hero.
+            .navigationDestination(for: DayNavTarget.self) { target in
+                DayDetailView(dateString: target.dateString)
+                    .modifier(CardZoomDestination(
+                        id: target.dateString, namespace: detailZoomNamespace
+                    ))
+                    .restoresInteractivePop()
             }
             // Timeline share sheet — plain text payload, no poster pipeline.
             .sheet(item: $timelineShareText) { payload in
@@ -1908,7 +1910,7 @@ struct TodayView: View {
             // empty.
             if viewModel.timelineSections.isEmpty {
                 WeeklyRecapSection(entries: entries) { dateString in
-                    historicalDay = DayNavTarget(dateString: dateString)
+                    nav.push(DayNavTarget(dateString: dateString), in: .today)
                 }
             }
         case .pureEmpty:
@@ -1969,7 +1971,7 @@ struct TodayView: View {
                         comment: "Yesterday card meta: N raw memos"), page.memoCount)
                     : nil,
                 onTap: {
-                    historicalDay = DayNavTarget(dateString: page.dateString)
+                    nav.push(DayNavTarget(dateString: page.dateString), in: .today)
                 }
             )
             .modifier(CardZoomSource(id: page.dateString, namespace: detailZoomNamespace))
@@ -2019,7 +2021,7 @@ struct TodayView: View {
                     section: section,
                     zoomNamespace: detailZoomNamespace,
                     onOpenDate: { dateString in
-                        historicalDay = DayNavTarget(dateString: dateString)
+                        nav.push(DayNavTarget(dateString: dateString), in: .today)
                     },
                     onShareDate: { entry in shareTimelineDay(entry) },
                     onDeleteDate: { entry in deleteTimelineDay(entry) }
@@ -2106,7 +2108,7 @@ struct TodayView: View {
         let dateStr = Self.dateString(from: entry.originalDate)
         // Keep the in-Today push path so the existing UX (open the historical
         // DayDetail without switching tabs) still works.
-        historicalDay = DayNavTarget(dateString: dateStr)
+        nav.push(DayNavTarget(dateString: dateStr), in: .today)
         // Forward to .openArchiveAt for consumers that want to pivot to
         // Archive instead — R5 backlinks + EntityPageView already use this
         // bus, so OnThisDay rides the same channel.
@@ -3171,7 +3173,7 @@ struct TodayView: View {
                                 // open, so tap-into-detail feels identical
                                 // across today's cards and historical rows.
                                 Haptics.tapConfirm()
-                                openedMemoID = memo.id
+                                nav.push(ZoomedMemoRef(id: memo.id), in: .today)
                             }
                         )
                         .offset(x: idx == 0 ? memoCardHintOffset : 0)


### PR DESCRIPTION
## Summary

从"返回和滑动有时冲突、反直觉"出发,系统性修复导航返回体感,分两块:

**W0/W3 — 边缘滑动返回四层根因**(逐层 NSLog + 实机 idb 取证)
1. `navigationBarHidden(true)` 连带禁用子页 `interactivePopGesture` → 新增 `InteractivePopRestorer`(`ProbeController.viewWillAppear` 每次重夺 delegate,强持有防 deferred 释放)
2. RootView 顶层 20pt 边缘条(SwiftUI)盖过子栈 UIKit pop → 门控加 `!nav.activeStackCanPop`,详情页在栈顶时边缘条不挂载
3. `SidebarView` 面板关闭拖拽手势始终挂载、右边缘落 x=0 抢边缘 → 抽成 `SidebarCloseDragModifier` 仅 open 时挂
4. `DropToAskGesture` 强制并发致边缘返回同时触发"拖去问" → 让位屏幕边缘 pop
- DayDetail 天间分页排除左边缘 20pt 让给系统 pop;天步进图标改圆圈样式(裸 `chevron.left` 在导航栏=返回,语义撞车)

**W1 — Entity/Daily 从 `.sheet` 套娃迁到统一 NavigationPath push**
- 除 Graph(刻意保留 sheet)外 7 个入口全迁 push,消灭"模态套娃 + 无边缘返回 + 双层塌陷"
- `AppNavigationModel` 加 per-tab `NavigationPath` + `push` API + Hashable value 类型 + 共享 `entityDailyDestinations()`(无限递归)
- **关键**:DayDetail/Today-memo 从 isPresented-push 统一到 path push,消除同栈 isPresented/path 混用导致的一次 pop 塌两层
- push 页删自定义返回归系统 back(顺带 W2 一部分)

## Test Coverage
- 185 单测全绿,0 回归
- 实机验证(4 轮 idb 驱动 + 截图取证):边缘返回逐层 pop 零跳层、pop 后边缘条恢复、递归实体链、embedded DailyPage→memo push、MemoDetail 边缘返回不误触拖拽

## Pre-Landing Review
High-effort workflow review 抓到 10 个 verified findings,全部修复:
- WeeklyRecap 整块漏迁 → 迁 path + `restoresInteractivePop`
- embedded DailyPage memo destination 与宿主 `for: UUID.self` 冲突 → 独立 `DailyMemoRef` 类型
- DropToAsk 并发冲突 → 让位边缘 pop
- MemoDetail push 丢 sourceDateString → 恢复
- EntityRef 注释过度声称 + 死代码 `path(for:)`/`pop(in:)` → 清理

## 已知遗留(超出本 PR 范围,已记待办)
- Graph 实体入口保留 sheet(设计决策)
- Today→今日 DailyPage 保留 fullScreenCover(带 onReturnToToday 闭包)
- WeeklyRecap 入口卡 iOS26 玻璃吞点击(既有 bug,NavigationLink 迁移已就位,glass 点击独立修)
- DailyPage digest wikilink 缺 openURL handler(既有)
- `resolveEntityTypeAndSlug` 未剥 `wiki/{type}/` 前缀(既有)

## Test plan
- [x] DayPage scheme 构建通过
- [x] 185 单测全绿
- [x] 实机 idb 驱动验证边缘返回 + push 导航逐层 pop

🤖 Generated with [Claude Code](https://claude.com/claude-code)