### PR TITLE
fix(design): 重构验收收官 — 补齐 8 处未达标 + 组件化(第 5 步)

### DIFF
--- a/DayPage/App/SidebarHeatmapView.swift
+++ b/DayPage/App/SidebarHeatmapView.swift
@@ -190,9 +190,12 @@ struct SidebarHeatmapView: View {
             let letters = ["M", "T", "W", "T", "F", "S", "S"]
             for (ri, letter) in letters.enumerated() {
                 let y = monthRowHeight + CGFloat(ri) * (cellHeight + cellSpacing) + cellHeight / 2
+                // Uniform faint weekday rail. The old `ri % 2` alternation between
+                // 0.4 and 0.9 opacity made the letters flicker row-to-row and read
+                // as a rendering bug rather than a legible axis. One quiet weight.
                 let text = Text(letter)
                     .font(.system(size: 8, design: .monospaced))
-                    .foregroundColor(DSColor.inkSubtle.opacity(ri % 2 == 1 ? 0.4 : 0.9))
+                    .foregroundColor(DSColor.inkSubtle.opacity(0.6))
                 context.draw(context.resolve(text), at: CGPoint(x: 5, y: y))
             }
 

--- a/DayPage/DesignSystem/Colors.swift
+++ b/DayPage/DesignSystem/Colors.swift
@@ -155,11 +155,11 @@ enum DSColor {
     /// adaptive for dark). Warmest of the three: themes are the "what".
     static let graphThemes = Color(light: Color(hex: "A8541B"), dark: Color(hex: "E8974D"))
 
-    // V4 amber-density heatmap (4-step)
-    static let densityNone   = Color(hex: "A8541B").opacity(0.06)
-    static let densityLow    = Color(hex: "A8541B").opacity(0.20)
-    static let densityMid    = Color(hex: "A8541B").opacity(0.45)
-    static let densityHigh   = Color(hex: "A8541B").opacity(0.85)
+    // (Removed) The old V4 single-hue-opacity density ramp `densityNone/Low/
+    // Mid/High` was a SECOND heat ramp parallel to `heatmap{Empty,Low,Mid,High}`,
+    // so the same busy day rendered one brown in the sidebar heat-map and a
+    // different brown in the archive calendar. The calendar now shares the
+    // heat-map ramp; this ramp had no remaining callers and was deleted.
 
     /// Foreground ink on amber-deep / amber-accent surfaces. Stays near-white
     /// in both light and dark schemes since the amber substrate carries the

--- a/DayPage/DesignSystem/DSChip.swift
+++ b/DayPage/DesignSystem/DSChip.swift
@@ -94,3 +94,32 @@ struct DSChip: View {
         }
     }
 }
+
+// MARK: - Amber pill surface
+//
+// The recurring "amber-soft fill + hairline amber rim" recipe. It was copy-
+// pasted verbatim across the detail view — the Save pill, the Ask-past CTA
+// card, the attachment icon tile, and the "Open" pill — each re-declaring
+// `background(amberSoft) + overlay(strokeBorder(amberRim, 0.5)) + clipShape`.
+// Four copies meant four places to drift. This modifier is the single source
+// of that surface; callers keep their own content, label, and padding (which
+// legitimately differ) but share one tinted-glass recipe. Shape is a parameter
+// so both the Capsule pills and the rounded-rect card/tile can adopt it.
+struct AmberPillSurface<S: InsettableShape>: ViewModifier {
+    let shape: S
+    func body(content: Content) -> some View {
+        content
+            .background(DSColor.amberSoft)
+            .clipShape(shape)
+            .overlay(shape.strokeBorder(DSColor.amberRim, lineWidth: 0.5))
+    }
+}
+
+extension View {
+    /// Applies the shared amber-soft-fill + amber-rim surface. Pass the shape
+    /// the pill should take (`Capsule()` for text pills, a
+    /// `RoundedRectangle(cornerRadius:)` for card CTAs / icon tiles).
+    func amberPillSurface<S: InsettableShape>(_ shape: S) -> some View {
+        modifier(AmberPillSurface(shape: shape))
+    }
+}

--- a/DayPage/DesignSystem/MarkdownBodyView.swift
+++ b/DayPage/DesignSystem/MarkdownBodyView.swift
@@ -77,11 +77,15 @@ struct MarkdownBodyView: View {
             Text(attributed(runs))
                 .lineSpacing(lineSpacing)
 
-        case .heading(let runs):
-            // 标题降维: every #-level lands on one quiet card-heading tier.
-            Text(attributed(runs, baseWeight: .semibold, size: bodySize + 2.5))
+        case .heading(let level, let runs):
+            // Restore a hierarchy the model used to drop. Still a quiet,
+            // museum-voice ramp (no dramatic display sizes), but H1 now reads
+            // distinctly above H2, and H3-and-deeper share the smallest heading
+            // tier — enough structure that long-form entries regain an outline
+            // without shouting. Was one flat `bodySize + 2.5` tier for all.
+            Text(attributed(runs, baseWeight: .semibold, size: headingSize(for: level)))
                 .lineSpacing(lineSpacing)
-                .padding(.top, 4)
+                .padding(.top, level <= 1 ? 8 : 5)
 
         case .bullets(let items):
             VStack(alignment: .leading, spacing: 4) {
@@ -152,6 +156,18 @@ struct MarkdownBodyView: View {
                 .frame(height: 0.5)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 4)
+        }
+    }
+
+    /// Heading size ramp keyed off the `#` count. Deliberately gentle — a
+    /// "museum voice" outline, not a web-page H1/H2/H3 blowout: H1 sits +6 over
+    /// body, H2 +3, and H3-and-deeper share a quiet +1 tier. Two clear steps of
+    /// hierarchy without any heading dominating the page.
+    private func headingSize(for level: Int) -> CGFloat {
+        switch level {
+        case ...1: return bodySize + 6   // H1
+        case 2:    return bodySize + 3   // H2
+        default:   return bodySize + 1   // H3–H6
         }
     }
 

--- a/DayPage/Features/Archive/ArchiveView.swift
+++ b/DayPage/Features/Archive/ArchiveView.swift
@@ -52,20 +52,28 @@ struct DayStats {
         case empty, low, medium, high
 
         var fillColor: Color {
+            // Unified onto the heat-map ramp (the carefully-tuned warm hex
+            // stops the sidebar already uses) so the SAME busy day reads the
+            // same colour in the sidebar heat-map and the archive calendar.
+            // Was the parallel `densityNone/Low/Mid/High` single-hue-opacity
+            // ramp — two ramps meant one busy day rendered two different browns.
             switch self {
-            case .empty:  return DSColor.densityNone
-            case .low:    return DSColor.densityLow
-            case .medium: return DSColor.densityMid
-            case .high:   return DSColor.densityHigh
+            case .empty:  return DSColor.heatmapEmpty
+            case .low:    return DSColor.heatmapLow
+            case .medium: return DSColor.heatmapMid
+            case .high:   return DSColor.heatmapHigh
             }
         }
 
         var textColor: Color {
             switch self {
-            case .empty, .low: return DSColor.inkPrimary
-            // medium / high density chips fill with amber → use onAmber token
-            // so the warm-cream foreground tracks dark mode correctly.
-            case .medium, .high: return DSColor.onAmber
+            // `.medium` now fills with `heatmapMid` (#C9A677 in light) — a light
+            // tan, NOT the old saturated `densityMid` amber. Near-white `onAmber`
+            // over that tan drops to ~2:1, below AA, so `.medium` joins the
+            // dark-ink group; only `.high` (heatmapHigh #5D3000 deep-brown) is
+            // dark enough to carry the near-white foreground.
+            case .empty, .low, .medium: return DSColor.inkPrimary
+            case .high: return DSColor.onAmber
             }
         }
 
@@ -1125,7 +1133,7 @@ struct ArchiveView: View {
                 if let d = density, d != .empty { return d.fillColor }
                 switch data {
                 case .compiled: return DSColor.amberDeep
-                case .rawOnly:  return DSColor.densityLow
+                case .rawOnly:  return DSColor.heatmapLow
                 case .none:     return DSColor.surfaceWhite.opacity(0.38)
                 }
             }()

--- a/DayPage/Features/Archive/SearchView.swift
+++ b/DayPage/Features/Archive/SearchView.swift
@@ -962,27 +962,12 @@ struct SearchView: View {
                     .buttonStyle(.plain)
                 }
 
-                let recentSuggestions = Array(vm.recentSearches.filter { $0 != vm.query }.prefix(4))
-                if !recentSuggestions.isEmpty {
-                    VStack(alignment: .leading, spacing: 10) {
-                        Text(NSLocalizedString("search.empty.tryAnother", comment: "Try another keyword suggestion label"))
-                            .monoLabelStyle(size: 10)
-                            .foregroundColor(DSColor.inkMuted)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.horizontal, DSSpacing.xl)
-
-                        ScrollView(.horizontal, showsIndicators: false) {
-                            HStack(spacing: DSSpacing.sm) {
-                                ForEach(recentSuggestions, id: \.self) { q in
-                                    entityChip(q)
-                                }
-                            }
-                            .padding(.horizontal, DSSpacing.xl)
-                            .padding(.vertical, DSSpacing.xs)
-                        }
-                    }
-                }
-
+                // A "no results" state should stay quiet. It used to stack TWO
+                // independent horizontal chip rails (recent searches + top
+                // entities), which crowded the empty state and fought for the
+                // eye. Only the entity rail survives — entities are real nodes in
+                // the knowledge graph, so they guide toward content that exists,
+                // whereas recent queries just replay dead ends.
                 let entitySuggestions = vm.topEntities.prefix(6).map(\.name).filter { $0 != vm.query }
                 if !entitySuggestions.isEmpty {
                     VStack(alignment: .leading, spacing: 10) {

--- a/DayPage/Features/Graph/GraphView.swift
+++ b/DayPage/Features/Graph/GraphView.swift
@@ -558,9 +558,14 @@ struct GraphView: View {
                 .font(DSType.sectionLabel)
                 .textCase(.uppercase)
                 .tracking(1.5)
-                .foregroundColor(Color.white)
+                .foregroundColor(DSColor.onAmber)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 12)
+                // `amberDeep` here is the SOLID-FILL tier (deep enough to carry a
+                // near-white label), not a second emphasis grade. All foreground
+                // emphasis in Graph — icons, strokes, search-match — is the single
+                // `amberAccent`; only filled pills go deep. Kept distinct on
+                // purpose so the two never overlap in the same role.
                 .background(DSColor.amberDeep)
                 .clipShape(Capsule())
         }

--- a/DayPage/Features/MemoDetail/MemoDetailView.swift
+++ b/DayPage/Features/MemoDetail/MemoDetailView.swift
@@ -280,9 +280,7 @@ struct MemoDetailView: View {
                                     .foregroundColor(DSColor.accentOnBg)
                                     .padding(.horizontal, 12)
                                     .padding(.vertical, 6)
-                                    .background(DSColor.amberSoft)
-                                    .clipShape(Capsule())
-                                    .overlay(Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
+                                    .amberPillSurface(Capsule())
                                 }
                                 .buttonStyle(.plain)
                                 .disabled(editedBody.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
@@ -456,12 +454,7 @@ struct MemoDetailView: View {
                         }
                         .padding(.horizontal, 14)
                         .padding(.vertical, DSSpacing.md)
-                        .background(DSColor.amberSoft)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: DSRadius.md)
-                                .strokeBorder(DSColor.amberRim, lineWidth: 0.5)
-                        )
-                        .clipShape(RoundedRectangle(cornerRadius: DSRadius.md))
+                        .amberPillSurface(RoundedRectangle(cornerRadius: DSRadius.md))
                     }
                     // #150 press feedback — this is a card-style CTA, so a
                     // slightly deeper dip with a fade reads as "the panel presses".
@@ -1041,18 +1034,11 @@ private struct DetailFileRow: View {
 
     var body: some View {
         HStack(spacing: DSSpacing.md) {
-            ZStack {
-                RoundedRectangle(cornerRadius: 8, style: .continuous)
-                    .fill(DSColor.amberSoft)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 8, style: .continuous)
-                            .strokeBorder(DSColor.amberRim, lineWidth: 0.5)
-                    )
-                    .frame(width: 32, height: 32)
-                Image(systemName: fileIcon)
-                    .font(.system(size: 14, weight: .regular))
-                    .foregroundColor(DSColor.accentOnBg)
-            }
+            Image(systemName: fileIcon)
+                .font(.system(size: 14, weight: .regular))
+                .foregroundColor(DSColor.accentOnBg)
+                .frame(width: 32, height: 32)
+                .amberPillSurface(RoundedRectangle(cornerRadius: 8, style: .continuous))
 
             VStack(alignment: .leading, spacing: 2) {
                 Text(fileName)
@@ -1076,9 +1062,7 @@ private struct DetailFileRow: View {
                     .foregroundColor(DSColor.accentOnBg)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 6)
-                    .background(DSColor.amberSoft)
-                    .clipShape(Capsule())
-                    .overlay(Capsule().strokeBorder(DSColor.amberRim, lineWidth: 0.5))
+                    .amberPillSurface(Capsule())
             }
             // #150 press feedback for the "Open" attachment pill.
             .pressScale(scale: 0.96, opacity: 0.9,

--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -513,11 +513,11 @@ struct InputBarV4: View {
             } label: {
                 Image(systemName: "plus")
                     .font(.system(size: 18, weight: .regular))
-                    // Was `inkMuted` — a desaturated brown-grey, while the
-                    // sparkle two slots over was amber. One row, two colour
-                    // languages. Both chrome glyphs now speak amber (muted to
-                    // 0.62 so the mic orb stays the row's only loud voice).
-                    .foregroundStyle(DSColor.dockChrome.opacity(0.62))
+                    // Neutral ink, not amber. Per the "one amber lead per screen"
+                    // law the mic orb is the row's sole accent; the chrome glyphs
+                    // (+, caret, sparkle) all recede to ink so the orb is the only
+                    // loud voice. Was `dockChrome` (=#A8541B burnt-orange).
+                    .foregroundStyle(DSColor.inkMuted)
                     .frame(width: 36, height: 44)
                     .contentShape(Rectangle())
             }
@@ -552,20 +552,20 @@ struct InputBarV4: View {
             } label: {
                 HStack(spacing: 5) {
                     Rectangle()
-                        .fill(DSColor.dockChrome.opacity(0.65))
+                        .fill(DSColor.inkSubtle.opacity(0.7))
                         .frame(width: 2, height: 14)
                         .modifier(BreathingCaretModifier())
                     if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                        // Deliberately NOT the serif body face. Rendering the
-                        // hint in the same type as a real entry is what made
-                        // the original italic version read as prefilled text
-                        // users had to delete. A small tracked mono label reads
-                        // as chrome — the same visual class as the `+` and the
-                        // "BY DAY" rail — so it invites without impersonating.
+                        // The invitation returns to the serif body family (§ type
+                        // discipline: mono is for numbers/labels, not sentences)
+                        // and to a legible weight (`inkMuted`, not the old 38%
+                        // `inkSubtle` mono). It stays UPRIGHT, never italic —
+                        // italic was the real reason the first version read as
+                        // prefilled text users had to delete, not the face itself.
+                        // Upright serif at mid-contrast reads as a written prompt.
                         Text(NSLocalizedString("input.dock.placeholder", comment: "Dock write affordance"))
-                            .font(DSFonts.jetBrainsMono(size: 11, relativeTo: .caption))
-                            .tracking(0.6)
-                            .foregroundStyle(DSColor.inkSubtle)
+                            .font(DSFonts.serif(size: 15, relativeTo: .subheadline))
+                            .foregroundStyle(DSColor.inkMuted)
                             .lineLimit(1)
                     }
                     Spacer(minLength: 0)
@@ -649,11 +649,10 @@ struct InputBarV4: View {
                 } label: {
                     Image(systemName: "sparkles")
                         .font(.system(size: 17, weight: .semibold))
-                        // Was `amberDeep` — near-black on the cream canvas, so
-                        // the "calm AI side-door" read as a soot smudge. Matches
-                        // the `+` glyph's weight now: same amber family, muted
-                        // below the mic orb.
-                        .foregroundStyle(DSColor.dockChrome.opacity(0.80))
+                        // Neutral ink, matching the `+` glyph. The calm AI
+                        // side-door is chrome, not an accent — only the mic orb
+                        // carries amber on this row. Was `dockChrome` amber.
+                        .foregroundStyle(DSColor.inkMuted)
                         .frame(width: 40, height: 44)
                         .contentShape(Rectangle())
                 }

--- a/DayPage/Features/Today/TodayViewComponents.swift
+++ b/DayPage/Features/Today/TodayViewComponents.swift
@@ -260,8 +260,13 @@ struct CompilationProgressBar: View {
                     Capsule()
                         .fill(DSColor.glassStd)
                         .frame(height: 3)
+                    // Progress fill is a BACKGROUND state, not a call to action —
+                    // per the "one amber lead per screen" law it must not compete
+                    // with the mic orb for the accent budget. Ink at 55% reads as a
+                    // determinate meter (quiet, mono-family with the % label below)
+                    // rather than a branded highlight. Was `accentAmber`.
                     Capsule()
-                        .fill(DSColor.accentAmber)
+                        .fill(DSColor.inkPrimary.opacity(0.55))
                         .frame(width: geo.size.width * progress, height: 3)
                         .animation(reduceMotion ? nil : .spring(response: 0.5, dampingFraction: 0.8), value: progress)
                 }

--- a/DayPageKit/Sources/DayPageModels/MemoMarkdown.swift
+++ b/DayPageKit/Sources/DayPageModels/MemoMarkdown.swift
@@ -69,8 +69,11 @@ public enum MemoMarkdown {
 
     public enum Block: Equatable {
         case paragraph([InlineRun])
-        /// `#`–`######` all collapse to this single tier (design: 标题降维).
-        case heading([InlineRun])
+        /// A markdown heading. `level` is the 1–6 `#` count, preserved so the
+        /// renderer can express at least two tiers (H1 vs the rest) — the old
+        /// model dropped `#` depth entirely and every heading rendered on one
+        /// flat tier, so long-form entries lost all structure.
+        case heading(level: Int, runs: [InlineRun])
         case bullets([ListItem])
         case ordered(start: Int, items: [ListItem])
         case tasks([TaskItem])
@@ -133,7 +136,9 @@ public enum MemoMarkdown {
         var parts: [String] = []
         for block in doc.blocks {
             switch block {
-            case .paragraph(let runs), .heading(let runs), .quote(let runs):
+            case .paragraph(let runs), .quote(let runs):
+                parts.append(fold(runs))
+            case .heading(_, let runs):
                 parts.append(fold(runs))
             case .bullets(let items):
                 parts.append(items.map { fold($0.runs) }.joined(separator: " "))
@@ -234,9 +239,9 @@ public enum MemoMarkdown {
                 continue
             }
 
-            if let content = headingContent(line) {
+            if let heading = headingContent(line) {
                 flushAll()
-                blocks.append(.heading(parseInline(content)))
+                blocks.append(.heading(level: heading.level, runs: parseInline(heading.content)))
                 continue
             }
 
@@ -310,7 +315,7 @@ public enum MemoMarkdown {
 
     /// `# Title` … `###### Title` → "Title". `#tag` (no space) is NOT a
     /// heading — hashtags survive as prose.
-    private static func headingContent(_ line: String) -> String? {
+    private static func headingContent(_ line: String) -> (level: Int, content: String)? {
         guard line.hasPrefix("#") else { return nil }
         var hashes = 0
         for ch in line {
@@ -320,7 +325,7 @@ public enum MemoMarkdown {
         let rest = line.dropFirst(hashes)
         guard rest.hasPrefix(" ") else { return nil }
         let content = rest.trimmingCharacters(in: .whitespaces)
-        return content.isEmpty ? nil : content
+        return content.isEmpty ? nil : (hashes, content)
     }
 
     /// `- [ ] text` / `- [x] text` (also `*` marker, case-insensitive x).

--- a/DayPageTests/MemoMarkdownTests.swift
+++ b/DayPageTests/MemoMarkdownTests.swift
@@ -141,16 +141,25 @@ struct MemoMarkdownTests {
         #expect(runs.map(\.text).joined() == "第一行\n第二行")
     }
 
-    @Test("all heading levels collapse to the single card-heading tier")
-    func headingCollapse() {
+    @Test("heading level (# count) is preserved so the renderer can tier it")
+    func headingLevelPreserved() {
+        // The model used to drop `#` depth and collapse every heading to one
+        // tier. It now carries `level` (1–6) so MarkdownBodyView can render H1
+        // above H2 above H3+. This guards that the depth survives parsing.
         let doc = MemoMarkdown.parse("# 大\n\n### 小")
         #expect(doc.blocks.count == 2)
-        for block in doc.blocks {
-            guard case .heading = block else {
-                Issue.record("expected heading, got \(block)")
-                return
-            }
+        guard case .heading(let l1, let r1) = doc.blocks[0] else {
+            Issue.record("expected heading, got \(doc.blocks[0])")
+            return
         }
+        guard case .heading(let l3, let r3) = doc.blocks[1] else {
+            Issue.record("expected heading, got \(doc.blocks[1])")
+            return
+        }
+        #expect(l1 == 1)
+        #expect(l3 == 3)
+        #expect(r1.map(\.text).joined() == "大")
+        #expect(r3.map(\.text).joined() == "小")
     }
 
     @Test("divider requires 3+ dashes on their own line")


### PR DESCRIPTION
## 背景

对重构清单做**证据驱动验收**(用户诉求:「认真分析打分评价,希望满分通过」)。派 2 个 Explore 审计 agent 逐行核对清单 64 条带行号发现在当前代码的真实状态,定位到「5 步表面全做、逐行核对差 8 处」。

验收前真实完成度:铁律1 **仅 50%**、铁律3 **仅 25%**、铁律4 90%。其中 3 处「未修」是作者刻意设计决策,和清单铁律直接冲突 —— 用户裁决**全部按清单强改到满分**。

评分 artifact:https://claude.ai/code/artifact/ef557392-3334-42e3-b106-b7fa1ae6648d

## 本 PR 补齐

| 铁律 | 前 → 后 |
|---|---|
| 铁律1 重音预算 | 50% → 100% |
| 铁律3 字体分工 | 25% → 95% |
| 铁律4 密度 | 90% → 100% |

**铁律1 重音预算**
- dock `+`、caret、sparkle 三个 chrome 图标从 `dockChrome`(#A8541B 烧橙)全改中性墨色 → mic orb 成为该行唯一 amber 主角
- 进度条填充 `accentAmber` → `inkPrimary` 0.55,读作安静的确定度量表

**铁律3 字体分工**
- dock placeholder 从 `jetBrainsMono` 回归 serif 正文字体、提对比,保持 upright 非 italic(italic 才是当初被误认为预填文本的真因)

**铁律4 / 一致性**
- 热力图/日历合并为一套色阶:日历弃用单色 opacity 阶梯,复用热力图暖色 hex 阶梯 → 同一忙碌日两处同色;死 token 删除
- weekday 字母统一 0.6 透明度,消除奇偶行 0.4/0.9 跳的「渲染 bug」观感
- 搜索空态删掉 recent 段,只留实体建议
- Graph:`amberAccent` 定为唯一前景强调档,`amberDeep` 明确限定实心填充档

**组件化(第 5 步)**
- 新增 `amberPillSurface(_:)` ViewModifier(amber-soft 底 + amber-rim 描边,shape 参数化),MemoDetailView 4 处复制的琥珀胶囊全部替换 → 从源头堵 drift

**Markdown 标题恢复层级(数据模型改造)**
- `Block.heading` 从丢弃 `#` 深度改为携带 `level: Int`;渲染按 H1(+6)/H2(+3)/H3+(+1)温和三档(museum voice 克制,非 web 式暴走)。补 `headingLevelPreserved` 回归测试

## 验证

- `BUILD SUCCEEDED`
- code-reviewer 交叉验证 5 大改动区**零 correctness bug**,并揪出一处连带对比回归(日历 `.medium` 合并后填充变浅 heatmapMid #C9A677 配近白前景跌破 WCAG AA)**已修**:`.medium` 归深墨前景组,仅 `.high` 深棕配白字
- 实机深色模式确认 dock 三图标已中性、placeholder 已 serif、orb 唯一 amber

## 诚实说明

`CompileUnlockCard` 中文口号仍跑 mono 未改 —— 全仓 grep 确认**零调用**,是死代码,不上任何屏幕;改它是浪费,清理死代码可另起一刀。

12 文件,净减 96 行(抽组件 + 精简都在删重复)。

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ