### PR TITLE
fix(voice): 发送即用实时转写文本 + 堵死"一直转录中"三陷阱

### DIFF
--- a/DayPage/Features/Today/InputBarV4.swift
+++ b/DayPage/Features/Today/InputBarV4.swift
@@ -1146,11 +1146,14 @@ struct InputBarV4: View {
             return
         }
         Haptics.medium()
-        // Send path: audio is saved instantly, transcription runs in the
-        // background via VoiceAttachmentQueue and patches the memo later.
-        // No await needed here — the memo lands within one frame.
-        if let result = voiceService.stopAndSaveAudio() {
-            onPressToTalkSend(result)
+        // Send path: audio is saved instantly. Live-streamed text (if any)
+        // becomes the transcript right away; otherwise the flash file pass runs
+        // in the background and patches the memo later. The short flush window
+        // (~2s) only applies when streaming was active and produced text.
+        Task {
+            if let result = await voiceService.stopAndSaveAudio() {
+                onPressToTalkSend(result)
+            }
         }
     }
 

--- a/DayPage/Features/Today/MemoCardView.swift
+++ b/DayPage/Features/Today/MemoCardView.swift
@@ -991,6 +991,19 @@ struct VoiceMemoPlayerRow: View {
                             } label: {
                                 Label("复制", systemImage: "doc.on.doc")
                             }
+                            // Long-press to re-run transcription even on an
+                            // already-transcribed clip. The live-stream draft is
+                            // fast but occasionally rougher than the flash file
+                            // pass; this lets the user upgrade it on demand
+                            // instead of being stuck with the first result.
+                            if onRetranscribe != nil {
+                                Button {
+                                    isRetranscribing = true
+                                    onRetranscribe?()
+                                } label: {
+                                    Label(NSLocalizedString("voice.retry.rerun", value: "重新转写", comment: "Re-run transcription on an already-transcribed clip"), systemImage: "arrow.clockwise")
+                                }
+                            }
                         }
                     Text("\u{201D}")
                         .font(DSFonts.serif(size: 20, weight: .medium, relativeTo: .title3))

--- a/DayPage/Features/Today/VoiceRecordingView.swift
+++ b/DayPage/Features/Today/VoiceRecordingView.swift
@@ -340,14 +340,17 @@ struct VoiceRecordingView: View {
             .accessibilityLabel(NSLocalizedString("voice.recording.a11y.discard", value: "丢弃录音", comment: "Voice recording — discard button a11y label"))
             .accessibilityHint(NSLocalizedString("voice.recording.a11y.discard.hint", value: "永久删除此次录音内容", comment: "Voice recording — discard hint"))
 
-            // 保存 — send path: audio saves instantly, transcription runs in the
-            // background via VoiceAttachmentQueue and patches the memo later.
+            // 保存 — send path: audio saves instantly. When live streaming
+            // produced text it becomes the transcript immediately; otherwise
+            // the flash file pass runs in the background and patches later.
             Button(action: {
                 guard canSave else { return }
-                if let result = voiceService.stopAndSaveAudio() {
-                    onComplete(result)
-                } else {
-                    onCancel()
+                Task {
+                    if let result = await voiceService.stopAndSaveAudio() {
+                        onComplete(result)
+                    } else {
+                        onCancel()
+                    }
                 }
             }) {
                 Text(NSLocalizedString("voice.recording.save", value: "保存", comment: "Save recording"))

--- a/DayPage/Features/Today/WriteSheetView.swift
+++ b/DayPage/Features/Today/WriteSheetView.swift
@@ -636,10 +636,13 @@ struct WriteSheetView: View {
             voiceService.cancelRecording()
             return
         }
-        // Send path: audio is saved instantly, transcription runs in the
-        // background via VoiceAttachmentQueue and patches the memo later.
-        if let result = voiceService.stopAndSaveAudio() {
-            onPressToTalkSend(result)
+        // Send path: audio is saved instantly. Live-streamed text (if any)
+        // becomes the transcript right away; otherwise the flash file pass runs
+        // in the background and patches the memo later.
+        Task {
+            if let result = await voiceService.stopAndSaveAudio() {
+                onPressToTalkSend(result)
+            }
         }
     }
 

--- a/DayPage/Resources/en.lproj/Localizable.strings
+++ b/DayPage/Resources/en.lproj/Localizable.strings
@@ -481,6 +481,7 @@
 "voice.retry.transcribing"     = "Transcribing…";
 "voice.retry.failed_permanent" = "Transcription unavailable";
 "voice.retry.failed_permanent_a11y" = "Transcription permanently failed after 3 attempts. Audio is saved.";
+"voice.retry.rerun"            = "Re-transcribe";
 
 "search.undo.cleared" = "Recent searches cleared";
 

--- a/DayPage/Resources/zh-Hans.lproj/Localizable.strings
+++ b/DayPage/Resources/zh-Hans.lproj/Localizable.strings
@@ -543,6 +543,7 @@
 "voice.retry.transcribing"     = "正在转写…";
 "voice.retry.failed_permanent" = "转写不可用";
 "voice.retry.failed_permanent_a11y" = "已重试 3 次，转写失败。音频已保存。";
+"voice.retry.rerun"            = "重新转写";
 
 "search.undo.cleared" = "已清除搜索记录";
 

--- a/DayPage/Services/VoiceAttachmentQueue.swift
+++ b/DayPage/Services/VoiceAttachmentQueue.swift
@@ -40,6 +40,23 @@ final class VoiceAttachmentQueue: ObservableObject {
         updateCount()
         observeNetworkChanges()
         observeAppActive()
+        kickOnLaunch()
+    }
+
+    /// Cold-start recovery. The exponential-backoff retry chain
+    /// (`scheduleBackoffRetry`) lives entirely in an in-memory `Task.sleep`, so
+    /// killing the app mid-chain strands any not-yet-`.failed` entry: only
+    /// `attempts` is persisted, not the pending timer. Nothing re-drives the
+    /// queue on a fresh launch except `didBecomeActive`, which may fire before
+    /// or after this singleton exists. This kicks the queue once at startup
+    /// (deferred off the init frame to avoid touching `vaultURL` synchronously —
+    /// see the iCloud launch-watchdog fix) so a stranded card resumes instead of
+    /// shimmering forever.
+    private func kickOnLaunch() {
+        Task { @MainActor [weak self] in
+            guard let self, self.pendingCount > 0 else { return }
+            await self.processQueue()
+        }
     }
 
     // MARK: - Public API
@@ -91,7 +108,20 @@ final class VoiceAttachmentQueue: ObservableObject {
                 }
 
                 if let transcript = await VoiceService.shared.transcribeAudio(at: audioURL) {
-                    writeTranscriptBack(transcript: transcript, entry: entry)
+                    let written = writeTranscriptBack(transcript: transcript, entry: entry)
+                    // Transcription succeeded but the write-back found no
+                    // matching attachment (memo deleted / moved / date drift).
+                    // Retrying can never help — the target row is gone — so drop
+                    // the entry instead of leaving a card frozen at `.pending`
+                    // forever while the queue silently thinks it's done. Loud
+                    // breadcrumb so this stops being invisible.
+                    if !written {
+                        SentryReporter.breadcrumb(
+                            category: "voice-queue",
+                            level: .warning,
+                            message: "transcript ready but no matching attachment — dropping entry \(entry.audioPath)"
+                        )
+                    }
                     entries.remove(at: i)
                     changedThisPass = true
                     consumedOne = true
@@ -105,7 +135,18 @@ final class VoiceAttachmentQueue: ObservableObject {
                         // into the day file — the card UI keys off the
                         // attachment's transcription_status, and leaving it
                         // `pending` froze the shimmer placeholder forever.
-                        Self.applyStatus(.failed, audioPath: entry.audioPath, memoDate: entry.memoDate)
+                        let wrote = Self.applyStatus(.failed, audioPath: entry.audioPath, memoDate: entry.memoDate)
+                        if !wrote {
+                            // The queue is about to mark this entry done, but the
+                            // attachment status never flipped — the card would
+                            // shimmer forever with no retry. Surface it instead
+                            // of failing silently.
+                            SentryReporter.breadcrumb(
+                                category: "voice-queue",
+                                level: .warning,
+                                message: "retries exhausted but no matching attachment for .failed write: \(entry.audioPath)"
+                            )
+                        }
                     }
                     changedThisPass = true
                 }
@@ -180,7 +221,10 @@ final class VoiceAttachmentQueue: ObservableObject {
         }
     }
 
-    private func writeTranscriptBack(transcript: String, entry: VoiceQueueEntry) {
+    /// Returns whether a matching attachment was found and rewritten. A `false`
+    /// means the transcript had nowhere to land — the caller drops the entry.
+    @discardableResult
+    private func writeTranscriptBack(transcript: String, entry: VoiceQueueEntry) -> Bool {
         Self.applyTranscript(
             transcript: transcript,
             audioPath: entry.audioPath,

--- a/DayPage/Services/VoiceService.swift
+++ b/DayPage/Services/VoiceService.swift
@@ -414,6 +414,67 @@ final class VoiceService: NSObject, ObservableObject {
         Task { await client?.close() }
     }
 
+    /// Flushes the live-streaming recognizer and returns the best transcript we
+    /// can get for the take, WITHOUT tearing anything down.
+    ///
+    /// Why this exists: the send path used to throw the already-recognized live
+    /// text away and re-transcribe the saved .m4a from scratch via the flash
+    /// file endpoint — a second, separately-provisioned service that can fail
+    /// while streaming works, leaving the card stuck at "转录中" forever. When
+    /// streaming already produced text, that text IS the transcript; the file
+    /// pass becomes an optional refinement, not the only source.
+    ///
+    /// Flow: stop the mic pump so no more audio flows, send the terminal frame
+    /// (`isLast: true`) so the server flushes its final result, then drain for a
+    /// short bounded window for an `isFinal` packet that's usually a hair more
+    /// complete than the last partial. If the window elapses, we fall back to
+    /// whatever `liveTranscript` already holds — never blocking the send.
+    ///
+    /// Returns the trimmed transcript, or "" when streaming wasn't active or
+    /// produced nothing.
+    private func finalizeLiveTranscript(maxWait: TimeInterval = 2.0) async -> String {
+        guard let client = streamClient else {
+            return liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        // Stop feeding the socket and cancel the background drain so we own
+        // `receive()` for the flush window — two concurrent receivers on one
+        // WebSocket task race for frames.
+        liveCapture?.stop()
+        liveCapture = nil
+        streamTask?.cancel()
+        streamTask = nil
+
+        // Ask the server to flush. Best-effort: a send failure here just means
+        // we return the partial text we already have.
+        try? await client.send(audio: Data(), isLast: true)
+
+        // Bounded drain, all on the main actor (no @Sendable hop needed): race
+        // each `receive()` against the remaining budget so a server that never
+        // sends its terminal frame can't stall the send. `receive()` on an
+        // actor is itself cancellable via the timeout child task.
+        let deadline = Date().addingTimeInterval(maxWait)
+        while Date() < deadline {
+            let remaining = deadline.timeIntervalSinceNow
+            guard remaining > 0 else { break }
+            let update = await withTaskGroup(of: DoubaoStreamASRClient.Update?.self) { group in
+                group.addTask { try? await client.receive() }
+                group.addTask {
+                    try? await Task.sleep(nanoseconds: UInt64(remaining * 1_000_000_000))
+                    return nil
+                }
+                let first = await group.next() ?? nil
+                group.cancelAll()
+                return first
+            }
+            guard let update else { break }        // timeout or stream closed
+            if !update.text.isEmpty { setLiveTranscript(update.text) }
+            if update.isFinal { break }
+        }
+
+        return liveTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
     // MARK: - Pause / Resume
 
     func pauseRecording() {
@@ -439,16 +500,18 @@ final class VoiceService: NSObject, ObservableObject {
 
     // MARK: - Stop & Transcribe
 
-    /// 停止录制、保存 .m4a 文件，并**立即**返回一个 transcript=nil 的结果。
+    /// 停止录制、保存 .m4a 文件，并返回结果。
     ///
-    /// 转录任务被推入 VoiceAttachmentQueue，由它在后台跑 Whisper 并事后
-    /// patch memo.attachment.transcript。这样"点击发送"的体感 = 停止
-    /// 录音的那一帧，不会再被 Whisper HTTPS 往返阻塞。
+    /// 若实时流式转写在录音期间已产出文本，则**直接把它作为 transcript 返回**，
+    /// memo 落盘即 `.done`，不再入队、不再走文件极速版。仅当没有实时文本
+    /// （未开流式 / 离线 / 未识别到内容）时，才把转录任务推入
+    /// VoiceAttachmentQueue 由文件极速版事后补写。
+    ///
+    /// 返回前会给流式一个 ~2s 的短窗口冲刷最终结果（`finalizeLiveTranscript`），
+    /// 因此不是零延迟，但绝不会无限等待。
     ///
     /// 用于用户显式选择"发送"的路径（长按松手→send、录音条→送出）。
-    /// 需要 transcript **在返回前**已经就绪的场景（例如松开手指后立即
-    /// 把文字填进输入框），请继续使用 `stopAndTranscribe()`。
-    func stopAndSaveAudio() -> VoiceRecordingResult? {
+    func stopAndSaveAudio() async -> VoiceRecordingResult? {
         guard let rec = recorder, let fileURL = currentFileURL else {
             state = .failed("没有活跃的录音")
             return nil
@@ -456,7 +519,23 @@ final class VoiceService: NSObject, ObservableObject {
 
         stopTimer()
         stopMeteringTimer()
+
+        // While we flush the stream (~2s), surface "正在转写…" instead of
+        // leaving the pulsing "正在录音" dot up — the mic is already off. Only
+        // when streaming was actually active; a non-streaming take returns
+        // instantly and shouldn't flash a processing state.
+        if streamClient != nil {
+            state = .processing
+        }
+
+        // Flush the live recognizer FIRST, while the socket is still open, so
+        // the text the user already watched appear becomes the memo's initial
+        // transcript. Only then tear the stream down. This is the fix for
+        // "发送后一直转录中": streaming text that already exists is used
+        // directly instead of re-running the flash file endpoint from scratch.
+        let liveText = await finalizeLiveTranscript()
         teardownLiveTranscription()
+
         let finalDuration = Double(elapsedSeconds)
         rec.stop()
         recorder = nil
@@ -469,23 +548,33 @@ final class VoiceService: NSObject, ObservableObject {
 
         let filePath = "raw/assets/\(fileURL.lastPathComponent)"
         lastTranscriptFailed = false
-        VoiceAttachmentQueue.shared.enqueue(audioPath: filePath, memoDate: Date())
+
+        // When live streaming gave us text, that IS the transcript — the memo
+        // lands as `.done` immediately (TodayViewModel maps transcript != nil →
+        // .done) and never touches the queue. Only enqueue the flash file pass
+        // when we have NO live text (streaming off, offline, or nothing
+        // recognized), so the audio still gets transcribed later.
+        let transcript = liveText.isEmpty ? nil : liveText
+        if transcript == nil {
+            VoiceAttachmentQueue.shared.enqueue(audioPath: filePath, memoDate: Date())
+        }
 
         state = .done
         return VoiceRecordingResult(
             filePath: filePath,
             fileURL: fileURL,
             duration: finalDuration,
-            transcript: nil
+            transcript: transcript
         )
     }
 
-    /// 停止录制、保存 .m4a 文件、调用 Whisper API 并返回结果。
-    /// 网络失败时音频仍会保存；transcript 将为 nil。
-    /// 仅在没有有效可保存的录音时返回 nil。
+    /// 停止录制、保存 .m4a 文件、返回带 transcript 的结果（转录文本在返回前
+    /// 就绪）。用于"松开手指立即把 transcript 填进输入框"的场景。
     ///
-    /// **阻塞**在 Whisper 上 —— 仅用于"松开手指立即把 transcript 填进
-    /// 输入框"这类需要转录文本在返回前就绪的场景。
+    /// 优先使用录音期间已产出的实时流式文本 —— 若有,则**不再**阻塞去跑
+    /// 文件极速版 / Whisper,松手即得文字。仅当实时文本为空时才退回到事后
+    /// 转写（此时会阻塞在该 API 上）。网络失败时音频仍会保存,transcript 为 nil。
+    /// 仅在没有有效可保存的录音时返回 nil。
     func stopAndTranscribe() async -> VoiceRecordingResult? {
         guard let rec = recorder, let fileURL = currentFileURL else {
             state = .failed("没有活跃的录音")
@@ -494,6 +583,13 @@ final class VoiceService: NSObject, ObservableObject {
 
         stopTimer()
         stopMeteringTimer()
+
+        // Prefer the text streaming already produced. Flush it (~2s) BEFORE
+        // teardown, same as the send path — otherwise this blocks the user's
+        // input box on a flash/Whisper round trip that can fail even when
+        // streaming works.
+        state = streamClient != nil ? .processing : state
+        let liveText = await finalizeLiveTranscript()
         teardownLiveTranscription()
         let finalDuration = Double(elapsedSeconds)
         rec.stop()
@@ -521,15 +617,23 @@ final class VoiceService: NSObject, ObservableObject {
         let filePath = "raw/assets/\(fileURL.lastPathComponent)"
 
         lastTranscriptFailed = false
-        let transcript = await transcribeAudio(at: fileURL)
 
-        if transcript == nil {
-            if NetworkMonitor.shared.isOnline {
-                // Online but transcription failed — surface banner so user knows audio is saved.
-                lastTranscriptFailed = true
-            } else {
-                // Offline — queue for later retry.
-                VoiceAttachmentQueue.shared.enqueue(audioPath: filePath, memoDate: Date())
+        // Live text wins: if streaming already recognized speech, use it and
+        // skip the blocking file/Whisper round trip entirely. Only fall back to
+        // post-hoc transcription when there's no live text.
+        let transcript: String?
+        if !liveText.isEmpty {
+            transcript = liveText
+        } else {
+            transcript = await transcribeAudio(at: fileURL)
+            if transcript == nil {
+                if NetworkMonitor.shared.isOnline {
+                    // Online but transcription failed — surface banner so user knows audio is saved.
+                    lastTranscriptFailed = true
+                } else {
+                    // Offline — queue for later retry.
+                    VoiceAttachmentQueue.shared.enqueue(audioPath: filePath, memoDate: Date())
+                }
             }
         }
 

--- a/DayPageTests/VoiceTranscriptWritebackTests.swift
+++ b/DayPageTests/VoiceTranscriptWritebackTests.swift
@@ -117,6 +117,46 @@ final class VoiceTranscriptWritebackTests: XCTestCase {
         XCTAssertFalse(ok)
     }
 
+    // MARK: - applyStatus (retry-exhaustion path, #821 + stuck-pending fix)
+
+    /// When retries are exhausted the queue writes a bare `.failed` status so
+    /// the card can downgrade from the shimmer to a retry affordance. If this
+    /// silently no-ops, the card shimmers forever — the exact "一直转录中" bug.
+    func testApplyStatus_writesFailedOnMatchingAttachment() throws {
+        let memo = makeVoiceMemo(audioPath: "raw/assets/voice-a.m4a")
+        try seedDayFile(memos: [memo])
+
+        let ok = VoiceAttachmentQueue.applyStatus(
+            .failed,
+            audioPath: "raw/assets/voice-a.m4a",
+            memoDate: dateString
+        )
+        XCTAssertTrue(ok)
+
+        let m = try readBack().first!
+        XCTAssertEqual(m.attachments.first?.transcriptionStatus, .failed,
+            "status must flip to .failed so the card leaves the shimmer state")
+        XCTAssertNil(m.attachments.first?.transcript, "no transcript text on a failed write")
+    }
+
+    /// The match-miss must be observable (returns false), not silent — the
+    /// caller relies on this to breadcrumb instead of leaving a frozen card.
+    func testApplyStatus_noMatchingAttachment_returnsFalse() throws {
+        let memo = makeVoiceMemo(audioPath: "raw/assets/voice-a.m4a")
+        try seedDayFile(memos: [memo])
+
+        let ok = VoiceAttachmentQueue.applyStatus(
+            .failed,
+            audioPath: "raw/assets/voice-DOES-NOT-EXIST.m4a",
+            memoDate: dateString
+        )
+        XCTAssertFalse(ok)
+
+        // The real attachment's status is untouched — we didn't clobber it.
+        let m = try readBack().first!
+        XCTAssertEqual(m.attachments.first?.transcriptionStatus, .pending)
+    }
+
     // MARK: - YAML escape safety (the prior implementation broke on these)
 
     func testApplyTranscript_handlesQuotesBackslashesAndNewlines() throws {


### PR DESCRIPTION
## 问题

实时转文字能用，但**发送语音后转录一直卡在"转录中"，永不完成**。

## 根因（分层）

**"一直转录中" = 附件 `transcription_status` 永停 `.pending`。**

1. **设计浪费**：录音期间实时流式（`sauc.duration`）已转好的 `liveTranscript`，发送时被 teardown 直接丢弃，返回 `transcript=nil`，逼后台用**另一个需单独开通**的文件极速版（`auc_turbo`）从头重转。两服务共享凭据但各自授权。`liveTranscript` 此前全项目仅录音界面显示、零复用。

2. **代码陷阱**（即便走后台转写也会永久 shimmer）：
   - `applyTranscript`/`applyStatus` 靠 `att.file==audioPath` 匹配，不中则静默 no-op：队列内部标 done（pendingCount 归零、停重试），但附件 status 一字未写，卡片永久转圈。`@discardableResult` 返回值还被丢弃无人察觉。
   - 退避重试链 15+60+240s 全内存 `Task.sleep`，app 被杀即断，冷启动仅靠 `didBecomeActive` 驱动，无 launch 补跑。

> 运维已排除：真机连通测试三行全绿，`auc_turbo` 已开通 → 纯代码/设计 bug。

## 修复

- **`finalizeLiveTranscript()`**：停 mic pump → 发终止帧 → ~2s 有界排空最终结果，全程 MainActor 无 `@Sendable` 隐患，绝不无限等待。
- **`stopAndSaveAudio()` / `stopAndTranscribe()`** 改 async，优先用实时文本：有则直接作 transcript（memo 落盘即 `.done`，不入队），空才退回后台/阻塞转写。
- 队列回写/失败写入匹配不中时**丢弃 entry 或 breadcrumb 告警**，不再静默留 pending。
- `init` 加 **`kickOnLaunch()`**：冷启动若有 pending 主动补跑一次队列。
- 语音卡长按菜单加 **"重新转写"**，复用 `retranscribe` 走文件极速版精修。
- 补 `voice.retry.rerun` 中英文案。

## 验证

- ✅ BUILD SUCCEEDED（iPhone 17 / iOS 26.1）
- ✅ 全量 DayPageTests **187/187** 通过
- ✅ 新增 2 条回归：`testApplyStatus_writesFailedOnMatchingAttachment`、`testApplyStatus_noMatchingAttachment_returnsFalse`

## 用户端行为

1. 录一段说话（能看到实时字幕）→ 发送 → 卡片 1-2 秒内直接出文字，不再转圈。
2. 长按已出文字的语音卡 → "重新转写"菜单。

https://claude.ai/code/session_0184kndbMT2pKQVBgNJoccpZ