### PR TITLE
feat: 调度与通知重设计 — 提醒分层 + 侧边调度中心 + 闹钟语音跳转修复 + 录音舱可拉全屏

### DIFF
--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		A10000046 /* OnThisDayCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000046 /* OnThisDayCard.swift */; };
 		A10000047 /* OnThisDayScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000047 /* OnThisDayScheduler.swift */; };
 		CRS0000001 /* CaptureReminderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRS1000001 /* CaptureReminderService.swift */; };
+		SCH0000001 /* ScheduleHubView.swift in Sources */ = {isa = PBXBuildFile; fileRef = SCH1000001 /* ScheduleHubView.swift */; };
 		CVI0000001 /* CaptureVoiceIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CVI1000001 /* CaptureVoiceIntent.swift */; };
 		RMD0000001 /* Reminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMD1000001 /* Reminder.swift */; };
 		RTR0000001 /* RelativeTimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = RTR1000001 /* RelativeTimeResolver.swift */; };
@@ -399,6 +400,7 @@
 		A20000046 /* OnThisDayCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayCard.swift; sourceTree = "<group>"; };
 		A20000047 /* OnThisDayScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayScheduler.swift; sourceTree = "<group>"; };
 		CRS1000001 /* CaptureReminderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureReminderService.swift; sourceTree = "<group>"; };
+		SCH1000001 /* ScheduleHubView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScheduleHubView.swift; sourceTree = "<group>"; };
 		CVI1000001 /* CaptureVoiceIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureVoiceIntent.swift; sourceTree = "<group>"; };
 		RMD1000001 /* Reminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reminder.swift; sourceTree = "<group>"; };
 		RTR1000001 /* RelativeTimeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTimeResolver.swift; sourceTree = "<group>"; };
@@ -832,8 +834,17 @@
 				A50000022 /* Feedback */,
 				MD5000001 /* MemoDetail */,
 				08775C73D4E048DD3BC96559 /* Ask */,
+				A50000023 /* Schedule */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		A50000023 /* Schedule */ = {
+			isa = PBXGroup;
+			children = (
+				SCH1000001 /* ScheduleHubView.swift */,
+			);
+			path = Schedule;
 			sourceTree = "<group>";
 		};
 		A50000005 /* Models */ = {
@@ -1590,6 +1601,7 @@
 				INF0000001 /* InflightDraftStore.swift in Sources */,
 				A10000047 /* OnThisDayScheduler.swift in Sources */,
 				CRS0000001 /* CaptureReminderService.swift in Sources */,
+				SCH0000001 /* ScheduleHubView.swift in Sources */,
 				CVI0000001 /* CaptureVoiceIntent.swift in Sources */,
 				RMD0000001 /* Reminder.swift in Sources */,
 				RTR0000001 /* RelativeTimeResolver.swift in Sources */,

--- a/DayPage.xcodeproj/project.pbxproj
+++ b/DayPage.xcodeproj/project.pbxproj
@@ -102,6 +102,7 @@
 		A10000046 /* OnThisDayCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000046 /* OnThisDayCard.swift */; };
 		A10000047 /* OnThisDayScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20000047 /* OnThisDayScheduler.swift */; };
 		CRS0000001 /* CaptureReminderService.swift in Sources */ = {isa = PBXBuildFile; fileRef = CRS1000001 /* CaptureReminderService.swift */; };
+		CVI0000001 /* CaptureVoiceIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = CVI1000001 /* CaptureVoiceIntent.swift */; };
 		RMD0000001 /* Reminder.swift in Sources */ = {isa = PBXBuildFile; fileRef = RMD1000001 /* Reminder.swift */; };
 		RTR0000001 /* RelativeTimeResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = RTR1000001 /* RelativeTimeResolver.swift */; };
 		RCS0000001 /* ReminderCapsuleStrip.swift in Sources */ = {isa = PBXBuildFile; fileRef = RCS1000001 /* ReminderCapsuleStrip.swift */; };
@@ -398,6 +399,7 @@
 		A20000046 /* OnThisDayCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayCard.swift; sourceTree = "<group>"; };
 		A20000047 /* OnThisDayScheduler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnThisDayScheduler.swift; sourceTree = "<group>"; };
 		CRS1000001 /* CaptureReminderService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureReminderService.swift; sourceTree = "<group>"; };
+		CVI1000001 /* CaptureVoiceIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CaptureVoiceIntent.swift; sourceTree = "<group>"; };
 		RMD1000001 /* Reminder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reminder.swift; sourceTree = "<group>"; };
 		RTR1000001 /* RelativeTimeResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RelativeTimeResolver.swift; sourceTree = "<group>"; };
 		RCS1000001 /* ReminderCapsuleStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderCapsuleStrip.swift; sourceTree = "<group>"; };
@@ -858,6 +860,7 @@
 				A20000039 /* VoiceAttachmentQueue.swift */,
 				A20000047 /* OnThisDayScheduler.swift */,
 				CRS1000001 /* CaptureReminderService.swift */,
+				CVI1000001 /* CaptureVoiceIntent.swift */,
 				RMD1000001 /* Reminder.swift */,
 				RTR1000001 /* RelativeTimeResolver.swift */,
 				RIP1000001 /* ReminderIntentParser.swift */,
@@ -1587,6 +1590,7 @@
 				INF0000001 /* InflightDraftStore.swift in Sources */,
 				A10000047 /* OnThisDayScheduler.swift in Sources */,
 				CRS0000001 /* CaptureReminderService.swift in Sources */,
+				CVI0000001 /* CaptureVoiceIntent.swift in Sources */,
 				RMD0000001 /* Reminder.swift in Sources */,
 				RTR0000001 /* RelativeTimeResolver.swift in Sources */,
 				RCS0000001 /* ReminderCapsuleStrip.swift in Sources */,

--- a/DayPage/App/AppNavigationModel.swift
+++ b/DayPage/App/AppNavigationModel.swift
@@ -166,6 +166,13 @@ final class AppNavigationModel: ObservableObject {
     /// keyword search (Archive) or the memory-chat agent without ambiguity.
     @Published var pendingAskQuery: String? = nil
 
+    /// vNext:调度中心(ScheduleHubView)的呈现开关。放在 nav(全局稳定层)而非
+    /// SidebarView 的 @State —— 侧边栏点「调度」要先 closeSidebar,抽屉随即被
+    /// offset 离屏 + accessibilityHidden,若 sheet 状态挂在 SidebarView 上,它的
+    /// @State 在动画中不可靠(实测延迟置 true 也被丢),sheet 不呈现。改由稳定的
+    /// RootView 挂 .sheet 驱动,和 pendingAskQuery 从侧边栏可靠打开是同款模式。
+    @Published var showScheduleHub: Bool = false
+
     init() {}
 
     private static func initialTab() -> AppTab {

--- a/DayPage/App/RootView.swift
+++ b/DayPage/App/RootView.swift
@@ -372,6 +372,12 @@ struct RootView: View {
                 nav.pendingAskQuery = nil
             }
         }
+        // vNext 调度中心 sheet。驱动源 `nav.showScheduleHub`(全局稳定层),由
+        // 侧边栏「调度」行置 true。挂在 RootView 而非 SidebarView 上 —— 抽屉关闭
+        // 后 SidebarView 被离屏隐藏,其 @State 不可靠,sheet 呈现会被丢(实测)。
+        .sheet(isPresented: $nav.showScheduleHub) {
+            NavigationStack { ScheduleHubView() }
+        }
     }
 
     /// Bridges the optional `pendingAskQuery` string to a `.sheet(item:)`

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -347,8 +347,15 @@ struct SidebarView: View {
         let upcomingCount = reminderService.upcoming(limit: 99).count
         return Button {
             Haptics.light()
+            // closeSidebar() 会 animate 抽屉离屏并标 .accessibilityHidden;若在
+            // 同一 tick 里 showSchedule = true,SidebarView(sheet 宿主)正被移出,
+            // .sheet 呈现被抑制 → 点了没反应(实测)。等关闭动画走完再弹,复用
+            // 本文件 recentDays 刷新用的同款延迟模式。
             nav.closeSidebar()
-            showSchedule = true
+            Task { @MainActor in
+                try? await Task.sleep(nanoseconds: 320_000_000)
+                showSchedule = true
+            }
         } label: {
             HStack(spacing: DSSpacing.md) {
                 Image(systemName: "clock")

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -12,6 +12,12 @@ struct SidebarView: View {
     @EnvironmentObject private var sidebarVM: SidebarViewModel
     @State private var showSettings = false
     @State private var showAccountSheet = false
+    @State private var showSchedule = false
+
+    /// Live reminder service — drives the schedule row's "upcoming" badge and
+    /// the feature-flag gate. Shared singleton so it stays in sync with Today.
+    @StateObject private var reminderService = CaptureReminderService.shared
+    @StateObject private var flagStore = FeatureFlagStore.shared
 
     /// Disclosure state for the Recent jump list — collapsed by default so
     /// the drawer opens to a single, calm screen (heatmap + stats + nav).
@@ -93,6 +99,9 @@ struct SidebarView: View {
         }
         .sheet(isPresented: $showSettings) {
             SettingsView()
+        }
+        .sheet(isPresented: $showSchedule) {
+            NavigationStack { ScheduleHubView() }
         }
         .sheet(isPresented: $showAccountSheet) {
             AccountSheet()
@@ -320,8 +329,58 @@ struct SidebarView: View {
             // ask" ladder.
             searchRow
             askRow
+            // Schedule hub — capture-reminder CRUD lives here. Gated by the
+            // same feature flag as the reminder scheduler, so it disappears
+            // entirely when the flag is off (kill switch parity).
+            if flagStore.isEnabled(.captureReminder) {
+                scheduleRow
+            }
         }
         .padding(.horizontal, DSSpacing.md)
+    }
+
+    /// Entry to the "调度中心" (ScheduleHubView). Mirrors `askRow`/`searchRow`
+    /// styling, plus a mono badge showing how many reminders will fire next so
+    /// the drawer surfaces at-a-glance scheduling state. Closes the drawer,
+    /// then presents the hub as a sheet (Settings-style).
+    private var scheduleRow: some View {
+        let upcomingCount = reminderService.upcoming(limit: 99).count
+        return Button {
+            Haptics.light()
+            nav.closeSidebar()
+            showSchedule = true
+        } label: {
+            HStack(spacing: DSSpacing.md) {
+                Image(systemName: "clock")
+                    .font(.system(size: 15, weight: .medium))
+                    .frame(width: 26, height: 26)
+                    .foregroundColor(DSColor.inkMuted)
+                Text(NSLocalizedString("sidebar.nav.schedule", value: "调度", comment: "Schedule hub nav row"))
+                    .font(DSType.bodyMD)
+                    .foregroundColor(DSColor.inkMuted)
+                if upcomingCount > 0 {
+                    Spacer(minLength: DSSpacing.sm)
+                    Text("\(upcomingCount)")
+                        .font(DSType.mono9)
+                        .foregroundColor(DSColor.inkMuted)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 1)
+                        .background(DSColor.amberSoft, in: Capsule())
+                }
+            }
+            .padding(.horizontal, 10)
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("sidebar.schedule")
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(NSLocalizedString("sidebar.nav.schedule", value: "调度", comment: "Schedule hub nav row"))
+        .accessibilityValue(upcomingCount > 0
+            ? String(format: NSLocalizedString("sidebar.schedule.upcoming", value: "%d 条即将触发", comment: "Upcoming reminders count"), upcomingCount)
+            : "")
+        .accessibilityHint(NSLocalizedString("sidebar.schedule.hint", value: "打开调度中心", comment: "Schedule hub hint"))
     }
 
     /// Issue #16 (2026-07-03): entry to the app-wide SearchView. Reuses

--- a/DayPage/App/SidebarView.swift
+++ b/DayPage/App/SidebarView.swift
@@ -12,7 +12,6 @@ struct SidebarView: View {
     @EnvironmentObject private var sidebarVM: SidebarViewModel
     @State private var showSettings = false
     @State private var showAccountSheet = false
-    @State private var showSchedule = false
 
     /// Live reminder service — drives the schedule row's "upcoming" badge and
     /// the feature-flag gate. Shared singleton so it stays in sync with Today.
@@ -99,9 +98,6 @@ struct SidebarView: View {
         }
         .sheet(isPresented: $showSettings) {
             SettingsView()
-        }
-        .sheet(isPresented: $showSchedule) {
-            NavigationStack { ScheduleHubView() }
         }
         .sheet(isPresented: $showAccountSheet) {
             AccountSheet()
@@ -347,15 +343,11 @@ struct SidebarView: View {
         let upcomingCount = reminderService.upcoming(limit: 99).count
         return Button {
             Haptics.light()
-            // closeSidebar() 会 animate 抽屉离屏并标 .accessibilityHidden;若在
-            // 同一 tick 里 showSchedule = true,SidebarView(sheet 宿主)正被移出,
-            // .sheet 呈现被抑制 → 点了没反应(实测)。等关闭动画走完再弹,复用
-            // 本文件 recentDays 刷新用的同款延迟模式。
+            // sheet 由 RootView 挂在 nav.showScheduleHub 上(全局稳定层),关抽屉
+            // 不会影响它 —— 所以同 tick closeSidebar + 置 true 即可,无需延迟。
+            // (旧法把 sheet 挂在 SidebarView 上,抽屉离屏后其 @State 失活,呈现被丢。)
             nav.closeSidebar()
-            Task { @MainActor in
-                try? await Task.sleep(nanoseconds: 320_000_000)
-                showSchedule = true
-            }
+            nav.showScheduleHub = true
         } label: {
             HStack(spacing: DSSpacing.md) {
                 Image(systemName: "clock")

--- a/DayPage/Features/Schedule/ScheduleHubView.swift
+++ b/DayPage/Features/Schedule/ScheduleHubView.swift
@@ -1,0 +1,408 @@
+import SwiftUI
+import DayPageServices
+
+// MARK: - ScheduleHubView
+//
+// "调度中心" — the single, fully editable home for capture reminders. Where
+// SettingsRemindersView.swift shows a read-only summary, this page is the
+// canonical CRUD surface: every reminder (user- or AI-authored) can be added,
+// edited, toggled, re-leveled, and deleted here.
+//
+// Structure (top → bottom, "museum" ladder):
+//   1. Reminder list — one row per reminder, sorted by next fire time, with a
+//      tappable level chip (quiet ⇄ loud) + enable toggle + swipe-to-delete.
+//   2. Global config — frequency preset, quiet hours (toggle + times), and the
+//      iOS 26 AlarmKit switch (mirrors SettingsRemindersView's logic).
+//
+// Presentation: pushed inside a NavigationStack from the sidebar sheet. All
+// mutations route through CaptureReminderService's unified API.
+
+@MainActor
+struct ScheduleHubView: View {
+
+    @StateObject private var service = CaptureReminderService.shared
+    @State private var sheetTarget: ReminderSheetTarget?
+
+    var body: some View {
+        List {
+            reminderSection
+            frequencySection
+            quietHoursSection
+            alarmKitSection
+        }
+        .scrollContentBackground(.hidden)
+        .background(DSColor.bgWarm.ignoresSafeArea())
+        .tint(DSColor.primary)
+        .navigationTitle(NSLocalizedString("schedule.hub.title", value: "调度", comment: "Schedule hub page title"))
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Button {
+                    Haptics.light()
+                    sheetTarget = ReminderSheetTarget(reminder: nil)
+                } label: {
+                    Image(systemName: "plus")
+                }
+                .accessibilityLabel(NSLocalizedString("schedule.add", value: "新建提醒", comment: "Add reminder"))
+                .accessibilityIdentifier("schedule-add-reminder")
+            }
+        }
+        .sheet(item: $sheetTarget) { target in
+            ReminderEditSheet(service: service, editing: target.reminder)
+        }
+    }
+
+    // MARK: - Reminder List Section
+
+    /// One row per reminder, sorted so the soonest-to-fire sits on top (disabled
+    /// reminders — which have no next fire — settle at the bottom by label).
+    private var reminderSection: some View {
+        Section {
+            if sortedReminders.isEmpty {
+                emptyRow
+            } else {
+                ForEach(sortedReminders) { reminder in
+                    ReminderHubRow(
+                        reminder: reminder,
+                        onTap: {
+                            Haptics.light()
+                            sheetTarget = ReminderSheetTarget(reminder: reminder)
+                        },
+                        onToggle: { enabled in
+                            service.setReminder(reminder.id, enabled: enabled)
+                        },
+                        onCycleLevel: {
+                            Haptics.selection()
+                            service.setLevel(reminder.id, reminder.level == .quiet ? .loud : .quiet)
+                        }
+                    )
+                    .listRowBackground(DSColor.surfaceWhite)
+                    .swipeActions(edge: .trailing) {
+                        Button(role: .destructive) {
+                            Haptics.light()
+                            service.removeReminder(reminder.id)
+                        } label: {
+                            Label(
+                                NSLocalizedString("schedule.delete", value: "删除", comment: "Delete reminder swipe"),
+                                systemImage: "trash"
+                            )
+                        }
+                    }
+                }
+            }
+        } header: {
+            Text(NSLocalizedString("schedule.section.reminders", value: "提醒", comment: "Reminders list section title"))
+        } footer: {
+            Text(NSLocalizedString(
+                "schedule.section.reminders.footer",
+                value: "点一条编辑;右滑删除;点级别芯片在「安静 / 重要」间切换。到点会发一条本地通知(灵动岛落点)召唤你记一句。",
+                comment: "Reminders section footer"
+            ))
+            .font(.caption)
+        }
+    }
+
+    /// Sorted for display: enabled reminders first (by soonest next fire), then
+    /// disabled ones grouped at the end sorted by label so the list is stable.
+    private var sortedReminders: [Reminder] {
+        service.reminders.sorted { lhs, rhs in
+            switch (lhs.nextFireDate(), rhs.nextFireDate()) {
+            case let (l?, r?): return l < r
+            case (_?, nil):    return true
+            case (nil, _?):    return false
+            case (nil, nil):   return lhs.label < rhs.label
+            }
+        }
+    }
+
+    private var emptyRow: some View {
+        HStack(spacing: DSSpacing.md) {
+            Image(systemName: "bell.slash")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundColor(DSColor.inkSubtle)
+            Text(NSLocalizedString(
+                "schedule.empty",
+                value: "还没有提醒。点右上角「＋」排一条,或在「问过去」里让 AI 帮你排。",
+                comment: "Empty reminders hint"
+            ))
+            .font(DSType.bodySM)
+            .foregroundColor(DSColor.inkMuted)
+        }
+        .padding(.vertical, DSSpacing.xs)
+        .listRowBackground(DSColor.surfaceWhite)
+        .accessibilityIdentifier("schedule-empty")
+    }
+
+    // MARK: - Frequency Section
+
+    private var frequencySection: some View {
+        Section {
+            Picker(
+                NSLocalizedString("settings.reminder.frequency", value: "提醒频率", comment: "Capture reminder frequency preset"),
+                selection: Binding(
+                    get: { service.preset },
+                    set: { newValue in
+                        Haptics.selection()
+                        service.apply(preset: newValue)
+                    }
+                )
+            ) {
+                ForEach(ReminderPreset.allCases, id: \.rawValue) { preset in
+                    Text(preset.title).tag(preset)
+                }
+            }
+            .listRowBackground(DSColor.surfaceWhite)
+        } header: {
+            Text(NSLocalizedString("schedule.section.frequency", value: "频率", comment: "Frequency section title"))
+        } footer: {
+            Text(NSLocalizedString(
+                "schedule.section.frequency.footer",
+                value: "切换预设会替换上面的重复提醒。「自定义」保留你手动排的每一条。",
+                comment: "Frequency footer"
+            ))
+            .font(.caption)
+        }
+    }
+
+    // MARK: - Quiet Hours Section
+
+    private var quietHoursSection: some View {
+        Section {
+            Toggle(isOn: Binding(
+                get: { service.quietHours.enabled },
+                set: { enabled in
+                    var hours = service.quietHours
+                    hours.enabled = enabled
+                    service.updateQuietHours(hours)
+                }
+            )) {
+                SettingsLabel(
+                    title: NSLocalizedString("settings.reminder.quiet", value: "静音时段", comment: "Quiet hours toggle"),
+                    systemImage: "moon.zzz"
+                )
+            }
+            .listRowBackground(DSColor.surfaceWhite)
+            .accessibilityIdentifier("schedule-quiet-hours")
+
+            if service.quietHours.enabled {
+                quietTimeRow(
+                    titleKey: "schedule.quiet.start",
+                    fallback: "开始",
+                    minutes: service.quietHours.startMinutes,
+                    onChange: { newMinutes in
+                        var hours = service.quietHours
+                        hours.startMinutes = newMinutes
+                        service.updateQuietHours(hours)
+                    }
+                )
+                .listRowBackground(DSColor.surfaceWhite)
+
+                quietTimeRow(
+                    titleKey: "schedule.quiet.end",
+                    fallback: "结束",
+                    minutes: service.quietHours.endMinutes,
+                    onChange: { newMinutes in
+                        var hours = service.quietHours
+                        hours.endMinutes = newMinutes
+                        service.updateQuietHours(hours)
+                    }
+                )
+                .listRowBackground(DSColor.surfaceWhite)
+            }
+        } header: {
+            Text(NSLocalizedString("schedule.section.quiet", value: "静音", comment: "Quiet hours section title"))
+        } footer: {
+            Text(NSLocalizedString(
+                "schedule.section.quiet.footer",
+                value: "静音时段内的重复提醒会自动跳过。跨午夜也支持(如 23:30–08:00)。",
+                comment: "Quiet hours footer"
+            ))
+            .font(.caption)
+        }
+    }
+
+    /// A single quiet-hours time picker row. Bridges the service's
+    /// "minutes since midnight" model to a `.hourAndMinute` DatePicker.
+    private func quietTimeRow(titleKey: String, fallback: String, minutes: Int, onChange: @escaping (Int) -> Void) -> some View {
+        DatePicker(
+            NSLocalizedString(titleKey, value: fallback, comment: "Quiet hours time"),
+            selection: Binding(
+                get: { Self.dateFrom(minutes: minutes) },
+                set: { onChange(Self.minutes(from: $0)) }
+            ),
+            displayedComponents: [.hourAndMinute]
+        )
+        .foregroundColor(DSColor.inkPrimary)
+    }
+
+    // MARK: - AlarmKit Section (iOS 26+)
+
+    @ViewBuilder
+    private var alarmKitSection: some View {
+        // Only iOS 26+ exposes the system Live Activity (AlarmKit) path.
+        if service.isAlarmKitAvailable {
+            Section {
+                Toggle(isOn: Binding(
+                    get: { service.preferAlarmKit },
+                    set: { enabled in
+                        service.preferAlarmKit = enabled
+                        guard enabled, #available(iOS 26.0, *) else { return }
+                        Task { await service.requestAlarmKitAuthorization() }
+                    }
+                )) {
+                    SettingsLabel(
+                        title: NSLocalizedString("settings.reminder.alarmkit", value: "系统灵动岛提醒", comment: "Use AlarmKit system Live Activity"),
+                        systemImage: "bell.badge.waveform"
+                    )
+                }
+                .listRowBackground(DSColor.surfaceWhite)
+                .accessibilityIdentifier("schedule-prefer-alarmkit")
+
+                if service.preferAlarmKit && !service.alarmKitAuthorized {
+                    Label(
+                        NSLocalizedString(
+                            "settings.reminder.alarmkit.denied",
+                            value: "系统未授权提醒,灵动岛不会出现 —— 前往「设置 › DayPage」开启。",
+                            comment: "AlarmKit permission missing hint"
+                        ),
+                        systemImage: "exclamationmark.triangle"
+                    )
+                    .font(.caption)
+                    .foregroundColor(DSColor.warnAmber)
+                    .listRowBackground(DSColor.surfaceWhite)
+                    .accessibilityIdentifier("schedule-alarmkit-denied-hint")
+                }
+            } header: {
+                Text(NSLocalizedString("schedule.section.alarmkit", value: "系统提醒", comment: "AlarmKit section title"))
+            }
+        }
+    }
+
+    // MARK: - Minutes ⇄ Date helpers
+
+    /// Anchor a "minutes since midnight" value onto today's date so a
+    /// `.hourAndMinute` DatePicker can bind to it.
+    private static func dateFrom(minutes: Int) -> Date {
+        var comps = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        comps.hour = (minutes / 60) % 24
+        comps.minute = minutes % 60
+        return Calendar.current.date(from: comps) ?? Date()
+    }
+
+    private static func minutes(from date: Date) -> Int {
+        let c = Calendar.current.dateComponents([.hour, .minute], from: date)
+        return (c.hour ?? 0) * 60 + (c.minute ?? 0)
+    }
+}
+
+// MARK: - ReminderHubRow
+
+/// One reminder row: leading icon (clock for one-shot, bell for repeating),
+/// primary line + label, an "AI" source badge, a tappable level chip, and the
+/// enable toggle. Kept as a standalone view so `body` stays readable.
+private struct ReminderHubRow: View {
+    let reminder: Reminder
+    let onTap: () -> Void
+    let onToggle: (Bool) -> Void
+    let onCycleLevel: () -> Void
+
+    var body: some View {
+        HStack(spacing: DSSpacing.md) {
+            leadingIcon
+
+            Button(action: onTap) {
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(primaryLine)
+                        .font(DSType.bodyMD)
+                        .foregroundColor(DSColor.inkPrimary)
+                        .lineLimit(1)
+
+                    HStack(spacing: 6) {
+                        if !reminder.label.isEmpty {
+                            Text(reminder.label)
+                                .font(DSType.bodySM)
+                                .foregroundColor(DSColor.inkMuted)
+                                .lineLimit(1)
+                        }
+                        if reminder.source == .ai {
+                            aiBadge
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+
+            levelChip
+
+            Toggle("", isOn: Binding(
+                get: { reminder.enabled },
+                set: { onToggle($0) }
+            ))
+            .labelsHidden()
+            .accessibilityLabel(NSLocalizedString("schedule.row.enabled", value: "启用", comment: "Reminder enabled toggle"))
+        }
+        .padding(.vertical, DSSpacing.xs)
+        .accessibilityElement(children: .contain)
+    }
+
+    // MARK: Subviews
+
+    private var leadingIcon: some View {
+        Image(systemName: reminder.isOneShot ? "clock" : "bell")
+            .font(.system(size: 15, weight: .medium))
+            .foregroundColor(reminder.enabled ? DSColor.accentOnBg : DSColor.inkSubtle)
+            .frame(width: 26, height: 26)
+            .background(
+                RoundedRectangle(cornerRadius: 7, style: .continuous)
+                    .fill(reminder.enabled ? DSColor.amberSoft : Color.clear)
+            )
+    }
+
+    private var aiBadge: some View {
+        Text("AI")
+            .font(DSType.mono9)
+            .tracking(0.5)
+            .foregroundColor(DSColor.accentOnBg)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 1)
+            .background(DSColor.amberSoft, in: Capsule())
+            .accessibilityLabel(NSLocalizedString("schedule.badge.ai", value: "AI 排的提醒", comment: "AI-authored reminder badge"))
+    }
+
+    /// Tappable pill communicating the presentation level. Quiet = soft green
+    /// (calm, floats), loud = terracotta (alarm). Tapping cycles between them.
+    private var levelChip: some View {
+        let isQuiet = reminder.level == .quiet
+        let tint = isQuiet ? DSColor.statusSuccess : DSColor.statusError
+        return Button(action: onCycleLevel) {
+            Text(isQuiet
+                ? NSLocalizedString("reminder.level.quiet", value: "安静", comment: "Quiet reminder level")
+                : NSLocalizedString("reminder.level.loud", value: "重要", comment: "Loud reminder level"))
+                .font(DSType.labelSM)
+                .foregroundColor(tint)
+                .padding(.horizontal, DSSpacing.sm)
+                .padding(.vertical, 3)
+                .background(tint.opacity(0.12), in: Capsule())
+                .overlay(Capsule().strokeBorder(tint.opacity(0.24), lineWidth: 0.5))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(isQuiet
+            ? NSLocalizedString("schedule.level.a11y.quiet", value: "级别:安静,点按切换为重要", comment: "Quiet level chip a11y")
+            : NSLocalizedString("schedule.level.a11y.loud", value: "级别:重要,点按切换为安静", comment: "Loud level chip a11y"))
+        .accessibilityIdentifier("schedule-level-chip")
+    }
+
+    /// One-shot → relative day label; repeating → "每天 21:00" style line.
+    private var primaryLine: String {
+        if reminder.isOneShot {
+            return reminder.repeatDescription
+        }
+        return "\(reminder.repeatDescription) \(reminder.timeString)"
+    }
+}
+
+#Preview {
+    NavigationStack { ScheduleHubView() }
+}

--- a/DayPage/Features/Settings/SettingsRemindersView.swift
+++ b/DayPage/Features/Settings/SettingsRemindersView.swift
@@ -37,6 +37,20 @@ struct SettingsRemindersView: View {
 
     private var captureReminderSection: some View {
         Section {
+            // 提醒的增删改现在归到「调度中心」(侧边栏 › 调度)。这里只留频率、
+            // 静音、系统提醒等全局配置 + 一行指引,避免两处都能改造成漂移。
+            HStack {
+                SettingsLabel(
+                    title: NSLocalizedString("settings.reminder.hub_hint", value: "在调度中心增删改提醒", comment: "Pointer to schedule hub for CRUD"),
+                    systemImage: "clock.badge"
+                )
+                Spacer()
+                Image(systemName: "arrow.up.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(DSColor.inkSubtle)
+            }
+            .accessibilityIdentifier("reminder-hub-hint")
+
             Picker(
                 NSLocalizedString("settings.reminder.frequency", value: "提醒频率", comment: "Capture reminder frequency preset"),
                 selection: Binding(

--- a/DayPage/Features/Today/ReminderEditSheet.swift
+++ b/DayPage/Features/Today/ReminderEditSheet.swift
@@ -48,6 +48,8 @@ struct ReminderEditSheet: View {
     @State private var time: Date
     @State private var selectedDays: Set<Int>
     @State private var label: String
+    /// 呈现级别 —— 安静(灵动岛/横幅悬浮)/ 重要(闹钟)。默认安静。
+    @State private var level: Reminder.Level
 
     // MARK: Init
 
@@ -72,11 +74,13 @@ struct ReminderEditSheet: View {
                 _selectedDays = State(initialValue: days)
             }
             _label = State(initialValue: r.label)
+            _level = State(initialValue: r.level)
         } else {
             _kind = State(initialValue: .once)
             _time = State(initialValue: Self.defaultOnceTime())
             _selectedDays = State(initialValue: [2, 3, 4, 5, 6])
             _label = State(initialValue: "")
+            _level = State(initialValue: .quiet)
         }
     }
 
@@ -92,6 +96,26 @@ struct ReminderEditSheet: View {
                     }
                     .pickerStyle(.segmented)
                     .accessibilityIdentifier("reminder-kind-picker")
+                }
+
+                // 呈现级别 —— 安静(默认,灵动岛/横幅悬浮不吵)/ 重要(闹钟+声音)。
+                // vNext 分层的落点:先答"这条有多重要",再定时间。
+                Section {
+                    Picker("", selection: $level) {
+                        Text(NSLocalizedString("reminder.level.quiet", value: "安静", comment: "Quiet reminder level"))
+                            .tag(Reminder.Level.quiet)
+                        Text(NSLocalizedString("reminder.level.loud", value: "重要", comment: "Loud reminder level"))
+                            .tag(Reminder.Level.loud)
+                    }
+                    .pickerStyle(.segmented)
+                    .accessibilityIdentifier("reminder-level-picker")
+                } header: {
+                    Text(NSLocalizedString("reminder.level.section", value: "提醒方式", comment: "Reminder presentation level"))
+                } footer: {
+                    Text(level == .quiet
+                        ? NSLocalizedString("reminder.level.quiet.hint", value: "到点在灵动岛 / 锁屏优雅悬浮,不响、不夺屏。", comment: "Quiet level footer")
+                        : NSLocalizedString("reminder.level.loud.hint", value: "到点全屏闹钟 + 声音。留给不能错过的事。", comment: "Loud level footer"))
+                        .font(.caption)
                 }
 
                 // 一次性快捷 chips —— 直接落一个绝对时间点到轮盘。
@@ -270,10 +294,10 @@ struct ReminderEditSheet: View {
         }
 
         if let editing {
-            service.updateReminder(editing.id, trigger: trigger, label: trimmedLabel)
+            service.updateReminder(editing.id, trigger: trigger, label: trimmedLabel, level: level)
         } else {
             let fallbackLabel = trimmedLabel.isEmpty ? defaultLabel(for: kind) : trimmedLabel
-            service.addReminder(Reminder(trigger: trigger, label: fallbackLabel, source: .user))
+            service.addReminder(Reminder(trigger: trigger, label: fallbackLabel, source: .user, level: level))
         }
         Haptics.success()
         dismiss()

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1670,9 +1670,14 @@ struct TodayView: View {
     /// Reminder vNext: 即将触发的提醒胶囊条。FeatureFlag.captureReminder 关
     /// 时整条不挂载（kill switch 与调度器一致）。点胶囊 → 编辑；点「＋」→
     /// 新建。数据源是统一调度器，AI 排的提醒也会出现在这里。
+    ///
+    /// Today 瘦身（vNext 2026-07-19）：增删改已迁到「调度中心」，主流里只在
+    /// 真有「即将触发」提醒时才挂载这一条，让空态不占位；没有即将触发的提醒
+    /// 时整条消失，用户去侧边栏「调度」管理。
     @ViewBuilder
     private var reminderStrip: some View {
-        if FeatureFlagStore.shared.isEnabled(.captureReminder) {
+        if FeatureFlagStore.shared.isEnabled(.captureReminder),
+           !reminderService.upcoming(limit: 1, now: currentTime).isEmpty {
             ReminderCapsuleStrip(
                 service: reminderService,
                 now: currentTime,

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -195,6 +195,9 @@ struct TodayView: View {
     /// #821: true while a whole-dock press-to-talk session is recording.
     /// Drives the timeline spotlight scrim behind the in-place capsule.
     @State private var isDockVoiceActive: Bool = false
+    /// vNext:tap 录音持久 sheet 的当前档位。每次打开重置为 .medium("弹一点点"),
+    /// 用户可拖拽拉到 .large 全屏。
+    @State private var voiceRecorderDetent: PresentationDetent = .medium
 
     /// Issue #804: Today sparkle 现在打开 `TodayCoachView`（陪写引导）。
     /// AskPastView（RAG 「问过去」）保留在侧边栏 + Siri intent —— 两条路径
@@ -925,8 +928,13 @@ struct TodayView: View {
                         viewModel.cancelVoiceRecording()
                     }
                 )
-                .presentationDetents([.medium])
-                .presentationDragIndicator(.hidden)
+                // vNext:tap 录音的持久舱从"只弹一半"升级为可从 medium 拉到
+                // large 全屏 —— 用户明确要"这个弹窗可以拉上去"。显示 drag
+                // indicator 让"可拖拽放大"可发现。detent 变化由 sheet 原生驱动,
+                // 录音在 VoiceRecordingView 内部持续,拖拽不中断音频。
+                .presentationDetents([.medium, .large], selection: $voiceRecorderDetent)
+                .presentationDragIndicator(.visible)
+                .onAppear { voiceRecorderDetent = .medium }
             }
             .sheet(isPresented: $showSettings) {
                 SettingsView()

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -1431,3 +1431,25 @@
 "heatmap.a11y.base"           = "Activity heatmap, %d entries over the last 16 weeks";
 "heatmap.a11y.current_streak" = "%1$@, current streak %2$d days";
 "heatmap.a11y.best_streak"    = "%1$@, current streak 0 days, best ever %2$d days";
+
+
+/* MARK: - 调度中心 vNext (Schedule & Notifications) */
+"reminder.level.section" = "Reminder style";
+"reminder.level.quiet" = "Quiet";
+"reminder.level.loud" = "Important";
+"reminder.level.quiet.hint" = "Hovers gently on the Dynamic Island / Lock Screen — no sound, no takeover.";
+"reminder.level.loud.hint" = "A full-screen alarm with sound. For things you can't miss.";
+"schedule.hub.title" = "Schedule";
+"schedule.add" = "New reminder";
+"schedule.delete" = "Delete";
+"schedule.badge.ai" = "Scheduled by AI";
+"schedule.row.enabled" = "Enabled";
+"schedule.section.reminders" = "Reminders";
+"schedule.section.frequency" = "Frequency";
+"schedule.section.quiet" = "Quiet hours";
+"schedule.section.alarmkit" = "System alerts";
+"schedule.level.a11y.quiet" = "Level: Quiet. Tap to switch to Important.";
+"schedule.level.a11y.loud" = "Level: Important. Tap to switch to Quiet.";
+"sidebar.nav.schedule" = "Schedule";
+"sidebar.schedule.hint" = "Open the schedule center";
+"sidebar.schedule.upcoming" = "%d upcoming";

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -1438,3 +1438,25 @@
 "heatmap.a11y.base"           = "活动热力图，过去 16 周共 %d 条记录";
 "heatmap.a11y.current_streak" = "%1$@，当前连续 %2$d 天";
 "heatmap.a11y.best_streak"    = "%1$@，当前连续 0 天，历史最佳 %2$d 天";
+
+
+/* MARK: - 调度中心 vNext (Schedule & Notifications) */
+"reminder.level.section" = "提醒方式";
+"reminder.level.quiet" = "安静";
+"reminder.level.loud" = "重要";
+"reminder.level.quiet.hint" = "到点在灵动岛 / 锁屏优雅悬浮，不响、不夺屏。";
+"reminder.level.loud.hint" = "到点全屏闹钟 + 声音。留给不能错过的事。";
+"schedule.hub.title" = "调度";
+"schedule.add" = "新建提醒";
+"schedule.delete" = "删除";
+"schedule.badge.ai" = "AI 排的提醒";
+"schedule.row.enabled" = "启用";
+"schedule.section.reminders" = "提醒";
+"schedule.section.frequency" = "频率";
+"schedule.section.quiet" = "静音";
+"schedule.section.alarmkit" = "系统提醒";
+"schedule.level.a11y.quiet" = "级别：安静，点按切换为重要";
+"schedule.level.a11y.loud" = "级别：重要，点按切换为安静";
+"sidebar.nav.schedule" = "调度";
+"sidebar.schedule.hint" = "打开调度中心";
+"sidebar.schedule.upcoming" = "%d 条即将触发";

--- a/DayPage/Services/CaptureReminderService.swift
+++ b/DayPage/Services/CaptureReminderService.swift
@@ -120,12 +120,22 @@ final class CaptureReminderService: ObservableObject {
         refreshSchedule()
     }
 
-    /// 整体替换某条提醒的 trigger(编辑 sheet 保存时用)。
-    func updateReminder(_ id: UUID, trigger: Reminder.Trigger, label: String? = nil) {
+    /// 整体替换某条提醒的 trigger / label / level(编辑 sheet 保存时用)。
+    func updateReminder(_ id: UUID, trigger: Reminder.Trigger, label: String? = nil, level: Reminder.Level? = nil) {
         guard let idx = reminders.firstIndex(where: { $0.id == id }) else { return }
         reminders[idx].trigger = trigger
         if let label { reminders[idx].label = label }
+        if let level { reminders[idx].level = level }
         sortReminders()
+        persist()
+        refreshSchedule()
+    }
+
+    /// 仅切换某条提醒的呈现级别(调度中心快捷切换 / 芯片点击用)。
+    func setLevel(_ id: UUID, _ level: Reminder.Level) {
+        guard let idx = reminders.firstIndex(where: { $0.id == id }) else { return }
+        guard reminders[idx].level != level else { return }
+        reminders[idx].level = level
         persist()
         refreshSchedule()
     }
@@ -220,19 +230,36 @@ final class CaptureReminderService: ObservableObject {
 
     // MARK: - Scheduling
 
-    /// 幂等重排。先剔除过期一次性,再按两条路径装载:
-    ///   • iOS 26+ 且 AlarmKit 已授权 → AlarmKit(真灵动岛),同时清 UNCalendar 侧。
-    ///   • 否则 → UN 通知(一次性用 TimeInterval,重复用 Calendar)。
-    /// FeatureFlag 关时只清不装(两条路径都清)。
+    /// 幂等重排。先剔除过期一次性,再<b>按每条提醒的 level 分派</b>(vNext 分层):
+    ///   • `.loud` 且 iOS 26+ AlarmKit 已授权 → AlarmKit 全屏闹钟 alert。
+    ///   • `.quiet`(或 AlarmKit 不可用时的 `.loud` 降级)→ UN 通知:安静态
+    ///     用 interruptionLevel .active + sound nil(真无声悬浮)。
+    /// 两条路径每次都各自全清再重装(前缀清 UN,遍历 cancel AlarmKit),所以
+    /// 一条提醒改 level 后不会在旧路径留残影。FeatureFlag 关时只清不装。
     func refreshSchedule() {
         registerCategoryIfNeeded()
         pruneExpiredOneShots()
 
-        if #available(iOS 26.0, *), useAlarmKit {
-            refreshViaAlarmKit()
-            return
-        }
+        // UN 路径始终处理"安静 + AlarmKit 降级的 loud";AlarmKit 路径只处理
+        // "loud 且可用"。两者的 reminder 集合互斥,靠 shouldUseAlarmKit(for:)
+        // 单一判定,避免同一条被两边都装。
         refreshViaNotifications()
+
+        if #available(iOS 26.0, *) {
+            refreshViaAlarmKit()
+        }
+    }
+
+    /// 某条提醒是否走 AlarmKit(全屏闹钟)。仅 `.loud` + iOS26+ + 已授权 + flag 开。
+    /// 其余(含 AlarmKit 未授权时的 `.loud`)一律降级 UN。
+    private func shouldUseAlarmKit(for reminder: Reminder) -> Bool {
+        guard reminder.level == .loud else { return false }
+        guard FeatureFlagStore.shared.isEnabled(.captureReminder) else { return false }
+        guard preferAlarmKit else { return false }
+        if #available(iOS 26.0, *) {
+            return alarmKitAuthorized
+        }
+        return false
     }
 
     /// 剔除已过期的一次性提醒(fireDate < now)。重复提醒不受影响。
@@ -269,6 +296,8 @@ final class CaptureReminderService: ObservableObject {
     private func installActiveReminders(into center: UNUserNotificationCenter) {
         var scheduled = 0
         for reminder in reminders where reminder.enabled {
+            // 走 AlarmKit(全屏闹钟)的 loud 提醒不在 UN 侧装,避免双份触发。
+            if shouldUseAlarmKit(for: reminder) { continue }
             // 一条 Reminder 可能展开成多条 UN request(weekdays:每个周几一条)。
             // sub-identifier 用 "<prefix><id>" 或 "<prefix><id>.w<weekday>",
             // 都以 requestPrefix 打头,重排时被前缀清理统一带走。
@@ -276,9 +305,9 @@ final class CaptureReminderService: ObservableObject {
                 let content = UNMutableNotificationContent()
                 content.title = "记录此刻"
                 content.body = reminder.promptBody
-                content.sound = .default
                 content.categoryIdentifier = Self.categoryID
                 content.userInfo = ["captureReminderID": reminder.id.uuidString]
+                applyPresentation(reminder.level, to: content)
 
                 let request = UNNotificationRequest(
                     identifier: spec.identifier,
@@ -293,7 +322,23 @@ final class CaptureReminderService: ObservableObject {
                 scheduled += 1
             }
         }
-        DayPageLogger.shared.info("[CaptureReminder] scheduled \(scheduled) requests")
+        DayPageLogger.shared.info("[CaptureReminder] scheduled \(scheduled) UN requests")
+    }
+
+    /// 把 level 映射到 UN content 的呈现强度(vNext 分层):
+    ///   • .quiet → interruptionLevel .active + sound nil —— 优雅悬浮、真无声,
+    ///     不夺屏(UN 的 sound 是 Optional,nil = 完全静音,这是 AlarmKit 缺的)。
+    ///   • .loud  → 到这条路径说明 AlarmKit 不可用(降级):给声音 + timeSensitive,
+    ///     尽量接近"重要"语义。真全屏闹钟需 AlarmKit 可用时才有。
+    private func applyPresentation(_ level: Reminder.Level, to content: UNMutableNotificationContent) {
+        switch level {
+        case .quiet:
+            content.interruptionLevel = .active
+            content.sound = nil
+        case .loud:
+            content.interruptionLevel = .timeSensitive
+            content.sound = .default
+        }
     }
 
     /// 把一条 Reminder 展开成 (identifier, trigger) 列表。
@@ -359,18 +404,13 @@ final class CaptureReminderService: ObservableObject {
         }
     }
 
-    // MARK: - AlarmKit (iOS 26+ 真灵动岛路径)
+    // MARK: - AlarmKit (iOS 26+ 全屏闹钟路径 · 仅 .loud 提醒)
+    //
+    // vNext(2026-07-19):AlarmKit 不再是"全局默认",而是"重要提醒"的落点。
+    // 每条提醒的路由由 shouldUseAlarmKit(for:) 按 level 判定;preferAlarmKit
+    // 从"是否全用 AlarmKit"降级为"允许 .loud 走 AlarmKit"的总闸(默认 on)。
 
-    private var useAlarmKit: Bool {
-        guard FeatureFlagStore.shared.isEnabled(.captureReminder) else { return false }
-        guard preferAlarmKit else { return false }
-        if #available(iOS 26.0, *) {
-            return alarmKitAuthorized
-        }
-        return false
-    }
-
-    /// 用户偏好:iOS 26+ 上是否用 AlarmKit 系统灵动岛(默认 on)。存 UserDefaults。
+    /// 用户偏好:iOS 26+ 上是否允许 .loud 提醒走 AlarmKit 全屏闹钟(默认 on)。存 UserDefaults。
     var preferAlarmKit: Bool {
         get {
             let v = defaults.object(forKey: Keys.preferAlarmKit)
@@ -441,6 +481,36 @@ final class CaptureReminderService: ObservableObject {
         refreshSchedule()
     }
 
+    /// 构造闹钟 alert 呈现 —— 副按钮「记一句」+ .custom。iOS 26.1 起停止按钮
+    /// 由系统自动提供(不带 stopButton 的 init 也从 26.1 才可用);26.0 回退带
+    /// stopButton 的旧构造。两分支的副按钮都靠 config.secondaryIntent 落地。
+    @available(iOS 26.0, *)
+    private static func makeCaptureAlert() -> AlarmPresentation.Alert {
+        let secondary = AlarmButton(
+            text: LocalizedStringResource(stringLiteral: "记一句"),
+            textColor: .white,
+            systemImageName: "mic.fill"
+        )
+        if #available(iOS 26.1, *) {
+            return AlarmPresentation.Alert(
+                title: LocalizedStringResource(stringLiteral: "记录此刻"),
+                secondaryButton: secondary,
+                secondaryButtonBehavior: .custom
+            )
+        } else {
+            return AlarmPresentation.Alert(
+                title: LocalizedStringResource(stringLiteral: "记录此刻"),
+                stopButton: AlarmButton(
+                    text: LocalizedStringResource(stringLiteral: "稍后"),
+                    textColor: .white,
+                    systemImageName: "xmark"
+                ),
+                secondaryButton: secondary,
+                secondaryButtonBehavior: .custom
+            )
+        }
+    }
+
     /// AlarmKit 重排:清 UNCalendar 侧旧通知 → 取消旧 alarm → 为每条启用的
     /// 提醒排 alarm(一次性 = .fixed;重复 = .relative)。
     @available(iOS 26.0, *)
@@ -463,6 +533,8 @@ final class CaptureReminderService: ObservableObject {
             }
             var scheduled = 0
             for reminder in reminders where reminder.enabled {
+                // 只装"重要 + AlarmKit 可用"的;安静态与降级 loud 已在 UN 侧装。
+                guard shouldUseAlarmKit(for: reminder) else { continue }
                 if await scheduleAlarm(for: reminder) { scheduled += 1 }
             }
             DayPageLogger.shared.info("[CaptureReminder] AlarmKit scheduled \(scheduled) alarms")
@@ -495,20 +567,11 @@ final class CaptureReminderService: ObservableObject {
             schedule = .relative(.init(time: time, repeats: .weekly(weekdays)))
         }
 
-        let alert = AlarmPresentation.Alert(
-            title: LocalizedStringResource(stringLiteral: "记录此刻"),
-            stopButton: AlarmButton(
-                text: LocalizedStringResource(stringLiteral: "稍后"),
-                textColor: .white,
-                systemImageName: "xmark"
-            ),
-            secondaryButton: AlarmButton(
-                text: LocalizedStringResource(stringLiteral: "记一句"),
-                textColor: .white,
-                systemImageName: "mic.fill"
-            ),
-            secondaryButtonBehavior: .custom
-        )
+        // 副按钮「记一句」走 .custom + secondaryIntent —— 修好"点了没反应"的
+        // 静默失效 bug(见下方 config 的 secondaryIntent)。iOS 26.1 起 stopButton
+        // 已废弃(停止按钮由系统自动提供),但无 stopButton 的 init 也只在 26.1+
+        // 可用;部署 gate 是 26.0,故按版本分支,26.0 仍用带 stopButton 的旧构造。
+        let alert = Self.makeCaptureAlert()
         let presentation = AlarmPresentation(alert: alert)
         let metadata = CaptureAlarmMetadata(prompt: reminder.promptBody, slotID: reminder.id.uuidString)
         let attributes = AlarmAttributes(
@@ -519,12 +582,14 @@ final class CaptureReminderService: ObservableObject {
             // attributes.tintColor,不再各自硬编码副本(单源防漂移)。
             tintColor: Color(red: 0.788, green: 0.533, blue: 0.227)
         )
+        // secondaryIntent 必须是 LiveActivityIntent(SDK 类型约束),点副按钮
+        // 前台唤起 app + open daypage://record → 录音。这是本次核心 bug 修复。
         let config = AlarmManager.AlarmConfiguration(
             countdownDuration: nil,
             schedule: schedule,
             attributes: attributes,
             stopIntent: nil,
-            secondaryIntent: nil,
+            secondaryIntent: CaptureVoiceIntent(reminderID: reminder.id.uuidString),
             sound: .default
         )
         do {
@@ -543,20 +608,7 @@ final class CaptureReminderService: ObservableObject {
     @available(iOS 26.0, *)
     func qaStartCountdownTimer(seconds: TimeInterval) async {
         _ = await requestAlarmKitAuthorization()
-        let alert = AlarmPresentation.Alert(
-            title: LocalizedStringResource(stringLiteral: "记录此刻"),
-            stopButton: AlarmButton(
-                text: LocalizedStringResource(stringLiteral: "稍后"),
-                textColor: .white,
-                systemImageName: "xmark"
-            ),
-            secondaryButton: AlarmButton(
-                text: LocalizedStringResource(stringLiteral: "记一句"),
-                textColor: .white,
-                systemImageName: "mic.fill"
-            ),
-            secondaryButtonBehavior: .custom
-        )
+        let alert = Self.makeCaptureAlert()
         let countdown = AlarmPresentation.Countdown(
             title: LocalizedStringResource(stringLiteral: "记录此刻"))
         let presentation = AlarmPresentation(alert: alert, countdown: countdown)

--- a/DayPage/Services/CaptureVoiceIntent.swift
+++ b/DayPage/Services/CaptureVoiceIntent.swift
@@ -1,0 +1,59 @@
+import AppIntents
+import Foundation
+#if canImport(UIKit) && !EXTENSION
+import UIKit
+#endif
+
+// MARK: - CaptureVoiceIntent
+//
+// AlarmKit 全屏闹钟(.loud 提醒)上「记一句」副按钮的落地 intent。
+//
+// 为什么单独存在、不复用 StartRecordingIntent —— AlarmKit 的 secondaryIntent
+// 类型约束是 `(any LiveActivityIntent)?`(逐行核对 iOS 26.4 SDK),必须遵从
+// `LiveActivityIntent` 协议;而 StartRecordingIntent 是普通 `AppIntent`,传进
+// AlarmConfiguration 编不过。这正是"点闹钟语音按钮没反应"的根因:旧代码
+// `secondaryButtonBehavior: .custom` 但 `secondaryIntent: nil`,.custom 行为
+// 缺 intent → 运行期静默失效(编译器不拦)。
+//
+// 落点复用既有深链:openAppWhenRun 前台唤起 app 后 open `daypage://record`,
+// 走 DayPageApp.onOpenURL 的 record 分支 → pendingRecordingTrigger → TodayView
+// 起录音舱。与 Widget / Siri / 控制中心 / 普通通知的语音 action 同一条轨道。
+//
+// 归属:app target(DayPage/Services/,与 CaptureReminderService 同 group,
+// 因为它只被后者引用且需 open URL,不进 Widget target)。
+
+@available(iOS 26.0, *)
+struct CaptureVoiceIntent: LiveActivityIntent {
+
+    static let title: LocalizedStringResource = "记一句"
+
+    static var description = IntentDescription(
+        "从提醒直接开始语音录音。",
+        categoryName: "Capture"
+    )
+
+    /// 前台打开 app —— 麦克风访问要求 app 在前台。
+    static var openAppWhenRun: Bool { true }
+
+    /// 触发这条 intent 的提醒 id(便于未来埋点/关联,当前仅透传)。
+    @Parameter(title: "提醒")
+    var reminderID: String
+
+    init() {}
+
+    init(reminderID: String) {
+        self.reminderID = reminderID
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        #if !EXTENSION
+        if let url = URL(string: "daypage://record") {
+            #if canImport(UIKit)
+            await UIApplication.shared.open(url)
+            #endif
+        }
+        #endif
+        return .result()
+    }
+}

--- a/DayPage/Services/Reminder.swift
+++ b/DayPage/Services/Reminder.swift
@@ -35,24 +35,58 @@ struct Reminder: Codable, Identifiable, Equatable {
         case ai
     }
 
+    /// 呈现级别 —— 到点时"多大声"。这是 vNext(2026-07-19)分层的支点:
+    ///   • .quiet —— 安静。轻量 UN 通知(interruptionLevel .active + sound nil),
+    ///     不夺屏、可真无声,只在锁屏/横幅优雅悬浮。默认。
+    ///   • .loud  —— 重要。AlarmKit 全屏闹钟 alert + 声音,给不能错过的事。
+    ///
+    /// 技术依据(逐行核对 iOS 26.4 SDK):AlarmKit 的 sound 非 Optional、无静音
+    /// 档,到点必全屏 alert —— 做不到"安静不响";故安静态走 UN,只有 .loud 走
+    /// AlarmKit。Codable 缺字段解码回退 .quiet,老数据无损升级。
+    enum Level: String, Codable, Equatable {
+        case quiet
+        case loud
+    }
+
     let id: UUID
     var trigger: Trigger
     var label: String
     var enabled: Bool
     var source: Source
+    var level: Level
 
     init(
         id: UUID = UUID(),
         trigger: Trigger,
         label: String,
         enabled: Bool = true,
-        source: Source = .user
+        source: Source = .user,
+        level: Level = .quiet
     ) {
         self.id = id
         self.trigger = trigger
         self.label = label
         self.enabled = enabled
         self.source = source
+        self.level = level
+    }
+
+    // MARK: Codable — level 向后兼容
+
+    /// 手写 decode 只为一件事:老数据(无 `level` 字段)解码成 `.quiet` 而非
+    /// 抛错。其余字段用默认合成行为。`trigger`/`source` 仍走自动 Codable。
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(UUID.self, forKey: .id)
+        trigger = try c.decode(Trigger.self, forKey: .trigger)
+        label = try c.decode(String.self, forKey: .label)
+        enabled = try c.decode(Bool.self, forKey: .enabled)
+        source = try c.decode(Source.self, forKey: .source)
+        level = try c.decodeIfPresent(Level.self, forKey: .level) ?? .quiet
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, trigger, label, enabled, source, level
     }
 
     // MARK: - Derived display


### PR DESCRIPTION
把散在 Today 首页的调度搬进侧边独立的「调度中心」,给每条提醒一个呈现级别 —— 安静的在灵动岛/横屏悬浮,重要的才响闹钟;顺手修好点了没反应的闹钟语音按钮,让 tap 录音舱能从"弹一点点"拉到全屏。

技术选型逐行核对 iOS 26.4 SDK,含几个决定性发现(见下)。

## 改动(7 步 + 2 轮 bug 修复,8 commits)

### 提醒分层(安静 / 重要)
- `Reminder` 加 `level: enum {quiet, loud}`,默认 quiet。手写 `init(from:)` + `decodeIfPresent ?? .quiet` 让老数据无字段无损升级。
- **安静态走 UN**:`interruptionLevel = .active` + `sound = nil`(真无声悬浮)。**AlarmKit 的 sound 非 Optional、到点必全屏 alert,做不到无声** —— 故只有 loud 走 AlarmKit。调度按每条 level 分派(`shouldUseAlarmKit(for:)`),两条路径 reminder 集合互斥。
- `ReminderEditSheet` 加「提醒方式」安静/重要分段,footer 随选变。

### 修 bug:闹钟「记一句」语音按钮点了没反应
- 根因:`secondaryButtonBehavior: .custom` 但 `AlarmConfiguration(secondaryIntent: nil)` → .custom 缺 intent 运行期静默失效。
- **secondaryIntent 必须是 `LiveActivityIntent`(SDK 类型约束),不是普通 AppIntent** → 新建 `CaptureVoiceIntent: LiveActivityIntent`,复用 `daypage://record` 深链录音。
- 顺带迁移 iOS 26.1 废弃的 `Alert(stopButton:)`;无 stopButton 的 init 也仅 26.1+,按版本分支兼容 26.0。

### 侧边调度中心
- 新建 `ScheduleHubView`:提醒完整增删改 + 可点级别芯片(安静柔绿↔重要赤陶)+ AI 徽标 + 全局配置(频率/静音时段/灵动岛)。
- 侧边栏 flag 门控「调度」入口;**sheet 由 RootView 挂在 `nav.showScheduleHub` 上**(全局稳定层,和「问过去」同款)—— 早期挂 SidebarView 会因抽屉关闭后 @State 失活而不呈现(实测踩坑,两版才修对)。
- Settings 留跳转指引;Today 提醒条仅在有即将触发时挂载(空态不占位)。

### 录音舱可拉到全屏
- 定位到用户说的"弹一点点"= tap mic 的 `VoiceRecordingView` sheet,原锁死 `.presentationDetents([.medium])`。改 `[.medium, .large]` + drag indicator,能从半屏拉到全屏,音频不中断。

## 验证
- 构建通过;`ReminderIntentParserTests` 23 个单测全绿(Reminder 结构改动无回归)。
- 模拟器(iPhone 17 / iOS 26.1)真机验证 **5/5 项 PASS**:调度入口打开页、级别芯片切换、新建提醒+级别分段、级别持久化(杀 app 重启后仍在)、录音舱可拉全屏(拖拽中计时/波形不断)。
- 补齐 19 个新 key 的中英双语翻译。

## 设计稿
https://claude.ai/code/artifact/da75c77b-80f7-4ea9-b7ab-ac9424cdd833

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ