### PR TITLE
fix(memo-detail): 修复含图片 memo 详情闪退 — EXIF 无界浮点 Int 转换 crash

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		09C6E4728050D69F54949DD1 /* HapticFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FFEA3DDB8DCB528A4189BF /* HapticFeedbackTests.swift */; };
+		0AE41F00C0DE515000EF0001 /* MemoExifShutterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0AE41F00C0DE515000EF0002 /* MemoExifShutterTests.swift */; };
 		0AA94A9D087DA366336C8480 /* DayPageServices in Frameworks */ = {isa = PBXBuildFile; productRef = 160D427C0AE7DAC5724A134F /* DayPageServices */; };
 		14188AFE740A834ADF7A41F4 /* DayPageWidget.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = B2DFF2B446D2F0AC8DE530A1 /* DayPageWidget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		0B7722A154C2145670104616 /* DayPageWatch.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = 23EA9C83B41565EDB263FB35 /* DayPageWatch.app */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -342,6 +343,7 @@
 		7909ED56F96754E4C4FA21CC /* QuickCaptureWidget.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = QuickCaptureWidget.swift; sourceTree = "<group>"; };
 		82AF0D6D988BC74555DFB3ED /* AISummaryCard.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AISummaryCard.swift; sourceTree = "<group>"; };
 		84FFEA3DDB8DCB528A4189BF /* HapticFeedbackTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HapticFeedbackTests.swift; sourceTree = "<group>"; };
+		0AE41F00C0DE515000EF0002 /* MemoExifShutterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MemoExifShutterTests.swift; sourceTree = "<group>"; };
 		8DB2FBA71981BA7516DA9A3F /* LiquidGlassEngine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LiquidGlassEngine.swift; sourceTree = "<group>"; };
 		8F07950D8A46BAC7B9CCB1ED /* ShareCardSystem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareCardSystem.swift; path = ShareCard/ShareCardSystem.swift; sourceTree = "<group>"; };
 		912420086719F3FFFB45FE7A /* InputBarTutorialOverlay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InputBarTutorialOverlay.swift; sourceTree = "<group>"; };
@@ -1200,6 +1202,7 @@
 				WR1000003 /* WeeklyCompilationServiceTests.swift */,
 				T20000006 /* ComposerContextProviderTests.swift */,
 				84FFEA3DDB8DCB528A4189BF /* HapticFeedbackTests.swift */,
+				0AE41F00C0DE515000EF0002 /* MemoExifShutterTests.swift */,
 				KC1000001 /* KeychainHelperTests.swift */,
 				DBR1000001 /* DoubaoASRResolutionTests.swift */,
 				SR40000001 /* DoubaoConnectivityTesterTests.swift */,
@@ -1700,6 +1703,7 @@
 				WR0000003 /* WeeklyCompilationServiceTests.swift in Sources */,
 				T10000006 /* ComposerContextProviderTests.swift in Sources */,
 				09C6E4728050D69F54949DD1 /* HapticFeedbackTests.swift in Sources */,
+				0AE41F00C0DE515000EF0001 /* MemoExifShutterTests.swift in Sources */,
 				KC0000001 /* KeychainHelperTests.swift in Sources */,
 				DBR0000001 /* DoubaoASRResolutionTests.swift in Sources */,
 				SR30000001 /* DoubaoConnectivityTesterTests.swift in Sources */,

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -830,15 +830,17 @@ private struct DetailPhotoSection: View {
            let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
            let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any] {
             var parts: [String] = [filename]
-            if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double {
-                parts.append("\(Int(focal))mm")
+            if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double,
+               let label = MemoExifFormat.focalLengthLabel(focal) {
+                parts.append(label)
             }
-            if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double {
-                parts.append(String(format: "f/%.1f", aperture))
+            if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double,
+               let label = MemoExifFormat.apertureLabel(aperture) {
+                parts.append(label)
             }
-            if let shutter = exif[kCGImagePropertyExifExposureTime as String] as? Double {
-                let denom = Int(1.0 / shutter)
-                parts.append("1/\(denom)s")
+            if let shutter = exif[kCGImagePropertyExifExposureTime as String] as? Double,
+               let label = MemoExifFormat.shutterLabel(exposureTime: shutter) {
+                parts.append(label)
             }
             return parts.joined(separator: "  //  ")
         }
@@ -1267,19 +1269,21 @@ private struct DetailMetadataSection: View {
         }
         var rows: [(label: String, value: String)] = []
         if let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any] {
-            if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double {
-                rows.append(("Aperture", String(format: "f/%.1f", aperture)))
+            if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double,
+               let label = MemoExifFormat.apertureLabel(aperture) {
+                rows.append(("Aperture", label))
             }
-            if let shutter = exif[kCGImagePropertyExifExposureTime as String] as? Double {
-                let denom = Int(1.0 / shutter)
-                rows.append(("Shutter", "1/\(denom)s"))
+            if let shutter = exif[kCGImagePropertyExifExposureTime as String] as? Double,
+               let label = MemoExifFormat.shutterLabel(exposureTime: shutter) {
+                rows.append(("Shutter", label))
             }
             if let iso = exif[kCGImagePropertyExifISOSpeedRatings as String] as? [Int],
                let isoVal = iso.first {
                 rows.append(("ISO", "\(isoVal)"))
             }
-            if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double {
-                rows.append(("Focal Length", "\(Int(focal))mm"))
+            if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double,
+               let label = MemoExifFormat.focalLengthLabel(focal) {
+                rows.append(("Focal Length", label))
             }
         }
         if let w = props[kCGImagePropertyPixelWidth as String] as? Int,
@@ -1531,4 +1535,65 @@ private func sectionLabel(_ title: String) -> some View {
         .font(DSType.mono10)
         .foregroundColor(DSColor.inkMuted)
         .tracking(1.2)
+}
+
+// MARK: - EXIF formatting helpers
+
+/// Formatting for EXIF fields that appear in the photo detail sections.
+///
+/// CRASH-FIX (2026-07-19): the shutter label used to be `Int(1.0 / shutter)`
+/// inline in two places (the photo EXIF overlay and the metadata "Shutter"
+/// row). When a photo's EXIF `ExposureTime` is exactly 0 — common in
+/// screenshots, composited/exported images, and some messaging-app re-encodes —
+/// `1.0 / 0.0` is `+Inf`, and `Int(+Inf)` is a Swift fatal error
+/// ("Double value cannot be converted to Int because it is either infinite or
+/// NaN"), crashing the app the instant such a photo's detail view rendered.
+/// The three OTHER EXIF-shutter sites in the codebase (ShareCardSystem,
+/// PhotoService ×2) already guarded with `> 0` / `isFinite`; MemoDetailView's
+/// two sites were the only unguarded ones. This helper centralises the guarded
+/// conversion so the guard can never drift out of a call site again.
+enum MemoExifFormat {
+
+    /// Human-readable shutter label for an EXIF exposure time in seconds:
+    /// fast exposures render as a fraction ("1/125s"), exposures of one second
+    /// or longer render as whole seconds ("2s"). Returns `nil` when the value
+    /// can't form a sensible label — zero, negative, infinite, or NaN. Never
+    /// traps: the `Int(...)` conversions are always fed a guarded finite value.
+    static func shutterLabel(exposureTime: Double) -> String? {
+        guard exposureTime > 0, exposureTime.isFinite else { return nil }
+        // Sub-second exposures are the fractional "1/N s" case. One second and
+        // longer read as whole seconds — "1/1s" / "1/0s" would be nonsense.
+        if exposureTime < 1.0 {
+            let reciprocal = 1.0 / exposureTime
+            guard reciprocal.isFinite else { return nil }
+            let denom = Int(reciprocal.rounded())
+            guard denom > 1 else { return nil }
+            return "1/\(denom)s"
+        } else {
+            let seconds = Int(exposureTime.rounded())
+            guard seconds > 0 else { return nil }
+            return "\(seconds)s"
+        }
+    }
+
+    /// Human-readable focal-length label ("26mm") for an EXIF focal length in
+    /// millimetres, or `nil` when the value can't form a label — non-positive,
+    /// infinite, or NaN. Guards the same `Int(...)` trap the shutter path had:
+    /// `Int(Double.infinity)`/`Int(.nan)` is a fatal error. Focal length is far
+    /// less likely to be 0/∞ than exposure time, but it is the same class of
+    /// unguarded EXIF→Int conversion in the same two functions, so it gets the
+    /// same guard rather than being left as a twin landmine.
+    static func focalLengthLabel(_ focalLength: Double) -> String? {
+        guard focalLength > 0, focalLength.isFinite else { return nil }
+        return "\(Int(focalLength.rounded()))mm"
+    }
+
+    /// Human-readable aperture label ("f/2.8") for an EXIF f-number, or `nil`
+    /// when the value is non-positive, infinite, or NaN. `String(format:)`
+    /// wouldn't trap on ∞/NaN the way `Int(...)` does, but it would print
+    /// "f/inf" / "f/nan"; the guard keeps the metadata honest.
+    static func apertureLabel(_ fNumber: Double) -> String? {
+        guard fNumber > 0, fNumber.isFinite else { return nil }
+        return String(format: "f/%.1f", fNumber)
+    }
 }

--- a/DayPageTests/MemoExifShutterTests.swift
+++ b/DayPageTests/MemoExifShutterTests.swift
@@ -1,0 +1,98 @@
+import Testing
+@testable import DayPage
+
+// Regression suite for the MemoDetailView photo-detail crash (2026-07-19).
+//
+// Bug: a memo card containing a photo whose EXIF `ExposureTime` was exactly 0
+// crashed the app on opening MemoDetailView. The two shutter-label sites used
+// `Int(1.0 / shutter)` with no guard; `1.0 / 0.0` is `+Inf`, and `Int(+Inf)`
+// is a Swift fatal error ("Double value cannot be converted to Int because it
+// is either infinite or NaN"), taking the whole process down.
+//
+// The fix routes both sites through `MemoExifFormat.shutterLabel(exposureTime:)`,
+// which guards `> 0` and `isFinite` before the `Int(...)` conversion. These
+// tests pin that contract: every input that used to trap now yields `nil`
+// (the field is simply omitted), and valid exposures still format correctly.
+//
+// Note: these inputs (0 / negative / infinity / NaN) are exactly the values
+// that made the OLD inline `Int(1.0 / shutter)` trap or produce garbage. The
+// suite exercising them without crashing IS the proof the fix holds — a build
+// with the old code would have needed the same guard to even run this.
+@Suite("MemoExifFormat.shutterLabel")
+struct MemoExifShutterTests {
+
+    // MARK: - Crash inputs (the regression) — must be nil, never trap
+
+    @Test func zeroExposureReturnsNil() {
+        // The exact crash trigger: 1.0 / 0.0 = +Inf → Int(+Inf) fatal.
+        #expect(MemoExifFormat.shutterLabel(exposureTime: 0) == nil)
+    }
+
+    @Test func negativeExposureReturnsNil() {
+        #expect(MemoExifFormat.shutterLabel(exposureTime: -0.5) == nil)
+    }
+
+    @Test func infiniteExposureReturnsNil() {
+        #expect(MemoExifFormat.shutterLabel(exposureTime: .infinity) == nil)
+    }
+
+    @Test func nanExposureReturnsNil() {
+        #expect(MemoExifFormat.shutterLabel(exposureTime: .nan) == nil)
+    }
+
+    // MARK: - Valid exposures — format correctly
+
+    @Test func fastShutterFormats() {
+        // 1/125s exposure → "1/125s".
+        #expect(MemoExifFormat.shutterLabel(exposureTime: 1.0 / 125.0) == "1/125s")
+    }
+
+    @Test func typicalHandheldShutterFormats() {
+        // 1/60s.
+        #expect(MemoExifFormat.shutterLabel(exposureTime: 1.0 / 60.0) == "1/60s")
+    }
+
+    @Test func slowSubSecondShutterFormatsAsFraction() {
+        // 0.5s → reciprocal 2 → "1/2s". Rounding (not truncation) keeps
+        // near-integer reciprocals from drifting a frame.
+        #expect(MemoExifFormat.shutterLabel(exposureTime: 0.5) == "1/2s")
+    }
+
+    @Test func oneSecondAndLongerRenderAsWholeSeconds() {
+        // The old inline code turned a 2s exposure into "1/0s" (Int(0.5)=0);
+        // ≥1s exposures now read as whole seconds. Neither traps.
+        #expect(MemoExifFormat.shutterLabel(exposureTime: 1.0) == "1s")
+        #expect(MemoExifFormat.shutterLabel(exposureTime: 2.0) == "2s")
+        #expect(MemoExifFormat.shutterLabel(exposureTime: 30.0) == "30s")
+    }
+
+    // MARK: - Focal length (same Int(Double) trap class as shutter)
+
+    @Test func focalLengthFormats() {
+        #expect(MemoExifFormat.focalLengthLabel(26.0) == "26mm")
+        #expect(MemoExifFormat.focalLengthLabel(50.4) == "50mm")  // rounds
+    }
+
+    @Test func focalLengthCrashInputsReturnNil() {
+        // Int(.infinity) / Int(.nan) is a fatal error — the same trap the
+        // shutter path had. These must be guarded to nil, never trap.
+        #expect(MemoExifFormat.focalLengthLabel(0) == nil)
+        #expect(MemoExifFormat.focalLengthLabel(-5) == nil)
+        #expect(MemoExifFormat.focalLengthLabel(.infinity) == nil)
+        #expect(MemoExifFormat.focalLengthLabel(.nan) == nil)
+    }
+
+    // MARK: - Aperture
+
+    @Test func apertureFormats() {
+        #expect(MemoExifFormat.apertureLabel(2.8) == "f/2.8")
+        #expect(MemoExifFormat.apertureLabel(1.4) == "f/1.4")
+    }
+
+    @Test func apertureCrashInputsReturnNil() {
+        // Doesn't trap, but "f/inf" / "f/nan" is nonsense metadata.
+        #expect(MemoExifFormat.apertureLabel(0) == nil)
+        #expect(MemoExifFormat.apertureLabel(.infinity) == nil)
+        #expect(MemoExifFormat.apertureLabel(.nan) == nil)
+    }
+}


### PR DESCRIPTION
## 症状
归档/日页里含文字+图片的 memo 卡，点进详情页 `MemoDetailView` **概率性闪退**。

## 根因
`MemoDetailView` 的 EXIF 快门格式化 `Int(1.0 / shutter)` 无防护。当照片 EXIF `ExposureTime == 0`（截图 / 合成图 / 微信等 app 重编码常见）时 `1.0 / 0.0 = +Inf`，`Int(+Inf)` 是 **Swift fatal error**（"Double value cannot be converted to Int because it is either infinite or NaN"），直接崩进程。

概率性 = 只有 `shutter=0` 的图触发，正常相机图不崩，所以早期没暴露。命令行 `swift` 一行即可复现该 crash。

## 深度排查
这不是孤例，而是 **`MemoDetailView` 的 EXIF 格式化整体缺乏无界浮点防护**：
- 同两个函数（`exifOverlayText` / `loadPhotoExifRows`）里 focal length 的 `Int(focal)` 是**同一崩溃类的孪生地雷**（focal=Inf/NaN 同样 fatal）
- aperture 的 `f/%.1f` 虽不崩但会印 "f/inf"

全项目同款 EXIF-shutter 模式共 5 处，其他 3 处（`ShareCardSystem`、`PhotoService` ×2）早有 `>0`/`isFinite` 防护，唯独 `MemoDetailView` 漏了。

## 修复
抽出可测的 `MemoExifFormat` 命名空间，三个 EXIF 字段格式化统一走 guarded 辅助，危险输入一律返回 `nil`（字段省略）而非 fatal trap：
- `shutterLabel(exposureTime:)` — `>0 && isFinite`；`<1s` → "1/Ns"，`≥1s` → "Ns"（顺带修好旧代码把 2s 曝光算成 "1/0s" 的隐性错误）
- `focalLengthLabel(_:)`
- `apertureLabel(_:)`

`MemoDetailView` 4 处调用点全部改用。

## 验证
- **命令行复现** `Int(1.0/0)` fatal crash，确认根因
- **回归测试** `MemoExifShutterTests` 12 例全绿（shutter/focal/aperture 的 0/负/Inf/NaN → nil + 正常格式化）
- **实机验证**：注入 EXIF ExposureTime=0 的图片 memo，详情页两次正常打开、照片正常显示、Shutter 行正确省略、无 `.ips` 崩溃、log stream 零 fatal 匹配

## 影响面
纯 bug 修复，3 个文件：`MemoDetailView.swift`（修复 + `MemoExifFormat` 辅助）、新增 `MemoExifShutterTests.swift`、`project.pbxproj`（测试文件入 target）。无行为回归。

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ