### PR TITLE
feat(weekly-recap): 周摘要页杂志编排重构 + 补齐 5问/孤峰 + 修入口卡与回写

### DIFF
--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -1614,12 +1614,14 @@ struct ArchiveView: View {
             // NavigationLink), unifying it with the entity/day pushes on this
             // stack so edge-back pops it and the pop gesture is re-armed.
             //
-            // NOTE (pre-existing, tracked separately): on iOS 26 the
-            // `.liquidGlassCard` (role .panel, no `.interactive()`) can swallow a
-            // synthetic tap on this card, so the entry is hard to trigger in the
-            // simulator. That is an existing Liquid Glass hit-testing issue on
-            // this card, independent of this navigation migration — the push
-            // wiring here is correct and matches every other Archive push.
+            // Hit-testing fix (2026-07-18): the card body used `.liquidGlassCard`
+            // (role .panel, no `.interactive()`), whose iOS 26 native
+            // `glassEffect` layer swallowed the synthetic/real tap over most of
+            // the card — only a tap near the trailing chevron registered, so the
+            // entry was hard to open on device and in the simulator. Switched the
+            // body to `.solidCard` (surface-white + hairline, no glass layer),
+            // which never intercepts the NavigationLink label's tap and also
+            // matches the surface-white card language of WeeklyRecapDetailView.
             NavigationLink(value: WeeklyRecapRef(referenceDate: Date())) {
                 weeklyRecapEntryCardBody
             }
@@ -1663,7 +1665,9 @@ struct ArchiveView: View {
         .padding(.horizontal, DSSpacing.lg)
         .padding(.vertical, 14)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .liquidGlassCard(cornerRadius: DSRadius.md)
+        // solidCard (not liquidGlassCard): a glass layer here swallowed the
+        // NavigationLink's tap on iOS 26 (see note above the NavigationLink).
+        .solidCard(cornerRadius: DSRadius.md)
     }
 
     private func relativeDateLabel(_ dateString: String) -> String {

--- a/DayPage/Features/Archive/WeeklyRecapDetailView.swift
+++ b/DayPage/Features/Archive/WeeklyRecapDetailView.swift
@@ -12,6 +12,16 @@ import DayPageServices
 // Why a dedicated view (not a sheet): the recap is a first-class artifact
 // alongside Daily Page detail screens; reading + recompile should feel
 // like a navigated page, not a transient modal.
+//
+// 2026-07-18 杂志编排重构（Apple design）：
+//  - Hero 头部：衬线大字周标题 + 编号眼睫毛 + ISO周·日期范围，占首屏视觉重心。
+//  - 每节带 `NN` 编号 + 章节名的杂志式分节，板块间大留白呼吸。
+//  - 补齐两块此前从未渲染的字段：`reflectionQuestions`(本周 5 问，点击回写
+//    Today composer) 与 `outliers`(值得回看的孤峰，引用式高光卡)。注释一直
+//    声称这里渲染 5 问，但呈现层从未接上 —— 现补齐。
+//  - 顶栏材质化：navigationBar 半透明 + 内容滚动其下；进场时 hero 元素做
+//    轻微上浮 + 淡入，呼应从归档卡 push 进来的空间连续性。
+//  - 边缘返回：入口已 `.restoresInteractivePop()`，此处不再叠加手势。
 struct WeeklyRecapDetailView: View {
 
     let referenceDate: Date
@@ -24,6 +34,10 @@ struct WeeklyRecapDetailView: View {
     /// unmodelled error.
     @State private var detailedError: WeeklyCompilationError?
     @State private var error: String?
+
+    /// 进场动画开关。首帧为 false，`.onAppear` 里翻 true 触发 hero + 分节的
+    /// 上浮淡入 —— 从归档卡 push 进来时的空间连续感（§7 spatial consistency）。
+    @State private var appeared: Bool = false
 
     /// W1: keyword chip / place row taps push an `EntityRef` onto the host
     /// (Archive) stack instead of opening a local sheet — inherits system back
@@ -39,8 +53,10 @@ struct WeeklyRecapDetailView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: DSSpacing.xl2) {
-                header
+            VStack(alignment: .leading, spacing: 0) {
+                hero
+                    .padding(.horizontal, DSSpacing.xl)
+                    .padding(.top, DSSpacing.lg)
 
                 if isLoading {
                     loadingState
@@ -50,17 +66,25 @@ struct WeeklyRecapDetailView: View {
                     errorState(message: err)
                 } else if let output = output {
                     sections(output: output)
-                    refreshButton
+                        .padding(.top, DSSpacing.xl2)
+                    footer(output: output)
                 }
             }
-            .padding(.horizontal, DSSpacing.xl)
-            .padding(.vertical, DSSpacing.xl2)
+            .padding(.bottom, 48)
         }
         .background(DSColor.backgroundWarm.ignoresSafeArea())
         .navigationBarTitleDisplayMode(.inline)
         .navigationTitle(NSLocalizedString("weekly.recap.title", comment: ""))
+        .toolbarBackground(.visible, for: .navigationBar)
+        .toolbarBackground(.ultraThinMaterial, for: .navigationBar)
         .task {
             await loadInitial()
+        }
+        .onAppear {
+            // 进场 hero：只在首次出现时播一次。用 Motion.rise 的柔和曲线做
+            // 内容上浮，避免弹跳（非动量交互，§4 critically-damped）。
+            guard !appeared else { return }
+            withAnimation(Motion.rise.delay(0.04)) { appeared = true }
         }
         // R8-LOW B3: when the network comes back online and we're parked on
         // the .offline error state, auto-retry once so the user doesn't have
@@ -72,28 +96,49 @@ struct WeeklyRecapDetailView: View {
         }
     }
 
-    // MARK: - Header
-
-    private var header: some View {
+    // MARK: - Hero
+    //
+    // Magazine masthead: a small mono eyebrow, a large serif week title, and
+    // an ISO-week · date-range dateline. This is the page's visual anchor —
+    // it earns the top of the fold the way a Daily Page's hero date does.
+    private var hero: some View {
         let rangeText = output?.dateRange
             ?? Self.fallbackDateRange(for: referenceDate)
         let isoWeek = output?.isoWeek
             ?? WeeklyCompilationService.isoWeekKey(for: referenceDate)
 
-        return VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: DSSpacing.sm) {
-                Image(systemName: "calendar")
-                    .font(.system(size: 18, weight: .medium))
-                    .foregroundColor(DSColor.accentOnBg)
-                Text(NSLocalizedString("weekly.recap.title", comment: ""))
-                    .font(DSType.headlineMD)
-                    .foregroundColor(DSColor.inkPrimary)
-            }
+        return VStack(alignment: .leading, spacing: 10) {
+            // Eyebrow — mono, wide-tracked, quiet.
+            Text(NSLocalizedString("weekly.recap.hero.eyebrow", comment: "")
+                .uppercased())
+                .font(DSType.mono11)
+                .tracking(2.4)
+                .foregroundColor(DSColor.accentOnBg)
+
+            // Serif week title — the masthead. Ranges like "06.22 – 06.28"
+            // read as a magazine issue span.
+            Text(Self.heroRangeTitle(from: rangeText, fallback: referenceDate))
+                .font(DSType.serifDisplay32)
+                .foregroundColor(DSColor.inkPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            // Dateline — ISO week + full range, mono, muted.
             Text("\(isoWeek) · \(rangeText)")
                 .font(DSType.mono11)
                 .foregroundColor(DSColor.inkMuted)
+                .padding(.top, 2)
+
+            // Hairline rule closes the masthead off from the body — a thin
+            // amber rule, not a full-width grey divider (§12 scroll edges over
+            // hard dividers).
+            Rectangle()
+                .fill(DSColor.amberRim)
+                .frame(width: 44, height: 2)
+                .padding(.top, DSSpacing.sm)
         }
         .frame(maxWidth: .infinity, alignment: .leading)
+        .opacity(appeared ? 1 : 0)
+        .offset(y: appeared ? 0 : 12)
         .accessibilityElement(children: .combine)
         .accessibilityLabel("\(NSLocalizedString("weekly.recap.title", comment: "")), \(isoWeek), \(rangeText)")
     }
@@ -104,12 +149,13 @@ struct WeeklyRecapDetailView: View {
         VStack(spacing: DSSpacing.md) {
             ProgressView()
                 .scaleEffect(1.2)
+                .tint(DSColor.accentOnBg)
             Text(NSLocalizedString("weekly.recap.loading", comment: ""))
                 .font(DSType.bodyMD)
                 .foregroundColor(DSColor.inkMuted)
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 40)
+        .padding(.top, 72)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(NSLocalizedString("weekly.recap.loading", comment: ""))
     }
@@ -128,150 +174,224 @@ struct WeeklyRecapDetailView: View {
                 .foregroundColor(DSColor.inkMuted)
                 .multilineTextAlignment(.center)
                 .lineLimit(3)
-            Button {
-                Task { await reload(forceRefresh: true) }
-            } label: {
-                Text(NSLocalizedString("weekly.recap.refresh", comment: ""))
-                    .font(DSType.labelSM)
-                    .foregroundColor(DSColor.accentOnBg)
-                    .padding(.horizontal, DSSpacing.lg)
-                    .padding(.vertical, DSSpacing.sm)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .stroke(DSColor.amberRim, lineWidth: 1)
-                    )
-            }
-            .accessibilityHint(NSLocalizedString("weekly.recap.refresh.hint", comment: ""))
+            retryButton
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 40)
+        .padding(.horizontal, DSSpacing.xl)
+        .padding(.top, 64)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(NSLocalizedString("weekly.recap.error.body", comment: ""))
     }
 
     @ViewBuilder
     private func sections(output: WeeklyRecapOutput) -> some View {
-        keywordsSection(output.keywords)
-        moodSection(output.moodNotes)
-        placesSection(output.placeNotes)
-        highlightsSection(output.highlights)
+        // Ordered as a magazine table of contents. Numbers are assigned in
+        // render order and skip sections with no content, so a recap missing
+        // outliers still numbers 01…04 cleanly.
+        let blocks = Self.orderedBlocks(for: output)
+        VStack(alignment: .leading, spacing: DSSpacing.xl2 + DSSpacing.sm) {
+            ForEach(Array(blocks.enumerated()), id: \.offset) { idx, block in
+                section(number: idx + 1, block: block, output: output)
+                    // Stagger the rise so blocks cascade in rather than
+                    // popping as one slab (§8 hint in the direction of motion).
+                    .opacity(appeared ? 1 : 0)
+                    .offset(y: appeared ? 0 : 16)
+                    .animation(Motion.rise.delay(0.06 + Double(idx) * 0.04), value: appeared)
+            }
+        }
+        .padding(.horizontal, DSSpacing.xl)
     }
 
-    // MARK: - Sections
-
-    private func keywordsSection(_ keywords: [String]) -> some View {
+    @ViewBuilder
+    private func section(number: Int, block: Block, output: WeeklyRecapOutput) -> some View {
         VStack(alignment: .leading, spacing: DSSpacing.md) {
-            sectionLabel(NSLocalizedString("weekly.recap.section.keywords", comment: ""))
-            keywordChipFlow(keywords)
+            sectionHeader(number: number, title: block.title)
+            switch block {
+            case .keywords:    keywordFlow(output.keywords)
+            case .reflections: reflectionsBody(output.reflectionQuestions)
+            case .mood:        moodBody(output.moodNotes)
+            case .places:      placesBody(output.placeNotes)
+            case .highlights:  highlightsBody(output.highlights)
+            case .outliers:    outliersBody(output.outliers)
+            }
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .accessibilityElement(children: .contain)
-        .accessibilityLabel(NSLocalizedString("weekly.recap.section.keywords.a11y", comment: ""))
+        .accessibilityLabel(block.a11yTitle)
     }
 
-    private func keywordChipFlow(_ keywords: [String]) -> some View {
-        // Wrap-around HStack via VStack rows of ~3 chips — simple and
-        // dependency-free; flow layout was excessive for the current
-        // 3-5-chip case.
-        //
-        // R8-MEDIUM B2: each chip is a Button → push EntityPageView via
-        // the shared `handleKeywordTap` slug-resolver. Wrapped with
-        // `.buttonStyle(.plain)` so the chip visual stays identical to
-        // the original `Text(kw)` rendering.
-        let rows = Self.chunk(keywords, size: 3)
-        return VStack(alignment: .leading, spacing: DSSpacing.sm) {
-            ForEach(0..<rows.count, id: \.self) { rowIdx in
-                HStack(spacing: DSSpacing.sm) {
-                    ForEach(rows[rowIdx], id: \.self) { kw in
-                        Button {
-                            handleKeywordTap(kw)
-                        } label: {
-                            Text(kw)
-                                .font(DSType.bodyMD)
-                                .foregroundColor(DSColor.accentOnBg)
-                                .padding(.horizontal, DSSpacing.md)
-                                .padding(.vertical, 6)
-                                .background(
-                                    Capsule().fill(DSColor.amberAccent.opacity(0.14))
-                                )
-                        }
-                        .buttonStyle(.plain)
-                        .accessibilityLabel(Text(kw))
-                        .accessibilityHint(Text(NSLocalizedString(
-                            "weekly.recap.keyword.hint",
-                            value: "打开实体页",
-                            comment: "VoiceOver hint for tapping a weekly recap keyword chip"
-                        )))
+    // MARK: - Section header (magazine numbering)
+
+    private func sectionHeader(number: Int, title: String) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 10) {
+            Text(String(format: NSLocalizedString("weekly.recap.section.number.format", comment: ""), number))
+                .font(DSType.mono11)
+                .foregroundColor(DSColor.accentOnBg)
+            Text(title.uppercased())
+                .font(DSType.sectionLabel)
+                .tracking(1.5)
+                .foregroundColor(DSColor.inkMuted)
+            Rectangle()
+                .fill(DSColor.inkFaint)
+                .frame(height: 1)
+        }
+    }
+
+    // MARK: - Keywords (true flow)
+
+    private func keywordFlow(_ keywords: [String]) -> some View {
+        // Real wrap-around flow layout replaces the old "3 per row" chunking:
+        // chips now pack tightly and wrap on width, so a 7-word week no longer
+        // leaves ragged half-empty rows. Each chip is a Button → push
+        // EntityPageView via the shared `handleKeywordTap` slug-resolver.
+        FlowLayout(spacing: DSSpacing.sm) {
+            ForEach(keywords, id: \.self) { kw in
+                Button {
+                    Haptics.selection()
+                    handleKeywordTap(kw)
+                } label: {
+                    Text(kw)
+                        .font(DSType.bodyMD)
+                        .foregroundColor(DSColor.accentOnBg)
+                        .padding(.horizontal, DSSpacing.md)
+                        .padding(.vertical, 7)
+                        .background(
+                            Capsule().fill(DSColor.amberAccent.opacity(0.12))
+                        )
+                        .overlay(
+                            Capsule().stroke(DSColor.amberRim, lineWidth: 1)
+                        )
+                }
+                .pressScale(scale: 0.94, opacity: 0.9, animation: Motion.press)
+                .accessibilityLabel(Text(kw))
+                .accessibilityHint(Text(NSLocalizedString(
+                    "weekly.recap.keyword.hint",
+                    value: "打开实体页",
+                    comment: "VoiceOver hint for tapping a weekly recap keyword chip"
+                )))
+            }
+        }
+    }
+
+    // MARK: - Reflections (本周 5 问 — newly rendered)
+
+    private func reflectionsBody(_ questions: [String]) -> some View {
+        // Each question is a tappable card. Tapping routes to Today with the
+        // question pre-filled into the composer (via the official
+        // `pendingDraftText` rail — the same track QuickCapture / capture
+        // reminders use), so the answer becomes a fresh memo. This finally
+        // wires up the interaction the model comment promised since Issue #9.
+        VStack(alignment: .leading, spacing: DSSpacing.sm) {
+            ForEach(Array(questions.enumerated()), id: \.offset) { idx, q in
+                Button {
+                    Haptics.tapConfirm()
+                    handleReflectionTap(q)
+                } label: {
+                    HStack(alignment: .top, spacing: DSSpacing.md) {
+                        Text(String(format: "%02d", idx + 1))
+                            .font(DSType.mono11)
+                            .foregroundColor(DSColor.accentOnBg)
+                            .padding(.top, 3)
+                        Text(q)
+                            .font(DSType.bodyMD)
+                            .foregroundColor(DSColor.inkPrimary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                        Image(systemName: "square.and.pencil")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundColor(DSColor.inkSubtle)
+                            .padding(.top, 3)
                     }
-                    Spacer(minLength: 0)
+                    .padding(DSSpacing.lg)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                            .fill(DSColor.surfaceWhite)
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                            .stroke(DSColor.borderSubtle, lineWidth: 1)
+                    )
+                    .contentShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
                 }
+                .pressScale(scale: 0.98, opacity: 0.95, animation: Motion.press)
+                .accessibilityLabel(Text(q))
+                .accessibilityHint(Text(NSLocalizedString(
+                    "weekly.recap.reflection.hint",
+                    value: "带着这个问题去写一段",
+                    comment: "VoiceOver hint for tapping a reflection question"
+                )))
             }
         }
     }
 
-    private func moodSection(_ text: String) -> some View {
-        VStack(alignment: .leading, spacing: DSSpacing.md) {
-            sectionLabel(NSLocalizedString("weekly.recap.section.mood", comment: ""))
-            Text(text.isEmpty ? "—" : text)
-                .font(DSType.bodyMD)
-                .foregroundColor(DSColor.inkPrimary)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(DSSpacing.lg)
-                .background(
-                    RoundedRectangle(cornerRadius: 12, style: .continuous)
-                        .fill(DSColor.amberAccent.opacity(0.06))
-                )
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(NSLocalizedString("weekly.recap.section.mood.a11y", comment: ""))
+    // MARK: - Mood
+
+    private func moodBody(_ text: String) -> some View {
+        Text(text.isEmpty ? "—" : text)
+            .font(DSType.serifBody16)
+            .foregroundColor(DSColor.inkPrimary)
+            .lineSpacing(4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(DSSpacing.lg)
+            .background(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .fill(DSColor.amberAccent.opacity(0.06))
+            )
     }
 
-    private func placesSection(_ text: String) -> some View {
-        VStack(alignment: .leading, spacing: DSSpacing.md) {
-            sectionLabel(NSLocalizedString("weekly.recap.section.places", comment: ""))
-            // R8-MEDIUM B2: the place row is interactive. We pick the first
-            // non-empty noun-ish token from `placeNotes` as the slug —
-            // mirrors the heuristic used by keyword chips. The whole row is
-            // a Button so the mappin icon + text are tappable as one unit.
-            let firstPlace = Self.firstPlaceToken(from: text)
-            Button {
-                guard let p = firstPlace, !p.isEmpty else { return }
-                handlePlaceTap(p)
-            } label: {
-                HStack(alignment: .top, spacing: 10) {
-                    Image(systemName: "mappin")
-                        .font(.system(size: 16))
-                        .foregroundColor(DSColor.accentOnBg)
-                        .padding(.top, 2)
-                    Text(text.isEmpty ? "—" : text)
-                        .font(DSType.bodyMD)
-                        .foregroundColor(DSColor.inkPrimary)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
-                .contentShape(Rectangle())
+    // MARK: - Places
+
+    private func placesBody(_ text: String) -> some View {
+        // R8-MEDIUM B2: the place row is interactive. We pick the first
+        // non-empty noun-ish token from `placeNotes` as the slug. The whole
+        // row is a Button so the mappin icon + text are tappable as one unit.
+        let firstPlace = Self.firstPlaceToken(from: text)
+        return Button {
+            guard let p = firstPlace, !p.isEmpty else { return }
+            Haptics.selection()
+            handlePlaceTap(p)
+        } label: {
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: "mappin.and.ellipse")
+                    .font(.system(size: 15))
+                    .foregroundColor(DSColor.accentOnBg)
+                    .padding(.top, 2)
+                Text(text.isEmpty ? "—" : text)
+                    .font(DSType.bodyMD)
+                    .foregroundColor(DSColor.inkPrimary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
             }
-            .buttonStyle(.plain)
-            .disabled(firstPlace == nil || (firstPlace?.isEmpty ?? true))
-            .accessibilityHint(Text(NSLocalizedString(
-                "weekly.recap.place.hint",
-                value: "打开地点页",
-                comment: "VoiceOver hint for tapping the weekly recap place row"
-            )))
+            .padding(DSSpacing.lg)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .fill(DSColor.surfaceWhite)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
+                    .stroke(DSColor.borderSubtle, lineWidth: 1)
+            )
+            .contentShape(RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous))
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(NSLocalizedString("weekly.recap.section.places.a11y", comment: ""))
+        .pressScale(scale: 0.98, opacity: 0.95, animation: Motion.press)
+        .disabled(firstPlace == nil || (firstPlace?.isEmpty ?? true))
+        .accessibilityHint(Text(NSLocalizedString(
+            "weekly.recap.place.hint",
+            value: "打开地点页",
+            comment: "VoiceOver hint for tapping the weekly recap place row"
+        )))
     }
 
-    private func highlightsSection(_ items: [String]) -> some View {
-        VStack(alignment: .leading, spacing: 10) {
-            sectionLabel(NSLocalizedString("weekly.recap.section.highlights", comment: ""))
+    // MARK: - Highlights
+
+    private func highlightsBody(_ items: [String]) -> some View {
+        VStack(alignment: .leading, spacing: DSSpacing.md) {
             ForEach(0..<items.count, id: \.self) { idx in
-                HStack(alignment: .top, spacing: DSSpacing.sm) {
-                    Text("✦")
-                        .font(DSType.bodyMD)
+                HStack(alignment: .top, spacing: DSSpacing.md) {
+                    Image(systemName: "sparkle")
+                        .font(.system(size: 13, weight: .semibold))
                         .foregroundColor(DSColor.accentOnBg)
+                        .padding(.top, 3)
                     Text(items[idx])
                         .font(DSType.bodyMD)
                         .foregroundColor(DSColor.inkPrimary)
@@ -306,38 +426,76 @@ struct WeeklyRecapDetailView: View {
                 }
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .accessibilityElement(children: .contain)
-        .accessibilityLabel(NSLocalizedString("weekly.recap.section.highlights.a11y", comment: ""))
     }
 
-    private func sectionLabel(_ title: String) -> some View {
-        Text(title.uppercased())
-            .font(DSType.sectionLabel)
-            .foregroundColor(DSColor.inkMuted)
-            .tracking(1.2)
+    // MARK: - Outliers (值得回看的孤峰 — newly rendered)
+
+    private func outliersBody(_ items: [String]) -> some View {
+        // Quote-style cards: low-frequency, high-signal moments the ordinary
+        // highlight extractor drops. A left amber rule + serif italic gives
+        // them the weight of a pull-quote — the opposite tone of the compact
+        // highlight bullets, on purpose.
+        VStack(alignment: .leading, spacing: DSSpacing.md) {
+            ForEach(0..<items.count, id: \.self) { idx in
+                HStack(spacing: 0) {
+                    RoundedRectangle(cornerRadius: 1.5, style: .continuous)
+                        .fill(DSColor.amberRim)
+                        .frame(width: 3)
+                    Text(items[idx])
+                        .font(DSType.serifBody16)
+                        .foregroundColor(DSColor.inkPrimary)
+                        .lineSpacing(4)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.leading, DSSpacing.md)
+                        .padding(.vertical, 2)
+                }
+                .padding(.vertical, DSSpacing.xs)
+            }
+        }
     }
 
-    private var refreshButton: some View {
-        HStack {
-            Spacer()
-            Button {
-                Task { await reload(forceRefresh: true) }
-            } label: {
+    // MARK: - Footer (compiled-at + recompile)
+
+    private func footer(output: WeeklyRecapOutput) -> some View {
+        VStack(spacing: DSSpacing.lg) {
+            Text(String(
+                format: NSLocalizedString("weekly.recap.compiled.at.format", comment: ""),
+                Self.compiledAtLabel(output.compiledAt)
+            ))
+            .font(DSType.mono10)
+            .foregroundColor(DSColor.inkSubtle)
+
+            retryButton
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, 40)
+        .padding(.horizontal, DSSpacing.xl)
+        .opacity(appeared ? 1 : 0)
+        .animation(Motion.fade.delay(0.28), value: appeared)
+    }
+
+    /// Shared recompile affordance — used by success footer and every error
+    /// state so the button never drifts between contexts.
+    private var retryButton: some View {
+        Button {
+            Haptics.tapConfirm()
+            Task { await reload(forceRefresh: true) }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "arrow.triangle.2.circlepath")
+                    .font(.system(size: 12, weight: .semibold))
                 Text(NSLocalizedString("weekly.recap.refresh", comment: ""))
                     .font(DSType.labelSM)
-                    .foregroundColor(DSColor.accentOnBg)
-                    .padding(.horizontal, DSSpacing.xl)
-                    .padding(.vertical, 10)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: DSRadius.sm, style: .continuous)
-                            .stroke(DSColor.amberRim, lineWidth: 1)
-                    )
             }
-            .accessibilityHint(NSLocalizedString("weekly.recap.refresh.hint", comment: ""))
-            Spacer()
+            .foregroundColor(DSColor.accentOnBg)
+            .padding(.horizontal, DSSpacing.xl)
+            .padding(.vertical, 10)
+            .overlay(
+                Capsule().stroke(DSColor.amberRim, lineWidth: 1)
+            )
         }
-        .padding(.top, DSSpacing.sm)
+        .pressScale(scale: 0.96, opacity: 0.92, animation: Motion.press)
+        .accessibilityHint(NSLocalizedString("weekly.recap.refresh.hint", comment: ""))
     }
 
     // MARK: - Loading logic
@@ -390,24 +548,12 @@ struct WeeklyRecapDetailView: View {
                     .lineLimit(3)
             }
             if copy.showRetry {
-                Button {
-                    Task { await reload(forceRefresh: true) }
-                } label: {
-                    Text(NSLocalizedString("weekly.recap.refresh", comment: ""))
-                        .font(DSType.labelSM)
-                        .foregroundColor(DSColor.accentOnBg)
-                        .padding(.horizontal, DSSpacing.lg)
-                        .padding(.vertical, DSSpacing.sm)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 8, style: .continuous)
-                                .stroke(DSColor.amberRim, lineWidth: 1)
-                        )
-                }
-                .accessibilityHint(NSLocalizedString("weekly.recap.refresh.hint", comment: ""))
+                retryButton
             } else if case .offline = err {
                 // Spinner mirrors NetworkMonitor waiting state.
                 HStack(spacing: DSSpacing.sm) {
                     ProgressView()
+                        .tint(DSColor.accentOnBg)
                     Text(NSLocalizedString(
                         "weekly.recap.error.offline.waiting",
                         value: "等待网络恢复…",
@@ -419,7 +565,8 @@ struct WeeklyRecapDetailView: View {
             }
         }
         .frame(maxWidth: .infinity)
-        .padding(.vertical, 40)
+        .padding(.horizontal, DSSpacing.xl)
+        .padding(.top, 64)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(copy.title)
     }
@@ -575,6 +722,56 @@ struct WeeklyRecapDetailView: View {
         let showRetry: Bool
     }
 
+    // MARK: - Section model
+    //
+    // Blocks are the magazine "articles". `orderedBlocks` keeps only the ones
+    // with content so numbering never gaps, and fixes the read order:
+    // keywords → reflections → mood → places → highlights → outliers.
+    enum Block {
+        case keywords
+        case reflections
+        case mood
+        case places
+        case highlights
+        case outliers
+
+        var title: String {
+            switch self {
+            case .keywords:    return NSLocalizedString("weekly.recap.section.keywords", comment: "")
+            case .reflections: return NSLocalizedString("weekly.recap.section.reflections", comment: "")
+            case .mood:        return NSLocalizedString("weekly.recap.section.mood", comment: "")
+            case .places:      return NSLocalizedString("weekly.recap.section.places", comment: "")
+            case .highlights:  return NSLocalizedString("weekly.recap.section.highlights", comment: "")
+            case .outliers:    return NSLocalizedString("weekly.recap.section.outliers", comment: "")
+            }
+        }
+
+        var a11yTitle: String {
+            switch self {
+            case .keywords:    return NSLocalizedString("weekly.recap.section.keywords.a11y", comment: "")
+            case .reflections: return NSLocalizedString("weekly.recap.section.reflections.a11y", comment: "")
+            case .mood:        return NSLocalizedString("weekly.recap.section.mood.a11y", comment: "")
+            case .places:      return NSLocalizedString("weekly.recap.section.places.a11y", comment: "")
+            case .highlights:  return NSLocalizedString("weekly.recap.section.highlights.a11y", comment: "")
+            case .outliers:    return NSLocalizedString("weekly.recap.section.outliers.a11y", comment: "")
+            }
+        }
+    }
+
+    /// Render order + content gating. A block only appears when it carries
+    /// content, so an old cached recap without reflections/outliers still
+    /// numbers its present sections 01…N with no holes.
+    static func orderedBlocks(for output: WeeklyRecapOutput) -> [Block] {
+        var blocks: [Block] = []
+        if !output.keywords.isEmpty { blocks.append(.keywords) }
+        if !output.reflectionQuestions.isEmpty { blocks.append(.reflections) }
+        if !output.moodNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { blocks.append(.mood) }
+        if !output.placeNotes.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty { blocks.append(.places) }
+        if !output.highlights.isEmpty { blocks.append(.highlights) }
+        if !output.outliers.isEmpty { blocks.append(.outliers) }
+        return blocks
+    }
+
     // MARK: - Entity Navigation (R8-MEDIUM B2)
 
     /// Resolve the slug → entity type by probing the vault's wiki tree
@@ -594,6 +791,18 @@ struct WeeklyRecapDetailView: View {
         guard !slug.isEmpty else { return }
         let (type, resolved) = Self.resolveEntityTypeAndSlug(slug, preferPlaces: true)
         nav.push(EntityRef(type: type, slug: resolved), in: nav.selectedTab)
+    }
+
+    /// Reflection question tap → route to Today with the question pre-filled
+    /// into the composer. Uses `pendingDraftText`, the same official rail the
+    /// QuickCapture intent and capture reminders drive, so the answer becomes
+    /// a fresh memo. This is the interaction the model comment on
+    /// `reflectionQuestions` promised (Issue #9) but the view never wired up.
+    private func handleReflectionTap(_ question: String) {
+        let trimmed = question.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        nav.navigate(to: .today)
+        nav.pendingDraftText = trimmed
     }
 
     /// Mirrors DailyPageView.resolveEntityTypeAndSlug. Static so we can hit
@@ -648,15 +857,34 @@ struct WeeklyRecapDetailView: View {
         return "\(f.string(from: start)) to \(f.string(from: end))"
     }
 
-    private static func chunk<T>(_ array: [T], size: Int) -> [[T]] {
-        guard size > 0, !array.isEmpty else { return [] }
-        var result: [[T]] = []
-        var i = 0
-        while i < array.count {
-            let end = min(i + size, array.count)
-            result.append(Array(array[i..<end]))
-            i = end
+    /// Turn a raw "2026-06-22 to 2026-06-28" range into a compact masthead
+    /// title "06.22 – 06.28". Falls back to the reference date's own
+    /// month.day when the range can't be parsed.
+    static func heroRangeTitle(from range: String, fallback: Date) -> String {
+        let iso = DateFormatter()
+        iso.locale = Locale(identifier: "en_US_POSIX")
+        iso.dateFormat = "yyyy-MM-dd"
+        let parts = range.components(separatedBy: " to ")
+        if parts.count == 2,
+           let start = iso.date(from: parts[0].trimmingCharacters(in: .whitespaces)),
+           let end = iso.date(from: parts[1].trimmingCharacters(in: .whitespaces)) {
+            let md = DateFormatter()
+            md.locale = Locale(identifier: "en_US_POSIX")
+            md.dateFormat = "MM.dd"
+            return "\(md.string(from: start)) – \(md.string(from: end))"
         }
-        return result
+        let md = DateFormatter()
+        md.locale = Locale(identifier: "en_US_POSIX")
+        md.dateFormat = "MM.dd"
+        return md.string(from: fallback)
+    }
+
+    /// "MM-dd HH:mm" compiled-at label, local time zone.
+    static func compiledAtLabel(_ date: Date) -> String {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.timeZone = TimeZone.current
+        f.dateFormat = "MM-dd HH:mm"
+        return f.string(from: date)
     }
 }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -796,14 +796,26 @@ struct TodayView: View {
                 }
             }
             // US-017: consume pending draft text from daypage://memo/new?text=…
+            // 以及周摘要「本周 5 问」点击回写(WeeklyRecapDetailView.handleReflectionTap)。
             .onChange(of: nav.pendingDraftText) { text in
                 guard let text else { return }
                 draftText = text
                 nav.pendingDraftText = nil
-                // 「记录提醒」的「文字」action 传空串 → 只聚焦输入框、光标就绪,
-                // 让用户到点点一下就能直接打字(复用既有 orbFocusToggle 聚焦轨道)。
                 if text.isEmpty {
+                    // 「记录提醒」的「文字」action 传空串 → 只聚焦输入框、光标就绪,
+                    // 让用户到点点一下就能直接打字(复用既有 orbFocusToggle 聚焦轨道)。
                     orbFocusToggle.toggle()
+                } else {
+                    // 带文本的预填(QuickCapture / 周摘要 5 问)：draftText 由 dock 的
+                    // press-to-talk InputBarV4 与 WriteSheet 共享,但 dock 栏是语音形态,
+                    // 不把 draftText 当可编辑文字显示 —— 只设 draftText 而不展开 WriteSheet
+                    // 会让预填文本进了状态却看不见(用户只见空聚焦框)。所以带文本时主动
+                    // 打开 WriteSheet,预填内容立即可见可编辑。async 一拍确保跨 tab 切换
+                    // 后视图已稳定再呈现 sheet,避免与 tab 选择的同批更新竞态。
+                    DispatchQueue.main.async {
+                        guard !showWriteSheet else { return }
+                        showWriteSheet = true
+                    }
                 }
             }
             // Bridge the ViewModel settings flag to the View-local sheet binding.

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -997,6 +997,16 @@
 "weekly.recap.section.places.a11y"                = "Places section";
 "weekly.recap.section.highlights.a11y"            = "Highlights section";
 
+// Magazine layout refactor — hero / reflections / outliers / compiled time
+"weekly.recap.hero.eyebrow"                       = "WEEKLY RECAP";
+"weekly.recap.compiled.at.format"                 = "Compiled %@";
+"weekly.recap.section.reflections"                = "Five Questions";
+"weekly.recap.section.reflections.a11y"           = "Reflection questions section";
+"weekly.recap.reflection.hint"                    = "Write a memo answering this";
+"weekly.recap.section.outliers"                   = "Peaks Worth Revisiting";
+"weekly.recap.section.outliers.a11y"              = "Outlier moments section";
+"weekly.recap.section.number.format"              = "%02d";
+
 // R8 — chip/place tap (B2) + detailed error state (B3) + Today preview (B1)
 "weekly.recap.keyword.hint"                       = "Open entity page";
 "weekly.recap.place.hint"                         = "Open place page";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -1004,6 +1004,16 @@
 "weekly.recap.section.places.a11y"                = "本周地点区域";
 "weekly.recap.section.highlights.a11y"            = "本周高光区域";
 
+// 杂志编排重构 — hero / 5 问 / 孤峰 / 编译时间
+"weekly.recap.hero.eyebrow"                       = "本周回顾";
+"weekly.recap.compiled.at.format"                 = "编译于 %@";
+"weekly.recap.section.reflections"                = "本周 5 问";
+"weekly.recap.section.reflections.a11y"           = "本周反思问题区域";
+"weekly.recap.reflection.hint"                    = "带着这个问题去写一段";
+"weekly.recap.section.outliers"                   = "值得回看的孤峰";
+"weekly.recap.section.outliers.a11y"              = "值得回看的孤峰区域";
+"weekly.recap.section.number.format"              = "%02d";
+
 // R8 — chip/place tap (B2) + detailed error state (B3) + Today preview (B1)
 "weekly.recap.keyword.hint"                       = "打开实体页";
 "weekly.recap.place.hint"                         = "打开地点页";


### PR DESCRIPTION
## 概述
将「周摘要」详情页 `WeeklyRecapDetailView` 从朴素 VStack 表单深度重构为 **日式美术馆·杂志编排**，并补齐两个长期从未渲染的板块，同时连带修复了实机验证暴露的两个真 bug。

## 改动

### 1. 杂志编排重构（视觉/观感/动效/返回）
- **Hero 头部**：mono eyebrow「WEEKLY RECAP」+ 衬线大字周范围「07.13 – 07.19」+ ISO周·日期 dateline + 琥珀小横线
- **杂志式分节**：每节带 `01/02/03…` mono 编号 + 章节名 + 细分隔线；空板块自动跳过、编号连续无洞
- 关键词真流式 `FlowLayout`（替换旧的「每行3个」分块）
- 进场 hero + 各分节上浮淡入 stagger；顶栏 `ultraThinMaterial` 材质化；边缘返回由既有 `.restoresInteractivePop()` 保障

### 2. 补齐两个「幽灵板块」
`WeeklyRecapOutput` 的 `reflectionQuestions`（本周 5 问，Issue #9）和 `outliers`（值得回看的孤峰，Issue #14）注释一直声称由本页渲染，但**呈现层从来没接上**。现补齐：
- **本周 5 问** → 可点击卡片，点击跳回 Today 并预填进写作面板作答
- **值得回看的孤峰** → 左琥珀竖条 + 衬线正文的引用式卡片

### 3. 连带修复两个实机真 bug
- **入口卡吞点击**（既有）：`ArchiveView` 的 `weeklyRecapEntryCard` 用了 `.liquidGlassCard`，iOS 26 native `glassEffect` 层吞掉 NavigationLink 卡心点击（只有 chevron 边缘能进）→ 改 `.solidCard`
- **5问回写空文本**（本次引入后当场发现）：`draftText` 被 dock 语音栏与底部 WriteSheet 共享，只设 `pendingDraftText` 不展开 sheet → 文本进了状态却看不见 → 修 `TodayView` 消费逻辑主动展开 WriteSheet（也顺带修好 QuickCapture 深链同类隐性问题）

### 清理
删失效死代码 `chunk`；去掉 `pressScale` 上冗余的 `.buttonStyle(.plain)`。保留 `copy(for:)`/`resolveEntityTypeAndSlug`/`firstPlaceToken` 等静态测试锚点。

## 验证
- 构建 ✅
- `WeeklyCompilation` / `WeeklyRecapRange` / `AutoTrigger` / `SwipePolish` / `WriteSheetCount` / `AppIntents` 6 套测试全绿 ✅
- 3 轮模拟器实机截图验证：6 板块连续编号、两新板块渲染真实数据、入口卡点卡心可进、5 问回写预填可见可编辑 ✅
- 无崩溃

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ