### PR TITLE
fix(launch): 修复卸载重装首启白屏后闪退 — 主线程 iCloud 阻塞越过 watchdog

### DIFF
--- a/DayPageKit/Sources/DayPageStorage/VaultInitializer.swift
+++ b/DayPageKit/Sources/DayPageStorage/VaultInitializer.swift
@@ -7,13 +7,26 @@ public enum VaultInitializer {
 
     // MARK: - Vault root
 
-    /// Swappable storage backend. Lazily resolved: uses iCloudVaultLocator when
-    /// the ubiquity container is available; falls back to LocalVaultLocator otherwise.
-    /// Can be overridden at runtime (e.g., after the user enables iCloud in Settings).
-    public static var shared: VaultLocator = {
-        let icloud = iCloudVaultLocator()
-        return icloud.isUsingiCloud ? icloud : LocalVaultLocator()
-    }()
+    /// Swappable storage backend.
+    ///
+    /// Defaults to `LocalVaultLocator` — a pure local-Documents path that never
+    /// touches the iCloud daemon. This is deliberate: `iCloudVaultLocator`
+    /// resolves the ubiquity container via `FileManager.url(forUbiquityContainerIdentifier:)`,
+    /// which Apple documents as a *blocking* call that must not run on the main
+    /// thread. `initializeIfNeeded()` reads `vaultURL` 13+ times synchronously
+    /// inside `DayPageApp.init()` (before the first frame). On a fresh install the
+    /// iCloud daemon hasn't provisioned the container yet, so each call could hang
+    /// for seconds — enough to blow past the launch watchdog (~20s) and get the
+    /// process killed with `0x8badf00d` (symptom: blank screen, then crash on
+    /// first launch after reinstall).
+    ///
+    /// iCloud detection is instead performed off the main thread in
+    /// `DayPageApp.init`'s `Task.detached` re-probe, which hot-swaps this locator
+    /// to `iCloudVaultLocator` once the container becomes available. Runtime
+    /// readers (`MemoCardView`, the sync/conflict monitors, migration) observe the
+    /// swap transparently. Can also be overridden at runtime (e.g., after the user
+    /// toggles iCloud in Settings).
+    public static var shared: VaultLocator = LocalVaultLocator()
 
     /// Test-only override. When non-nil, `vaultURL` returns this instead of the
     /// locator-derived URL. Keep `internal` so `@testable import DayPage` tests


### PR DESCRIPTION
## 问题

用户报告:**卸载重装后进不去,白屏一会然后闪退**。真机专属,模拟器复现不了。

## 根因

`DayPageApp.init()` 在首帧渲染前的主线程上,同步调用 `VaultInitializer.initializeIfNeeded()`。其内部:
- `createDirectories()` 循环 7 个目录,每次读 `vaultURL`
- `createSeedFiles()` 4 个种子文件,各读一次 `vaultURL`
- migration/prefetch guard 2 次

累计 **13+ 次** 读 `vaultURL` → 命中未缓存的 `iCloudVaultLocator.ubiquityContainer` → `FileManager.url(forUbiquityContainerIdentifier:)`。

Apple 文档明确该调用**会阻塞、禁止主线程使用**。全新安装时 iCloud daemon 冷启动、容器未就绪,每次挂起数秒,累计越过启动 watchdog(~20s) 被 `0x8badf00d` 杀进程。

- **白屏** = 主线程卡死,SwiftUI 渲染不出首帧
- **闪退** = watchdog 超时杀进程

## 修复

`VaultInitializer.shared` 默认值从「主线程急探 iCloud」改为 `LocalVaultLocator()`(`isUsingiCloud` 常量 false,零 IO)。

iCloud 探测由**既有的** `DayPageApp.swift` 后台 `Task.detached` 承担 —— 探到就绪后热切换 locator 并在后台线程重建目录。这套热切换逻辑本就写好,只是默认值此前抢在主线程做了它的活。顺带消除 monitor 重复解析(monitor 首启读 local 即 false 返回)。

## 为什么之前没发现

真机专属 bug:仅「真机 + 登录 iCloud + 全新安装」三者同时触发。模拟器无 iCloud 账号走 local 路径、老用户升级时容器已热,故日常开发与模拟器均测不出。

## 影响面 / 无回归

所有 `VaultInitializer.shared` 消费点(`MemoCardView` / `iCloudSyncMonitor` / `iCloudConflictMonitor` / `VaultMigrationService`)均运行时读当前态,对热切换透明;`SettingsSyncDataView` 本就手动设 local,证明 local 是合法运行态。

## 验证

- ✅ `xcodebuild -scheme DayPage` BUILD SUCCEEDED
- ⏳ 真机验收(唯一能最终确认的方式):卸载 → 重装 → 打开,预期秒进不白屏

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ