### PR TITLE
fix(design): 拔掉三处「一眼廉价」硬伤 — 文件名字幕/stub 泄漏/markdown 符号

### DIFF
--- a/DayPage/Features/Daily/DailyPageSummarySection.swift
+++ b/DayPage/Features/Daily/DailyPageSummarySection.swift
@@ -33,34 +33,37 @@ struct DailyPageSummarySection: View {
                 narrativeParagraph(model.summary).padding(.bottom, 8)
             }
 
-            // Threads
-            let displayThreads = model.threads.isEmpty ? stubThreads : model.threads
-            hairlineDivider.padding(.vertical, 22)
-            threadsView(threads: displayThreads)
+            // Threads — hide the whole block when empty. Filling it with
+            // placeholder threads shipped stub data as real content: users saw
+            // "Daily reflection" / "Work notes" for days that had neither.
+            if !model.threads.isEmpty {
+                hairlineDivider.padding(.vertical, 22)
+                threadsView(threads: model.threads)
+            }
 
-            // Mentions
-            let displayMentions = model.mentions.isEmpty ? stubMentions : model.mentions
-            hairlineDivider.padding(.vertical, 22)
-            mentionsView(mentions: displayMentions)
+            // Mentions — likewise. The old stub emitted @today / @log, which
+            // rendered as tappable entity chips leading to pages that don't
+            // exist. An empty mentions list simply shows nothing.
+            if !model.mentions.isEmpty {
+                hairlineDivider.padding(.vertical, 22)
+                mentionsView(mentions: model.mentions)
+            }
         }
     }
 
     // MARK: - Sub-views
 
     private func narrativeParagraph(_ body: String) -> some View {
-        // Markdown M1: the compiler model occasionally emits **emphasis** in
-        // narrative prose — render it instead of leaking syntax characters.
-        Group {
-            if FeatureFlagStore.shared.isEnabled(.markdownRendering) {
-                MarkdownBodyView(text: body, lineSpacing: 8)
-            } else {
-                Text(CJKTextPolish.polish(body))
-                    .font(DSType.serifBody16)
-                    .foregroundColor(DSColor.inkPrimary)
-                    .lineSpacing(8)
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        // The compiler model occasionally emits **emphasis** / `#` in narrative
+        // prose. MarkdownBodyView is the single ink engine: it folds those
+        // markers whether or not markdown is present (plain text takes its
+        // `isPlain` fast path to the same serif look). The old flag-gated
+        // `else Text(polish(body))` branch skipped parsing entirely, so with
+        // the experiment off users saw raw `**` asterisks — the one path that
+        // leaked syntax. Rendering through MarkdownBodyView unconditionally
+        // removes that leak.
+        MarkdownBodyView(text: body, lineSpacing: 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
     }
 
     /// Issue #4: "引用 N 条" evidence chip row. Empty ID list renders
@@ -165,15 +168,4 @@ struct DailyPageSummarySection: View {
             .overlay(Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
             .clipShape(Capsule())
     }
-
-    // MARK: - Stubs
-
-    private var stubThreads: [DailyPageModel.ThreadEntry] {
-        [
-            DailyPageModel.ThreadEntry(label: "Daily reflection", color: DSColor.amberAccent),
-            DailyPageModel.ThreadEntry(label: "Work notes", color: DSColor.amberDeep),
-        ]
-    }
-
-    private var stubMentions: [String] { ["@today", "@log"] }
 }

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -293,30 +293,25 @@ struct MemoDetailView: View {
                         }
                         .padding(.bottom, 14)
                     } else if !bodyTrimmed.isEmpty && !isBodyDuplicate {
-                        // Markdown M1 — full block rendering with entity ink
-                        // merged in one pass (MarkdownBodyView is the ink
-                        // engine; flag-off falls back inside via isPlain to
-                        // the same serif look, so only the markdown parse is
-                        // gated here).
-                        Group {
-                            if FeatureFlagStore.shared.isEnabled(.markdownRendering) {
-                                MarkdownBodyView(
-                                    text: bodyTrimmed,
-                                    // Line-spacing 8 (≈1.5× serifBody16) so
-                                    // long-form journal entries breathe like a
-                                    // printed page.
-                                    lineSpacing: 8,
-                                    blockSpacing: 12,
-                                    entitySlugs: memo.entityMentions,
-                                    entityDisplayNames: entityDisplayNames
-                                )
-                            } else {
-                                Text(inkedBody(bodyTrimmed))
-                                    .font(DSType.serifBody16)
-                                    .foregroundColor(DSColor.inkPrimary)
-                                    .lineSpacing(8)
-                            }
-                        }
+                        // Single ink engine — MarkdownBodyView renders block
+                        // markdown + entity ink in one pass, and folds inline
+                        // `**`/`#` whether or not the source contains markdown
+                        // (plain prose takes its `isPlain` fast path to the
+                        // same serif look, still inking entity mentions). The
+                        // former flag-off `Text(inkedBody(...))` branch skipped
+                        // parsing, so with the markdown experiment disabled the
+                        // detail body showed raw `**` asterisks. Rendering here
+                        // unconditionally closes that leak and collapses the two
+                        // divergent body paths into one.
+                        MarkdownBodyView(
+                            text: bodyTrimmed,
+                            // Line-spacing 8 (≈1.5× serifBody16) so long-form
+                            // journal entries breathe like a printed page.
+                            lineSpacing: 8,
+                            blockSpacing: 12,
+                            entitySlugs: memo.entityMentions,
+                            entityDisplayNames: entityDisplayNames
+                        )
                         .frame(maxWidth: .infinity, alignment: .leading)
                         .textSelection(.enabled)
                         .contentShape(Rectangle())
@@ -604,51 +599,6 @@ struct MemoDetailView: View {
 
     // MARK: - Entity Ink (issue #835)
 
-    /// Body text with compiled entity mentions rendered as quiet amber-underlined
-    /// links. Mentions that don't literally appear in the text are skipped —
-    /// the ink never guesses.
-    private func inkedBody(_ text: String) -> AttributedString {
-        let polished = CJKTextPolish.polish(text)
-        var attr = AttributedString(polished)
-        guard !memo.entityMentions.isEmpty else { return attr }
-
-        for slug in memo.entityMentions where !slug.isEmpty {
-            // Latin slugs may appear verbatim or space-separated; CJK prose
-            // is matched via the wiki page's display name (resolved async).
-            // First variant that matches wins.
-            var terms = [slug, slug.replacingOccurrences(of: "-", with: " ")]
-            if let display = entityDisplayNames[slug], !display.isEmpty {
-                terms.insert(display, at: 0)
-            }
-            for term in terms {
-                var matched = false
-                var searchRange = polished.startIndex..<polished.endIndex
-                while let r = polished.range(
-                    of: term,
-                    options: [.caseInsensitive, .diacriticInsensitive],
-                    range: searchRange
-                ) {
-                    matched = true
-                    if let ar = Range(r, in: attr) {
-                        let encoded = slug.addingPercentEncoding(
-                            withAllowedCharacters: .alphanumerics
-                        ) ?? slug
-                        attr[ar].link = URL(string: "daypage-entity://o?s=\(encoded)")
-                        attr[ar].underlineStyle = Text.LineStyle(
-                            pattern: .solid,
-                            color: DSColor.amberAccent.opacity(0.5)
-                        )
-                        // Links default to tint blue — keep journal ink.
-                        attr[ar].foregroundColor = DSColor.inkPrimary
-                    }
-                    searchRange = r.upperBound..<polished.endIndex
-                }
-                if matched { break }
-            }
-        }
-        return attr
-    }
-
     /// Reads each mention's wiki page frontmatter `name:` so display names
     /// can be matched in prose. Slugs with no wiki page simply stay unmapped.
     nonisolated private static func resolveDisplayNames(for slugs: [String]) -> [String: String] {
@@ -824,27 +774,31 @@ private struct DetailPhotoSection: View {
         }
     }
 
+    /// A film-strip caption of *real* camera parameters — e.g.
+    /// "26MM · F/1.8 · 1/125S". The raw filename is deliberately excluded: it
+    /// is a file-system detail, not a photo credit, and `//` (a code comment
+    /// marker) leaked the technical layer into the museum surface. No EXIF
+    /// params → `nil`, so the caption vanishes rather than showing a filename.
     nonisolated private static func exifOverlayText(file: String, photoURL: URL) -> String? {
-        let filename = URL(fileURLWithPath: file).lastPathComponent.uppercased()
-        if let source = CGImageSourceCreateWithURL(photoURL as CFURL, nil),
-           let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
-           let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any] {
-            var parts: [String] = [filename]
-            if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double,
-               let label = MemoExifFormat.focalLengthLabel(focal) {
-                parts.append(label)
-            }
-            if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double,
-               let label = MemoExifFormat.apertureLabel(aperture) {
-                parts.append(label)
-            }
-            if let shutter = exif[kCGImagePropertyExifExposureTime as String] as? Double,
-               let label = MemoExifFormat.shutterLabel(exposureTime: shutter) {
-                parts.append(label)
-            }
-            return parts.joined(separator: "  //  ")
+        guard let source = CGImageSourceCreateWithURL(photoURL as CFURL, nil),
+              let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
+              let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any]
+        else { return nil }
+
+        var parts: [String] = []
+        if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double,
+           let label = MemoExifFormat.focalLengthLabel(focal) {
+            parts.append(label)
         }
-        return filename
+        if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double,
+           let label = MemoExifFormat.apertureLabel(aperture) {
+            parts.append(label)
+        }
+        if let shutter = exif[kCGImagePropertyExifExposureTime as String] as? Double,
+           let label = MemoExifFormat.shutterLabel(exposureTime: shutter) {
+            parts.append(label)
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
     private func loadFullResImage(from url: URL) async -> UIImage? {

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -1494,17 +1494,32 @@ struct PhotoThumbnailView: View {
         }
     }
 
-    /// "IMG_… // FOCUS: 26MM" caption. Metadata-only read (no pixel decode),
-    /// but still disk I/O — call off the main actor.
+    /// A film-strip caption of *real* camera parameters — e.g. "26MM · F/1.8".
+    /// Metadata-only read (no pixel decode), but still disk I/O — call off the
+    /// main actor.
+    ///
+    /// Deliberately returns `nil` when no meaningful EXIF is present. The raw
+    /// filename (`IMG_2043.JPG`, `WECHAT_XXX.JPG`, a screenshot's name) must
+    /// never surface as a caption: it reads as a debug watermark, not a photo
+    /// credit, and leaks the file system into the museum surface. No params →
+    /// no caption at all. Formatting is shared with the detail-view overlay via
+    /// `MemoExifFormat`, which also carries the EXIF→Int crash guards.
     static func exifText(for fileURL: URL) -> String? {
-        let filename = fileURL.lastPathComponent.uppercased()
-        if let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil),
-           let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
-           let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any],
-           let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double {
-            return "\(filename) // FOCUS: \(Int(focal))mm"
+        guard let source = CGImageSourceCreateWithURL(fileURL as CFURL, nil),
+              let props = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [String: Any],
+              let exif = props[kCGImagePropertyExifDictionary as String] as? [String: Any]
+        else { return nil }
+
+        var parts: [String] = []
+        if let focal = exif[kCGImagePropertyExifFocalLength as String] as? Double,
+           let label = MemoExifFormat.focalLengthLabel(focal) {
+            parts.append(label)
         }
-        return filename
+        if let aperture = exif[kCGImagePropertyExifFNumber as String] as? Double,
+           let label = MemoExifFormat.apertureLabel(aperture) {
+            parts.append(label)
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 
     /// Convenience for callers that hold a vault-relative path (viewer).


### PR DESCRIPTION
## 背景

对比 flomo 做了一次全页面视觉审计(3 个并行 agent 逐行审 `DayPage/Features` + `DesignSystem`,共 64 条带行号发现),归纳为**重音/语言/字体/密度**四条铁律。本 PR 是重构第一步:三处最伤高级感、改动最小的执行硬伤。均为局部改动,**不触碰设计系统本身**(DSTokens v9.0.0 地基是专业完整的,问题在各页面对 token 的使用)。

## 三处修复

### 1. 图片文件名不再上屏
`MemoCardView.exifText` / `MemoDetailView.exifOverlayText` 在拿不到有意义 EXIF 时曾 `return filename`,把 `WECHAT_XXX.JPG`、截图文件名等**裸文件名压在照片上**,读作调试水印而非摄影图注;详情页还用 `//`(代码注释符)分隔,把文件系统底层泄漏进「日式美术馆」表面。

**改为**:无相机参数 → `return nil`(整条 caption 隐藏);有参数只显示纯参数 `26MM · F/1.8`,分隔符 `//` → `·`。两处统一复用 `MemoExifFormat`(继承其 EXIF→Int 崩溃防护),消除格式漂移。

### 2. DailyPage stub 假数据不再泄漏到真实 UI
`DailyPageSummarySection` 在 threads/mentions 为空时曾填充 `"Daily reflection"`/`"Work notes"` 和 `@today`/`@log` stub —— **用户会点到不存在的实体页**。改为空则隐藏整段,删除 `stubThreads`/`stubMentions`。

### 3. markdown 符号不再泄漏
正文渲染曾按 `markdownRendering` flag 分叉:flag-off 走 `Text(polish/inkedBody)` 跳过解析,一旦用户在实验功能里关掉该 flag,正文**直接显示裸 `**加粗**` 星号**。实为冗余分支 —— `MarkdownBodyView` 本身 flag 无关地正确渲染(纯文本走 `isPlain` 快路径,实体墨迹不丢)。删除 `else` 分支,无条件走单一 ink 引擎,顺手**收敛掉双渲染路径**(审计 [4.1]),删除随之死代码 `inkedBody`。

## 验证

- ✅ DayPage scheme 构建通过
- ✅ 277 测试全绿(`MemoMarkdown` / `MemoExifFormat` 相关全过)
- ✅ 模拟器实机确认:带 EXIF 图显示 `26MM · F/1.8`、无 EXIF 图无字幕

净删 39 行(+90/−129):不只是补丁,把两处漂移的正文渲染合并回单一 ink 引擎。

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ