### PR TITLE
fix(design): 强调色去重 — 每屏一个琥珀主角

### DIFF
--- a/DayPage/Features/Archive/WeeklyRecapDetailView.swift
+++ b/DayPage/Features/Archive/WeeklyRecapDetailView.swift
@@ -109,11 +109,16 @@ struct WeeklyRecapDetailView: View {
 
         return VStack(alignment: .leading, spacing: 10) {
             // Eyebrow — mono, wide-tracked, quiet.
+            // Accent-budget (§2): the eyebrow is a masthead label, not an
+            // action. On a page where every section number, reflection index
+            // and place pin also pulled amber, tinting it too made the accent
+            // meaningless. Neutral ink; amber is reserved for the one action
+            // per screen (the highlight "→ tomorrow's to-do" CTA).
             Text(NSLocalizedString("weekly.recap.hero.eyebrow", comment: "")
                 .uppercased())
                 .font(DSType.mono11)
                 .tracking(2.4)
-                .foregroundColor(DSColor.accentOnBg)
+                .foregroundColor(DSColor.inkMuted)
 
             // Serif week title — the masthead. Ranges like "06.22 – 06.28"
             // read as a magazine issue span.
@@ -128,11 +133,12 @@ struct WeeklyRecapDetailView: View {
                 .foregroundColor(DSColor.inkMuted)
                 .padding(.top, 2)
 
-            // Hairline rule closes the masthead off from the body — a thin
-            // amber rule, not a full-width grey divider (§12 scroll edges over
-            // hard dividers).
+            // Hairline rule closes the masthead off from the body — a short
+            // rule, not a full-width divider (§12 scroll edges over hard
+            // dividers). Was amber; demoted to ink so it stops being one more
+            // amber anchor in a page that had one per section (§2).
             Rectangle()
-                .fill(DSColor.amberRim)
+                .fill(DSColor.inkFaint)
                 .frame(width: 44, height: 2)
                 .padding(.top, DSSpacing.sm)
         }
@@ -224,9 +230,11 @@ struct WeeklyRecapDetailView: View {
 
     private func sectionHeader(number: Int, title: String) -> some View {
         HStack(alignment: .firstTextBaseline, spacing: 10) {
+            // §2: the section index repeats once per section — amber here made
+            // the accent a structural motif rather than a signal. Neutral ink.
             Text(String(format: NSLocalizedString("weekly.recap.section.number.format", comment: ""), number))
                 .font(DSType.mono11)
-                .foregroundColor(DSColor.accentOnBg)
+                .foregroundColor(DSColor.inkSubtle)
             Text(title.uppercased())
                 .font(DSType.sectionLabel)
                 .tracking(1.5)
@@ -250,16 +258,21 @@ struct WeeklyRecapDetailView: View {
                     Haptics.selection()
                     handleKeywordTap(kw)
                 } label: {
+                    // Was triple-amber (ink + fill + rim). §2: one cue is
+                    // enough — ink text on a faint amber wash reads as tappable
+                    // without three amber layers stacking. Rim demoted to a
+                    // neutral hairline so the chip stops being a saturated
+                    // block competing with the page's real accent.
                     Text(kw)
                         .font(DSType.bodyMD)
-                        .foregroundColor(DSColor.accentOnBg)
+                        .foregroundColor(DSColor.inkPrimary)
                         .padding(.horizontal, DSSpacing.md)
                         .padding(.vertical, 7)
                         .background(
-                            Capsule().fill(DSColor.amberAccent.opacity(0.12))
+                            Capsule().fill(DSColor.amberAccent.opacity(0.08))
                         )
                         .overlay(
-                            Capsule().stroke(DSColor.amberRim, lineWidth: 1)
+                            Capsule().stroke(DSColor.glassRim, lineWidth: 1)
                         )
                 }
                 .pressScale(scale: 0.94, opacity: 0.9, animation: Motion.press)
@@ -290,7 +303,7 @@ struct WeeklyRecapDetailView: View {
                     HStack(alignment: .top, spacing: DSSpacing.md) {
                         Text(String(format: "%02d", idx + 1))
                             .font(DSType.mono11)
-                            .foregroundColor(DSColor.accentOnBg)
+                            .foregroundColor(DSColor.inkSubtle)  // §2: index, not accent
                             .padding(.top, 3)
                         Text(q)
                             .font(DSType.bodyMD)
@@ -334,8 +347,11 @@ struct WeeklyRecapDetailView: View {
             .frame(maxWidth: .infinity, alignment: .leading)
             .padding(DSSpacing.lg)
             .background(
+                // §2: was a faint amber wash — one more amber surface on a page
+                // full of them. Neutral sunken keeps the mood block set apart
+                // from the body without spending accent.
                 RoundedRectangle(cornerRadius: DSRadius.md, style: .continuous)
-                    .fill(DSColor.amberAccent.opacity(0.06))
+                    .fill(DSColor.surfaceSunken)
             )
     }
 
@@ -354,7 +370,7 @@ struct WeeklyRecapDetailView: View {
             HStack(alignment: .top, spacing: 10) {
                 Image(systemName: "mappin.and.ellipse")
                     .font(.system(size: 15))
-                    .foregroundColor(DSColor.accentOnBg)
+                    .foregroundColor(DSColor.inkMuted)  // §2: locator glyph, not accent
                     .padding(.top, 2)
                 Text(text.isEmpty ? "—" : text)
                     .font(DSType.bodyMD)
@@ -390,7 +406,7 @@ struct WeeklyRecapDetailView: View {
                 HStack(alignment: .top, spacing: DSSpacing.md) {
                     Image(systemName: "sparkle")
                         .font(.system(size: 13, weight: .semibold))
-                        .foregroundColor(DSColor.accentOnBg)
+                        .foregroundColor(DSColor.inkMuted)  // §2: bullet glyph, repeats per item — not accent
                         .padding(.top, 3)
                     Text(items[idx])
                         .font(DSType.bodyMD)

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -827,7 +827,13 @@ struct GraphView: View {
             let label = Text(node.name)
                 .font(.custom("JetBrainsMono-Regular", fixedSize: fontSize))
                 .fontWeight(isSearchMatch ? .bold : .regular)
-                .foregroundColor((isSearchMatch ? DSColor.amberDeep : DSColor.inkPrimary).opacity(focusAlpha))
+                // §2: search-match emphasis was `amberDeep` (#5D3000) — a second
+                // amber grade doing the same job as the `amberAccent` the rest
+                // of the graph's emphasis uses, AND it sank into the charcoal
+                // canvas in dark mode. `accentOnBg` is the single ink-amber
+                // token (adaptive light/dark), so matches stay legible and the
+                // graph speaks one amber for emphasis.
+                .foregroundColor((isSearchMatch ? DSColor.accentOnBg : DSColor.inkPrimary).opacity(focusAlpha))
             ctx.draw(label, at: CGPoint(x: x, y: labelY), anchor: .center)
         }
     }

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -493,17 +493,23 @@ struct TodayView: View {
                                     .frame(width: 28, height: 28)
                                     .glassSurface(in: Circle())
                                     .overlay(
+                                        // Accent-budget (§2): the scroll progress
+                                        // ring is a background-state indicator, not
+                                        // an action — it read as a second amber
+                                        // voice competing with the mic orb. Demoted
+                                        // to ink so the "new content" dot below stays
+                                        // the row's only warm signal.
                                         Circle()
                                             .trim(from: 0, to: scrollProgress)
                                             .stroke(
-                                                DSColor.accentAmber,
+                                                DSColor.inkSubtle,
                                                 style: StrokeStyle(lineWidth: 1.5, lineCap: .round)
                                             )
                                             .rotationEffect(.degrees(-90))
                                             .animation(reduceMotion ? nil : Motion.fade, value: scrollProgress)
                                     )
                                     .shadow(
-                                        color: DSColor.accentAmber.opacity(scrollRingGlow ? 0.5 : 0),
+                                        color: DSColor.inkSubtle.opacity(scrollRingGlow ? 0.5 : 0),
                                         radius: scrollRingGlow ? 14 : 0
                                     )
                                     .animation(reduceMotion ? nil : .easeOut(duration: 0.6), value: scrollRingGlow)
@@ -1578,18 +1584,24 @@ struct TodayView: View {
                 Haptics.soft()
                 focusStore.toggle(focus)
             } label: {
+                // Accent-budget (§2): only the SELECTED chip lights amber.
+                // Previously every chip — selected or not — was amber text on
+                // an amber wash with an amber rim, so an untouched focus row
+                // read as a wall of active pills competing with the mic orb.
+                // Unselected now sits in neutral ink/sunken; selection is what
+                // spends the accent.
                 Text(focus.displayName)
                     .font(DSType.bodySM)
-                    .foregroundColor(isSelected ? DSColor.surfaceWhite : DSColor.amberDeep)
+                    .foregroundColor(isSelected ? DSColor.onAmber : DSColor.inkMuted)
                     .lineLimit(1)
                     .minimumScaleFactor(0.85)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 6)
                     .background(
-                        Capsule().fill(isSelected ? DSColor.amberDeep : DSColor.amberSoft)
+                        Capsule().fill(isSelected ? DSColor.amberDeep : DSColor.surfaceSunken)
                     )
                     .overlay(
-                        Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5)
+                        Capsule().strokeBorder(isSelected ? DSColor.amberRim : DSColor.glassRim, lineWidth: 0.5)
                     )
             }
             .buttonStyle(.plain)
@@ -1700,7 +1712,12 @@ struct TodayView: View {
                 // motion at all.
                 Image(systemName: "arrow.triangle.2.circlepath")
                     .font(.system(size: 14, weight: .semibold))
-                    .foregroundColor(DSColor.amberAccent)
+                    // Accent-budget (§2): sync is pipeline *status*, not an
+                    // action the user takes here. The amber icon + amber wash
+                    // made a background housekeeping strip shout as loud as the
+                    // mic orb. Demoted to ink; the amber is reserved for the
+                    // one saturated action per screen.
+                    .foregroundColor(DSColor.inkMuted)
                     .rotationEffect(.degrees(syncQueue.isFlushingNow ? 360 : 0))
                     .dsAnimation(
                         syncQueue.isFlushingNow
@@ -1754,7 +1771,10 @@ struct TodayView: View {
             .padding(.horizontal, DSSpacing.pageMargin)
             .frame(maxWidth: .infinity)
             .frame(height: 44)
-            .background(DSColor.amberAccent.opacity(0.14))
+            // Was a 14% amber wash — a whole strip tinted the brand accent for
+            // a background sync state. Neutral sunken surface keeps it legible
+            // and tappable without spending the screen's accent budget.
+            .background(DSColor.surfaceSunken)
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
视觉重构 **第 2 步 · 强调色去重**(接续 PR #857 的第 1 步「拔掉三处一眼廉价硬伤」)。

## 为什么
琥珀是重音色,本该稀有。审计发现 **首屏 17 个琥珀热点、周摘要几乎每个 section 锚点都是 amber**——重音一泛滥,就失去了「重」的意义,直接违反 HIG 的 **Deference** 原则(UI 应让位于内容,不与内容争夺注意力)。

## 改了什么
把染在「非主动作」上的琥珀降级为中性墨色,让每屏只保留**一个真正的琥珀主角**。

### Today 首屏
- **同步 banner**:14% amber 底 → `surfaceSunken`,同步图标 → `inkMuted`(同步是管道状态,非用户在此发起的动作)
- **今日焦点 chips**:未选态三层全 amber → 中性,只有选中态点亮(选中文字改 `onAmber`,暗色下不沉底)
- **scroll-to-top 进度环 + 辉光** → `inkSubtle`(背景态指示器)

### 周摘要 Weekly Recap
- eyebrow / section 编号 / reflections 序号 / hero 竖条 / mood 底 / mappin / sparkle → 全部中性
- **keyword chip**:文字+底+边三重琥珀 → 单层(墨字 + 极淡琥珀底 + 中性 hairline)
- 保留 **outliers pull-quote 竖条** 为整页唯一琥珀主角

### 知识图谱 Graph
- 搜索命中标签 `amberDeep` → `accentOnBg`:统一强调档(其余强调都用 `amberAccent`)**+ 兼修** `#5D3000` 在暗色 charcoal 上几乎不可见的真 bug

## 刻意保留(有既有设计依据,不推翻)
- **dock chrome**(+/sparkle)的暖色统一 —— 第 1 步确立的「dock 讲同一种暖语言、orb 靠 fill 做唯一饱和主角」意图
- **graph 三色相分离**(people 靛蓝 / places+themes 暖轴)—— 同为第 1 步刻意
- **编译进度条** —— 前台活跃主动作反馈
- **通知红点** —— 唯一「有新内容」注意信号

## 验证
- 纯颜色 token 替换,**无逻辑变更**
- `BUILD SUCCEEDED`
- **277 测试全绿**(36 suites)
- 首屏暗色实机截图确认:麦克风 orb 为全屏唯一饱和琥珀,同步 banner 已中性化

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ