### PR TITLE
feat(island): 灵动岛倒计时进岛 + 品牌化各态 + Today 收敛胶囊条

### DIFF
--- a/DayPage/App/DayPageApp.swift
+++ b/DayPage/App/DayPageApp.swift
@@ -458,10 +458,15 @@ struct DayPageApp: App {
                            let seconds = TimeInterval(args[idx + 1]), seconds > 0 {
                             Task {
                                 await CaptureReminderService.shared.requestAlarmKitAuthorization()
-                                CaptureReminderService.shared.scheduleOnce(
-                                    at: Date().addingTimeInterval(seconds),
-                                    label: "QA 灵动岛测试"
+                                // 必须 .loud 才走 AlarmKit 路径(.quiet 走 UN,测不到岛)。
+                                // seconds 应 > islandPreheatSeconds(60),否则一进 App
+                                // 就已过预热窗口起点,岛在剩余不足 60s 内即时上屏。
+                                let r = Reminder(
+                                    trigger: .once(Date().addingTimeInterval(seconds)),
+                                    label: "QA 灵动岛测试",
+                                    level: .loud
                                 )
+                                CaptureReminderService.shared.addReminder(r)
                             }
                         }
                         // `-qaAlarmTimerSeconds 120`:起 countdown 计时器。

--- a/DayPage/Features/Today/TodayView.swift
+++ b/DayPage/Features/Today/TodayView.swift
@@ -1675,28 +1675,15 @@ struct TodayView: View {
         }
     }
 
-    /// Reminder vNext: 即将触发的提醒胶囊条。FeatureFlag.captureReminder 关
-    /// 时整条不挂载（kill switch 与调度器一致）。点胶囊 → 编辑；点「＋」→
-    /// 新建。数据源是统一调度器，AI 排的提醒也会出现在这里。
+    /// Reminder vNext: 即将触发的提醒胶囊条。
     ///
-    /// Today 瘦身（vNext 2026-07-19）：增删改已迁到「调度中心」，主流里只在
-    /// 真有「即将触发」提醒时才挂载这一条，让空态不占位；没有即将触发的提醒
-    /// 时整条消失，用户去侧边栏「调度」管理。
+    /// Today 收敛（2026-07-20）：整条胶囊行从 Today 主流移除 —— 提醒的增删改查
+    /// 全部收进侧边栏「调度中心」（ScheduleHubView），主页只写「今天」本身、
+    /// 不再把日程 chrome 摆在首屏。挂载点保留（padding 布局不塌），body 返回
+    /// EmptyView。若日后要恢复,把下面的 ReminderCapsuleStrip 重新挂回即可。
     @ViewBuilder
     private var reminderStrip: some View {
-        if FeatureFlagStore.shared.isEnabled(.captureReminder),
-           !reminderService.upcoming(limit: 1, now: currentTime).isEmpty {
-            ReminderCapsuleStrip(
-                service: reminderService,
-                now: currentTime,
-                onEdit: { reminder in
-                    reminderSheetTarget = ReminderSheetTarget(reminder: reminder)
-                },
-                onAdd: {
-                    reminderSheetTarget = ReminderSheetTarget(reminder: nil)
-                }
-            )
-        }
+        EmptyView()
     }
 
     /// Ghost-line text: bare label when nothing is chosen, "· 工作 · 学习"

--- a/DayPage/Services/CaptureReminderService.swift
+++ b/DayPage/Services/CaptureReminderService.swift
@@ -481,6 +481,27 @@ final class CaptureReminderService: ObservableObject {
         refreshSchedule()
     }
 
+    /// 灵动岛「预热窗口」—— alarm 触发前多少秒进入 .countdown 态、把品牌灵动岛
+    /// 推上屏。这是让自定义琥珀岛 UI 真正可见的唯一窗口:AlarmKit 的 .alerting
+    /// (响铃)态灵动岛由系统 chrome 强制接管,widget 的 dynamicIsland 闭包只在
+    /// .countdown 态被调用。技术依据(2026-07-20 逐条核对 iOS26.4 SDK swiftinterface
+    /// + Apple 官方 countdownDuration 属性文档):配了 countdownDuration 后,
+    /// 倒计时 UI 在「下一次 alert 时刻 − preAlert」自动上屏,归零进 .alerting;
+    /// .relative 重复日程每次触发前都重演这个预热。
+    ///
+    /// 取 60s:提醒前 1 分钟悄悄进岛,克制、不长时间占岛(呼应「悄悄召唤、不打扰」
+    /// 的产品气质)。别设太长 —— 重复提醒每天都会提前这么久常驻灵动岛。
+    static let islandPreheatSeconds: TimeInterval = 60
+
+    /// 构造闹钟 countdown 呈现 —— .countdown 态(预热窗口内)的模板 UI。
+    /// 生产必须给 AlarmPresentation 配 countdown,否则预热窗口进 .countdown 态却
+    /// 没有呈现内容;widget 的自定义岛 UI 也才在这个态被系统调用。
+    @available(iOS 26.0, *)
+    private static func makeCaptureCountdown() -> AlarmPresentation.Countdown {
+        AlarmPresentation.Countdown(
+            title: LocalizedStringResource(stringLiteral: "记录此刻"))
+    }
+
     /// 构造闹钟 alert 呈现 —— 副按钮「记一句」+ .custom。iOS 26.1 起停止按钮
     /// 由系统自动提供(不带 stopButton 的 init 也从 26.1 才可用);26.0 回退带
     /// stopButton 的旧构造。两分支的副按钮都靠 config.secondaryIntent 落地。
@@ -571,8 +592,13 @@ final class CaptureReminderService: ObservableObject {
         // 静默失效 bug(见下方 config 的 secondaryIntent)。iOS 26.1 起 stopButton
         // 已废弃(停止按钮由系统自动提供),但无 stopButton 的 init 也只在 26.1+
         // 可用;部署 gate 是 26.0,故按版本分支,26.0 仍用带 stopButton 的旧构造。
+        // countdown 态呈现 —— 预热窗口(触发前 islandPreheatSeconds 秒)灵动岛
+        // 由 widget 的自定义琥珀 UI 渲染;.alerting 响铃态由系统接管。
         let alert = Self.makeCaptureAlert()
-        let presentation = AlarmPresentation(alert: alert)
+        let presentation = AlarmPresentation(
+            alert: alert,
+            countdown: Self.makeCaptureCountdown()
+        )
         let metadata = CaptureAlarmMetadata(prompt: reminder.promptBody, slotID: reminder.id.uuidString)
         let attributes = AlarmAttributes(
             presentation: presentation,
@@ -582,10 +608,14 @@ final class CaptureReminderService: ObservableObject {
             // attributes.tintColor,不再各自硬编码副本(单源防漂移)。
             tintColor: Color(red: 0.788, green: 0.533, blue: 0.227)
         )
+        // countdownDuration.preAlert = 预热窗口:灵动岛在「alert 时刻 − preAlert」
+        // 进 .countdown 态上屏(SDK 语义,见 islandPreheatSeconds 注释),归零响铃。
+        // postAlert nil —— 不配贪睡/重复倒计时(响铃后不自动再倒计)。
         // secondaryIntent 必须是 LiveActivityIntent(SDK 类型约束),点副按钮
-        // 前台唤起 app + open daypage://record → 录音。这是本次核心 bug 修复。
+        // 前台唤起 app + open daypage://record → 录音。
         let config = AlarmManager.AlarmConfiguration(
-            countdownDuration: nil,
+            countdownDuration: Alarm.CountdownDuration(
+                preAlert: Self.islandPreheatSeconds, postAlert: nil),
             schedule: schedule,
             attributes: attributes,
             stopIntent: nil,
@@ -609,9 +639,7 @@ final class CaptureReminderService: ObservableObject {
     func qaStartCountdownTimer(seconds: TimeInterval) async {
         _ = await requestAlarmKitAuthorization()
         let alert = Self.makeCaptureAlert()
-        let countdown = AlarmPresentation.Countdown(
-            title: LocalizedStringResource(stringLiteral: "记录此刻"))
-        let presentation = AlarmPresentation(alert: alert, countdown: countdown)
+        let presentation = AlarmPresentation(alert: alert, countdown: Self.makeCaptureCountdown())
         let metadata = CaptureAlarmMetadata(prompt: "记一句给今天", slotID: UUID().uuidString)
         let attributes = AlarmAttributes(
             presentation: presentation,

--- a/DayPageWidget/CaptureReminderLiveActivity.swift
+++ b/DayPageWidget/CaptureReminderLiveActivity.swift
@@ -76,24 +76,17 @@ struct CaptureReminderLiveActivity: Widget {
                 .activitySystemActionForegroundColor(Palette.amber)
         } dynamicIsland: { context in
             DynamicIsland {
+                // ── Expanded:一张有呼吸的卡。品牌行明确写「DayPage」释除
+                //    「这是谁的」疑惑;大倒计时是主角;底部一句提示 + 琥珀 CTA。
                 DynamicIslandExpandedRegion(.leading) {
-                    HStack(spacing: 7) {
-                        Image(systemName: "mic.fill")
-                            .font(.title3)
-                            .foregroundStyle(context.attributes.tintColor)
-                            .symbolEffect(.breathe, options: .repeat(.continuous),
-                                          isActive: Self.isAlerting(context))
-                        Text("记录此刻")
-                            .font(.subheadline.weight(.semibold))
-                            .foregroundStyle(.white)
-                    }
+                    Self.brandMark(context)
                 }
                 DynamicIslandExpandedRegion(.trailing) {
-                    // countdown 态给剩余时间(对齐系统计时器的数据位);
-                    // alerting 态由系统横幅接管 expanded,这里自然留白。
+                    // countdown 态给剩余时间(数据位,mono 大字);alerting 态由
+                    // 系统横幅接管 expanded,这里自然留白。
                     if case .countdown(let cd) = context.state.mode {
                         Text(timerInterval: cd.startDate...cd.fireDate, countsDown: true)
-                            .font(.subheadline.weight(.semibold).monospacedDigit())
+                            .font(.title3.weight(.semibold).monospacedDigit())
                             .foregroundStyle(context.attributes.tintColor)
                             .multilineTextAlignment(.trailing)
                             .padding(.trailing, 2)
@@ -103,39 +96,36 @@ struct CaptureReminderLiveActivity: Widget {
                     HStack(spacing: 10) {
                         Text(context.attributes.metadata?.prompt ?? "记一句给今天")
                             .font(.footnote)
-                            .foregroundStyle(.white.opacity(0.65))
+                            .foregroundStyle(.white.opacity(0.62))
                             .lineLimit(1)
+                            .minimumScaleFactor(0.85)
                         Spacer(minLength: 8)
                         Link(destination: Self.recordURL) {
                             Label("记一句", systemImage: "waveform")
                                 .font(.footnote.weight(.semibold))
-                                .foregroundStyle(.black)
+                                .foregroundStyle(Self.onAmberInk(context))
                                 .symbolEffect(.variableColor.iterative.reversing,
                                               options: .repeat(.continuous),
                                               isActive: Self.isAlerting(context))
-                                .padding(.horizontal, 12)
+                                .padding(.horizontal, 13)
                                 .padding(.vertical, 6)
                                 .background(context.attributes.tintColor, in: Capsule())
                         }
                     }
-                    .padding(.top, 6)
+                    .padding(.top, 8)
                 }
             } compactLeading: {
-                Image(systemName: "mic.fill")
-                    .foregroundStyle(context.attributes.tintColor)
-                    .symbolEffect(.breathe, options: .repeat(.continuous),
-                                  isActive: Self.isAlerting(context))
+                // 复合品牌标:琥珀圆底盛麦克风 —— 比裸符号更有辨识度,一眼是
+                // 「有品牌的记录提醒」而非通用闹钟。呼吸只在 alerting。
+                Self.compactBadge(context)
             } compactTrailing: {
-                // 2026-07-17 实测:只放 6pt 小圆点时,compact 岛拉宽后中间
-                // 大片乌黑、信息量为零,被用户点名「占了位置却什么都不显示」。
-                // 改成可扫读信息 —— compact 态的 trailing 本就该是数据位
-                // (参照系统计时器/Now Playing):countdown 态给实时倒计时,
-                // 其余(alerting)给 3 字 CTA,宽度预算内不会截断。
+                // compact trailing 是数据位:countdown 给实时倒计时;
+                // 其余(alerting)给 3 字 CTA。宽度预算内不截断。
                 if case .countdown(let cd) = context.state.mode {
                     Text(timerInterval: cd.startDate...cd.fireDate, countsDown: true)
-                        .font(.caption2.weight(.semibold).monospacedDigit())
+                        .font(.caption.weight(.semibold).monospacedDigit())
                         .foregroundStyle(context.attributes.tintColor)
-                        .frame(maxWidth: 44)
+                        .frame(maxWidth: 46)
                         .multilineTextAlignment(.trailing)
                 } else {
                     Text("记一句")
@@ -143,8 +133,11 @@ struct CaptureReminderLiveActivity: Widget {
                         .foregroundStyle(context.attributes.tintColor)
                 }
             } minimal: {
+                // minimal 空间只一个符号:琥珀麦克风,呼吸态 = alerting。
                 Image(systemName: "mic.fill")
                     .foregroundStyle(context.attributes.tintColor)
+                    .symbolEffect(.breathe, options: .repeat(.continuous),
+                                  isActive: Self.isAlerting(context))
             }
             .widgetURL(Self.recordURL)
             .keylineTint(context.attributes.tintColor)
@@ -158,6 +151,46 @@ struct CaptureReminderLiveActivity: Widget {
         return false
     }
 
+    // MARK: - Brand marks(建立「这是 DayPage」的辨识度)
+
+    /// Expanded leading 的品牌行:琥珀圆底麦克风 + 「DayPage」名 + 一句状态。
+    /// 明确写出 App 名,释除用户「主屏冒出个麦克风倒计时,谁的?」的疑惑。
+    @ViewBuilder
+    private static func brandMark(_ context: Context) -> some View {
+        HStack(spacing: 9) {
+            compactBadge(context)
+            VStack(alignment: .leading, spacing: 1) {
+                Text("DayPage")
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundStyle(.white)
+                Text("记录此刻")
+                    .font(.caption2)
+                    .foregroundStyle(.white.opacity(0.55))
+            }
+        }
+    }
+
+    /// compact leading / expanded 品牌圆标:琥珀圆底盛麦克风。比裸 SF Symbol
+    /// 更有辨识度 —— 圆底 + 品牌琥珀让它读作「有身份的记录提醒」。呼吸态 =
+    /// alerting(响铃前的预热窗口静态,不抢注意力)。
+    @ViewBuilder
+    private static func compactBadge(_ context: Context) -> some View {
+        Image(systemName: "mic.fill")
+            .font(.system(size: 11, weight: .bold))
+            .foregroundStyle(onAmberInk(context))
+            .frame(width: 22, height: 22)
+            .background(context.attributes.tintColor, in: Circle())
+            .symbolEffect(.breathe, options: .repeat(.continuous),
+                          isActive: isAlerting(context))
+    }
+
+    /// 琥珀底上的前景墨色:琥珀偏亮(暗色变体 #C9883A)→ 用深墨够对比;
+    /// tintColor 由 app 侧单源下发,这里取一个恒定深墨(灵动岛恒黑底语境)。
+    private static func onAmberInk(_ context: Context) -> Color {
+        // 灵动岛恒黑底 + 琥珀 tint(#C9883A 亮琥珀)→ 深墨字对比最佳。
+        Color(red: 0.102, green: 0.094, blue: 0.078)
+    }
+
     @ViewBuilder
     private func lockScreen(_ context: Context) -> some View {
         HStack(spacing: 14) {
@@ -167,9 +200,16 @@ struct CaptureReminderLiveActivity: Widget {
                 .symbolEffect(.breathe, options: .repeat(.continuous),
                               isActive: Self.isAlerting(context))
             VStack(alignment: .leading, spacing: 3) {
-                Text("记录此刻")
-                    .font(.headline)
-                    .foregroundStyle(Palette.ink)
+                // 锁屏也明确写 App 名 —— 与灵动岛 expanded 品牌行一致,
+                // 用户一眼知道是 DayPage 在召唤记录。
+                HStack(spacing: 6) {
+                    Text("DayPage")
+                        .font(.headline)
+                        .foregroundStyle(Palette.ink)
+                    Text("记录此刻")
+                        .font(.subheadline.weight(.medium))
+                        .foregroundStyle(Palette.inkMuted)
+                }
                 Text(context.attributes.metadata?.prompt ?? "记一句给今天")
                     .font(.subheadline)
                     .foregroundStyle(Palette.inkMuted)


### PR DESCRIPTION
## 背景

灵动岛此前只有 alerting 响铃态,由 iOS 系统 chrome 强制接管 —— 用户反馈「黑乎乎、能点但没内容、鬼知道是谁的、设计太丑」。

根因:生产 alarm 走 AlarmKit 闹钟路径,`countdownDuration: nil`,一生只有 `.alerting` 态,而该态灵动岛由系统接管,自定义 widget UI 从不上屏。那片「黑」是系统响铃条本身。

## 改动

### 1. 倒计时进岛(让品牌 UI 能上屏)
- `scheduleAlarm` 从 `countdownDuration: nil` 改为配 `preAlert` 预热窗口(`islandPreheatSeconds = 60`)+ `AlarmPresentation` 加 `countdown` 态。
- SDK 语义(逐条核对 iOS 26.4 swiftinterface + Apple `countdownDuration` 属性文档):倒计时 UI 在「alert 时刻 − preAlert」自动上屏,归零进 `.alerting`;`.relative` 重复日程每次触发前都重演预热。
- `.countdown` 是自定义琥珀岛 UI 唯一能上屏的窗口。

### 2. 品牌化灵动岛各态
- **expanded**:一张有呼吸的卡 —— 琥珀圆底品牌标 + 明确写「DayPage」名 + 大 mono 倒计时 + 底部提示 + 琥珀胶囊 CTA。
- **compact**:同一 `compactBadge` 复合标(圆底盛麦克风,非裸符号)。
- **锁屏卡**:标题写明「DayPage · 记录此刻」。
- 释除「这是谁的」疑惑,建立品牌辨识度。

### 3. Today 收敛
- `reminderStrip` 整条从主流移除(返回 `EmptyView`),提醒的增删改查全部收进侧边栏「调度中心」。

### 附
- QA 桥 `-qaAlarmInSeconds` 修正为排 `.loud` 提醒(此前 `.quiet` 走 UN 测不到 AlarmKit 岛)。

## 验证

- ✅ `xcodebuild build` BUILD SUCCEEDED
- ✅ `CaptureReminderServiceTests` 27 tests passed
- ✅ **展开态** + **锁屏卡** 模拟器实测渲染正确(见下)
- ⚠️ **compact 态**因模拟器对 AlarmKit 灵动岛回退系统默认 UI 的架构限制,须真机(iPhone 14 Pro+)验证;代码复用同一 `compactBadge`,已随展开态验证渲染正确。

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ