### PR TITLE
feat(today): Loop 输入乐观落盘 — 先上屏落盘，再后台补 GPS/天气

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -1109,11 +1109,11 @@ struct InputBarV4: View {
             isFocused = false
             return
         }
-        // Fire the commit haptic on THIS frame (causality) — the memo's
-        // async append later fires `.successNotification()` on completion, but
-        // waiting for the disk write to feed back reads as "half a beat late".
-        // Mirrors WriteSheetView.handleSave(), which already commits on tap.
-        Haptics.commit()
+        // No tap-time haptic here: submitCombinedMemo now inserts the memo and
+        // fires the single authoritative `.successNotification()` on this same
+        // frame (optimistic commit), so a separate commit-on-tap buzz would
+        // just double up. It only existed to cover the old multi-second delay
+        // between tap and the async landing haptic, which no longer exists.
         onSubmit()
         isFocused = false
         transition(to: .collapsing)

--- a/DayPage/Features/Today/TodayViewModel.swift
+++ b/DayPage/Features/Today/TodayViewModel.swift
@@ -828,136 +828,206 @@ final class TodayViewModel: ObservableObject, MemoDetailViewModel {
 
     /// Submits a memo combining the draft text with all staged pendingAttachments.
     /// Determines type automatically: text | voice | photo | mixed.
+    ///
+    /// **落盘先于加载 (persist-then-enrich).** The memo is built from data we
+    /// already hold — body, attachments, EXIF timestamp/GPS, device — with **no
+    /// awaits**, then committed in three synchronous steps the user feels this
+    /// frame: it flies into the list, the composer clears, and a haptic fires.
+    /// Only after the card is on screen do we (a) durably append it to disk and
+    /// (b) chase the two slow, optional signals — GPS + weather — which are
+    /// patched in afterward by `enrichMetadata`. The old flow awaited a 3-second
+    /// location lookup + a weather network call *before* the card ever appeared,
+    /// so a send read as a multi-second stall for metadata the Today card does
+    /// not even render.
     func submitCombinedMemo(body: String) {
         let trimmed = body.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasText = !trimmed.isEmpty
-        let attachments = pendingAttachments
-        guard hasText || !attachments.isEmpty else { return }
+        let snapshotAttachments = pendingAttachments
+        guard hasText || !snapshotAttachments.isEmpty else { return }
 
-        // B4: re-entrancy guard. Without this, a rapid double-tap on the send
-        // arrow (or send + an auto-submit from photo batch processing) can
-        // enqueue two parallel Tasks that both append the same memo and race
-        // on the inflight-draft store. Drops the second call as a no-op.
+        // B4: re-entrancy guard. The commit below is fully synchronous on the
+        // MainActor, so this only ever trips on a genuine second invocation
+        // (e.g. a photo-batch auto-submit racing a manual send) — and by then
+        // the composer state is already cleared, so no memo can be duplicated.
         guard !isSubmitting else { return }
-
         isSubmitting = true
         submitError = nil
 
-        let loc = pendingLocation
-        let snapshotAttachments = attachments
+        let userSetLocation = pendingLocation
 
-        // Persist an inflight record BEFORE we await anything. If the user
-        // kills the app (or the OS does) during the location/weather/append
-        // await chain, this on-disk record lets the next launch restore the
-        // body into the composer — without it, the synchronous `draftText
-        // = ""` in TodayView's Send handler would have silently destroyed
-        // the user's typed text. Issue #23.
-        let inflightAttachmentPaths = snapshotAttachments.map { $0.attachment.file }
-        let inflightURL = InflightDraftStore.enqueue(
-            body: trimmed,
-            attachmentPaths: inflightAttachmentPaths
-        )
+        // --- Build the memo synchronously, from data already in hand ---
 
-        submitMemoTask = Task { @MainActor in
-            defer { isSubmitting = false }
+        // created: photo-only memos inherit the shot's EXIF capture time.
+        var created = Date()
+        if !hasText, case .photo(let r) = snapshotAttachments.first,
+           let exifDate = r.exif?.capturedAt {
+            created = exifDate
+        }
 
-            // Auto-fetch location for every memo when not already set by the user.
-            // Falls back silently on denial or timeout — location is best-effort metadata.
-            var memoLocation: Memo.Location? = loc
-            if memoLocation == nil {
-                memoLocation = try? await locationService.currentLocation(timeout: 3)
-            }
-
-            // Derive location from first photo EXIF when GPS is still missing
-            if memoLocation == nil {
-                for att in snapshotAttachments {
-                    if case .photo(let r) = att,
-                       let lat = r.exif?.gpsLat,
-                       let lng = r.exif?.gpsLng {
-                        memoLocation = Memo.Location(name: nil, lat: lat, lng: lng)
-                        break
-                    }
-                }
-            }
-
-            let weatherString = await weatherService.currentWeather(at: memoLocation)
-
-            // Determine created date: prefer first photo EXIF date when text is absent
-            var created = Date()
-            if !hasText, case .photo(let r) = snapshotAttachments.first,
-               let exifDate = r.exif?.capturedAt {
-                created = exifDate
-            }
-
-            // Build Memo.Attachment array
-            let memoAttachments = snapshotAttachments.map { $0.attachment }
-
-            // Determine type
-            let hasPhotos = snapshotAttachments.contains { if case .photo = $0 { return true }; return false }
-            let hasVoice  = snapshotAttachments.contains { if case .voice = $0 { return true }; return false }
-            let hasFiles  = snapshotAttachments.contains { if case .file = $0 { return true }; return false }
-            let memoType: Memo.MemoType
-            let typeCount = (hasText ? 1 : 0) + (hasPhotos ? 1 : 0) + (hasVoice ? 1 : 0) + (hasFiles ? 1 : 0)
-            if typeCount > 1 {
-                memoType = .mixed
-            } else if hasPhotos {
-                memoType = .photo
-            } else if hasVoice {
-                memoType = .voice
-            } else if hasFiles {
-                memoType = .mixed
-            } else {
-                memoType = .text
-            }
-
-            // Body is always the user-typed text (trimmed). For voice-only memos this
-            // is empty — the transcript lives exclusively in attachment.transcript and
-            // is rendered by VoiceMemoPlayerRow, preventing duplicate display.
-            let finalBody = trimmed
-
-            let memo = Memo(
-                type: memoType,
-                created: created,
-                location: memoLocation,
-                weather: weatherString,
-                device: deviceDescription(),
-                attachments: memoAttachments,
-                body: finalBody
-            )
-
-            do {
-                try RawStorage.append(memo)
-                InflightDraftStore.dequeue(inflightURL)
-                // Issue #18 (2026-07-03): record the creation event with
-                // the memo kind so the debug board can show a per-kind
-                // stack for "what am I capturing this month?".
-                AnalyticsService.shared.record(
-                    AnalyticsService.Name.memoCreated,
-                    props: ["kind": memo.type.rawValue]
-                )
-                withAnimation(Motion.spring) {
-                    memos.insert(memo, at: 0)
-                }
-                Haptics.successNotification()
-                pendingLocation = nil
-                pendingAttachments = []
-                // B4: clear any residual failed-body breadcrumb from a prior
-                // attempt. Without this, after recovery + successful resubmit
-                // the next onChange of `lastFailedBody` could re-fire and
-                // restore stale text into the now-clean composer.
-                lastFailedBody = nil
-                // Track save count for sync banner (US-010)
-                let count = UserDefaults.standard.integer(forKey: AppSettings.Keys.memoSaveCount)
-                UserDefaults.standard.set(count + 1, forKey: AppSettings.Keys.memoSaveCount)
-            } catch {
-                // The inflight record stays on disk — next launch (or the
-                // user retrying via lastFailedBody) gets the body back.
-                submitError = String(format: NSLocalizedString("error.memo.save_failed", comment: ""), error.localizedDescription)
-                if !finalBody.isEmpty {
-                    lastFailedBody = finalBody
+        // location: prefer the user's explicit pin, else a photo's EXIF GPS.
+        // If neither is present the field stays nil and `enrichMetadata` fills
+        // it in from a live GPS fix after the card is already on screen.
+        var initialLocation: Memo.Location? = userSetLocation
+        if initialLocation == nil {
+            for att in snapshotAttachments {
+                if case .photo(let r) = att,
+                   let lat = r.exif?.gpsLat,
+                   let lng = r.exif?.gpsLng {
+                    initialLocation = Memo.Location(name: nil, lat: lat, lng: lng)
+                    break
                 }
             }
         }
+
+        let memoAttachments = snapshotAttachments.map { $0.attachment }
+
+        // Determine type
+        let hasPhotos = snapshotAttachments.contains { if case .photo = $0 { return true }; return false }
+        let hasVoice  = snapshotAttachments.contains { if case .voice = $0 { return true }; return false }
+        let hasFiles  = snapshotAttachments.contains { if case .file = $0 { return true }; return false }
+        let memoType: Memo.MemoType
+        let typeCount = (hasText ? 1 : 0) + (hasPhotos ? 1 : 0) + (hasVoice ? 1 : 0) + (hasFiles ? 1 : 0)
+        if typeCount > 1 {
+            memoType = .mixed
+        } else if hasPhotos {
+            memoType = .photo
+        } else if hasVoice {
+            memoType = .voice
+        } else if hasFiles {
+            memoType = .mixed
+        } else {
+            memoType = .text
+        }
+
+        // Body is always the user-typed text (trimmed). For voice-only memos this
+        // is empty — the transcript lives exclusively in attachment.transcript and
+        // is rendered by VoiceMemoPlayerRow, preventing duplicate display.
+        let memo = Memo(
+            type: memoType,
+            created: created,
+            location: initialLocation,
+            weather: nil,               // enriched after the card lands (see enrichMetadata)
+            device: deviceDescription(),
+            attachments: memoAttachments,
+            body: trimmed
+        )
+
+        // Persist an inflight record BEFORE the durable append is scheduled. If
+        // the app is killed in the (now tiny, await-free) window between the
+        // optimistic insert and the disk write, this on-disk record lets the
+        // next launch restore the body into the composer. Issue #23.
+        let inflightURL = InflightDraftStore.enqueue(
+            body: trimmed,
+            attachmentPaths: memoAttachments.map { $0.file }
+        )
+
+        // --- 1. Optimistic insert: the memo is on screen THIS frame. ---
+        withAnimation(Motion.spring) {
+            memos.insert(memo, at: 0)
+        }
+        // Single authoritative "committed" haptic, now firing on the same frame
+        // as the visual — the composers no longer fire a redundant tap-time
+        // haptic to paper over the old multi-second landing delay.
+        Haptics.successNotification()
+
+        // --- 2. Clear composer state synchronously. ---
+        pendingLocation = nil
+        pendingAttachments = []
+        // B4: clear any residual failed-body breadcrumb from a prior attempt so
+        // a later onChange of `lastFailedBody` can't restore stale text.
+        lastFailedBody = nil
+
+        // The perceived work is done — re-enable the send affordance now so a
+        // heavy-capturing user can fire the next memo without waiting on disk.
+        isSubmitting = false
+
+        // Issue #18: record the creation event with the memo kind, and bump the
+        // save count (US-010). The memo is committed to the UI, so these are
+        // true now regardless of how the background enrichment resolves.
+        AnalyticsService.shared.record(
+            AnalyticsService.Name.memoCreated,
+            props: ["kind": memo.type.rawValue]
+        )
+        let count = UserDefaults.standard.integer(forKey: AppSettings.Keys.memoSaveCount)
+        UserDefaults.standard.set(count + 1, forKey: AppSettings.Keys.memoSaveCount)
+
+        // --- 3. Durable write (落盘), then 4. progressive enrichment. ---
+        submitMemoTask = Task { @MainActor in
+            // Persist first. Disk I/O is offloaded so the append + atomic
+            // rename never blocks the main thread (CLAUDE.md convention). The
+            // failure is surfaced as a plain String so no Error existential
+            // crosses the actor boundary.
+            let writeErrorMessage: String? = await Task.detached(priority: .userInitiated) { () -> String? in
+                do { try RawStorage.append(memo); return nil }
+                catch { return error.localizedDescription }
+            }.value
+
+            if let writeErrorMessage {
+                // Durable write failed — roll the optimistic card back out and
+                // hand the body back to the composer. The inflight record stays
+                // on disk for next-launch recovery.
+                withAnimation(Motion.rise) {
+                    self.memos.removeAll { $0.id == memo.id }
+                }
+                self.submitError = String(format: NSLocalizedString("error.memo.save_failed", comment: ""), writeErrorMessage)
+                if !trimmed.isEmpty { self.lastFailedBody = trimmed }
+                Haptics.warn()
+                return
+            }
+
+            InflightDraftStore.dequeue(inflightURL)
+            // Chase the slow, optional GPS + weather signals only now that the
+            // memo is safely on disk.
+            await self.enrichMetadata(for: memo)
+        }
+    }
+
+    /// Fills in the slow, optional GPS + weather signals AFTER a memo is already
+    /// on screen and on disk. Reverse of the old submit order: the user never
+    /// waits on these. Best-effort — any signal that can't be resolved is simply
+    /// left off. The raw file is patched in place via `RawStorage.mutate` (which
+    /// runs on the write queue, so it can't clobber a concurrent append/rewrite)
+    /// and the resolved values crossfade into the on-screen card.
+    private func enrichMetadata(for memo: Memo) async {
+        // 1. Resolve a live GPS fix only when we don't already have coordinates
+        //    (user pin / photo EXIF already supplied them at commit time).
+        let needsLocation = memo.location?.lat == nil
+        var resolvedLocation = memo.location
+        if needsLocation {
+            resolvedLocation = try? await locationService.currentLocation(timeout: 3)
+        }
+        let locationChanged = needsLocation && resolvedLocation?.lat != nil
+
+        // 2. Weather needs coordinates; fetch once location has settled.
+        let resolvedWeather = await weatherService.currentWeather(at: resolvedLocation)
+
+        // Nothing new to write — leave the memo as committed.
+        guard locationChanged || resolvedWeather != nil else { return }
+
+        // 3. Patch the raw file in place, keyed by memo id. Returning nil (memo
+        //    no longer present — e.g. deleted mid-enrichment) aborts the write.
+        let memoID = memo.id
+        let createdDate = memo.created
+        let locationToWrite = locationChanged ? resolvedLocation : nil
+        Task.detached(priority: .utility) {
+            try? RawStorage.mutate(for: createdDate) { current in
+                guard let idx = current.firstIndex(where: { $0.id == memoID }) else { return nil }
+                var updated = current
+                if let loc = locationToWrite { updated[idx].location = loc }
+                if let w = resolvedWeather { updated[idx].weather = w }
+                return updated
+            }
+        }
+
+        // 4. Reflect the enriched metadata in the on-screen card (gentle
+        //    crossfade — the row is unchanged except for these quiet fields).
+        guard let idx = memos.firstIndex(where: { $0.id == memoID }) else { return }
+        var patched = memos[idx]
+        if let loc = locationToWrite { patched.location = loc }
+        if let w = resolvedWeather { patched.weather = w }
+        var newMemos = memos
+        newMemos[idx] = patched
+        withAnimation(Motion.fade) { memos = newMemos }
     }
 
     // MARK: - Fetch Location

--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -1008,7 +1008,9 @@ struct WriteSheetView: View {
 
     private func handleSave() {
         guard isDirty else { return }
-        Haptics.medium()
+        // No tap-time haptic: submitCombinedMemo fires the single authoritative
+        // `.successNotification()` on the same frame it inserts the memo
+        // (optimistic commit), so a commit-on-tap buzz would double up.
         isFocused = false
         onSave()
     }

--- a/DayPageTests/TodayViewModelTests.swift
+++ b/DayPageTests/TodayViewModelTests.swift
@@ -141,6 +141,43 @@ struct TodayViewModelTests {
         #expect(vm.memos.first?.pinnedAt != nil)
     }
 
+    // MARK: - submitCombinedMemo (optimistic commit + durable persist)
+
+    /// 落盘先于加载：the memo must appear in `memos` on the SAME synchronous turn
+    /// the user taps send — no awaiting location/weather first — and must still
+    /// land on disk afterward via the background durable-write task.
+    @Test func submitCombinedMemo_insertsOptimisticallyThenPersists() async throws {
+        defer { cleanup() }
+        #expect(vm.memos.isEmpty)
+
+        vm.submitCombinedMemo(body: "optimistic hello")
+
+        // Optimistic insert + composer reset happen synchronously — the user
+        // perceives the memo immediately, before any GPS/weather await.
+        #expect(vm.memos.count == 1)
+        #expect(vm.memos.first?.body == "optimistic hello")
+        #expect(vm.isSubmitting == false)
+        #expect(vm.pendingAttachments.isEmpty)
+
+        // The durable append runs off-main; poll until the raw file reflects it.
+        let deadline = Date().addingTimeInterval(5)
+        var persisted: [Memo] = []
+        while Date() < deadline {
+            persisted = (try? RawStorage.read(for: Date())) ?? []
+            if !persisted.isEmpty { break }
+            try await Task.sleep(nanoseconds: 50_000_000)
+        }
+        #expect(persisted.contains { $0.body == "optimistic hello" })
+    }
+
+    /// An empty submit with no attachments is a no-op — no ghost card, no write.
+    @Test func submitCombinedMemo_emptyBodyNoAttachments_isNoOp() {
+        defer { cleanup() }
+        vm.submitCombinedMemo(body: "   \n  ")
+        #expect(vm.memos.isEmpty)
+        #expect(vm.isSubmitting == false)
+    }
+
     // MARK: - signalCount
 
     @Test func signalCount_matchesMemoCount() {


### PR DESCRIPTION
## 问题（很本质的一个）

用户在 Loop 里输入（文字 / 语音 / 图片）点发送后，卡片要等好几秒才出现——这是「先加载再落盘」，非常反人性。

根因在 `TodayViewModel.submitCombinedMemo`（所有发送路径的唯一漏斗）：它在卡片上屏**之前**，先

1. `await locationService.currentLocation(timeout: 3)` —— 最长 **3 秒**
2. `await weatherService.currentWeather(...)` —— 一次网络往返
3. 才 `RawStorage.append`（落盘）→ 才 `memos.insert`（卡片出现）

两条佐证这确实是设计缺陷：
- `MemoCardView` 的 Today 卡片**只渲染时间戳**，定位/天气早已被 museum-aesthetic 改版隐藏（`MemoCardView.swift:415`）。为这两项阻塞卡片，视觉上零收益。
- `WeatherService.currentWeather` 自己的文档就写着*「调用方不得阻塞此方法 —— 从提交流程中调用时采用即发即忘模式」*。旧代码违背了它自己的契约。

## 方案：乐观提交 + 渐进补全

采用成熟 App 通用的做法（iMessage / Bear / Things / Apple Notes 皆如此）——**先落盘、先感知，元数据缓慢补全**：

1. **同步**用手头已有的数据（正文、附件、EXIF 时间/GPS、设备）构造 memo，**零 await**：
   - `memos.insert` 上屏（动画）
   - 清空 composer
   - 单次 `Haptics.successNotification()`
   - 立即重置 `isSubmitting`，重度记录的用户可连发下一条
2. **落盘（落盘先于加载）**：后台 `Task.detached` 执行 `RawStorage.append`（磁盘 I/O 不压主线程）。失败则回滚乐观卡片、把正文还给 composer；inflight 记录继续兜住崩溃窗口（现已缩到无 await）。
3. **补全**：`enrichMetadata` 在落盘之后才去取实时 GPS + 天气，经 `RawStorage.mutate` 按 `id` 原位回写 raw（走 `writeQueue`，不与并发 append/rewrite 打架），并以 fade 把结果补进卡片。

顺带把 haptic 收敛成单一权威信号：VM 在乐观 insert 那一帧发 `successNotification`，移除 `InputBarV4` / `WriteSheetView` 里两处仅为掩盖旧「落地延迟」而加的 tap-time haptic，避免同帧双震。

## 改动

| 文件 | 改动 |
|---|---|
| `TodayViewModel.swift` | 重写 `submitCombinedMemo` 为乐观提交；新增 `enrichMetadata(for:)` |
| `InputBarV4.swift` | 移除冗余的 tap-time `Haptics.commit()` |
| `WriteSheetView.swift` | 移除冗余的 tap-time `Haptics.medium()` |
| `TodayViewModelTests.swift` | 新增：发送后 `memos` 同步含该 memo（先感知）且随后确实落盘（先落盘）；空提交为 no-op |

## 兼容性 / 行为保持

- 语音 pending 转写、EXIF 时间/GPS 派生、memo 类型判定、inflight 崩溃恢复、失败回滚——逐一保留。
- 定位/天气仍对每条 memo 尽力补全，只是移到卡片上屏之后；写盘顺序与并发安全由 `RawStorage.writeQueue`（append / mutate / rewrite 全序列化，且都在临界区内重读文件）保证。

## 验证

⚠️ 本次在 Linux 容器完成，无法跑 `xcodebuild` / Simulator。已逐一静态核对所引用符号（`Motion.rise/fade/spring`、`Haptics.warn/successNotification`、`RawStorage.mutate`、`LocationService.currentLocation`、`WeatherService.currentWeather`）均存在且签名匹配。**合并前请在 macOS 上按 CLAUDE.md 跑一次 `DayPage` scheme 构建 + 测试套件，并在 Simulator 里目视确认发送即时上屏。**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WVGnSmuamA4amMjN49Jh3w

---
_Generated by [Claude Code](https://claude.ai/code/session_01WVGnSmuamA4amMjN49Jh3w)_