### PR TITLE
fix(web): db client 惰性初始化，修复生产部署构建失败

### DIFF
--- a/web/src/lib/db/client.ts
+++ b/web/src/lib/db/client.ts
@@ -2,11 +2,6 @@ import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import * as schema from "./schema";
 
-const connectionString = process.env.DATABASE_URL;
-if (!connectionString) {
-  throw new Error("DATABASE_URL is not set");
-}
-
 // In dev, Next.js re-executes this module on every HMR hot-reload. A bare
 // `postgres(connectionString)` would open a NEW connection pool each time
 // without closing the old one, leaking idle connections until Postgres hits
@@ -18,18 +13,38 @@ if (!connectionString) {
 // PostgREST / pg_cron / pg_net, which need headroom).
 const globalForDb = globalThis as unknown as {
   __dpQueryClient?: ReturnType<typeof postgres>;
+  __dpDb?: ReturnType<typeof drizzle<typeof schema>>;
 };
 
-const queryClient =
-  globalForDb.__dpQueryClient ??
-  postgres(connectionString, {
-    max: process.env.NODE_ENV === "production" ? 10 : 5,
-    idle_timeout: 20, // close idle connections after 20s instead of holding them
-    max_lifetime: 60 * 30, // recycle connections every 30 min
-  });
+function createDb() {
+  const connectionString = process.env.DATABASE_URL;
+  if (!connectionString) {
+    throw new Error("DATABASE_URL is not set");
+  }
 
-if (process.env.NODE_ENV !== "production") {
-  globalForDb.__dpQueryClient = queryClient;
+  const queryClient =
+    globalForDb.__dpQueryClient ??
+    postgres(connectionString, {
+      max: process.env.NODE_ENV === "production" ? 10 : 5,
+      idle_timeout: 20, // close idle connections after 20s instead of holding them
+      max_lifetime: 60 * 30, // recycle connections every 30 min
+    });
+
+  if (process.env.NODE_ENV !== "production") {
+    globalForDb.__dpQueryClient = queryClient;
+  }
+
+  return drizzle(queryClient, { schema });
 }
 
-export const db = drizzle(queryClient, { schema });
+// Connecting eagerly at module scope broke `next build`: collecting page data
+// imports every route, the Docker build stage has no DATABASE_URL (it is a
+// runtime secret), and the throw above aborted the whole build. Defer both the
+// env check and the connection to first property access, so importing a route
+// costs nothing and the error still surfaces on the first real query.
+export const db = new Proxy({} as ReturnType<typeof drizzle<typeof schema>>, {
+  get(_target, prop, receiver) {
+    const instance = (globalForDb.__dpDb ??= createDb());
+    return Reflect.get(instance, prop, receiver);
+  },
+});


### PR DESCRIPTION
## 问题

`Deploy web production` 自 7/20 起**连续失败 6+ 次**，每次都报：

```
Error: Failed to collect page data for /api/annotations/[id]
```

## 根因

不在那个路由。`web/src/lib/db/client.ts` 在**模块顶层**读取并校验环境变量：

```ts
const connectionString = process.env.DATABASE_URL;
if (!connectionString) {
  throw new Error("DATABASE_URL is not set");
}
```

而 `next build` 的 "collect page data" 阶段会导入每一个 route → 导入 db client → 顶层抛错。

`deploy/Dockerfile.web:6` 的构建阶段并没有 `DATABASE_URL`（它是运行时注入的 secret），所以构建必然失败。`annotations/[id]` 只是恰好第一个被收集到的路由，换成别的也一样炸。

## 修复

改为惰性初始化：用 `Proxy` 把 env 检查和建连都推迟到**首次属性访问**。

- 导入 route 不再有副作用 → 构建期不连库
- 配置缺失依然会在第一次真实查询时抛出同样的错 → 保护没有削弱
- `globalThis` 缓存保留 → HMR 热重载仍不会泄漏连接池

## 验证

```
env -u DATABASE_URL npx next build
```

在**完全没有 `DATABASE_URL`** 的环境下（即 Docker 构建阶段的条件）完整构建通过。

https://claude.ai/code/session_014UhgCkPoqtza4kw39pbVkY